### PR TITLE
feat(iotda): device linkage rule resource support new fields

### DIFF
--- a/docs/resources/iotda_device_linkage_rule.md
+++ b/docs/resources/iotda_device_linkage_rule.md
@@ -162,11 +162,15 @@ the rule. Exactly one of `device_id` or `product_id` must be provided.
 * `path` - (Required, String) Specifies the path of the device property, in the format: **service_id/DataProperty**.
 
 * `operator` - (Required, String) Specifies the data comparison operator. The valid values are: **>**, **<**,
-**>=**, **<=**, **=** and **between**.
+  **>=**, **<=**, **=**, **in** and **between**.
 
-* `value` - (Required, String) Specifies the Rvalue of a data comparison expression. When the `operator` is `between`,
-the Rvalue represents the minimum and maximum values, separated by commas, such as "20,30",
-which means greater than or equal to 20 and less than 30.
+* `value` - (Optional, String) Specifies the Rvalue of a data comparison expression. When the `operator` is **between**,
+  the Rvalue represents the minimum and maximum values, separated by commas, such as **20,30**,
+  which means greater than or equal to `20` and less than `30`.
+
+* `in_values` - (Optional, List) Specifies the Rvalue of a data comparison expression. Only when the `operator` is
+  **in**, this field is valid and required, with a maximum of `20` characters, represents matching within the specified
+  values, e.g. **20,30,40**,
 
 * `trigger_strategy` - (Optional, String) Specifies the trigger strategy. The options are as follows:
   + **pulse**: When the data reported by the device meets the conditions, the rule can be triggered.
@@ -242,6 +246,23 @@ The `device_command` block supports:
       - **body**: optional, the message body of the command, which contains key-value pairs, each key is the parameter
         name of the command in the product model. The specific format requires application and device conventions.
 
+* `buffer_timeout` - (Optional, Int) Specifies the cache time of device commands, in seconds. Representing the effective
+  time for the IoT platform to cache commands before issuing them to the device. After this time, the commands will no
+  longer be issued. The default value is `172,800` seconds (`48` hours). If set to `0`, the command will be immediately
+  issued to the device regardless of the command issuance mode set on the IoT platform.
+
+* `response_timeout` - (Optional, Int) Specifies the effective time of the command response, in seconds. Indicating that
+  the device responds effectively within the `response_timeout` time after receiving the command. If no response is
+  received after this time, the command response is considered to have timed out. The default value is `1,800` seconds.
+
+* `mode` - (Optional, String) Specifies the issuance mode of device commands, which is only valid when the value of
+  `buffer_timeout` is greater than `0`.  
+  The valid values are as follows:
+  + **ACTIVE**: Active mode, the IoT platform actively issues commands to devices.
+  + **PASSIVE**: Passive mode, after the IoT platform creates device commands, it will directly cache the commands.
+    Wait until the device goes online again or reports the execution result of the previous command before issuing the
+    command.
+
 <a name="IoTDA_smn_forwarding"></a>
 The `smn_forwarding` block supports:
 
@@ -253,8 +274,9 @@ The `smn_forwarding` block supports:
 
 * `message_title` - (Required, String) Specifies the message title.
 
-* `message_content` - (Required, String) Specifies the message content.  
-  The value can contain a maximum of `256` characters.
+* `message_content` - (Optional, String) Specifies the message content.  
+
+* `message_template_name` - (Optional, String) Specifies the template name corresponding to the SMN service.
 
 * `project_id` - (Optional, String) Specifies the project ID to which the SMN belongs.
 If omitted, the default project in the region will be used.
@@ -270,6 +292,14 @@ The `device_alarm` block supports:
 
 * `severity` - (Required, String) Specifies the severity level of the alarm.
 The valid values are **warning**, **minor**, **major** and **critical**.
