### PR TITLE
chore(waf): maintain waf dedicated instance resource (datasource) and fix some problems

### DIFF
--- a/docs/data-sources/waf_dedicated_instances.md
+++ b/docs/data-sources/waf_dedicated_instances.md
@@ -2,7 +2,8 @@
 subcategory: "Web Application Firewall (WAF)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_waf_dedicated_instances"
-description: ""
+description: |
+  Use this data source to get a list of WAF dedicated instances.
 ---
 
 # huaweicloud_waf_dedicated_instances
@@ -14,7 +15,7 @@ Use this data source to get a list of WAF dedicated instances.
 ```hcl
 variable instance_name {}
 
-data "huaweicloud_waf_dedicated_instances" "instances" {
+data "huaweicloud_waf_dedicated_instances" "test" {
   name = var.instance_name
 }
 ```
@@ -23,14 +24,15 @@ data "huaweicloud_waf_dedicated_instances" "instances" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) The region in which to query the WAF dedicated instance.
+* `region` - (Optional, String) Specifies the region in which to query the WAF dedicated instance.
   If omitted, the provider-level region will be used.
 
-* `id` - (Optional, String) The id of WAF dedicated instance.
+* `id` - (Optional, String) Specifies the ID of WAF dedicated instance.
 
-* `name` - (Optional, String) The name of WAF dedicated instance.
+* `name` - (Optional, String) Specifies the name of WAF dedicated instance.
 
-* `enterprise_project_id` - (Optional, String) The enterprise project ID of WAF dedicated instance.
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of WAF dedicated instance.
+  For enterprise users, if omitted, default enterprise project will be used.
 
 ## Attribute Reference
 
@@ -38,7 +40,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID.
 
-* `instances` - An array of available WAF dedicated instances.
+* `instances` - The WAF dedicated instances list.
 
 The `instances` block supports:
 
@@ -46,36 +48,33 @@ The `instances` block supports:
 
 * `name` - The name of WAF dedicated instance.
 
-* `available_zone` - The available zone names for the WAF dedicated instances.
+* `available_zone` - The available zone name of the WAF dedicated instance.
 
-* `specification_code` - The specification code of instance.
-  Different specifications have different throughput. Values are:
-  + `waf.instance.professional` - The professional edition, throughput: 100 Mbit/s; QPS: 2,000 (Reference only).
-  +`waf.instance.enterprise` - The enterprise edition, throughput: 500 Mbit/s; QPS: 10,000 (Reference only).
-
-* `cpu_architecture` - The ECS cpu architecture of WAF dedicated instance.
+* `cpu_architecture` - The ECS CPU architecture of WAF dedicated instance.
 
 * `ecs_flavor` - The flavor of the ECS used by the WAF instance.
 
-* `vpc_id` - The VPC id of WAF dedicated instance.
+* `vpc_id` - The VPC ID of WAF dedicated instance.
 
-* `subnet_id` - The subnet id of WAF dedicated instance VPC.
+* `subnet_id` - The subnet ID of WAF dedicated instance VPC.
 
-* `security_group` - The security group of the instance. This is an array of security group ids.
+* `security_group` - The security group of the instance. This is an array of security group IDs.
 
-* `server_id` - The service of the instance.
+* `server_id` - The ID of the ECS hosting the dedicated engine.
 
-* `service_ip` - The service ip of the instance.
+* `service_ip` - The service plane IP address of the dedicated WAF instance.
 
 * `run_status` - The running status of the instance. Values are:
-  + `0` - Instance is creating.
-  + `1` - Instance has created.
-  + `2` - Instance is deleting.
-  + `3` - Instance has deleted.
-  + `4` - Instance create failed.
+  + `0` - Creating.
+  + `1` - Running.
+  + `2` - Deleting.
+  + `3` - Deleted.
+  + `4` - Creation failed.
+  + `5` - Frozen.
+  + `6` - Abnormal.
+  + `7` - Updating.
+  + `8` - Update failed.
 
 * `access_status` - The access status of the instance. `0`: inaccessible, `1`: accessible.
 
-* `upgradable` - The instance is to support upgrades. `0`: Cannot be upgraded, `1`: Can be upgraded.
-
-* `group_id` - The instance group ID used by the WAF dedicated instance in ELB mode.
+* `upgradable` - Whether the dedicated WAF instance can be upgraded. `0`: Cannot be upgraded; `1`: Can be upgraded.

