### PR TITLE
feat(dds): support to get parameter template application and modification records

### DIFF
--- a/docs/data-sources/dds_pt_application_records.md
+++ b/docs/data-sources/dds_pt_application_records.md
@@ -1,0 +1,53 @@
+---
+subcategory: "Document Database Service (DDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dds_pt_application_records"
+description: |-
+  Use this data source to get the list of DDS parameter template application records.
+---
+
+# huaweicloud_dds_pt_application_records
+
+Use this data source to get the list of DDS parameter template application records.
+
+## Example Usage
+
+```hcl
+variable "configuration_id"  {}
+
+data "huaweicloud_dds_pt_application_records" "test" {
+  configuration_id = var.configuration_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `configuration_id` - (Required, String) Specifies the ID of the parameter template.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `histories` - Indicates the application records.
+
+  The [histories](#histories_struct) structure is documented below.
+
+<a name="histories_struct"></a>
+The `histories` block supports:
+
+* `instance_id` - Indicates the instance ID.
+
+* `instance_name` - Indicates the instance name.
+
+* `applied_at` - Indicates the application time, in the **yyyy-mm-ddThh:mm:ssZ** format.
+
+* `apply_result` - Indicates the application result.
+
+* `failure_reason` - Indicates the failure reason.

--- a/docs/data-sources/dds_pt_modification_records.md
+++ b/docs/data-sources/dds_pt_modification_records.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Document Database Service (DDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dds_pt_modification_records"
+description: |-
+  Use this data source to get the list of DDS parameter template modification records.
+---
+
+# huaweicloud_dds_pt_modification_records
+
+Use this data source to get the list of DDS parameter template modification records.
+
+## Example Usage
+
+```hcl
+variable "configuration_id"  {}
+
+data "huaweicloud_dds_pt_modification_records" "test" {
+  configuration_id = var.configuration_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `configuration_id` - (Required, String) Specifies the ID of the parameter template.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `histories` - Indicates the modification records.
+
+  The [histories](#histories_struct) structure is documented below.
+
+<a name="histories_struct"></a>
+The `histories` block supports:
+
+* `parameter_name` - Indicates the parameter name.
+
+* `new_value` - Indicates the new value.
+
+* `old_value` - Indicates the old value.
+
+* `updated_at` - Indicates the update time, in the **yyyy-mm-ddThh:mm:ssZ** format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -651,6 +651,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dds_instances":                  dds.DataSourceDdsInstance(),
 			"huaweicloud_dds_parameter_templates":        dds.DataSourceDdsParameterTemplates(),
 			"huaweicloud_dds_pt_applicable_instances":    dds.DataSourceDdsPtApplicableInstances(),
+			"huaweicloud_dds_pt_application_records":     dds.DataSourceDdsPtApplicationRecords(),
+			"huaweicloud_dds_pt_modification_records":    dds.DataSourceDdsPtModificationRecords(),
 			"huaweicloud_dds_databases":                  dds.DataSourceDdsDatabases(),
 			"huaweicloud_dds_database_users":             dds.DateSourceDDSDatabaseUser(),
 			"huaweicloud_dds_storage_types":              dds.DataSourceDdsStorageTypes(),

--- a/huaweicloud/services/acceptance/dds/data_source_huaweicloud_dds_pt_application_records_test.go
+++ b/huaweicloud/services/acceptance/dds/data_source_huaweicloud_dds_pt_application_records_test.go
@@ -1,0 +1,48 @@
+package dds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDdsPtApplicationRecords_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_dds_pt_application_records.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDdsPtApplicationRecords_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "histories.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "histories.0.instance_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "histories.0.instance_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "histories.0.applied_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "histories.0.apply_result"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDdsPtApplicationRecords_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_dds_pt_application_records" "test" {
+  depends_on = [huaweicloud_dds_parameter_template_apply.test]
+
+  configuration_id = huaweicloud_dds_parameter_template.test.id
+}
+`, testParameterTemplateApply_basic(name))
+}

--- a/huaweicloud/services/acceptance/dds/data_source_huaweicloud_dds_pt_modification_records_test.go
+++ b/huaweicloud/services/acceptance/dds/data_source_huaweicloud_dds_pt_modification_records_test.go
@@ -1,0 +1,52 @@
+package dds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDdsPtModificationRecords_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_dds_pt_modification_records.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDdsParameterTemplate_basic(rName),
+			},
+			{
+				Config: testDdsParameterTemplate_basic_update(rName),
+			},
+			{
+				Config: testDataSourceDdsPtModificationRecords_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "histories.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "histories.0.parameter_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "histories.0.new_value"),
+					resource.TestCheckResourceAttrSet(dataSource, "histories.0.old_value"),
+					resource.TestCheckResourceAttrSet(dataSource, "histories.0.updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDdsPtModificationRecords_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_dds_pt_modification_records" "test" {
+  configuration_id = huaweicloud_dds_parameter_template.test.id
+}
+`, testDdsParameterTemplate_basic_update(name))
+}

