### PR TITLE
feat(iotda): the device resource supports new API and new fields

### DIFF
--- a/docs/resources/iotda_device.md
+++ b/docs/resources/iotda_device.md
@@ -120,6 +120,30 @@ are allowed: `?'#().,&%@!`.
 
 * `frozen` - (Optional, Bool) Specifies whether to freeze the device. Defaults to **false**.
 
+* `extension_info` - (Optional, Map) Specifies the extended information of the device.
+  The users can be customized the content. The maximum size of the value is `1` KB.
+
+* `shadow` - (Optional, List) Specifies the initial configuration of the device.
+  The [shadow](#device_shadow) structure is documented below.
+
+  -> 1.You can use this parameter to specify the initial configuration for the device. The system compares the property
+  values specified by `service_id` and the `desired` section with the default values of the corresponding properties
+  in the product. If they are different, the property values specified by the `shadow` parameter are written to the
+  device shadow.
+  <br>2.The value of `service_id` and the properties in the `desired` section must be defined in the product model.
+  <br>3.If you want to config `shadow` data, the `method` value of the properties in the product model must
+  contain **W**.
+
+<a name="device_shadow"></a>
+The `shadow` block supports:
+
+* `service_id` - (Required, String) Specifies the service ID of the device.
+  Which is defined in the product model associated with the device.
+
+* `desired` - (Required, Map) Specifies the initial properties data of the device.
+  The each key is a parameter name of a property in the product model.
+  If you want to delete the entire `desired`, please enter an empty Map. e.g. **desired = {}**.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -146,7 +170,8 @@ $ terraform import huaweicloud_iotda_device.test 10022532f4f94f26b01daa1e424853e
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: `force_disconnect`.
+API response, security or some other reason.
+The missing attributes include: `force_disconnect`, `extension_info`, `shadow`.
 It is generally recommended running `terraform plan` after importing a resource.
 You can then decide if changes should be applied to the resource, or the resource definition
 should be updated to align with the resource. Also you can ignore changes as below.
@@ -157,7 +182,7 @@ resource "huaweicloud_iotda_device" "test" {
   
   lifecycle {
     ignore_changes = [
-      force_disconnect,
+      force_disconnect, extension_info, shadow,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_test.go
@@ -26,7 +26,7 @@ func TestAccDevice_basic(t *testing.T) {
 	var obj model.ShowDeviceResponse
 
 	nodeId := acceptance.RandomAccResourceName()
-	updateName := acceptance.RandomAccResourceName()
+	name := acceptance.RandomAccResourceName()
 	rName := "huaweicloud_iotda_device.test"
 	childDeviceName := "huaweicloud_iotda_device.test2"
 
@@ -42,10 +42,10 @@ func TestAccDevice_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testDevice_basic(nodeId, nodeId),
+				Config: testDevice_basic(name, nodeId),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", nodeId),
+					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "node_id", nodeId),
 					resource.TestCheckResourceAttr(rName, "secret", "1234567890"),
 					resource.TestCheckResourceAttr(rName, "secondary_secret", "test123456"),
@@ -56,7 +56,9 @@ func TestAccDevice_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "auth_type", "SECRET"),
 					resource.TestCheckResourceAttr(rName, "node_type", "GATEWAY"),
 					resource.TestCheckResourceAttr(rName, "frozen", "false"),
-					resource.TestCheckResourceAttr(childDeviceName, "name", nodeId+"_2"),
+					resource.TestCheckResourceAttr(rName, "extension_info.tf", "terraform"),
+					resource.TestCheckResourceAttr(rName, "shadow.#", "2"),
+					resource.TestCheckResourceAttr(childDeviceName, "name", name+"_2"),
 					resource.TestCheckResourceAttr(childDeviceName, "node_id", nodeId+"_2"),
 					resource.TestCheckResourceAttr(childDeviceName, "status", "INACTIVE"),
 					resource.TestCheckResourceAttr(childDeviceName, "node_type", "ENDPOINT"),
@@ -64,9 +66,9 @@ func TestAccDevice_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testDevice_basic_update(updateName, nodeId),
+				Config: testDevice_basic_update(name, nodeId),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
 					resource.TestCheckResourceAttr(rName, "node_id", nodeId),
 					resource.TestCheckResourceAttr(rName, "fingerprint", "1234567890123456789012345678901234567890"),
 					resource.TestCheckResourceAttr(rName, "secondary_fingerprint", "dc0f1016f495157344ac5f1296335cff725ef22f"),
@@ -77,7 +79,9 @@ func TestAccDevice_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "frozen", "true"),
 					resource.TestCheckResourceAttr(rName, "auth_type", "CERTIFICATES"),
 					resource.TestCheckResourceAttr(rName, "node_type", "GATEWAY"),
-					resource.TestCheckResourceAttr(childDeviceName, "name", updateName+"_2"),
+					resource.TestCheckResourceAttr(rName, "extension_info.tf", "update"),
+					resource.TestCheckResourceAttr(rName, "extension_info.test", "acc"),
+					resource.TestCheckResourceAttr(childDeviceName, "name", name+"_2_update"),
 					resource.TestCheckResourceAttr(childDeviceName, "node_id", nodeId+"_2"),
 					resource.TestCheckResourceAttr(childDeviceName, "status", "INACTIVE"),
 					resource.TestCheckResourceAttr(childDeviceName, "node_type", "ENDPOINT"),
@@ -89,7 +93,7 @@ func TestAccDevice_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"force_disconnect",
+					"force_disconnect", "extension_info", "shadow",
 				},
 			},
 		},
