### PR TITLE
feat(dms): support to get kafka topic partitions

### DIFF
--- a/docs/data-sources/dms_kafka_topic_partitions.md
+++ b/docs/data-sources/dms_kafka_topic_partitions.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_topic_partitions"
+description: |-
+  Use this data source to get the list of Kafka topic partitions.
+---
+
+# huaweicloud_dms_kafka_topic_partitions
+
+Use this data source to get the list of Kafka topic partitions.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "topic" {}
+
+data "huaweicloud_dms_kafka_topic_partitions" "test" {
+  instance_id = var.instance_id
+  topic       = var.topic
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the instance ID.
+
+* `topic` - (Required, String) Specifies the topic name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `partitions` - Indicates the partitions.
+  The [partitions](#attrblock--partitions) structure is documented below.
+
+<a name="attrblock--partitions"></a>
+The `partitions` block supports:
+
+* `partition` - Indicates the partition ID.
+
+* `start_offset` - Indicates the start offset.
+
+* `last_offset` - Indicates the last offset.
+
+* `last_update_time` - Indicates the last update time.
+
+* `message_count` - Indicates the message count.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -688,6 +688,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafkav2_smart_connect_tasks":   dms.DataSourceDmsKafkav2SmartConnectTasks(),
 			"huaweicloud_dms_kafka_user_client_quotas":      dms.DataSourceDmsKafkaUserClientQuotas(),
 			"huaweicloud_dms_kafka_topics":                  dms.DataSourceDmsKafkaTopics(),
+			"huaweicloud_dms_kafka_topic_partitions":        dms.DataSourceDmsKafkaTopicPartitions(),
 			"huaweicloud_dms_kafka_users":                   dms.DataSourceDmsKafkaUsers(),
 			"huaweicloud_dms_kafka_message_diagnosis_tasks": dms.DataSourceDmsKafkaMessageDiagnosisTasks(),
 

--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_kafka_topic_partitons_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_kafka_topic_partitons_test.go
@@ -1,0 +1,46 @@
+package dms
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDmsKafkaTopicPartitions_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_dms_kafka_topic_partitions.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDmsKafkaTopicPartitions_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "partitions.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "partitions.0.partition"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDmsKafkaTopicPartitions_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_dms_kafka_topic_partitions" "test" {
+  depends_on = [huaweicloud_dms_kafka_topic.topic]
+
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+  topic       = huaweicloud_dms_kafka_topic.topic.name
+}
+`, testAccDmsKafkaTopic_basic(name))
+}

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_kafka_topic_partitions.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_kafka_topic_partitions.go
@@ -1,0 +1,143 @@
+package dms
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Kafka GET /v2/{project_id}/kafka/instances/{instance_id}/topics/{topic}/partitions
+func DataSourceDmsKafkaTopicPartitions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDmsKafkaTopicPartitionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the instance ID.`,
+			},
+			"topic": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the topic name.`,
+			},
+			"partitions": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Indicates the partitions.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"partition": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the partition ID.`,
+						},
+						"start_offset": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the start offset.`,
+						},
+						"last_offset": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the last offset.`,
+						},
+						"last_update_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the last update time.`,
+						},
+						"message_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the message count.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDmsKafkaTopicPartitionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	getTopicPartitionsHttpUrl := "v2/{project_id}/kafka/instances/{instance_id}/topics/{topic}/partitions"
+	getTopicPartitionsPath := client.Endpoint + getTopicPartitionsHttpUrl
+	getTopicPartitionsPath = strings.ReplaceAll(getTopicPartitionsPath, "{project_id}", client.ProjectID)
+	getTopicPartitionsPath = strings.ReplaceAll(getTopicPartitionsPath, "{instance_id}", d.Get("instance_id").(string))
+	getTopicPartitionsPath = strings.ReplaceAll(getTopicPartitionsPath, "{topic}", d.Get("topic").(string))
+
+	getTopicPartitionsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	// pagelimit is `10`
+	getTopicPartitionsPath += fmt.Sprintf("?limit=%v", pageLimit)
+	currentTotal := 0
+	results := make([]map[string]interface{}, 0)
+	for {
+		currentPath := getTopicPartitionsPath + fmt.Sprintf("&offset=%d", currentTotal)
+		getTopicPartitionsResp, err := client.Request("GET", currentPath, &getTopicPartitionsOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving partitions: %s", err)
+		}
+		getTopicPartitionsRespBody, err := utils.FlattenResponse(getTopicPartitionsResp)
+		if err != nil {
+			return diag.Errorf("error flatten response: %s", err)
+		}
+
+		partitions := utils.PathSearch("partitions", getTopicPartitionsRespBody, make([]interface{}, 0)).([]interface{})
+		for _, partition := range partitions {
+			results = append(results, map[string]interface{}{
+				"partition":    utils.PathSearch("partition", partition, nil),
+				"start_offset": utils.PathSearch("start_offset", partition, nil),
+				"last_offset":  utils.PathSearch("last_offset", partition, nil),
+				"last_update_time": utils.FormatTimeStampRFC3339(
+					int64(utils.PathSearch("last_update_time", partition, float64(0)).(float64))/1000, false),
+				"message_count": utils.PathSearch("message_count", partition, nil),
+			})
+		}
+
+		currentTotal += len(partitions)
+		total := utils.PathSearch("total", getTopicPartitionsRespBody, float64(0)).(float64)
+		if currentTotal == int(total) {
+			break
+		}
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("partitions", results),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to get kafka topic partitions


## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/dms" TESTARGS="-run TestAccDataSourceDmsKafkaTopicPartitions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDataSourceDmsKafkaTopicPartitions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDmsKafkaTopicPartitions_basic
=== PAUSE TestAccDataSourceDmsKafkaTopicPartitions_basic
=== CONT  TestAccDataSourceDmsKafkaTopicPartitions_basic
--- PASS: TestAccDataSourceDmsKafkaTopicPartitions_basic (873.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       873.840s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
