### PR TITLE
fix(WAF): remove slices package function

### DIFF
--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_instance.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_instance.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"slices"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -169,7 +168,7 @@ func buildCreateOpts(d *schema.ResourceData, region string) *instances.CreateIns
 }
 
 func waitForInstanceCreated(c *golangsdk.ServiceClient, id string, epsId string) resource.StateRefreshFunc {
-	unexpectedRunStatus := []int{2, 3, 4, 5, 6, 7, 8}
+	unexpectedRunStatus := []interface{}{2, 3, 4, 5, 6, 7, 8}
 	return func() (interface{}, string, error) {
 		r, err := instances.GetWithEpsId(c, id, epsId)
 		if err != nil {
@@ -181,7 +180,7 @@ func waitForInstanceCreated(c *golangsdk.ServiceClient, id string, epsId string)
 			return r, "COMPLETED", nil
 		}
 
-		if slices.Contains(unexpectedRunStatus, runStatus) {
+		if utils.SliceContains(unexpectedRunStatus, runStatus) {
 			return r, "ERROR", fmt.Errorf("got unexpected run status %d", runStatus)
 		}
 		return r, "PENDING", nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

remove slices package function

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDedicatedInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDedicatedInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccWafDedicatedInstance_basic
=== PAUSE TestAccWafDedicatedInstance_basic
=== CONT  TestAccWafDedicatedInstance_basic
--- PASS: TestAccWafDedicatedInstance_basic (487.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       488.011s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