@@ -100,7 +104,7 @@ func TestAccDevice_derived(t *testing.T) {
 	var obj model.ShowDeviceResponse
 
 	nodeId := acceptance.RandomAccResourceName()
-	updateName := acceptance.RandomAccResourceName()
+	name := acceptance.RandomAccResourceName()
 	rName := "huaweicloud_iotda_device.test"
 	childDeviceName := "huaweicloud_iotda_device.test2"
 
@@ -119,10 +123,10 @@ func TestAccDevice_derived(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testDevice_basic(nodeId, nodeId),
+				Config: testDevice_basic(name, nodeId),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", nodeId),
+					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "node_id", nodeId),
 					resource.TestCheckResourceAttr(rName, "secret", "1234567890"),
 					resource.TestCheckResourceAttr(rName, "secondary_secret", "test123456"),
@@ -133,7 +137,9 @@ func TestAccDevice_derived(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "auth_type", "SECRET"),
 					resource.TestCheckResourceAttr(rName, "node_type", "GATEWAY"),
 					resource.TestCheckResourceAttr(rName, "frozen", "false"),
-					resource.TestCheckResourceAttr(childDeviceName, "name", nodeId+"_2"),
+					resource.TestCheckResourceAttr(rName, "extension_info.tf", "terraform"),
+					resource.TestCheckResourceAttr(rName, "shadow.#", "2"),
+					resource.TestCheckResourceAttr(childDeviceName, "name", name+"_2"),
 					resource.TestCheckResourceAttr(childDeviceName, "node_id", nodeId+"_2"),
 					resource.TestCheckResourceAttr(childDeviceName, "status", "INACTIVE"),
 					resource.TestCheckResourceAttr(childDeviceName, "node_type", "ENDPOINT"),
@@ -141,9 +147,9 @@ func TestAccDevice_derived(t *testing.T) {
 				),
 			},
 			{
-				Config: testDevice_basic_update(updateName, nodeId),
+				Config: testDevice_basic_update(name, nodeId),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
 					resource.TestCheckResourceAttr(rName, "node_id", nodeId),
 					resource.TestCheckResourceAttr(rName, "fingerprint", "1234567890123456789012345678901234567890"),
 					resource.TestCheckResourceAttr(rName, "secondary_fingerprint", "dc0f1016f495157344ac5f1296335cff725ef22f"),
@@ -154,7 +160,9 @@ func TestAccDevice_derived(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "frozen", "true"),
 					resource.TestCheckResourceAttr(rName, "auth_type", "CERTIFICATES"),
 					resource.TestCheckResourceAttr(rName, "node_type", "GATEWAY"),
-					resource.TestCheckResourceAttr(childDeviceName, "name", updateName+"_2"),
+					resource.TestCheckResourceAttr(rName, "extension_info.tf", "update"),
+					resource.TestCheckResourceAttr(rName, "extension_info.test", "acc"),
+					resource.TestCheckResourceAttr(childDeviceName, "name", name+"_2_update"),
 					resource.TestCheckResourceAttr(childDeviceName, "node_id", nodeId+"_2"),
 					resource.TestCheckResourceAttr(childDeviceName, "status", "INACTIVE"),
 					resource.TestCheckResourceAttr(childDeviceName, "node_type", "ENDPOINT"),
@@ -166,17 +174,62 @@ func TestAccDevice_derived(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"force_disconnect",
+					"force_disconnect", "extension_info", "shadow",
 				},
 			},
 		},
 	})
 }
 
