### PR TITLE
feat(vpn): VPN gateway flavor field supports updates

### DIFF
--- a/docs/resources/vpn_gateway.md
+++ b/docs/resources/vpn_gateway.md
@@ -167,17 +167,16 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `flavor` - (Optional, String, ForceNew) The flavor of the VPN gateway.
-  The value can be **Basic**, **Professional1**, **Professional2** and **GM**. Defaults to **Professional1**.
+* `flavor` - (Optional, String) The flavor of the VPN gateway.
+  + The value at creation can be **Basic**, **Professional1**, **Professional2** or **GM**. Defaults to **Professional1**.
+  + The value during update can be **Basic**, **Professional1** or **Professional2**.
 
-  Changing this parameter will create a new resource.
-
-* `attachment_type` - (Optional, String, ForceNew) The attachment type. The value can be **vpc** and **er**.
+* `attachment_type` - (Optional, String, ForceNew) The attachment type. The value can be **vpc** or **er**.
   Defaults to **vpc**.
 
   Changing this parameter will create a new resource.
 
-* `network_type` - (Optional, String, ForceNew) The network type. The value can be **public** and **private**.
+* `network_type` - (Optional, String, ForceNew) The network type. The value can be **public** or **private**.
   Defaults to **public**.
 
   Changing this parameter will create a new resource.

--- a/huaweicloud/services/acceptance/vpn/resource_huaweicloud_vpn_gateway_test.go
+++ b/huaweicloud/services/acceptance/vpn/resource_huaweicloud_vpn_gateway_test.go
@@ -88,6 +88,11 @@ func TestAccGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "name", name+"-update"),
 					resource.TestCheckResourceAttrPair(rName, "local_subnets.0", "huaweicloud_vpc_subnet.test", "cidr"),
 					resource.TestCheckResourceAttr(rName, "local_subnets.1", "192.168.2.0/24"),
+					resource.TestCheckResourceAttr(rName, "flavor", "Professional2"),
+					resource.TestCheckResourceAttrPair(rName, "availability_zones.0",
+						"data.huaweicloud_vpn_gateway_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttrPair(rName, "availability_zones.1",
+						"data.huaweicloud_vpn_gateway_availability_zones.test", "names.1"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "val"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar-update"),
 				),
@@ -478,6 +483,8 @@ resource "huaweicloud_vpn_gateway" "test" {
   vpc_id             = huaweicloud_vpc.test.id
   local_subnets      = [huaweicloud_vpc_subnet.test.cidr, "192.168.2.0/24"]
   connect_subnet     = huaweicloud_vpc_subnet.test.id
+  flavor             = "Professional2"
+  
   availability_zones = [
     data.huaweicloud_vpn_gateway_availability_zones.test.names[0],
     data.huaweicloud_vpn_gateway_availability_zones.test.names[1]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
VPN gateway flavor field supports updates
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. VPN gateway flavor field supports updates
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
 make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run TestAccGateway_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccGateway_basic
=== PAUSE TestAccGateway_basic
=== CONT  TestAccGateway_basic
--- PASS: TestAccGateway_basic (467.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       467.741s

make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run TestAccGateway_UpdateWithEpsId"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccGateway_UpdateWithEpsId -timeout 360m -parallel 4
=== RUN   TestAccGateway_UpdateWithEpsId
=== PAUSE TestAccGateway_UpdateWithEpsId
=== CONT  TestAccGateway_UpdateWithEpsId
--- PASS: TestAccGateway_UpdateWithEpsId (433.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       433.247s

```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
