### PR TITLE
feat(cts): CTS notification supports agency_name field

### DIFF
--- a/docs/resources/cts_notification.md
+++ b/docs/resources/cts_notification.md
@@ -2,7 +2,8 @@
 subcategory: "Cloud Trace Service (CTS)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_cts_notification"
-description: ""
+description: |-
+  Manages CTS key event notification resource within HuaweiCloud.
 ---
 
 # huaweicloud_cts_notification
@@ -72,6 +73,8 @@ The following arguments are supported:
   **customized**.
 
 * `smn_topic` - (Optional, String) Specifies the URN of a topic.
+
+* `agency_name` - (Optional, String) Specifies the cloud service agency name. The value can only be **cts_admin_trust**.
 
 * `operations` - (Optional, List) Specifies an array of operations that will trigger notifications.
   For details, see [Supported Services and Operations](https://support.huaweicloud.com/intl/en-us/usermanual-cts/cts_03_0022.html).

--- a/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_notification_test.go
+++ b/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_notification_test.go
@@ -66,6 +66,7 @@ func TestAccCTSNotification_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
 					resource.TestCheckResourceAttr(resourceName, "filter.0.condition", "AND"),
 					resource.TestCheckResourceAttr(resourceName, "filter.0.rule.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "agency_name", "cts_admin_trust"),
 					resource.TestCheckResourceAttrPair(resourceName, "smn_topic",
 						"huaweicloud_smn_topic.topic_1", "id"),
 				),
@@ -113,6 +114,7 @@ resource "huaweicloud_cts_notification" "notify" {
   name           = "%[1]s"
   operation_type = "complete"
   smn_topic      = huaweicloud_smn_topic.topic_1.id
+  agency_name    = "cts_admin_trust"
 
   filter {
     condition = "AND"
@@ -132,6 +134,7 @@ resource "huaweicloud_cts_notification" "notify" {
   name           = "%[1]s"
   operation_type = "customized"
   smn_topic      = huaweicloud_smn_topic.topic_1.id
+  agency_name    = "cts_admin_trust"
 
   filter {
     condition = "OR"
@@ -162,6 +165,7 @@ resource "huaweicloud_cts_notification" "notify" {
   name           = "%[1]s"
   operation_type = "customized"
   smn_topic      = huaweicloud_smn_topic.topic_1.id
+  agency_name    = "cts_admin_trust"
   enabled        = false
 
   operations {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
CTS notification supports agency_name field
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. CTS notification supports agency_name field
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```

TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSNotification_basic -timeout 360m -parallel 4
=== RUN   TestAccCTSNotification_basic
=== PAUSE TestAccCTSNotification_basic
=== CONT  TestAccCTSNotification_basic
--- PASS: TestAccCTSNotification_basic (84.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       84.476s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
