### PR TITLE
feat(dds): support to delete audit log

### DIFF
--- a/docs/resources/dds_audit_log_delete.md
+++ b/docs/resources/dds_audit_log_delete.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Document Database Service (DDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dds_audit_log_delete"
+description: |-
+  Manages a DDS audit log delete resource within HuaweiCloud.
+---
+
+# huaweicloud_dds_audit_log_delete
+
+Manages a DDS audit log delete resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "file_names" {}
+
+resource "huaweicloud_dds_audit_log_delete" "test" {
+  instance_id = var.instance_id
+  file_names  = var.file_names
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the instance ID.
+  Changing this creates a new resource.
+
+* `file_names` - (Required, List, ForceNew) Specifies the audit log file names.
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 50 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1466,6 +1466,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dds_backup":                      dds.ResourceDdsBackup(),
 			"huaweicloud_dds_parameter_template":          dds.ResourceDdsParameterTemplate(),
 			"huaweicloud_dds_audit_log_policy":            dds.ResourceDdsAuditLogPolicy(),
+			"huaweicloud_dds_audit_log_delete":            dds.ResourceDDSAuditLogDelete(),
 			"huaweicloud_dds_lts_log":                     dds.ResourceDdsLtsLog(),
 			"huaweicloud_dds_instance_restart":            dds.ResourceDDSInstanceRestart(),
 			"huaweicloud_dds_instance_internal_ip_modify": dds.ResourceDDSInstanceModifyIP(),

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_audit_log_delete_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_audit_log_delete_test.go
@@ -1,0 +1,47 @@
+package dds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDDSAuditLogDelete_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDDSInstanceID(t)
+			acceptance.TestAccPreCheckDDSTimeRange(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDDSAuditLogDelete_basic(),
+			},
+		},
+	})
+}
+
+func testAccDDSAuditLogDelete_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dds_audit_logs" "test" {
+  instance_id = "%[1]s"
+  start_time  = "%[2]s"
+  end_time    = "%[3]s"
+}
+
+resource "huaweicloud_dds_audit_log_delete" "test" {
+  instance_id = "%[1]s"
+  file_names  = [try(data.huaweicloud_dds_audit_logs.test.audit_logs[0].name, "")]
+
+  lifecycle {
+    ignore_changes = [
+      file_names,
+    ]
+  }
+}`, acceptance.HW_DDS_INSTANCE_ID, acceptance.HW_DDS_START_TIME, acceptance.HW_DDS_END_TIME)
+}

--- a/huaweicloud/services/dds/resource_huaweicloud_dds_audit_log_delete.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_audit_log_delete.go
@@ -1,0 +1,125 @@
+package dds
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DDS DELETE /v3/{project_id}/instances/{instance_id}/auditlog
+// @API DDS GET /v3/{project_id}/instances
+func ResourceDDSAuditLogDelete() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDDSAuditLogDeleteCreate,
+		ReadContext:   resourceDDSAuditLogDeleteRead,
+		DeleteContext: resourceDDSAuditLogDeleteDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(50 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"file_names": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceDDSAuditLogDeleteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.DdsV3Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DDS client: %s", err)
+	}
+
+	instId := d.Get("instance_id").(string)
+
+	deleteHttpUrl := "v3/{project_id}/instances/{instance_id}/auditlog"
+	deletePath := client.Endpoint + deleteHttpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildAuditLogDeleteBodyParams(d)),
+	}
+
+	// retry
+	retryFunc := func() (interface{}, bool, error) {
+		resp, err := client.Request("DELETE", deletePath, &deleteOpt)
+		retry, err := handleMultiOperationsError(err)
+		return resp, retry, err
+	}
+	deleteResp, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     ddsInstanceStateRefreshFunc(client, instId),
+		WaitTarget:   []string{"normal"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return diag.Errorf("error deleting audit log: %s", err)
+	}
+
+	// job ID is the ID for background task that are not perceived by users
+	deleteRespBody, err := utils.FlattenResponse(deleteResp.(*http.Response))
+	if err != nil {
+		return diag.Errorf("error flattening response: %s", err)
+	}
+	jobID := utils.PathSearch("job_id", deleteRespBody, "").(string)
+	if jobID == "" {
+		return diag.Errorf("unable to find job ID from API response")
+	}
+
+	d.SetId(jobID)
+
+	return nil
+}
+
+func buildAuditLogDeleteBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"file_names": d.Get("file_names"),
+	}
+}
+
+func resourceDDSAuditLogDeleteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDDSAuditLogDeleteDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting audit log delete resource is not supported. The delete resource is only removed from the state," +
+		" the instance remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to delete audit log

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSAuditLogDelete_basic" 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSAuditLogDelete_basic -timeout 360m -parallel 4
=== RUN   TestAccDDSAuditLogDelete_basic
=== PAUSE TestAccDDSAuditLogDelete_basic
=== CONT  TestAccDDSAuditLogDelete_basic
--- PASS: TestAccDDSAuditLogDelete_basic (23.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       23.463s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
