### PR TITLE
feat(rfs/stack): new param to reserve resources when deleting stack

### DIFF
--- a/docs/resources/rfs_stack.md
+++ b/docs/resources/rfs_stack.md
@@ -29,6 +29,9 @@ resource "huaweicloud_rfs_stack" "test" {
 
   template_uri = var.template_obs_uri
   vars_uri     = var.variable_obs_uri
+
+  retain_all_resources = true
+}
 ```
 
 ### Create an RFS resource stack with VPC deployment (using template and variable files)
@@ -151,6 +154,9 @@ The following arguments are supported:
   The default value is **false**.
   Change this parameter will create a new resource.
 
+* `retain_all_resources` - (Optional, Bool) Specifies whether to reserve resources when deleting the resource stack.  
+  The default value is **false**.
+
 <a name="stack_agency"></a>
 The `agency` block supports:
 
@@ -204,8 +210,9 @@ $ terraform import huaweicloud_rfs_stack.test edd2f099-e1ac-4bd0-be32-8b2185620a
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response. The missing attributes include: `agency`, `template_body`, `vars_body`, `template_uri`, `vars_uri`,
-`enable_auto_rollback` and `enable_deletion_protection`. It is generally recommended running `terraform plan` after
-importing a stack. You can keep the resource the same with its definition bo choosing any of them to update.
+`enable_auto_rollback`, `enable_deletion_protection` and `retain_all_resources`.
+It is generally recommended running `terraform plan` after importing a stack.
+You can keep the resource the same with its definition bo choosing any of them to update.
 Also you can ignore changes as below.
 
 ```hcl


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New API using that supports resources reserved when deleting resource stack.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. new param to reserve resources when deleting stack.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

![image](https://github.com/user-attachments/assets/275acf9d-c4b5-46e7-8d25-9746a8dd4020)
![image](https://github.com/user-attachments/assets/dbd429a3-bf53-4a6a-84ee-e0a2fedf6c1c)

Existing tests are not affected
```
./scripts/coverage.sh -o rfs -f TestAccStack
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rfs" -v -coverprofile="./huaweicloud/services/acceptance/rfs/rfs_coverage.cov" -coverpkg="./huaweicloud/services/rfs" -run TestAccStack -timeout 360m -parallel 10
=== RUN   TestAccStack_basic
=== PAUSE TestAccStack_basic
=== RUN   TestAccStack_withBody
=== PAUSE TestAccStack_withBody
=== RUN   TestAccStack_withUri
=== PAUSE TestAccStack_withUri
=== RUN   TestAccStack_archive
=== PAUSE TestAccStack_archive
=== CONT  TestAccStack_basic
=== CONT  TestAccStack_withUri
=== CONT  TestAccStack_archive
=== CONT  TestAccStack_withBody
=== CONT  TestAccStack_archive
    acceptance.go:1519: Skip the archive URI parameters acceptance test for RF resource stack.
--- SKIP: TestAccStack_archive (0.00s)
--- PASS: TestAccStack_basic (89.37s)
--- PASS: TestAccStack_withBody (175.01s)
--- PASS: TestAccStack_withUri (356.92s)
PASS
coverage: 32.4% of statements in ./huaweicloud/services/rfs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       356.972s        coverage: 32.4% of statements in ./huaweicloud/services/rfs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.
