### PR TITLE
feat(workspace/app_server): add resource to manage server

### DIFF
--- a/docs/resources/workspace_app_server.md
+++ b/docs/resources/workspace_app_server.md
@@ -1,0 +1,187 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_server"
+description: |-
+  Manages a Workspace APP server resource under specified server group within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_server
+
+Manages a Workspace APP server resource under specified server group within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "server_group_id" {}
+variable "flavor_id" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+
+resource "huaweicloud_workspace_app_server" "test" {
+  server_group_id = var.server_group_id
+  type            = "createApps"
+  flavor_id       = var.flavor_id
+
+  root_volume {
+    type = "SAS"
+    size = 80
+  }
+
+  vpc_id              = var.vpc_id
+  subnet_id           = var.subnet_id
+  update_access_agent = true
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `server_group_id` - (Required, String, ForceNew) Specifies the server group ID to which the server belongs.
+  Changing this creates a new resource.
+
+* `name` - (Optional, String) Specifies the name of the server.  
+  The name valid length is limited from `1` to `64`, only Chinese and English characters, digits, underscores (_) and
+  hyphens (-) are allowed.
+
+* `type` - (Required, String, ForceNew) Specifies the type of the server.
+  Changing this creates a new resource.  
+  Currently, only **createApps** is supported.
+  
+* `flavor_id` - (Required, String, ForceNew) Specifies the flavor ID of the server.
+  Changing this creates a new resource.  
+  This parameter value must be consistent with the server group to which it belongs.
+
+* `root_volume` - (Required, List) Specifies the system disk configuration of the server.  
+  This parameter value must be consistent with the server group to which it belongs.  
+  The [root_volume](#app_server_root_volume) structure is documented below.
+
+* `vpc_id` - (Required, String, ForceNew) Specifies the VPC ID to which the server belongs.
+  Changing this creates a new resource.  
+  This parameter value must be consistent with the server group to which it belongs.
+  
+* `subnet_id` - (Required, String, ForceNew) Specifies the subnet ID to which the server belongs.
+  Changing this creates a new resource.  
+  This parameter value must be consistent with the server group to which it belongs.
+
+* `os_type` - (Optional, String, ForceNew) Specifies the operating system type of the server.
+  Changing this creates a new resource.  
+  Currently, only **Windows** is supported.
+
+* `availability_zone` - (Optional, String, ForceNew) Specifies the availability zone of the server.
+  Changing this creates a new resource.  
+  If omitted, the AZ randomly assigned by the system is used.
+
+* `description` - (Optional, String) Specifies the description of the server.
+
+* `maintain_status` - (Optional, Bool) Specifies whether to enable maintenance mode. Defaults to **false**.
+
+* `ou_name` - (Optional, String) Specifies the OU name corresponding to the AD server.  
+  This parameter is available only when the AD server is connected.
+
+* `update_access_agent` - (Optional, Bool) Specifies whether to automatically upgrade protocol component. Defaults to **false**.
+
+* `scheduler_hints` - (Optional, List, ForceNew) Specifies the configuration of the dedicate host.
+  Changing this creates a new resource.  
+  This parameter is available only when `charging_mode` is set to **postPaid**.  
+  The [scheduler_hints](#app_server_scheduler_hints) structure is documented below.
+
+* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the server. Defaults to **postPaid**.
+  Changing this creates a new resource.  
+  The valid values are as follows:
+  + **prePaid**: the yearly/monthly billing mode.
+  + **postPaid**: the pay-per-use billing mode.
+  
+* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the server.
+  Changing this creates a new resource.  
+  This parameter is required and available if `charging_mode` is set to **prePaid**.  
+  The valid values are as follows:
+  + **month**
+  + **year**
+
+* `period` - (Optional, Int, ForceNew) Specifies the charging period of the server.
+  Changing this creates a new resource.
+  + If `period_unit` is set to **month**, the value ranges from `1` to `9`.
+  + If `period_unit` is set to **year**, the value ranges from `1` to `3`.
+
+  This parameter is required and available if `charging_mode` is set to **prePaid**.  
+  
+* `auto_renew` - (Optional, String) Specifies whether auto-renew is enabled. Defaults to **false**.  
+  This parameter is required and available if `charging_mode` is set to **prePaid**.  
+  The valid values are **true** and **false**.
+  
+<a name="app_server_root_volume"></a>
+The `root_volume` block supports:
+
+* `type` - (Required, String, ForceNew) Specifies the disk type of the server.
+  Changing this creates a new resource.  
+  The valid values are as follows:
+  + **ESSD**: Extreme SSD type.
+  + **SSD**: Ultra-high I/O type.
+  + **GPSSD**: General purpose SSD type.
+  + **SAS**: High I/O type.
+  + **SATA**: Common I/O type.
+
+* `size` - (Required, Int, ForceNew) Specifies the disk size of the server, in GB.
+  Changing this creates a new resource.
+
+<a name="app_server_scheduler_hints"></a>
+The `scheduler_hints` block supports:
+
+* `dedicated_host_id` - (Optional, String, ForceNew) Specifies the ID of the dedicate host.
+  Changing this creates a new resource.
+
+* `tenancy` - (Optional, String, ForceNew) Specifies the type of the dedicate host.
+  Changing this creates a new resource.  
+  Currently, only **dedicated** is supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also server ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 40 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The APP server resource can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_workspace_app_server.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes include: `type`, `vpc_id`, `subnet_id`, `update_access_agent`, `scheduler_hints`, `period_unit`,
+`period`, `auto_renew`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the instance, or the resource definition should be updated to
+align with the instance. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_workspace_app_server" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      type, vpc_id, subnet_id, update_access_agent, scheduler_hints, period_unit, period, auto_renew,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2082,6 +2082,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_policy_group":        workspace.ResourceAppPolicyGroup(),
 			"huaweicloud_workspace_app_publishment":         workspace.ResourceAppPublishment(),
 			"huaweicloud_workspace_app_server_group":        workspace.ResourceAppServerGroup(),
+			"huaweicloud_workspace_app_server":              workspace.ResourceAppServer(),
 			"huaweicloud_workspace_app_warehouse_app":       workspace.ResourceWarehouseApplication(),
 			"huaweicloud_workspace_user_group":              workspace.ResourceUserGroup(),
 			"huaweicloud_workspace_access_policy":           workspace.ResourceAccessPolicy(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_server_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_server_test.go
@@ -1,0 +1,291 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/workspace"
+)
+
+func getResourceAppServerFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("appstream", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	return workspace.GetServerById(client, state.Primary.ID)
+}
+
+func TestAccResourceAppServer_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_workspace_app_server.test"
+		name         = acceptance.RandomAccResourceName()
+
+		server interface{}
+		rc     = acceptance.InitResourceCheck(
+			resourceName,
+			&server,
+			getResourceAppServerFunc,
+		)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+			acceptance.TestAccPreCheckWorkspaceOUName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceAppServer_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "server_group_id", "huaweicloud_workspace_app_server_group.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "os_type", "Windows"),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor_id", "huaweicloud_workspace_app_server_group.test", "flavor_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "root_volume.0.type",
+						"huaweicloud_workspace_app_server_group.test", "system_disk_type"),
+					resource.TestCheckResourceAttrPair(resourceName, "root_volume.0.size",
+						"huaweicloud_workspace_app_server_group.test", "system_disk_size"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_id", acceptance.HW_WORKSPACE_AD_VPC_ID),
+					resource.TestCheckResourceAttr(resourceName, "subnet_id", acceptance.HW_WORKSPACE_AD_NETWORK_ID),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created server by script"),
+					resource.TestCheckResourceAttr(resourceName, "ou_name", acceptance.HW_WORKSPACE_OU_NAME),
+					resource.TestCheckResourceAttr(resourceName, "maintain_status", "true"),
+				),
+			},
+			{
+				Config: testResourceAppServer_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "maintain_status", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"type",
+					"vpc_id",
+					"subnet_id",
+					"update_access_agent",
+					"scheduler_hints",
+				},
+			},
+		},
+	})
+}
+
+func testResourceAppServer_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_app_server_group" "test" {
+  name             = "%[1]s"
+  os_type          = "Windows"
+  flavor_id        = "%[2]s"
+  vpc_id           = "%[3]s"
+  subnet_id        = "%[4]s"
+  system_disk_type = "SAS"
+  system_disk_size = 80
+  is_vdi           = true
+  image_id         = "%[5]s"
+  image_type       = "gold"
+  image_product_id = "%[6]s"
+}
+`, name, acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
+		acceptance.HW_WORKSPACE_AD_VPC_ID,
+		acceptance.HW_WORKSPACE_AD_NETWORK_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID,
+	)
+}
+
+func testResourceAppServer_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_server" "test" {
+  name            = "%[2]s" 
+  server_group_id = huaweicloud_workspace_app_server_group.test.id
+  type            = "createApps"
+  flavor_id       = huaweicloud_workspace_app_server_group.test.flavor_id
+
+  root_volume {
+    type = huaweicloud_workspace_app_server_group.test.system_disk_type
+    size = huaweicloud_workspace_app_server_group.test.system_disk_size
+  }
+
+  vpc_id              = huaweicloud_workspace_app_server_group.test.vpc_id
+  subnet_id           = huaweicloud_workspace_app_server_group.test.subnet_id
+  update_access_agent = false
+  ou_name             = "%[3]s"
+  description         = "Created server by script"
+  maintain_status     = true
+}
+`, testResourceAppServer_base(name), name, acceptance.HW_WORKSPACE_OU_NAME)
+}
+
+func testResourceAppServer_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_server" "test" {
+  name            = "%[2]s_update" 
+  server_group_id = huaweicloud_workspace_app_server_group.test.id
+  type            = "createApps"
+  flavor_id       = huaweicloud_workspace_app_server_group.test.flavor_id
+
+  root_volume {
+    type = huaweicloud_workspace_app_server_group.test.system_disk_type
+    size = huaweicloud_workspace_app_server_group.test.system_disk_size
+  }
+
+  vpc_id              = huaweicloud_workspace_app_server_group.test.vpc_id
+  subnet_id           = huaweicloud_workspace_app_server_group.test.subnet_id
+  update_access_agent = false
+  ou_name             = "%[3]s"
+  maintain_status     = false
+}
+`, testResourceAppServer_base(name), name, acceptance.HW_WORKSPACE_OU_NAME)
+}
+
+func TestAccResourceAppServer_prepaid(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_workspace_app_server.test"
+		name         = acceptance.RandomAccResourceName()
+
+		server interface{}
+		rc     = acceptance.InitResourceCheck(
+			resourceName,
+			&server,
+			getResourceAppServerFunc,
+		)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+			acceptance.TestAccPreCheckWorkspaceOUName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceAppServer_prepaid_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "server_group_id", "huaweicloud_workspace_app_server_group.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "os_type", "Windows"),
+					resource.TestCheckResourceAttr(resourceName, "os_type", "Windows"),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor_id", "huaweicloud_workspace_app_server_group.test", "flavor_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "root_volume.0.type",
+						"huaweicloud_workspace_app_server_group.test", "system_disk_type"),
+					resource.TestCheckResourceAttrPair(resourceName, "root_volume.0.size",
+						"huaweicloud_workspace_app_server_group.test", "system_disk_size"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_id", acceptance.HW_WORKSPACE_AD_VPC_ID),
+					resource.TestCheckResourceAttr(resourceName, "subnet_id", acceptance.HW_WORKSPACE_AD_NETWORK_ID),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created server by script"),
+					resource.TestCheckResourceAttr(resourceName, "ou_name", acceptance.HW_WORKSPACE_OU_NAME),
+					resource.TestCheckResourceAttr(resourceName, "maintain_status", "true"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "true"),
+				),
+			},
+			{
+				Config: testResourceAppServer_prepaid_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "maintain_status", "false"),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"type",
+					"vpc_id",
+					"subnet_id",
+					"update_access_agent",
+					"scheduler_hints",
+					"period_unit",
+					"period",
+					"auto_renew",
+				},
+			},
+		},
+	})
+}
+
+func testResourceAppServer_prepaid_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_server" "test" {
+  name            = "%[2]s" 
+  server_group_id = huaweicloud_workspace_app_server_group.test.id
+  type            = "createApps"
+  flavor_id       = huaweicloud_workspace_app_server_group.test.flavor_id
+
+  root_volume {
+    type = huaweicloud_workspace_app_server_group.test.system_disk_type
+    size = huaweicloud_workspace_app_server_group.test.system_disk_size
+  }
+
+  vpc_id              = huaweicloud_workspace_app_server_group.test.vpc_id
+  subnet_id           = huaweicloud_workspace_app_server_group.test.subnet_id
+  os_type             = "Windows"
+  update_access_agent = false
+  ou_name             = "%[3]s"
+  description         = "Created server by script"
+  maintain_status     = true
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = true
+}
+`, testResourceAppServer_base(name), name, acceptance.HW_WORKSPACE_OU_NAME)
+}
+
+func testResourceAppServer_prepaid_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_server" "test" {
+  name            = "%[2]s_update" 
+  server_group_id = huaweicloud_workspace_app_server_group.test.id
+  type            = "createApps"
+  flavor_id       = huaweicloud_workspace_app_server_group.test.flavor_id
+
+  root_volume {
+    type = huaweicloud_workspace_app_server_group.test.system_disk_type
+    size = huaweicloud_workspace_app_server_group.test.system_disk_size
+  }
+
+  vpc_id              = huaweicloud_workspace_app_server_group.test.vpc_id
+  subnet_id           = huaweicloud_workspace_app_server_group.test.subnet_id
+  update_access_agent = false
+  ou_name             = "%[3]s"
+  maintain_status     = false
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = false
+}
+`, testResourceAppServer_base(name), name, acceptance.HW_WORKSPACE_OU_NAME)
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_server.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_server.go
@@ -1,0 +1,581 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace POST /v1/{project_id}/app-servers/actions/create
+// @API Workspace GET /v1/{project_id}/app-servers
+// @API Workspace PATCH /v1/{project_id}/app-servers/{server_id}
+// @API Workspace POST /v1/{project_id}/app-servers/actions/batch-delete
+func ResourceAppServer() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppServerCreate,
+		ReadContext:   resourceAppServerRead,
+		UpdateContext: resourceAppServerUpdate,
+		DeleteContext: resourceAppServerDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(40 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"server_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The server group ID to which the server belongs.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The name of the server.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The type of the server.`,
+			},
+			"flavor_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The flavor ID of the server.`,
+			},
+			"root_volume": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+							Description: "The disk type of the server.",
+						},
+						"size": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							ForceNew:    true,
+							Description: "The disk size of the server, in GB.",
+						},
+					},
+				},
+				Description: `The system disk configuration of the server.`,
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The VPC ID to which the server belongs.`,
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The subnet ID to which the server belongs.`,
+			},
+			"os_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The operating system type of the server.`,
+			},
+			"availability_zone": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The availability zone of the server.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the server.`,
+			},
+			"maintain_status": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to enable maintenance mode.`,
+			},
+			"ou_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The OU name corresponding to the AD server.`,
+			},
+			"update_access_agent": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Whether to automatically upgrade protocol component.`,
+			},
+			"scheduler_hints": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Description: `The configuration of the dedicate host.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"dedicated_host_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `The ID of the dedicate host.`,
+						},
+						"tenancy": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `The type of the dedicate host.`,
+						},
+					},
+				},
+			},
+			"charging_mode": common.SchemaChargingMode(nil),
+			"period_unit":   common.SchemaPeriodUnit(nil),
+			"period":        common.SchemaPeriod(nil),
+			"auto_renew":    common.SchemaAutoRenewUpdatable(nil),
+		},
+	}
+}
+
+func buildCreateServerBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"server_group_id":     d.Get("server_group_id"),
+		"type":                d.Get("type"),
+		"product_id":          d.Get("flavor_id"),
+		"subscription_num":    1,
+		"root_volume":         buildAppServerRootVolume(d.Get("root_volume").([]interface{})),
+		"vpc_id":              d.Get("vpc_id"),
+		"subnet_id":           d.Get("subnet_id"),
+		"os_type":             utils.ValueIgnoreEmpty(d.Get("os_type")),
+		"availability_zone":   utils.ValueIgnoreEmpty(d.Get("availability_zone")),
+		"update_access_agent": d.Get("update_access_agent"),
+		"ou_name":             utils.ValueIgnoreEmpty(d.Get("ou_name")),
+		"scheduler_hints":     buildAppServerSchedulerHints(d.Get("scheduler_hints").([]interface{})),
+	}
+
+	if d.Get("charging_mode").(string) == "prePaid" {
+		params["create_server_extend_param"] = buildPrepaidOptionsBodyParams(d)
+	}
+
+	return params
+}
+
+func buildAppServerSchedulerHints(schedulerHint []interface{}) map[string]interface{} {
+	if len(schedulerHint) == 0 || schedulerHint[0] == nil {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"dedicated_host_id": utils.PathSearch("dedicated_host_id", schedulerHint[0], nil),
+		"tenancy":           utils.PathSearch("tenancy", schedulerHint[0], nil),
+	}
+}
+
+func buildAppServerRootVolume(rootVolume []interface{}) map[string]interface{} {
+	if len(rootVolume) == 0 {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"type": utils.PathSearch("type", rootVolume[0], nil),
+		"size": utils.PathSearch("size", rootVolume[0], nil),
+	}
+}
+
+func buildPrepaidOptionsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"charging_mode": "prePaid",
+		"period_type":   buildCreatePeriodTypeParam(d.Get("period_unit").(string)),
+		"period_num":    d.Get("period"),
+		"is_auto_renew": parseAutoRenewValue(d.Get("auto_renew").(string)),
+		"is_auto_pay":   true,
+	}
+}
+
+func buildCreatePeriodTypeParam(periodUnit string) interface{} {
+	switch periodUnit {
+	case "month":
+		return 2
+	case "year":
+		return 3
+	}
+
+	return nil
+}
+
+func parseAutoRenewValue(autoRenew string) bool {
+	result, err := strconv.ParseBool(autoRenew)
+	if err != nil {
+		log.Printf("[ERROR] unable to convert auto_renew to bool value")
+		return false
+	}
+	return result
+}
+
+func resourceAppServerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	httpUrl := "v1/{project_id}/app-servers/actions/create"
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	serverGroupId := d.Get("server_group_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateServerBodyParams(d)),
+	}
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP server under specified server group (%s): %s", serverGroupId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if d.Get("charging_mode").(string) == "prePaid" {
+		orderId := utils.PathSearch("order_id", respBody, "").(string)
+		resourceId, err := waitForPrePaidServerComplete(ctx, cfg, region, d.Timeout(schema.TimeoutCreate), orderId)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		d.SetId(resourceId)
+	} else {
+		jobId := utils.PathSearch("job_id", respBody, "").(string)
+		if jobId == "" {
+			return diag.Errorf("unable to find job ID from API response")
+		}
+
+		serverResp, err := waitForAppServerJobCompleted(ctx, client, d.Timeout(schema.TimeoutCreate), jobId)
+		if err != nil {
+			return diag.Errorf("error waiting for the job (%s) completed: %s", jobId, err)
+		}
+
+		serverId := utils.PathSearch("sub_jobs|[0].job_resource_info.resource_id", serverResp, "").(string)
+		if serverId == "" {
+			return diag.Errorf("unable to find server ID from API response")
+		}
+
+		d.SetId(serverId)
+	}
+
+	if err := updateAppServer(client, d, d.Id()); err != nil {
+		return diag.Errorf("error updating the server (%s): %s", d.Id(), err)
+	}
+
+	return resourceAppServerRead(ctx, d, meta)
+}
+
+func waitForPrePaidServerComplete(ctx context.Context, cfg *config.Config, region string, timeOut time.Duration, orderId string) (string, error) {
+	if orderId == "" {
+		return "", fmt.Errorf("unable to find order ID from API response")
+	}
+
+	bssClient, err := cfg.BssV2Client(region)
+	if err != nil {
+		return "", fmt.Errorf("error creating BSS v2 client: %s", err)
+	}
+
+	if err := common.WaitOrderComplete(ctx, bssClient, orderId, timeOut); err != nil {
+		return "", err
+	}
+
+	resourceId, err := common.WaitOrderResourceComplete(ctx, bssClient, orderId, timeOut)
+	if err != nil {
+		return "", fmt.Errorf("error waiting for Workspace APP server order (%s) complete: %s", orderId, err)
+	}
+
+	return resourceId, nil
+}
+
+func waitForAppServerJobCompleted(ctx context.Context, client *golangsdk.ServiceClient, timeout time.Duration, jobId string) (interface{},
+	error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"RUNNING"},
+		Target:       []string{"SUCCESS"},
+		Refresh:      refreshAppServerJobStatusFunc(client, jobId),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+
+	serverResp, err := stateConf.WaitForStateContext(ctx)
+	return serverResp, err
+}
+
+func refreshAppServerJobStatusFunc(client *golangsdk.ServiceClient, jobId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		httpUrl := "v2/{project_id}/job/{job_id}"
+		getJobPath := client.Endpoint + httpUrl
+		getJobPath = strings.ReplaceAll(getJobPath, "{project_id}", client.ProjectID)
+		getJobPath = strings.ReplaceAll(getJobPath, "{job_id}", jobId)
+		getOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+
+		resp, err := client.Request("GET", getJobPath, &getOpt)
+		if err != nil {
+			return resp, "ERROR", err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return resp, "ERROR", err
+		}
+
+		return respBody, utils.PathSearch("status", respBody, nil).(string), nil
+	}
+}
+
+func resourceAppServerRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	server, err := GetServerById(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "Workspace APP server")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("server_group_id", utils.PathSearch("server_group_id", server, nil)),
+		d.Set("name", utils.PathSearch("name", server, nil)),
+		d.Set("flavor_id", utils.PathSearch("product_info.product_id", server, nil)),
+		d.Set("root_volume", flattenAppServerRootVolume(utils.PathSearch("product_info", server, nil))),
+		d.Set("os_type", utils.PathSearch("os_type", server, nil)),
+		d.Set("charging_mode", flattenServerChargingMode(server)),
+		d.Set("availability_zone", utils.PathSearch("availability_zone", server, nil)),
+		d.Set("description", utils.PathSearch("description", server, nil)),
+		d.Set("ou_name", utils.PathSearch("ou_name", server, nil)),
+		d.Set("maintain_status", utils.PathSearch("maintain_status", server, nil)),
+	)
+
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func flattenServerChargingMode(getRespBody interface{}) string {
+	chargingMode := utils.PathSearch("metadata.charging_mode", getRespBody, "").(string)
+	if chargingMode == "1" {
+		return "prePaid"
+	}
+	if chargingMode == "0" {
+		return "postPaid"
+	}
+
+	log.Printf("[WARN] error parsing charging_mode from API response")
+	return ""
+}
+
+func flattenAppServerRootVolume(resp interface{}) []map[string]interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	diskSize := utils.PathSearch("system_disk_size", resp, "").(string)
+	return []map[string]interface{}{
+		{
+			"type": utils.PathSearch("system_disk_type", resp, nil),
+			"size": utils.StringToInt(&diskSize),
+		},
+	}
+}
+
+// GetServerById is amethod used to query server detail by server ID.
+func GetServerById(client *golangsdk.ServiceClient, serverId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/app-servers"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = fmt.Sprintf("%s?server_id=%s", getPath, serverId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving server (%s): %s", serverId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parsing server from API response: %s", err)
+	}
+
+	server := utils.PathSearch("items|[0]", respBody, nil)
+	if server == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return server, nil
+}
+
+func resourceAppServerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	serverId := d.Id()
+	if err := updateAppServer(client, d, serverId); err != nil {
+		return diag.Errorf("error updating server (%s): %s", serverId, err)
+	}
+
+	if d.HasChange("auto_renew") {
+		bssClient, err := cfg.BssV2Client(region)
+		if err != nil {
+			return diag.Errorf("error creating BSS V2 client: %s", err)
+		}
+		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), serverId); err != nil {
+			return diag.Errorf("error updating the auto-renew of the server (%s): %s", serverId, err)
+		}
+	}
+
+	return resourceAppServerRead(ctx, d, meta)
+}
+
+func updateAppServer(client *golangsdk.ServiceClient, d *schema.ResourceData, serverId string) error {
+	updateServerOpt := map[string]interface{}{}
+	if d.HasChange("name") {
+		updateServerOpt["name"] = d.Get("name")
+	}
+
+	if d.HasChange("description") {
+		updateServerOpt["description"] = d.Get("description")
+	}
+
+	if d.HasChange("maintain_status") {
+		updateServerOpt["maintain_status"] = d.Get("maintain_status")
+	}
+
+	if len(updateServerOpt) == 0 {
+		return nil
+	}
+
+	httpUrl := "v1/{project_id}/app-servers/{server_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{server_id}", serverId)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         updateServerOpt,
+	}
+
+	_, err := client.Request("PATCH", updatePath, &updateOpt)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAppServerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("appstream", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	serverId := d.Id()
+	if d.Get("charging_mode").(string) == "prePaid" {
+		if err := common.UnsubscribePrePaidResource(d, cfg, []string{d.Id()}); err != nil {
+			return diag.Errorf("error unsubscribing Workspace APP server (%s) under speficied server group (%s): %s",
+				serverId, d.Get("server_group_id").(string), err)
+		}
+	} else {
+		if err := deleteAppServerById(client, serverId); err != nil {
+			return common.CheckDeletedDiag(d, err, "delete Workspace APP server")
+		}
+	}
+
+	if err := waitingForServerDeleteCompleted(ctx, client, serverId, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.Errorf("error waiting for Workspace APP server (%s) deleted: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func deleteAppServerById(client *golangsdk.ServiceClient, serverId string) error {
+	httpUrl := "v1/{project_id}/app-servers/actions/batch-delete"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"items": []string{serverId},
+		},
+	}
+
+	// When deleting a non-existent server, the response status code is 200.
+	_, err := client.Request("POST", deletePath, &deleteOpt)
+	return err
+}
+
+func waitingForServerDeleteCompleted(ctx context.Context, client *golangsdk.ServiceClient, serverId string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			respBody, err := GetServerById(client, serverId)
+			if err != nil {
+				if _, ok := err.(golangsdk.ErrDefault404); ok {
+					return "deleted", "COMPLETED", nil
+				}
+				return nil, "ERROR", err
+			}
+			return respBody, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 20 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to manage server under specified server group.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to manage a server.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccResourceAppServer_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceAppServer_ -timeout 360m -parallel 10
=== RUN   TestAccResourceAppServer_basic
=== PAUSE TestAccResourceAppServer_basic
=== RUN   TestAccResourceAppServer_prepaid
=== PAUSE TestAccResourceAppServer_prepaid
=== CONT  TestAccResourceAppServer_basic
=== CONT  TestAccResourceAppServer_prepaid
--- PASS: TestAccResourceAppServer_basic (719.19s)
--- PASS: TestAccResourceAppServer_prepaid (1387.24s)
PASS
coverage: 12.2% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 1387.303s       coverage: 12.2% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found    
![image](https://github.com/user-attachments/assets/57c6ca11-96c7-4f4d-9636-d628f0fd0e7b)
    
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
     When the resource does not exist, the response status code is always 200.

    
    bb. Related resources (parent resources) not found
    When the Workspace service or cloud application is disabled.
![image](https://github.com/user-attachments/assets/ca4c92a3-a2a3-4ae2-babf-6dbf20c4be99)