-func testDevice_basic(name, nodeId string) string {
-	productbasic := testProduct_basic(name)
+func testAccDevice_base(name string) string {
 	return fmt.Sprintf(`
-%s
+resource "huaweicloud_iotda_space" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_iotda_product" "test" {
+  name        = "%[1]s-pro"
+  device_type = "Thermometer"
+  protocol    = "MQTT"
+  space_id    = huaweicloud_iotda_space.test.id
+  data_type   = "json"
+
+  services {
+    id   = "temp_1"
+    type = "temperature_a"
+
+    properties {
+      name       = "demo_1"
+      type       = "string"
+      max_length = 256
+      method     = "RW"
+    }
+  }
+
+  services {
+    id   = "temp_2"
+    type = "temperature_b"
+
+    properties {
+      name        = "demo_2"
+      type        = "int"
+      method      = "RW"
+    }
+
+    properties {
+      name        = "demo_3"
+      type        = "string"
+      max_length  = 256
+      method      = "RW"
+    }
+  }
+}
+`, name)
+}
+
+func testDevice_basic(name, nodeId string) string {
+	return fmt.Sprintf(`
+%[1]s
 
 resource "huaweicloud_iotda_device" "test" {
   node_id          = "%[3]s"
@@ -188,6 +241,26 @@ resource "huaweicloud_iotda_device" "test" {
   secure_access    = true
   force_disconnect = true
   description      = "demo"
+
+  extension_info = {
+    tf = "terraform"
+  }
+
+  shadow {
+    service_id = huaweicloud_iotda_product.test.services[0].id
+
+    desired = {
+      (huaweicloud_iotda_product.test.services[0].properties[0].name) = "test"
+    }
+  }
+
+  shadow {
+    service_id = huaweicloud_iotda_product.test.services[1].id
+
+    desired = {
+      (huaweicloud_iotda_product.test.services[1].properties[0].name) = "acc"
+    }
+  }
 
   tags = {
     foo = "bar"
@@ -202,17 +275,16 @@ resource "huaweicloud_iotda_device" "test2" {
   product_id = huaweicloud_iotda_product.test.id
   gateway_id = huaweicloud_iotda_device.test.id
 }
-`, productbasic, name, nodeId)
+`, testAccDevice_base(name), name, nodeId)
 }
 
 func testDevice_basic_update(name, nodeId string) string {
-	productbasic := testProduct_basic(name)
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_iotda_device" "test" {
   node_id               = "%[3]s"
-  name                  = "%[2]s"
+  name                  = "%[2]s_update"
   space_id              = huaweicloud_iotda_space.test.id
   product_id            = huaweicloud_iotda_product.test.id
   fingerprint           = "1234567890123456789012345678901234567890"
@@ -220,6 +292,26 @@ resource "huaweicloud_iotda_device" "test" {
   secure_access         = false
   description           = "demo_update"
   frozen                = true
+
+  extension_info = {
+    tf   = "update"
+    test = "acc"
+  }
+
+  shadow {
+    service_id = huaweicloud_iotda_product.test.services[0].id
+
+    desired = {}
+  }
+
+  shadow {
+    service_id = huaweicloud_iotda_product.test.services[1].id
+
+    desired = {
+      (huaweicloud_iotda_product.test.services[1].properties[0].name) = "update"
+      (huaweicloud_iotda_product.test.services[1].properties[1].name) = "retest"
+    }
+  }
 
   tags = {
     foo = "bar_update"
@@ -229,10 +321,10 @@ resource "huaweicloud_iotda_device" "test" {
 
 resource "huaweicloud_iotda_device" "test2" {
   node_id    = "%[3]s_2"
-  name       = "%[2]s_2"
+  name       = "%[2]s_2_update"
   space_id   = huaweicloud_iotda_space.test.id
   product_id = huaweicloud_iotda_product.test.id
   gateway_id = huaweicloud_iotda_device.test.id
 }
-`, productbasic, name, nodeId)
+`, testAccDevice_base(name), name, nodeId)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The device resource supports new API and new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDevice_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDevice_basic -timeout 360m -parallel 4
=== RUN   TestAccDevice_basic
--- PASS: TestAccDevice_basic (124.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     124.723s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDevice_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDevice_derived -timeout 360m -parallel 4
=== RUN   TestAccDevice_derived
--- PASS: TestAccDevice_derived (122.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     122.947s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
