### PR TITLE
fix(coc): script and execute resources support more 404 errors handle

### DIFF
--- a/huaweicloud/services/coc/resource_huaweicloud_coc_script_execute.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_script_execute.go
@@ -24,6 +24,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+var scriptOrderNotFoundErrCodes = []string{
+	"COC.00040709", // Script not found
+}
+
 // @API COC POST /v1/job/scripts/{script_uuid}
 // @API COC GET /v1/job/script/orders/{execute_uuid}
 // @API COC PUT /v1/job/script/orders/{execute_uuid}/operation
@@ -276,7 +280,8 @@ func resourceScriptExecuteRead(_ context.Context, d *schema.ResourceData, meta i
 	ticketID := d.Id()
 	ticketDetail, err := getExecutionTicketDetail(client, ticketID)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving COC script execute")
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code",
+			scriptOrderNotFoundErrCodes...), "COC script execute")
 	}
 
 	mErr := multierror.Append(nil,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Upgrade the CheckDeleted function to support more 404 errors.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. script and execute resources support more 404 errors handle
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    Script and related execution resource
    ![image](https://github.com/user-attachments/assets/2ab37fe6-976a-4491-ac0d-fa790172143b)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    Script resource
    ![image](https://github.com/user-attachments/assets/5883b6a6-e2e4-4802-b30c-adb6673044c3)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
