### PR TITLE
feat(iotda): device linkage rule resource support new structure

### DIFF
--- a/docs/resources/iotda_device_linkage_rule.md
+++ b/docs/resources/iotda_device_linkage_rule.md
@@ -138,17 +138,23 @@ The `triggers` block supports:
   + **DEVICE_DATA**: Triggered upon the property of device.
   + **SIMPLE_TIMER**: Triggered by policy.
   + **DAILY_TIMER**: Triggered at specified time every day.
+  + **DEVICE_LINKAGE_STATUS**: Triggered by device status.
 
 * `device_data_condition` - (Optional, List) Specifies the condition triggered upon the property of device. It is
-required when type is `DEVICE_DATA`. The [device_data_condition](#IoTDA_device_data_condition) structure is
-documented below.
+  required when `type` is **DEVICE_DATA**.
+  The [device_data_condition](#IoTDA_device_data_condition) structure is documented below.
 
-* `simple_timer_condition` - (Optional, List) Specifies the condition triggered by policy. It is required when type
-is `SIMPLE_TIMER`. The [simple_timer_condition](#IoTDA_simple_timer_condition) structure is documented below.
+* `simple_timer_condition` - (Optional, List) Specifies the condition triggered by policy. It is required when `type`
+  is **SIMPLE_TIMER**.
+  The [simple_timer_condition](#IoTDA_simple_timer_condition) structure is documented below.
 
 * `daily_timer_condition` - (Optional, List) Specifies the condition triggered at specified time every day. It is
-required when type is `DAILY_TIMER`. The [daily_timer_condition](#IoTDA_daily_timer_condition) structure is
-documented below.
+  required when `type` is **DAILY_TIMER**.
+  The [daily_timer_condition](#IoTDA_daily_timer_condition) structure is documented below.
+
+* `device_linkage_status_condition` - (Optional, List) Specifies the condition triggered by device status. It is
+  required when `type` is **DEVICE_LINKAGE_STATUS**.
+  The [device_linkage_status_condition](#IoTDA_device_status_condition) structure is documented below.
 
 <a name="IoTDA_device_data_condition"></a>
 The `device_data_condition` block supports:
@@ -202,6 +208,26 @@ For example: `03:00`.
 
 * `days_of_week` - (Optional, String) Specifies a list of days of week, separated by commas. 1 represents Sunday,
 2 represents Monday, and so on. Defaults to `1,2,3,4,5,6,7` (every day).
+
+<a name="IoTDA_device_status_condition"></a>
+The `device_linkage_status_condition` block supports:
+
+* `device_id` - (Optional, String) Specifies the device ID. If this field is set, the device attribute trigger will be
+  triggered based on the specified device.
+
+* `product_id` - (Optional, String) Specifies the product ID. If this field is set and the `device_id` is empty, the
+  device attribute will trigger the matching of all devices under this product.
+
+-> 1. `device_id` and `product_id` cannot be empty at the same time.<br/>2. If both the `device_id` and `product_id` are
+  set, the `device_id` field will prevail, and `product_id` will not take effect at this time.
+
+* `status_list` - (Optional, List) Specifies device status list, separate multiple status with commas.
+  e.g. **ONLINE**, **OFFLINE**.  
+  The valid device status values are as follows:
+  + **ONLINE**: Device online.
+  + **OFFLINE**: Device offline.
+
+* `duration` - (Optional, Int) Specifies the duration of device status. The valid value ranges from `0` to `60` minutes.
 
 <a name="IoTDA_actions"></a>
 The `actions` block supports:

--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_device_linkage_rules_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_device_linkage_rules_test.go
@@ -174,5 +174,5 @@ data "huaweicloud_iotda_device_linkage_rules" "not_found" {
 output "not_found_validation_pass" {
   value = length(data.huaweicloud_iotda_device_linkage_rules.not_found.rules) == 0
 }
-`, testDeviceLinkageRule_basic(name))
+`, testDeviceLinkageRule_deviceData(name))
 }

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_linkage_rule_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_linkage_rule_test.go
@@ -40,7 +40,7 @@ func TestAccDeviceLinkageRule_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testDeviceLinkageRule_basic(name),
+				Config: testDeviceLinkageRule_deviceData(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
@@ -70,7 +70,7 @@ func TestAccDeviceLinkageRule_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testDeviceLinkageRule_basic_update(name),
+				Config: testDeviceLinkageRule_deviceStatus(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
@@ -78,15 +78,11 @@ func TestAccDeviceLinkageRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "trigger_logic", "and"),
 					resource.TestCheckResourceAttr(rName, "enabled", "false"),
 					resource.TestCheckResourceAttr(rName, "triggers.#", "1"),
-					resource.TestCheckResourceAttr(rName, "triggers.0.type", "DEVICE_DATA"),
-					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.path", "service_1/p_1"),
-					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.operator", "in"),
-					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.in_values.#", "3"),
-					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.trigger_strategy", "pulse"),
-					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.data_validatiy_period",
-						"300"),
-					resource.TestCheckResourceAttrPair(rName, "triggers.0.device_data_condition.0.product_id",
-						"huaweicloud_iotda_product.test", "id"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.type", "DEVICE_LINKAGE_STATUS"),
+					resource.TestCheckResourceAttrPair(rName, "triggers.0.device_linkage_status_condition.0.device_id",
+						"huaweicloud_iotda_device.test", "id"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_linkage_status_condition.0.status_list.#", "2"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_linkage_status_condition.0.duration", "10"),
 					resource.TestCheckResourceAttr(rName, "actions.#", "1"),
 					resource.TestCheckResourceAttr(rName, "actions.0.type", "DEVICE_ALARM"),
 					resource.TestCheckResourceAttr(rName, "actions.0.device_alarm.0.name", name),
@@ -97,7 +93,7 @@ func TestAccDeviceLinkageRule_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testDeviceLinkageRule_timer(name),
+				Config: testDeviceLinkageRule_simpleTimer(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
@@ -119,7 +115,7 @@ func TestAccDeviceLinkageRule_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testDeviceLinkageRule_daily(name),
+				Config: testDeviceLinkageRule_dailyTimer(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
@@ -176,7 +172,7 @@ func TestAccDeviceLinkageRule_derived(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testDeviceLinkageRule_basic(name),
+				Config: testDeviceLinkageRule_deviceData(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
@@ -206,7 +202,7 @@ func TestAccDeviceLinkageRule_derived(t *testing.T) {
 				),
 			},
 			{
-				Config: testDeviceLinkageRule_basic_update(name),
+				Config: testDeviceLinkageRule_deviceStatus(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
@@ -214,15 +210,11 @@ func TestAccDeviceLinkageRule_derived(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "trigger_logic", "and"),
 					resource.TestCheckResourceAttr(rName, "enabled", "false"),
 					resource.TestCheckResourceAttr(rName, "triggers.#", "1"),
-					resource.TestCheckResourceAttr(rName, "triggers.0.type", "DEVICE_DATA"),
-					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.path", "service_1/p_1"),
-					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.operator", "in"),
-					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.in_values.#", "3"),
-					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.trigger_strategy", "pulse"),
-					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.data_validatiy_period",
-						"300"),
-					resource.TestCheckResourceAttrPair(rName, "triggers.0.device_data_condition.0.product_id",
-						"huaweicloud_iotda_product.test", "id"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.type", "DEVICE_LINKAGE_STATUS"),
+					resource.TestCheckResourceAttrPair(rName, "triggers.0.device_linkage_status_condition.0.device_id",
+						"huaweicloud_iotda_device.test", "id"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_linkage_status_condition.0.status_list.#", "2"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_linkage_status_condition.0.duration", "10"),
 					resource.TestCheckResourceAttr(rName, "actions.#", "1"),
 					resource.TestCheckResourceAttr(rName, "actions.0.type", "DEVICE_ALARM"),
 					resource.TestCheckResourceAttr(rName, "actions.0.device_alarm.0.name", name),
@@ -233,7 +225,7 @@ func TestAccDeviceLinkageRule_derived(t *testing.T) {
 				),
 			},
 			{
-				Config: testDeviceLinkageRule_timer(name),
+				Config: testDeviceLinkageRule_simpleTimer(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
@@ -255,7 +247,7 @@ func TestAccDeviceLinkageRule_derived(t *testing.T) {
 				),
 			},
 			{
-				Config: testDeviceLinkageRule_daily(name),
+				Config: testDeviceLinkageRule_dailyTimer(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
@@ -305,7 +297,7 @@ resource "huaweicloud_smn_message_template" "test" {
 `, name)
 }
 
-func testDeviceLinkageRule_basic(name string) string {
+func testDeviceLinkageRule_deviceData(name string) string {
 	deviceConfig := testDevice_basic(name, name)
 	deviceLinkageRuleBase := testDeviceLinkageRuleBase(name)
 
@@ -354,7 +346,7 @@ resource "huaweicloud_iotda_device_linkage_rule" "test" {
 `, deviceLinkageRuleBase, deviceConfig, name)
 }
 
-func testDeviceLinkageRule_basic_update(name string) string {
+func testDeviceLinkageRule_deviceStatus(name string) string {
 	deviceConfig := testDevice_basic(name, name)
 	deviceLinkageRuleBase := testDeviceLinkageRuleBase(name)
 
@@ -368,15 +360,12 @@ resource "huaweicloud_iotda_device_linkage_rule" "test" {
   enabled  = false
 
   triggers {
-    type = "DEVICE_DATA"
+    type = "DEVICE_LINKAGE_STATUS"
 
-    device_data_condition {
-      product_id            = huaweicloud_iotda_device.test.product_id
-      path                  = "service_1/p_1"
-      operator              = "in"
-      in_values             = ["20","30","40"]
-      trigger_strategy      = "pulse"
-      data_validatiy_period = 300
+    device_linkage_status_condition {
+      device_id   = huaweicloud_iotda_device.test.id
+      status_list = ["ONLINE", "OFFLINE"]
+      duration    = 10
     }
   }
 
@@ -402,7 +391,7 @@ resource "huaweicloud_iotda_device_linkage_rule" "test" {
 `, deviceLinkageRuleBase, deviceConfig, name)
 }
 
-func testDeviceLinkageRule_timer(name string) string {
+func testDeviceLinkageRule_simpleTimer(name string) string {
 	deviceConfig := testDevice_basic(name, name)
 	deviceLinkageRuleBase := testDeviceLinkageRuleBase(name)
 
@@ -447,7 +436,7 @@ resource "huaweicloud_iotda_device_linkage_rule" "test" {
 `, deviceLinkageRuleBase, deviceConfig, name)
 }
 
-func testDeviceLinkageRule_daily(name string) string {
+func testDeviceLinkageRule_dailyTimer(name string) string {
 	deviceConfig := testDevice_basic(name, name)
 	deviceLinkageRuleBase := testDeviceLinkageRuleBase(name)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Commit1: Device linkage rule resource support `triggers.device_linkage_status_condition` structure.

Commit2: Modify non-standard method names in the data source.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.


### Resource Test
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDeviceLinkageRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceLinkageRule_basic -timeout 360m -parallel 4
=== RUN   TestAccDeviceLinkageRule_basic
=== PAUSE TestAccDeviceLinkageRule_basic
=== CONT  TestAccDeviceLinkageRule_basic
--- PASS: TestAccDeviceLinkageRule_basic (46.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     46.227s



$ export HW_IOTDA_ACCESS_ADDRESS=xxxxxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDeviceLinkageRule_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceLinkageRule_derived -timeout 360m -parallel 4
=== RUN   TestAccDeviceLinkageRule_derived
=== PAUSE TestAccDeviceLinkageRule_derived
=== CONT  TestAccDeviceLinkageRule_derived
--- PASS: TestAccDeviceLinkageRule_derived (52.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     52.193s

```

### DataSource Test
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceLinkageRules_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceLinkageRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceLinkageRules_basic
=== PAUSE TestAccDataSourceDeviceLinkageRules_basic
=== CONT  TestAccDataSourceDeviceLinkageRules_basic
--- PASS: TestAccDataSourceDeviceLinkageRules_basic (18.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     18.649s



$ export HW_IOTDA_ACCESS_ADDRESS=xxxxxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceLinkageRules_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceLinkageRules_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceLinkageRules_derived
=== PAUSE TestAccDataSourceDeviceLinkageRules_derived
=== CONT  TestAccDataSourceDeviceLinkageRules_derived
--- PASS: TestAccDataSourceDeviceLinkageRules_derived (17.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     17.763s

```
* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
