### PR TITLE
feat(cph): support cph server updating keypair

### DIFF
--- a/docs/resources/cph_server.md
+++ b/docs/resources/cph_server.md
@@ -114,10 +114,8 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `keypair_name` - (Optional, String, ForceNew) The key pair name, which is used for logging in to
-  the cloud phone through ADB.  
-
-  Changing this parameter will create a new resource.
+* `keypair_name` - (Optional, String) Specifies the key pair name, which is used for logging in to
+  the cloud phone through ADB.
 
 * `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project ID.
 

--- a/huaweicloud/services/acceptance/cph/resource_huaweicloud_cph_server_test.go
+++ b/huaweicloud/services/acceptance/cph/resource_huaweicloud_cph_server_test.go
@@ -90,6 +90,7 @@ func TestAccCphServer_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name+"update"),
+					resource.TestCheckResourceAttrPair(rName, "keypair_name", "huaweicloud_kps_keypair.test1", "name"),
 				),
 			},
 			{
@@ -105,26 +106,31 @@ func TestAccCphServer_basic(t *testing.T) {
 func testCphServerBase(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "test" {
-  name = "%s"
+  name = "%[1]s"
   cidr = "192.168.0.0/16"
 }
 
 resource "huaweicloud_vpc_subnet" "test" {
-  name       = "%s"
+  name       = "%[1]s"
   cidr       = "192.168.0.0/24"
   vpc_id     = huaweicloud_vpc.test.id
   gateway_ip = "192.168.0.1"
 }
 
 resource "huaweicloud_kps_keypair" "test" {
-  name        = "%s"
-  description = "%s"
+  name        = "%[1]s"
+  description = "keypair test"
+}
+
+resource "huaweicloud_kps_keypair" "test1" {
+  name        = "%[1]s_1"
+  description = "keypair test1"
 }
 
 data "huaweicloud_cph_phone_images" "test" {
   image_label = "cloud_phone"
 }
-`, name, name, name, name)
+`, name)
 }
 
 func testCphServer_basic(name string) string {
@@ -170,7 +176,7 @@ resource "huaweicloud_cph_server" "test" {
   server_flavor = "physical.rx1.xlarge"
   phone_flavor  = "rx1.cp.c15.d46.e1v1"
   image_id      = data.huaweicloud_cph_phone_images.test.images[0].id
-  keypair_name  = huaweicloud_kps_keypair.test.name
+  keypair_name  = huaweicloud_kps_keypair.test1.name
 
   vpc_id    = huaweicloud_vpc.test.id
   subnet_id = huaweicloud_vpc_subnet.test.id


### PR DESCRIPTION
**What this PR does / why we need it**:
support cph server updating keypair

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
support cph server updating keypair
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/cph" TESTARGS="-run TestAccCphServer_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cph -v -run TestAccCphServer_basic -timeout 360m -parallel 4
=== RUN   TestAccCphServer_basic
=== PAUSE TestAccCphServer_basic
=== CONT  TestAccCphServer_basic
--- PASS: TestAccCphServer_basic (2064.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cph       2064.705s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