--- a/huaweicloud/services/dds/data_source_huaweicloud_dds_pt_application_records.go
+++ b/huaweicloud/services/dds/data_source_huaweicloud_dds_pt_application_records.go
@@ -1,0 +1,137 @@
+package dds
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DDS GET /v3/{project_id}/configurations/{config_id}/applied-histories
+func DataSourceDdsPtApplicationRecords() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDdsPtApplicationRecordsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"configuration_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the parameter template.`,
+			},
+			"histories": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Indicates the application records.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the instance ID.`,
+						},
+						"instance_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the instance name.`,
+						},
+						"applied_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the application time, in the **yyyy-mm-ddThh:mm:ssZ** format.`,
+						},
+						"apply_result": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the application result.`,
+						},
+						"failure_reason": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the failure reason.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDdsPtApplicationRecordsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dds", region)
+	if err != nil {
+		return diag.Errorf("error creating DDS client: %s", err)
+	}
+
+	getTasksHttpUrl := "v3/{project_id}/configurations/{config_id}/applied-histories"
+	getTasksPath := client.Endpoint + getTasksHttpUrl
+	getTasksPath = strings.ReplaceAll(getTasksPath, "{project_id}", client.ProjectID)
+	getTasksPath = strings.ReplaceAll(getTasksPath, "{config_id}", d.Get("configuration_id").(string))
+	getTasksOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	// pagelimit is `10`
+	getTasksPath += fmt.Sprintf("?limit=%v", pageLimit)
+	currentTotal := 0
+	results := make([]map[string]interface{}, 0)
+	for {
+		currentPath := getTasksPath + fmt.Sprintf("&offset=%d", currentTotal)
+		getTasksResp, err := client.Request("GET", currentPath, &getTasksOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving records: %s", err)
+		}
+		getTasksRespBody, err := utils.FlattenResponse(getTasksResp)
+		if err != nil {
+			return diag.Errorf("error flattening response: %s", err)
+		}
+
+		records := utils.PathSearch("histories", getTasksRespBody, make([]interface{}, 0)).([]interface{})
+		for _, record := range records {
+			results = append(results, map[string]interface{}{
+				"instance_id":    utils.PathSearch("instance_id", record, nil),
+				"instance_name":  utils.PathSearch("instance_name", record, nil),
+				"applied_at":     utils.PathSearch("applied_at", record, nil),
+				"apply_result":   utils.PathSearch("apply_result", record, nil),
+				"failure_reason": utils.PathSearch("failure_reason", record, nil),
+			})
+		}
+
+		if len(records) < pageLimit {
+			break
+		}
+		currentTotal += len(records)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("histories", results),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/dds/data_source_huaweicloud_dds_pt_modification_records.go
+++ b/huaweicloud/services/dds/data_source_huaweicloud_dds_pt_modification_records.go
@@ -1,0 +1,131 @@
+package dds
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DDS GET /v3/{project_id}/configurations/{config_id}/histories
+func DataSourceDdsPtModificationRecords() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDdsPtModificationRecordsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"configuration_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the parameter template.`,
+			},
+			"histories": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Indicates the modification records.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"parameter_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the parameter name.`,
+						},
+						"new_value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the new value.`,
+						},
+						"old_value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the old value.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the update time, in the **yyyy-mm-ddThh:mm:ssZ** format.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDdsPtModificationRecordsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dds", region)
+	if err != nil {
+		return diag.Errorf("error creating DDS client: %s", err)
+	}
+
+	getTasksHttpUrl := "v3/{project_id}/configurations/{config_id}/histories"
+	getTasksPath := client.Endpoint + getTasksHttpUrl
+	getTasksPath = strings.ReplaceAll(getTasksPath, "{project_id}", client.ProjectID)
+	getTasksPath = strings.ReplaceAll(getTasksPath, "{config_id}", d.Get("configuration_id").(string))
+	getTasksOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	// pagelimit is `10`
+	getTasksPath += fmt.Sprintf("?limit=%v", pageLimit)
+	currentTotal := 0
+	results := make([]map[string]interface{}, 0)
+	for {
+		currentPath := getTasksPath + fmt.Sprintf("&offset=%d", currentTotal)
+		getTasksResp, err := client.Request("GET", currentPath, &getTasksOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving records: %s", err)
+		}
+		getTasksRespBody, err := utils.FlattenResponse(getTasksResp)
+		if err != nil {
+			return diag.Errorf("error flattening response: %s", err)
+		}
+
+		records := utils.PathSearch("histories", getTasksRespBody, make([]interface{}, 0)).([]interface{})
+		for _, record := range records {
+			results = append(results, map[string]interface{}{
+				"parameter_name": utils.PathSearch("parameter_name", record, nil),
+				"new_value":      utils.PathSearch("new_value", record, nil),
+				"old_value":      utils.PathSearch("old_value", record, nil),
+				"updated_at":     utils.PathSearch("updated_at", record, nil),
+			})
+		}
+
+		if len(records) < pageLimit {
+			break
+		}
+		currentTotal += len(records)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("histories", results),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
…tion records

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to get parameter template application and modification records


## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDataSourceDdsPtApplicationRecords_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDataSourceDdsPtApplicationRecords_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDdsPtApplicationRecords_basic
=== PAUSE TestAccDataSourceDdsPtApplicationRecords_basic
=== CONT  TestAccDataSourceDdsPtApplicationRecords_basic
--- PASS: TestAccDataSourceDdsPtApplicationRecords_basic (955.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       956.018s

make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDataSourceDdsPtModificationRecords_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDataSourceDdsPtModificationRecords_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDdsPtModificationRecords_basic
=== PAUSE TestAccDataSourceDdsPtModificationRecords_basic
=== CONT  TestAccDataSourceDdsPtModificationRecords_basic
--- PASS: TestAccDataSourceDdsPtModificationRecords_basic (46.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       46.864s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