--- a/docs/resources/waf_dedicated_instance.md
+++ b/docs/resources/waf_dedicated_instance.md
@@ -2,7 +2,8 @@
 subcategory: "Web Application Firewall (WAF)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_waf_dedicated_instance"
-description: ""
+description: |
+  Manages a WAF dedicated instance resource within HuaweiCloud.
 ---
 
 # huaweicloud_waf_dedicated_instance
@@ -21,8 +22,8 @@ variable subnet_id {}
 variable security_group_id {}
 variable enterprise_project_id {}
 
-resource "huaweicloud_waf_dedicated_instance" "instance_1" {
-  name                  = "instance_1"
+resource "huaweicloud_waf_dedicated_instance" "test" {
+  name                  = "test-name"
   available_zone        = var.az_name
   specification_code    = "waf.instance.professional"
   ecs_flavor            = var.ecs_flavor_id
@@ -45,8 +46,8 @@ variable subnet_id {}
 variable security_group_id {}
 variable enterprise_project_id {}
 
-resource "huaweicloud_waf_dedicated_instance" "instance_1" {
-  name                  = "instance_1"
+resource "huaweicloud_waf_dedicated_instance" "test" {
+  name                  = "test-name"
   available_zone        = var.az_name
   specification_code    = "waf.instance.professional"
   vpc_id                = var.vpc_id
@@ -64,33 +65,35 @@ resource "huaweicloud_waf_dedicated_instance" "instance_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the WAF dedicated instance. If omitted, the
-  provider-level region will be used. Changing this setting will create a new instance.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the WAF dedicated instance.
+  If omitted, the provider-level region will be used. Changing this setting will create a new instance.
 
-* `name` - (Required, String) The name of WAF dedicated instance. Duplicate names are allowed, we suggest to keeping the
-  name unique.
+* `name` - (Required, String) Specifies the name of WAF dedicated instance. Duplicate names are allowed, we suggest to
+  keeping the name unique.
 
-* `available_zone` - (Required, String, ForceNew) The available zone names for the dedicated instances. It can be
+* `available_zone` - (Required, String, ForceNew) Specifies the available zone name for the dedicated instance. It can be
   obtained through this data source `huaweicloud_availability_zones`. Changing this will create a new instance.
 
-* `specification_code` - (Required, String, ForceNew) The specification code of instance. Different specifications have
-  different throughput. Changing this will create a new instance. Values are:
-  + `waf.instance.professional` - The professional edition, throughput: 100 Mbit/s; QPS: 2,000 (Reference only).
-  + `waf.instance.enterprise` - The enterprise edition, throughput: 500 Mbit/s; QPS: 10,000 (Reference only).
+* `specification_code` - (Required, String, ForceNew) Specifies the specification code of instance.
+  Different specifications have different throughput. Changing this will create a new instance.
+  Values are:
+  + **waf.instance.professional**: The professional edition, corresponding to WI-500 on the console.
+  + **waf.instance.enterprise**: The enterprise edition, corresponding to WI-100 on the console.
 
-* `vpc_id` - (Required, String, ForceNew) The VPC id of WAF dedicated instance. Changing this will create a new
+* `vpc_id` - (Required, String, ForceNew) Specifies the VPC ID of WAF dedicated instance. Changing this will create a new
   instance.
 
-* `subnet_id` - (Required, String, ForceNew) The subnet id of WAF dedicated instance VPC. Changing this will create a
-  new instance.
+* `subnet_id` - (Required, String, ForceNew) Specifies the subnet ID of WAF dedicated instance VPC. Changing this will
+  create a new instance.
 
-* `enterprise_project_id` - (Optional, String) The enterprise project ID of WAF dedicated instance. Changing this
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of WAF dedicated instance. Changing this
   will migrate the WAF instance to a new enterprise project.
+  For enterprise users, if omitted, default enterprise project will be used.
 
-* `security_group` - (Required, List, ForceNew) The security group of the instance. This is an array of security group
-  ids. Changing this will create a new instance.
+* `security_group` - (Required, List, ForceNew) Specifies the security group of the instance. This is an array of
+  security group IDs. Changing this will create a new instance.
 
-* `cpu_architecture` - (Optional, String, ForceNew) The ECS cpu architecture of instance, Default value is `x86`.
+* `cpu_architecture` - (Optional, String, ForceNew) Specifies the ECS CPU architecture of instance. Defaults to **x86**.
   Changing this will create a new instance.
 
 * `ecs_flavor` - (Optional, String, ForceNew) Specifies the flavor of the ECS used by the WAF instance. Flavors can be
@@ -99,9 +102,6 @@ The following arguments are supported:
 
   -> **NOTE:** If the instance specification is the professional edition, the ECS specification should be 2U4G. If the
   instance specification is the enterprise edition, the ECS specification should be 8U16G.
-
-* `group_id` - (Optional, String, ForceNew) The instance group ID used by the WAF dedicated instance in ELB mode.
-  Changing this will create a new instance.
 
 * `res_tenant` - (Optional, Bool, ForceNew) Specifies whether this is resource tenant.
   Changing this will create a new instance.
@@ -117,22 +117,26 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The id of the instance.
+* `id` - The resource ID (also the WAF dedicated instance ID).
 
-* `server_id` - The id of the instance server.
+* `server_id` - The ID of the ECS hosting the dedicated engine.
 
-* `service_ip` - The ip of the instance service.
+* `service_ip` - The service plane IP address of the WAF dedicated instance.
 
 * `run_status` - The running status of the instance. Values are:
-  + `0` - Instance is creating.
-  + `1` - Instance has created.
-  + `2` - Instance is deleting.
-  + `3` - Instance has deleted.
-  + `4` - Instance create failed.
+  + `0` - Creating.
+  + `1` - Running.
+  + `2` - Deleting.
+  + `3` - Deleted.
+  + `4` - Creation failed.
+  + `5` - Frozen.
+  + `6` - Abnormal.
+  + `7` - Updating.
+  + `8` - Update failed.
 
 * `access_status` - The access status of the instance. `0`: inaccessible, `1`: accessible.
 
-* `upgradable` - The instance is to support upgrades. `0`: Cannot be upgraded, `1`: Can be upgraded.
+* `upgradable` - Whether the dedicated engine can be upgraded. `0`: Cannot be upgraded, `1`: Can be upgraded.
 
 ## Timeouts
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1082,7 +1082,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_address_groups":                       waf.DataSourceWafAddressGroups(),
 			"huaweicloud_waf_certificate":                          waf.DataSourceWafCertificate(),
 			"huaweicloud_waf_dedicated_domains":                    waf.DataSourceWafDedicatedDomains(),
-			"huaweicloud_waf_dedicated_instances":                  waf.DataSourceWafDedicatedInstancesV1(),
+			"huaweicloud_waf_dedicated_instances":                  waf.DataSourceWafDedicatedInstances(),
 			"huaweicloud_waf_domains":                              waf.DataSourceWafDomains(),
 			"huaweicloud_waf_instance_groups":                      waf.DataSourceWafInstanceGroups(),
 			"huaweicloud_waf_policies":                             waf.DataSourceWafPoliciesV1(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_dedicated_instances_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_dedicated_instances_test.go
@@ -9,52 +9,24 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
+// Before running the test case, please ensure that there is at least one WAF dedicated instance in the current region.
 func TestAccDataSourceWafDedicatedInstances_basic(t *testing.T) {
-	name := acceptance.RandomAccResourceName()
-	resourceName1 := "data.huaweicloud_waf_dedicated_instances.instance_1"
-	resourceName2 := "data.huaweicloud_waf_dedicated_instances.instance_2"
+	var (
+		datasourceName = "data.huaweicloud_waf_dedicated_instances.test"
+		dc             = acceptance.InitDataSourceCheck(datasourceName)
 
-	dc := acceptance.InitDataSourceCheck(resourceName1)
+		byID   = "data.huaweicloud_waf_dedicated_instances.id_filter"
+		dcByID = acceptance.InitDataSourceCheck(byID)
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPrecheckWafInstance(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccWafDedicatedInstances_conf(name),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName1, "name", name),
-					resource.TestCheckResourceAttr(resourceName1, "instances.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.available_zone"),
-					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.ecs_flavor"),
-					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.cpu_architecture"),
-					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.security_group.#"),
-					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.server_id"),
-					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.service_ip"),
-					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.subnet_id"),
-					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.vpc_id"),
-					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.run_status"),
-					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.access_status"),
-					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.upgradable"),
+		byName   = "data.huaweicloud_waf_dedicated_instances.name_filter"
+		dcByName = acceptance.InitDataSourceCheck(byName)
 
-					resource.TestCheckResourceAttr(resourceName2, "instances.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName2, "name"),
-					resource.TestCheckResourceAttrSet(resourceName2, "instances.0.available_zone"),
-				),
-			},
-		},
-	})
-}
+		byAllParameters   = "data.huaweicloud_waf_dedicated_instances.all_parameters_filter"
+		dcByAllParameters = acceptance.InitDataSourceCheck(byAllParameters)
 
-func TestAccDataSourceWafDedicatedInstances_withEpsId(t *testing.T) {
-	name := acceptance.RandomAccResourceName()
-	resourceName := "data.huaweicloud_waf_dedicated_instances.instance_1"
-
-	dc := acceptance.InitDataSourceCheck(resourceName)
+		byNonExistID   = "data.huaweicloud_waf_dedicated_instances.non_exist_id_filter"
+		dcByNonExistID = acceptance.InitDataSourceCheck(byNonExistID)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -65,52 +37,113 @@ func TestAccDataSourceWafDedicatedInstances_withEpsId(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWafDedicatedInstances_epsId(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Config: testAccWafDedicatedInstances_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(
-						resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrSet(datasourceName, "instances.#"),
+					resource.TestCheckResourceAttrSet(datasourceName, "instances.0.id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "instances.0.name"),
+					resource.TestCheckResourceAttrSet(datasourceName, "instances.0.available_zone"),
+					resource.TestCheckResourceAttrSet(datasourceName, "instances.0.ecs_flavor"),
+					resource.TestCheckResourceAttrSet(datasourceName, "instances.0.cpu_architecture"),
+					resource.TestCheckResourceAttrSet(datasourceName, "instances.0.security_group.#"),
+					resource.TestCheckResourceAttrSet(datasourceName, "instances.0.server_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "instances.0.service_ip"),
+					resource.TestCheckResourceAttrSet(datasourceName, "instances.0.subnet_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "instances.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "instances.0.run_status"),
+					resource.TestCheckResourceAttrSet(datasourceName, "instances.0.access_status"),
+					resource.TestCheckResourceAttrSet(datasourceName, "instances.0.upgradable"),
+
+					dcByID.CheckResourceExists(),
+					resource.TestCheckOutput("id_filter_is_useful", "true"),
+
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+
+					dcByAllParameters.CheckResourceExists(),
+					resource.TestCheckOutput("all_parameters_filter_is_useful", "true"),
+
+					dcByNonExistID.CheckResourceExists(),
+					resource.TestCheckOutput("non_exist_id_filter_is_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccWafDedicatedInstances_conf(name string) string {
+func testAccWafDedicatedInstances_basic() string {
 	return fmt.Sprintf(`
-%s
+data "huaweicloud_waf_dedicated_instances" "test" {
+  enterprise_project_id = "%[1]s"
+}
 
-data "huaweicloud_waf_dedicated_instances" "instance_1" {
-  name = huaweicloud_waf_dedicated_instance.instance_1.name
+# Filter by ID
+locals {
+  id = data.huaweicloud_waf_dedicated_instances.test.instances.0.id
+}
 
-  depends_on = [
-    huaweicloud_waf_dedicated_instance.instance_1
+data "huaweicloud_waf_dedicated_instances" "id_filter" {
+  id                    = local.id
+  enterprise_project_id = "%[1]s"
+}
+
+locals {
+  id_filter_result = [
+    for v in data.huaweicloud_waf_dedicated_instances.id_filter.instances[*].id : v == local.id
   ]
 }
 
-data "huaweicloud_waf_dedicated_instances" "instance_2" {
-  id   = huaweicloud_waf_dedicated_instance.instance_1.id
-  name = huaweicloud_waf_dedicated_instance.instance_1.name
+output "id_filter_is_useful" {
+  value = length(local.id_filter_result) > 0 && alltrue(local.id_filter_result)  
+}
 
-  depends_on = [
-    huaweicloud_waf_dedicated_instance.instance_1
+# Filter by name
+locals {
+  name = data.huaweicloud_waf_dedicated_instances.test.instances.0.name
+}
+
+data "huaweicloud_waf_dedicated_instances" "name_filter" {
+  name                  = local.name
+  enterprise_project_id = "%[1]s"
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_waf_dedicated_instances.name_filter.instances[*].name : v == local.name
   ]
 }
-`, testAccWafDedicatedInstanceV1_conf(name))
+
+output "name_filter_is_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)  
 }
 
-func testAccWafDedicatedInstances_epsId(name string, epsId string) string {
-	return fmt.Sprintf(`
-%s
+# Filter by all parameters
+data "huaweicloud_waf_dedicated_instances" "all_parameters_filter" {
+  id                    = local.id
+  name                  = local.name
+  enterprise_project_id = "%[1]s"
+}
 
-data "huaweicloud_waf_dedicated_instances" "instance_1" {
-  id                    = huaweicloud_waf_dedicated_instance.instance_1.id
-  name                  = huaweicloud_waf_dedicated_instance.instance_1.name
-  enterprise_project_id = "%s"
-
-  depends_on = [
-    huaweicloud_waf_dedicated_instance.instance_1
+locals {
+  all_parameters_filter_result = [
+    for v in data.huaweicloud_waf_dedicated_instances.all_parameters_filter.instances[*] :
+    v.name == local.name && v.id == local.id
   ]
 }
-`, testAccWafDedicatedInstance_epsId(name, epsId), epsId)
+
+output "all_parameters_filter_is_useful" {
+  value = length(local.all_parameters_filter_result) > 0 && alltrue(local.all_parameters_filter_result)  
+}
+
+# Filter by non-exist ID
+data "huaweicloud_waf_dedicated_instances" "non_exist_id_filter" {
+  id                    = "non-exist-id"
+  enterprise_project_id = "%[1]s"
+}
+
+output "non_exist_id_filter_is_useful" {
+  value = length(data.huaweicloud_waf_dedicated_instances.non_exist_id_filter.instances) == 0
+}
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_instance_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_instance_test.go
@@ -18,15 +18,17 @@ import (
 func getWafDedicatedInstanceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := c.WafDedicatedV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmtp.Errorf("error creating HuaweiCloud WAF dedicated client : %s", err)
+		return nil, fmtp.Errorf("error creating WAF dedicated client: %s", err)
 	}
 	return instances.GetWithEpsId(client, state.Primary.ID, state.Primary.Attributes["enterprise_project_id"])
 }
 
 func TestAccWafDedicatedInstance_basic(t *testing.T) {
-	var instance instances.DedicatedInstance
-	resourceName := "huaweicloud_waf_dedicated_instance.instance_1"
-	name := acceptance.RandomAccResourceName()
+	var (
+		instance     instances.DedicatedInstance
+		resourceName = "huaweicloud_waf_dedicated_instance.test"
+		name         = acceptance.RandomAccResourceName()
+	)
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -38,171 +40,17 @@ func TestAccWafDedicatedInstance_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPrecheckWafInstance(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccWafDedicatedInstanceV1_conf(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "cpu_architecture", "x86"),
-					resource.TestCheckResourceAttr(resourceName, "specification_code", "waf.instance.professional"),
-					resource.TestCheckResourceAttr(resourceName, "security_group.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "run_status", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_status", "0"),
-					resource.TestCheckResourceAttr(resourceName, "upgradable", "0"),
-					resource.TestCheckResourceAttrSet(resourceName, "server_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "service_ip"),
-					resource.TestCheckResourceAttrSet(resourceName, "subnet_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "ecs_flavor"),
-					resource.TestCheckResourceAttrSet(resourceName, "available_zone"),
-				),
-			},
-			{
-				Config: testAccWafDedicatedInstance_update(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name+"_updated"),
-					resource.TestCheckResourceAttr(resourceName, "cpu_architecture", "x86"),
-					resource.TestCheckResourceAttr(resourceName, "specification_code", "waf.instance.professional"),
-					resource.TestCheckResourceAttr(resourceName, "security_group.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "run_status", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_status", "0"),
-					resource.TestCheckResourceAttr(resourceName, "upgradable", "0"),
-					resource.TestCheckResourceAttrSet(resourceName, "server_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "service_ip"),
-					resource.TestCheckResourceAttrSet(resourceName, "subnet_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "ecs_flavor"),
-					resource.TestCheckResourceAttrSet(resourceName, "available_zone"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccWafDedicatedInstance_withEpsId(t *testing.T) {
-	var instance instances.DedicatedInstance
-	resourceName := "huaweicloud_waf_dedicated_instance.instance_1"
-	name := acceptance.RandomAccResourceName()
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&instance,
-		getWafDedicatedInstanceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPrecheckWafInstance(t)
-			acceptance.TestAccPreCheckEpsID(t)
+			// Configure two enterprise projects to test enterprise project migration.
 			acceptance.TestAccPreCheckMigrateEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWafDedicatedInstance_epsId(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Config: testAccWafDedicatedInstance_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(
-						resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
-				),
-			},
-			{
-				Config: testAccWafDedicatedInstance_epsId(name, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(
-						resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: testWAFResourceImportState(resourceName),
-			},
-		},
-	})
-}
-
-func TestAccWafDedicatedInstance_elb_model(t *testing.T) {
-	var instance instances.DedicatedInstance
-	resourceName := "huaweicloud_waf_dedicated_instance.instance_1"
-	name := acceptance.RandomAccResourceName()
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&instance,
-		getWafDedicatedInstanceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPrecheckWafInstance(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccWafDedicatedInstance_elb_model(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "cpu_architecture", "x86"),
-					resource.TestCheckResourceAttr(resourceName, "specification_code", "waf.instance.professional"),
-					resource.TestCheckResourceAttr(resourceName, "security_group.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "run_status", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_status", "0"),
-					resource.TestCheckResourceAttr(resourceName, "upgradable", "0"),
-					resource.TestCheckResourceAttrSet(resourceName, "server_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "service_ip"),
-					resource.TestCheckResourceAttrSet(resourceName, "subnet_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "ecs_flavor"),
-					resource.TestCheckResourceAttrSet(resourceName, "available_zone"),
-					acceptance.TestCheckResourceAttrWithVariable(resourceName, "group_id",
-						"${huaweicloud_waf_instance_group.group_1.id}"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccWafDedicatedInstance_resourceTenant(t *testing.T) {
-	var instance instances.DedicatedInstance
-	resourceName := "huaweicloud_waf_dedicated_instance.instance_1"
-	name := acceptance.RandomAccResourceName()
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&instance,
-		getWafDedicatedInstanceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPrecheckWafInstance(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccWafDedicatedInstanceV1_resourceTenant(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "cpu_architecture", "x86"),
 					resource.TestCheckResourceAttr(resourceName, "specification_code", "waf.instance.professional"),
@@ -216,6 +64,29 @@ func TestAccWafDedicatedInstance_resourceTenant(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "service_ip"),
 					resource.TestCheckResourceAttrSet(resourceName, "subnet_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "ecs_flavor"),
+					resource.TestCheckResourceAttrSet(resourceName, "available_zone"),
+				),
+			},
+			{
+				Config: testAccWafDedicatedInstance_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "name", name+"_updated"),
+					resource.TestCheckResourceAttr(resourceName, "cpu_architecture", "x86"),
+					resource.TestCheckResourceAttr(resourceName, "specification_code", "waf.instance.professional"),
+					resource.TestCheckResourceAttr(resourceName, "security_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "run_status", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_status", "0"),
+					resource.TestCheckResourceAttr(resourceName, "upgradable", "0"),
+					resource.TestCheckResourceAttr(resourceName, "res_tenant", "true"),
+					resource.TestCheckResourceAttr(resourceName, "anti_affinity", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "server_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "service_ip"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "ecs_flavor"),
 					resource.TestCheckResourceAttrSet(resourceName, "available_zone"),
 				),
 			},
@@ -223,12 +94,58 @@ func TestAccWafDedicatedInstance_resourceTenant(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
+				ImportStateIdFunc:       testWAFResourceImportState(resourceName),
 				ImportStateVerifyIgnore: []string{"res_tenant", "anti_affinity"},
 			},
 		},
 	})
 }
 
+func testAccWafDedicatedInstance_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_waf_dedicated_instance" "test" {
+  name                  = "%[2]s"
+  available_zone        = data.huaweicloud_availability_zones.test.names[1]
+  specification_code    = "waf.instance.professional"
+  ecs_flavor            = data.huaweicloud_compute_flavors.test.ids[0]
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  res_tenant            = true
+  anti_affinity         = true
+  enterprise_project_id = "%[3]s"
+  
+  security_group = [
+    huaweicloud_networking_secgroup.test.id
+  ]
+}
+`, common.TestBaseComputeResources(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccWafDedicatedInstance_basic_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_waf_dedicated_instance" "test" {
+  name                  = "%[2]s_updated"
+  available_zone        = data.huaweicloud_availability_zones.test.names[1]
+  specification_code    = "waf.instance.professional"
+  ecs_flavor            = data.huaweicloud_compute_flavors.test.ids[0]
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  res_tenant            = true
+  anti_affinity         = true
+  enterprise_project_id = "%[3]s"
+  
+  security_group = [
+    huaweicloud_networking_secgroup.test.id
+  ]
+}
+`, common.TestBaseComputeResources(name), name, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST)
+}
+
+// This use case has dependencies and will be deleted later.
 func testAccWafDedicatedInstanceV1_conf(name string) string {
 	return fmt.Sprintf(`
 %s
@@ -248,25 +165,7 @@ resource "huaweicloud_waf_dedicated_instance" "instance_1" {
 `, common.TestBaseComputeResources(name), name)
 }
 
-func testAccWafDedicatedInstance_update(name string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_waf_dedicated_instance" "instance_1" {
-  name               = "%s_updated"
-  available_zone     = data.huaweicloud_availability_zones.test.names[1]
-  specification_code = "waf.instance.professional"
-  ecs_flavor         = data.huaweicloud_compute_flavors.test.ids[0]
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
-  
-  security_group = [
-    huaweicloud_networking_secgroup.test.id
-  ]
-}
-`, common.TestBaseComputeResources(name), name)
-}
-
+// This use case has dependencies and will be deleted later.
 func testAccWafDedicatedInstance_epsId(name, epsId string) string {
 	return fmt.Sprintf(`
 %s
@@ -285,49 +184,4 @@ resource "huaweicloud_waf_dedicated_instance" "instance_1" {
   ]
 }
 `, common.TestBaseComputeResources(name), name, epsId)
-}
-
-func testAccWafDedicatedInstance_elb_model(name string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_waf_instance_group" "group_1" {
-  name   = "%[2]s"
-  vpc_id = huaweicloud_vpc.test.id
-}
-
-resource "huaweicloud_waf_dedicated_instance" "instance_1" {
-  name               = "%[2]s"
-  available_zone     = data.huaweicloud_availability_zones.test.names[1]
-  specification_code = "waf.instance.professional"
-  ecs_flavor         = data.huaweicloud_compute_flavors.test.ids[0]
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
-  group_id           = huaweicloud_waf_instance_group.group_1.id
-  
-  security_group = [
-    huaweicloud_networking_secgroup.test.id
-  ]
-}
-`, common.TestBaseComputeResources(name), name)
-}
-
-func testAccWafDedicatedInstanceV1_resourceTenant(name string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_waf_dedicated_instance" "instance_1" {
-  name               = "%s"
-  available_zone     = data.huaweicloud_availability_zones.test.names[1]
-  specification_code = "waf.instance.professional"
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
-  res_tenant         = true
-  anti_affinity      = true
-
-  security_group = [
-    huaweicloud_networking_secgroup.test.id
-  ]
-}
-`, common.TestBaseComputeResources(name), name)
 }

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_dedicated_instances.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_dedicated_instances.go
@@ -2,21 +2,19 @@ package waf
 
 import (
 	"context"
-	"strings"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	instances "github.com/chnsz/golangsdk/openstack/waf_hw/v1/premium_instances"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 )
 
-// @API WAF GET /v1/{project_id}/premium-waf/instance/{instance_id}
 // @API WAF GET /v1/{project_id}/premium-waf/instance
-func DataSourceWafDedicatedInstancesV1() *schema.Resource {
+func DataSourceWafDedicatedInstances() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceWafDedicatedInstanceRead,
 
@@ -97,9 +95,13 @@ func DataSourceWafDedicatedInstancesV1() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+
+						// Deprecated; Reasons for abandonment are as follows:
+						// `group_id`: Legacy fields are no longer supported.
 						"group_id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `schema: Deprecated;`,
 						},
 					},
 				},
@@ -108,85 +110,82 @@ func DataSourceWafDedicatedInstancesV1() *schema.Resource {
 	}
 }
 
+func filterAndFlattenInstances(instanceResp *instances.DedicatedInstanceList, d *schema.ResourceData) []interface{} {
+	if instanceResp == nil {
+		return nil
+	}
+
+	var rst []interface{}
+	for _, v := range instanceResp.Items {
+		// In order to be compatible with historical logic, the following code is retained.
+		if instanceID, hasID := d.GetOk("id"); hasID && instanceID != v.Id {
+			continue
+		}
+
+		ins := map[string]interface{}{
+			"id":               v.Id,
+			"name":             v.InstanceName,
+			"available_zone":   v.Zone,
+			"cpu_architecture": v.Arch,
+			"ecs_flavor":       v.CupFlavor,
+			"vpc_id":           v.VpcId,
+			"subnet_id":        v.SubnetId,
+			"security_group":   v.SecurityGroupIds,
+			"server_id":        v.ServerId,
+			"service_ip":       v.ServiceIp,
+			"run_status":       v.RunStatus,
+			"access_status":    v.AccessStatus,
+			"upgradable":       v.Upgradable,
+			"group_id":         v.PoolId,
+		}
+		rst = append(rst, ins)
+	}
+	return rst
+}
+
+// Keep the historical code logic.
+// If an ID is configured, the value of the ID will be used first as the ID of the datasource.
+func generateDatasourceID(d *schema.ResourceData) (string, error) {
+	instanceID, hasID := d.GetOk("id")
+	if hasID {
+		return instanceID.(string), nil
+	}
+
+	return uuid.GenerateUUID()
+}
+
 func dataSourceWafDedicatedInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
-	client, err := conf.WafDedicatedV1Client(conf.GetRegion(d))
+	region := conf.GetRegion(d)
+	client, err := conf.WafDedicatedV1Client(region)
 	if err != nil {
 		return diag.Errorf("error creating WAF dedicated client: %s", err)
 	}
 
-	instanceId, hasId := d.GetOk("id")
-	epsId := d.Get("enterprise_project_id").(string)
-	var items []instances.DedicatedInstance
-	if hasId {
-		instance, err := instances.GetWithEpsId(client, instanceId.(string), epsId)
-		if err != nil {
-			return diag.Errorf("Your query returned no results. " +
-				"Please change your search criteria and try again.")
-		}
-		d.SetId(instanceId.(string))
-		items = append(items, *instance)
-
-		if n, ok := d.GetOk("name"); ok {
-			// If the instance name does not match name form schema, then clear the items
-			if !strings.Contains(strings.ToLower(instance.InstanceName), strings.ToLower(n.(string))) {
-				items = []instances.DedicatedInstance{}
-			}
-		}
-	} else {
-		// If the instance id is not set, or the name value is not set, the query list can be used.
-		opts := instances.ListInstanceOpts{
-			InstanceName:        d.Get("name").(string),
-			EnterpriseProjectId: epsId,
-		}
-
-		rst, err := instances.ListInstance(client, opts)
-		if err != nil {
-			return diag.Errorf("error retrieving WAF dedicated instances %s", err)
-		}
-		items = rst.Items
+	opts := instances.ListInstanceOpts{
+		InstanceName:        d.Get("name").(string),
+		EnterpriseProjectId: conf.GetEnterpriseProjectID(d),
 	}
 
-	if len(items) == 0 {
-		return diag.Errorf("Your query returned no results. " +
-			"Please change your search criteria and try again.")
+	instanceResp, err := instances.ListInstance(client, opts)
+	if err != nil {
+		return diag.Errorf("error retrieving WAF dedicated instances %s", err)
 	}
 
-	ids := make([]string, 0, len(items))
-	insts := make([]map[string]interface{}, 0, len(items))
-
-	for _, r := range items {
-		eng := map[string]interface{}{
-			"id":               r.Id,
-			"name":             r.InstanceName,
-			"available_zone":   r.Zone,
-			"cpu_architecture": r.Arch,
-			"ecs_flavor":       r.CupFlavor,
-			"vpc_id":           r.VpcId,
-			"subnet_id":        r.SubnetId,
-			"security_group":   r.SecurityGroupIds,
-			"server_id":        r.ServerId,
-			"service_ip":       r.ServiceIp,
-			"run_status":       r.RunStatus,
-			"access_status":    r.AccessStatus,
-			"upgradable":       r.Upgradable,
-			"group_id":         r.PoolId,
-		}
-		insts = append(insts, eng)
-		ids = append(ids, r.Id)
-	}
-
-	if !hasId {
-		d.SetId(hashcode.Strings(ids))
-	}
 	mErr := multierror.Append(nil,
-		d.Set("instances", insts),
+		d.Set("instances", filterAndFlattenInstances(instanceResp, d)),
 		d.Set("region", conf.GetRegion(d)),
 	)
 
-	if mErr.ErrorOrNil() != nil {
-		return diag.Errorf("error setting WAF dedicated instance fields: %s", mErr)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting WAF dedicated instance fields: %s", err)
 	}
+
+	dataSourceId, err := generateDatasourceID(d)
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
 
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- maintain waf dedicated instance resource and fix some problems.
- maintain waf dedicated instance datasource and fix some problems.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDedicatedInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDedicatedInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccWafDedicatedInstance_basic
=== PAUSE TestAccWafDedicatedInstance_basic
=== CONT  TestAccWafDedicatedInstance_basic
--- PASS: TestAccWafDedicatedInstance_basic (517.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       517.895s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccDataSourceWafDedicatedInstances_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceWafDedicatedInstances_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWafDedicatedInstances_basic
=== PAUSE TestAccDataSourceWafDedicatedInstances_basic
=== CONT  TestAccDataSourceWafDedicatedInstances_basic
--- PASS: TestAccDataSourceWafDedicatedInstances_basic (7.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       7.955s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