+
+* `dimension` - (Optional, String) Specifies the dimension of the alarm. Combine the alarm name and alarm level to
+  jointly identify an alarm.
+  The valid values are as follows:
+  + **device**: Device dimension
+  + **app**: Resource space dimension.
+
+  If not specified, default to user dimension.
 
 * `description` - (Optional, String) Specifies the description of the alarm.  
   The value can contain a maximum of `256` characters.

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_linkage_rule_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_linkage_rule_test.go
@@ -65,15 +65,44 @@ func TestAccDeviceLinkageRule_basic(t *testing.T) {
 						"huaweicloud_smn_topic.topic", "name"),
 					resource.TestCheckResourceAttrPair(rName, "actions.0.smn_forwarding.0.topic_urn",
 						"huaweicloud_smn_topic.topic", "topic_urn"),
+					resource.TestCheckResourceAttrPair(rName, "actions.0.smn_forwarding.0.message_template_name",
+						"huaweicloud_smn_message_template.test", "name"),
 				),
 			},
 			{
-				Config: testDeviceLinkageRule_timer(name + "_update"),
+				Config: testDeviceLinkageRule_basic_update(name),
 				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
 					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
 					resource.TestCheckResourceAttr(rName, "trigger_logic", "and"),
 					resource.TestCheckResourceAttr(rName, "enabled", "false"),
+					resource.TestCheckResourceAttr(rName, "triggers.#", "1"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.type", "DEVICE_DATA"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.path", "service_1/p_1"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.operator", "in"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.in_values.#", "3"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.trigger_strategy", "pulse"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.data_validatiy_period",
+						"300"),
+					resource.TestCheckResourceAttrPair(rName, "triggers.0.device_data_condition.0.product_id",
+						"huaweicloud_iotda_product.test", "id"),
+					resource.TestCheckResourceAttr(rName, "actions.#", "1"),
+					resource.TestCheckResourceAttr(rName, "actions.0.type", "DEVICE_ALARM"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_alarm.0.name", name),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_alarm.0.type", "fault"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_alarm.0.severity", "warning"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_alarm.0.dimension", "device"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_alarm.0.description", "description test"),
+				),
+			},
+			{
+				Config: testDeviceLinkageRule_timer(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
+					resource.TestCheckResourceAttr(rName, "trigger_logic", "and"),
+					resource.TestCheckResourceAttr(rName, "enabled", "true"),
 					resource.TestCheckResourceAttr(rName, "triggers.#", "1"),
 					resource.TestCheckResourceAttr(rName, "triggers.0.type", "SIMPLE_TIMER"),
 					resource.TestCheckResourceAttr(rName, "triggers.0.simple_timer_condition.0.start_time", "20220622T160000Z"),
@@ -95,7 +124,7 @@ func TestAccDeviceLinkageRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
 					resource.TestCheckResourceAttr(rName, "trigger_logic", "and"),
-					resource.TestCheckResourceAttr(rName, "enabled", "false"),
+					resource.TestCheckResourceAttr(rName, "enabled", "true"),
 					resource.TestCheckResourceAttr(rName, "triggers.#", "1"),
 					resource.TestCheckResourceAttr(rName, "triggers.0.type", "DAILY_TIMER"),
 					resource.TestCheckResourceAttr(rName, "triggers.0.daily_timer_condition.0.start_time", "19:02"),
@@ -107,6 +136,9 @@ func TestAccDeviceLinkageRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "actions.0.device_command.0.command_name", "cmd_1"),
 					resource.TestCheckResourceAttr(rName, "actions.0.device_command.0.command_body",
 						"{\"cmd_p_1\":\"3\"}"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_command.0.buffer_timeout", "180"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_command.0.response_timeout", "60"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_command.0.mode", "PASSIVE"),
 					resource.TestCheckResourceAttrPair(rName, "actions.0.device_command.0.device_id",
 						"huaweicloud_iotda_device.test", "id"),
 					resource.TestCheckResourceAttr(rName, "effective_period.0.start_time", "00:00"),
@@ -169,15 +201,44 @@ func TestAccDeviceLinkageRule_derived(t *testing.T) {
 						"huaweicloud_smn_topic.topic", "name"),
 					resource.TestCheckResourceAttrPair(rName, "actions.0.smn_forwarding.0.topic_urn",
 						"huaweicloud_smn_topic.topic", "topic_urn"),
+					resource.TestCheckResourceAttrPair(rName, "actions.0.smn_forwarding.0.message_template_name",
+						"huaweicloud_smn_message_template.test", "name"),
 				),
 			},
 			{
-				Config: testDeviceLinkageRule_timer(name + "_update"),
+				Config: testDeviceLinkageRule_basic_update(name),
 				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
 					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
 					resource.TestCheckResourceAttr(rName, "trigger_logic", "and"),
 					resource.TestCheckResourceAttr(rName, "enabled", "false"),
+					resource.TestCheckResourceAttr(rName, "triggers.#", "1"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.type", "DEVICE_DATA"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.path", "service_1/p_1"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.operator", "in"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.in_values.#", "3"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.trigger_strategy", "pulse"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.data_validatiy_period",
+						"300"),
+					resource.TestCheckResourceAttrPair(rName, "triggers.0.device_data_condition.0.product_id",
+						"huaweicloud_iotda_product.test", "id"),
+					resource.TestCheckResourceAttr(rName, "actions.#", "1"),
+					resource.TestCheckResourceAttr(rName, "actions.0.type", "DEVICE_ALARM"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_alarm.0.name", name),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_alarm.0.type", "fault"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_alarm.0.severity", "warning"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_alarm.0.dimension", "device"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_alarm.0.description", "description test"),
+				),
+			},
+			{
+				Config: testDeviceLinkageRule_timer(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
+					resource.TestCheckResourceAttr(rName, "trigger_logic", "and"),
+					resource.TestCheckResourceAttr(rName, "enabled", "true"),
 					resource.TestCheckResourceAttr(rName, "triggers.#", "1"),
 					resource.TestCheckResourceAttr(rName, "triggers.0.type", "SIMPLE_TIMER"),
 					resource.TestCheckResourceAttr(rName, "triggers.0.simple_timer_condition.0.start_time", "20220622T160000Z"),
@@ -199,7 +260,7 @@ func TestAccDeviceLinkageRule_derived(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
 					resource.TestCheckResourceAttr(rName, "trigger_logic", "and"),
-					resource.TestCheckResourceAttr(rName, "enabled", "false"),
+					resource.TestCheckResourceAttr(rName, "enabled", "true"),
 					resource.TestCheckResourceAttr(rName, "triggers.#", "1"),
 					resource.TestCheckResourceAttr(rName, "triggers.0.type", "DAILY_TIMER"),
 					resource.TestCheckResourceAttr(rName, "triggers.0.daily_timer_condition.0.start_time", "19:02"),
@@ -211,6 +272,9 @@ func TestAccDeviceLinkageRule_derived(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "actions.0.device_command.0.command_name", "cmd_1"),
 					resource.TestCheckResourceAttr(rName, "actions.0.device_command.0.command_body",
 						"{\"cmd_p_1\":\"3\"}"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_command.0.buffer_timeout", "180"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_command.0.response_timeout", "60"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_command.0.mode", "PASSIVE"),
 					resource.TestCheckResourceAttrPair(rName, "actions.0.device_command.0.device_id",
 						"huaweicloud_iotda_device.test", "id"),
 					resource.TestCheckResourceAttr(rName, "effective_period.0.start_time", "00:00"),
@@ -227,21 +291,35 @@ func TestAccDeviceLinkageRule_derived(t *testing.T) {
 	})
 }
 
-func testDeviceLinkageRule_basic(name string) string {
-	deviceConfig := testDevice_basic(name, name)
+func testDeviceLinkageRuleBase(name string) string {
 	return fmt.Sprintf(`
-%s
-
 resource "huaweicloud_smn_topic" "topic" {
-  name = "%s"
+  name = "%[1]s"
 }
 
+resource "huaweicloud_smn_message_template" "test" {
+  name     = "%[1]s"
+  protocol = "default"
+  content  = "content test"
+}
+`, name)
+}
+
+func testDeviceLinkageRule_basic(name string) string {
+	deviceConfig := testDevice_basic(name, name)
+	deviceLinkageRuleBase := testDeviceLinkageRuleBase(name)
+
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
 resource "huaweicloud_iotda_device_linkage_rule" "test" {
-  name     = "%s"
+  name     = "%[3]s"
   space_id = huaweicloud_iotda_space.test.id
 
   triggers {
     type = "DEVICE_DATA"
+
     device_data_condition {
       product_id            = huaweicloud_iotda_device.test.product_id
       path                  = "service_1/p_1"
@@ -254,39 +332,92 @@ resource "huaweicloud_iotda_device_linkage_rule" "test" {
 
   actions {
     type = "SMN_FORWARDING"
+
     smn_forwarding {
-      region          = huaweicloud_smn_topic.topic.region
-      topic_name      = huaweicloud_smn_topic.topic.name
-      topic_urn       = huaweicloud_smn_topic.topic.topic_urn
-      message_title   = "title"
-      message_content = "content"
+      region                = huaweicloud_smn_topic.topic.region
+      topic_name            = huaweicloud_smn_topic.topic.name
+      topic_urn             = huaweicloud_smn_topic.topic.topic_urn
+      message_title         = "title"
+      message_content       = "content"
+      message_template_name = huaweicloud_smn_message_template.test.name
+    }
+  }
+
+  depends_on = [
+    huaweicloud_iotda_space.test,
+    huaweicloud_iotda_product.test,
+    huaweicloud_iotda_device.test,
+    huaweicloud_smn_topic.topic,
+    huaweicloud_smn_message_template.test,
+  ]
+}
+`, deviceLinkageRuleBase, deviceConfig, name)
+}
+
+func testDeviceLinkageRule_basic_update(name string) string {
+	deviceConfig := testDevice_basic(name, name)
+	deviceLinkageRuleBase := testDeviceLinkageRuleBase(name)
+
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
+resource "huaweicloud_iotda_device_linkage_rule" "test" {
+  name     = "%[3]s_update"
+  space_id = huaweicloud_iotda_space.test.id
+  enabled  = false
+
+  triggers {
+    type = "DEVICE_DATA"
+
+    device_data_condition {
+      product_id            = huaweicloud_iotda_device.test.product_id
+      path                  = "service_1/p_1"
+      operator              = "in"
+      in_values             = ["20","30","40"]
+      trigger_strategy      = "pulse"
+      data_validatiy_period = 300
+    }
+  }
+
+  actions {
+    type = "DEVICE_ALARM"
+
+    device_alarm {
+      name        = "%[3]s"
+      type        = "fault"
+      severity    = "warning"
+      dimension   = "device"
+      description = "description test"
     }
   }
 
   depends_on = [
     huaweicloud_iotda_device.test,
     huaweicloud_iotda_product.test,
+    huaweicloud_smn_topic.topic,
+    huaweicloud_smn_message_template.test,
   ]
 }
-`, deviceConfig, name, name)
+`, deviceLinkageRuleBase, deviceConfig, name)
 }
 
 func testDeviceLinkageRule_timer(name string) string {
 	deviceConfig := testDevice_basic(name, name)
-	return fmt.Sprintf(`
-%s
+	deviceLinkageRuleBase := testDeviceLinkageRuleBase(name)
 
-resource "huaweicloud_smn_topic" "topic" {
-  name = "%s"
-}
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
 
 resource "huaweicloud_iotda_device_linkage_rule" "test" {
-  name     = "%s"
+  name     = "%[3]s"
   space_id = huaweicloud_iotda_space.test.id
-  enabled  = false
+  enabled  = true
 
   triggers {
     type = "SIMPLE_TIMER"
+
     simple_timer_condition {
       start_time      = "20220622T160000Z"
       repeat_interval = 2
@@ -297,38 +428,41 @@ resource "huaweicloud_iotda_device_linkage_rule" "test" {
   actions {
     type = "SMN_FORWARDING"
     smn_forwarding {
-      region          = huaweicloud_smn_topic.topic.region
-      topic_name      = huaweicloud_smn_topic.topic.name
-      topic_urn       = huaweicloud_smn_topic.topic.topic_urn
-      message_title   = "title"
-      message_content = "content"
+      region                = huaweicloud_smn_topic.topic.region
+      topic_name            = huaweicloud_smn_topic.topic.name
+      topic_urn             = huaweicloud_smn_topic.topic.topic_urn
+      message_title         = "title"
+      message_content       = "content"
+      message_template_name = huaweicloud_smn_message_template.test.name
     }
   }
 
   depends_on = [
     huaweicloud_iotda_device.test,
     huaweicloud_iotda_product.test,
+    huaweicloud_smn_topic.topic,
+    huaweicloud_smn_message_template.test,
   ]
 }
-`, deviceConfig, name, name)
+`, deviceLinkageRuleBase, deviceConfig, name)
 }
 
 func testDeviceLinkageRule_daily(name string) string {
 	deviceConfig := testDevice_basic(name, name)
-	return fmt.Sprintf(`
-%s
+	deviceLinkageRuleBase := testDeviceLinkageRuleBase(name)
 
-resource "huaweicloud_smn_topic" "topic" {
-  name = "%s"
-}
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
 
 resource "huaweicloud_iotda_device_linkage_rule" "test" {
-  name     = "%s"
+  name     = "%[3]s"
   space_id = huaweicloud_iotda_space.test.id
-  enabled  = false
+  enabled  = true
 
   triggers {
     type = "DAILY_TIMER"
+
     daily_timer_condition {
       start_time   = "19:02"
       days_of_week = "1,2,3,4,5,6,7"
@@ -337,11 +471,15 @@ resource "huaweicloud_iotda_device_linkage_rule" "test" {
 
   actions {
     type = "DEVICE_CMD"
+
     device_command {
-      device_id    = huaweicloud_iotda_device.test.id
-      service_id   = "service_1"
-      command_name = "cmd_1"
-      command_body = "{\"cmd_p_1\":\"3\"}"
+      device_id        = huaweicloud_iotda_device.test.id
+      service_id       = "service_1"
+      command_name     = "cmd_1"
+      command_body     = "{\"cmd_p_1\":\"3\"}"
+      buffer_timeout   = 180
+      response_timeout = 60
+      mode             = "PASSIVE"
     }
   }
 
@@ -354,7 +492,9 @@ resource "huaweicloud_iotda_device_linkage_rule" "test" {
   depends_on = [
     huaweicloud_iotda_device.test,
     huaweicloud_iotda_product.test,
+    huaweicloud_smn_topic.topic,
+    huaweicloud_smn_message_template.test,
   ]
 }
-`, deviceConfig, name, name)
+`, deviceLinkageRuleBase, deviceConfig, name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Device linkage rule resource support new fields

1. Add `triggers.device_data_condition.in_values`, `actions.device_command.buffer_timeout`, `actions.device_command.response_timeout`, `actions.device_command.mode`, `actions.smn_forwarding.message_template_name`, `actions.device_alarm.dimension` fields.
2. The fields `actions.smn_forwarding.message_content` and `triggers.device_data_condition.value` have been changed from mandatory to optional.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
### Basic Test
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDeviceLinkageRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceLinkageRule_basic -timeout 360m -parallel 4
=== RUN   TestAccDeviceLinkageRule_basic
=== PAUSE TestAccDeviceLinkageRule_basic
=== CONT  TestAccDeviceLinkageRule_basic
--- PASS: TestAccDeviceLinkageRule_basic (62.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     62.383s

```

### Derived Test
```
$ export HW_IOTDA_ACCESS_ADDRESS=xxxxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDeviceLinkageRule_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceLinkageRule_derived -timeout 360m -parallel 4
=== RUN   TestAccDeviceLinkageRule_derived
=== PAUSE TestAccDeviceLinkageRule_derived
=== CONT  TestAccDeviceLinkageRule_derived
--- PASS: TestAccDeviceLinkageRule_derived (76.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     76.304s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
