### PR TITLE
feat(dds): support to reset and copy parameter template

### DIFF
--- a/docs/resources/dds_parameter_template_copy.md
+++ b/docs/resources/dds_parameter_template_copy.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Document Database Service (DDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dds_parameter_template_copy"
+description: |-
+  Manages a DDS parameter template copy resource within HuaweiCloud.
+---
+
+# huaweicloud_dds_parameter_template_copy
+
+Manages a DDS parameter template copy resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "configuration_id" {}
+variable "name" {}
+
+resource "huaweicloud_dds_parameter_template_copy" "test" {
+  configuration_id = var.configuration_id
+  name             = var.name
+  description      = "test copy"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `configuration_id` - (Required, String, ForceNew) Specifies the parameter template ID.
+  Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of replicated parameter template.
+  The parameter template name can contain **1** to **64** characters. It can contain only letters, digits, hyphens (-),
+  underscores (_), and periods (.).
+  Changing this creates a new resource.
+
+* `description` - (Optional, String, ForceNew) Specifies the description of replicated parameter template.
+  The value is left blank by default. The description must consist of a maximum of **256** characters and cannot contain
+  the carriage return character or the following special characters: >!<"&'=
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/docs/resources/dds_parameter_template_reset.md
+++ b/docs/resources/dds_parameter_template_reset.md
@@ -1,0 +1,38 @@
+---
+subcategory: "Document Database Service (DDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dds_parameter_template_reset"
+description: |-
+  Manages a DDS parameter template reset resource within HuaweiCloud.
+---
+
+# huaweicloud_dds_parameter_template_reset
+
+Manages a DDS parameter template reset resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "configuration_id" {}
+
+resource "huaweicloud_dds_parameter_template_reset" "test" {
+  configuration_id = var.configuration_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `configuration_id` - (Required, String, ForceNew) Specifies the parameter template ID.
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1472,6 +1472,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dds_instance_parameters_modify":  dds.ResourceDDSInstanceParametersModify(),
 			"huaweicloud_dds_primary_standby_switch":      dds.ResourceDDSPrimaryStandbySwitch(),
 			"huaweicloud_dds_recycle_policy":              dds.ResourceDDSRecyclePolicy(),
+			"huaweicloud_dds_parameter_template_reset":    dds.ResourceDDSParameterTemplateReset(),
+			"huaweicloud_dds_parameter_template_copy":     dds.ResourceDDSParameterTemplateCopy(),
 			"huaweicloud_dds_parameter_template_compare":  dds.ResourceDDSParameterTemplateCompare(),
 
 			"huaweicloud_ddm_instance":               ddm.ResourceDdmInstance(),

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_parameter_template_copy_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_parameter_template_copy_test.go
@@ -1,0 +1,37 @@
+package dds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDDSParameterTemplateCopy_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testParameterTemplateCopy_basic(name),
+			},
+		},
+	})
+}
+
+func testParameterTemplateCopy_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dds_parameter_template_copy" "test" {
+  configuration_id = huaweicloud_dds_parameter_template.test.id
+  name             = "%[2]s_copy"
+  description      = "test_copy"
+}
+`, testDdsParameterTemplate_basic(name), name)
+}

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_parameter_template_reset_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_parameter_template_reset_test.go
@@ -1,0 +1,35 @@
+package dds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDDSParameterTemplateReset_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testParameterTemplateReset_basic(name),
+			},
+		},
+	})
+}
+
+func testParameterTemplateReset_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dds_parameter_template_reset" "test" {
+  configuration_id = huaweicloud_dds_parameter_template.test.id
+}
+`, testDdsParameterTemplate_basic(name))
+}

--- a/huaweicloud/services/dds/resource_huaweicloud_dds_parameter_template_compare.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_parameter_template_compare.go
@@ -135,7 +135,7 @@ func resourceParameterTemplateCompareRead(_ context.Context, _ *schema.ResourceD
 
 func resourceParameterTemplateCompareDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	errorMsg := "Deleting parameter template compare resource is not supported. The resource is only removed from the" +
-		"state, the DDS instance remains in the cloud."
+		"state, the DDS parameter template remains in the cloud."
 	return diag.Diagnostics{
 		diag.Diagnostic{
 			Severity: diag.Warning,

--- a/huaweicloud/services/dds/resource_huaweicloud_dds_parameter_template_copy.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_parameter_template_copy.go
@@ -1,0 +1,111 @@
+package dds
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DDS POST /v3/{project_id}/configurations/{config_id}/copy
+func ResourceDDSParameterTemplateCopy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceParameterTemplateCopyCreate,
+		ReadContext:   resourceParameterTemplateCopyRead,
+		DeleteContext: resourceParameterTemplateCopyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"configuration_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the parameter template ID.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the name of replicated parameter template.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the description of replicated parameter template.`,
+			},
+		},
+	}
+}
+
+func resourceParameterTemplateCopyCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dds", region)
+	if err != nil {
+		return diag.Errorf("error creating DDS client: %s", err)
+	}
+
+	configurationId := d.Get("configuration_id").(string)
+
+	httpUrl := "v3/{project_id}/configurations/{config_id}/copy"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{config_id}", configurationId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateParameterTemplateCopyBodyParams(d)),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error copying DDS parameter template: %s", err)
+	}
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("configuration_id", createRespBody, "").(string)
+	if id == "" {
+		return diag.Errorf("unable to find ID from the API response")
+	}
+
+	d.SetId(id)
+
+	return nil
+}
+
+func buildCreateParameterTemplateCopyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":        d.Get("name"),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+	return bodyParams
+}
+
+func resourceParameterTemplateCopyRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceParameterTemplateCopyDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting parameter template copy resource is not supported. The resource is only removed from the" +
+		"state, the DDS parameter template remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}

--- a/huaweicloud/services/dds/resource_huaweicloud_dds_parameter_template_reset.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_parameter_template_reset.go
@@ -1,0 +1,88 @@
+package dds
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API DDS POST /v3/{project_id}/configurations/{config_id}/reset
+func ResourceDDSParameterTemplateReset() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceParameterTemplateResetCreate,
+		ReadContext:   resourceParameterTemplateResetRead,
+		DeleteContext: resourceParameterTemplateResetDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"configuration_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the parameter template ID.`,
+			},
+		},
+	}
+}
+
+func resourceParameterTemplateResetCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dds", region)
+	if err != nil {
+		return diag.Errorf("error creating DDS client: %s", err)
+	}
+
+	configurationId := d.Get("configuration_id").(string)
+
+	httpUrl := "v3/{project_id}/configurations/{config_id}/reset"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{config_id}", configurationId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error resetting DDS parameter template: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	return nil
+}
+
+func resourceParameterTemplateResetRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceParameterTemplateResetDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting parameter template reset resource is not supported. The resource is only removed from the" +
+		"state, the parameter template still remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:


## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSParameterTemplateCopy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSParameterTemplateCopy_basic -timeout 360m -parallel 4
=== RUN   TestAccDDSParameterTemplateCopy_basic
=== PAUSE TestAccDDSParameterTemplateCopy_basic
=== CONT  TestAccDDSParameterTemplateCopy_basic
--- PASS: TestAccDDSParameterTemplateCopy_basic (22.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       22.648s

make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSParameterTemplateReset_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSParameterTemplateReset_basic -timeout 360m -parallel 4
=== RUN   TestAccDDSParameterTemplateReset_basic
=== PAUSE TestAccDDSParameterTemplateReset_basic
=== CONT  TestAccDDSParameterTemplateReset_basic
--- PASS: TestAccDDSParameterTemplateReset_basic (22.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       22.975s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
