### PR TITLE
feat(rfs): add resource to manage a execution plan

### DIFF
--- a/docs/resources/rfs_execution_plan.md
+++ b/docs/resources/rfs_execution_plan.md
@@ -1,0 +1,76 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_execution_plan"
+description: |-
+  Use this resource to manages a execution plan under specified resource stack within HuaweiCloud.
+---
+
+# huaweicloud_rfs_execution_plan
+
+Use this resource to manages a execution plan under specified resource stack within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "stack_name" {}
+variable "execution_plan_name" {}
+variable "template_uri" {}
+variable "vars_uri" {}
+
+resource "huaweicloud_rfs_execution_plan" "test" {
+  stack_name   = var.stack_name
+  name         = var.execution_plan_name
+  template_uri = var.template_uri
+  vars_uri     = var.vars_uri
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the related stack to which the execution plan belongs
+  is located. If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `stack_name` - (Required, String, ForceNew) Specifies the name of the resource stack to which the execution plan belongs.
+  Changing this creates a new resource.
+  
+* `name` - (Required, String, ForceNew) Specifies the name of the execution plan.
+  Changing this creates a new resource.  
+  The valid length is limited from `1` to `128`, only Chinese characters, English letters, digits, underscores (_) and
+  hyphens (-) are allowed.  
+  The name must start with a Chinese character or an English letter, and must be unique.
+
+* `stack_id` - (Optional, String, ForceNew) Specifies the ID of the resource stack to which the execution plan belongs.
+  Changing this creates a new resource.
+
+  -> To ensure the correctness of the stack resource being operated (there may be stacks with the same name), it is
+     recommended to use `stack_id` for strong matching.
+
+* `description` - (Optional, String, ForceNew) Specifies the description of the execution plan.
+  Changing this creates a new resource.
+
+* `template_body` - (Optional, String, ForceNew) Specifies the HCL/JSON template content for deployment resources.
+  Changing this creates a new resource.  
+  This parameter and `template_uri` are alternative and exactly one of them must be provided.
+
+* `vars_body` - (Optional, String, ForceNew) Specifies the variable content for deployment resources.
+  Changing this creates a new resource.  
+  This parameter and `vars_uri` parameters cannot be set at the same time.
+
+* `template_uri` - (Optional, String, ForceNew) Specifies the OBS address where the HCL/JSON template archive (**.zip** file,
+  which contains all resource **.tf.json** script files to be deployed) or **.tf.json** file is located, which describes
+  the target status of the deployment resources.  
+  Changing this creates a new resource.
+
+* `vars_uri` - (Optional, String, ForceNew) Specifies the OBS address where the variable (**.tfvars**) file corresponding
+  to the HCL/JSON template located, which describes the target status of the deployment resources.  
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1256,8 +1256,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_aom_alarm_rules_template":           aom.ResourceAlarmRulesTemplate(),
 			"huaweicloud_aom_alarm_group_rule":               aom.ResourceAlarmGroupRule(),
 
-			"huaweicloud_rfs_private_hook": rfs.ResourcePrivateHook(),
-			"huaweicloud_rfs_stack":        rfs.ResourceStack(),
+			"huaweicloud_rfs_execution_plan": rfs.ResourceExecutionPlan(),
+			"huaweicloud_rfs_private_hook":   rfs.ResourcePrivateHook(),
+			"huaweicloud_rfs_stack":          rfs.ResourceStack(),
 
 			"huaweicloud_api_gateway_api":         apigateway.ResourceAPI(),
 			"huaweicloud_api_gateway_environment": apigateway.ResourceEnvironment(),

--- a/huaweicloud/services/acceptance/rfs/resource_huaweicloud_rfs_execution_plan_test.go
+++ b/huaweicloud/services/acceptance/rfs/resource_huaweicloud_rfs_execution_plan_test.go
@@ -1,0 +1,74 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccExecutionPlan_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceNameWithDash()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExecutionPlan_basic(name),
+			},
+		},
+	})
+}
+
+func testAccExecutionPlan_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rfs_stack" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_rfs_execution_plan" "test" {
+  stack_name    = huaweicloud_rfs_stack.test.name
+  name          = "%[1]s"
+  stack_id      = huaweicloud_rfs_stack.test.id
+  description   = "Created plan by script"
+  template_body = %[2]s
+  vars_body     = %[3]s
+}
+`, name, updateTemplateInJsonFormat(), basicVariablesInVarsFormat(name))
+}
+
+func TestAccExecutionPlan_withUri(t *testing.T) {
+	name := acceptance.RandomAccResourceNameWithDash()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExecutionPlan_withUri(name),
+			},
+		},
+	})
+}
+
+func testAccExecutionPlan_withUri(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rfs_execution_plan" "test" {
+  stack_name   = huaweicloud_rfs_stack.test.name
+  name         = "%[2]s"
+  stack_id     = huaweicloud_rfs_stack.test.id
+  description  = "Created plan by script"
+  template_uri = huaweicloud_rfs_stack.test.template_uri
+  vars_uri     = huaweicloud_rfs_stack.test.vars_uri
+}
+`, testAccStack_withUri_hclBody(name, updateTemplateInHclFormat(), basicVariablesInVarsFormat(name)), name)
+}

--- a/huaweicloud/services/rfs/resource_huaweicloud_rfs_execution_plan.go
+++ b/huaweicloud/services/rfs/resource_huaweicloud_rfs_execution_plan.go
@@ -1,0 +1,192 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS POST /v1/{project_id}/stacks/{stack_name}/execution-plans
+// @API RFS DELETE /v1/{project_id}/stacks/{stack_name}/execution-plans/{execution_plan_name}
+func ResourceExecutionPlan() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceExecutionPlanCreate,
+		ReadContext:   resourceExecutionPlanRead,
+		DeleteContext: resourceExecutionPlanDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"stack_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the resource stack to which the execution plan belongs.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The name of the execution plan.`,
+			},
+			"stack_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The ID of the resource stack to which the execution plan belongs.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The description of the execution plan.`,
+			},
+			"template_body": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The HCL/JSON template content for deployment resources.",
+			},
+			"vars_body": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The variable content for deployment resources.",
+			},
+			"template_uri": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The OBS address where the HCL/JSON template archive (**.zip** file, which contains all " +
+					"resource **.tf.json** script files to be deployed) or **.tf.json** file is located, which " +
+					"describes the target status of the deployment resources.",
+			},
+			"vars_uri": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The OBS address where the variable (**.tfvars**) file corresponding to the HCL/JSON " +
+					"template located, which describes the target status of the deployment resources.",
+			},
+		},
+	}
+}
+
+func resourceExecutionPlanCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/stacks/{stack_name}/execution-plans"
+	)
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate RFS request ID: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{stack_name}", d.Get("stack_name").(string))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Client-Request-Id": requestId,
+			"Content-Type":      "application/json",
+			"X-Language":        "en-us",
+		},
+		JSONBody: utils.RemoveNil(buildExecutionPlanCreateBodyParams(d)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating execution plan: %s", err)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resourceId := utils.PathSearch("execution_plan_id", respBody, "").(string)
+	if resourceId == "" {
+		return diag.Errorf("unable to find the execution plan ID from the API response: %#v", respBody)
+	}
+	d.SetId(resourceId)
+
+	return resourceExecutionPlanRead(ctx, d, meta)
+}
+
+func buildExecutionPlanCreateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"execution_plan_name": d.Get("name"),
+		"stack_id":            utils.ValueIgnoreEmpty(d.Get("stack_id")),
+		"description":         utils.ValueIgnoreEmpty(d.Get("description")),
+		"template_body":       utils.ValueIgnoreEmpty(d.Get("template_body")),
+		"template_uri":        utils.ValueIgnoreEmpty(d.Get("template_uri")),
+		"vars_body":           utils.ValueIgnoreEmpty(d.Get("vars_body")),
+		"vars_uri":            utils.ValueIgnoreEmpty(d.Get("vars_uri")),
+	}
+}
+
+func resourceExecutionPlanRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceExecutionPlanDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg             = meta.(*config.Config)
+		region          = cfg.GetRegion(d)
+		httpUrl         = "v1/{project_id}/stacks/{stack_name}/execution-plans/{execution_plan_name}"
+		executionPlanId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate RFS request ID: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{stack_name}", d.Get("stack_name").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{execution_plan_name}", d.Get("name").(string))
+
+	deletetOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Client-Request-Id": requestId,
+			"Content-Type":      "application/json",
+			"X-Language":        "en-us",
+		},
+		JSONBody: map[string]interface{}{
+			"execution_plan_id": executionPlanId,
+		},
+	}
+	_, err = client.Request("DELETE", deletePath, &deletetOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting execution plan (%s)", executionPlanId))
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource to manage a execution plan under specified resource stack.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o rfs -f TestAccExecutionPlan_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rfs" -v -coverprofile="./huaweicloud/services/acceptance/rfs/rfs_coverage.cov" -coverpkg="./huaweicloud/services/rfs" -run TestAccExecutionPlan_ -timeout 360m -parallel 10
=== RUN   TestAccExecutionPlan_basic
=== PAUSE TestAccExecutionPlan_basic
=== RUN   TestAccExecutionPlan_withUri
=== PAUSE TestAccExecutionPlan_withUri
=== CONT  TestAccExecutionPlan_basic
=== CONT  TestAccExecutionPlan_withUri
--- PASS: TestAccExecutionPlan_basic (50.24s)
--- PASS: TestAccExecutionPlan_withUri (184.40s)
PASS
coverage: 32.1% of statements in ./huaweicloud/services/rfs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       184.476s        coverage: 32.1% of statements in ./huaweicloud/services/rfs
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
   ![image](https://github.com/user-attachments/assets/94f7bd55-597c-41ea-8383-915ffc57ec5a)

     bb. Related resources (parent resources) not found
  ![image](https://github.com/user-attachments/assets/d659c19d-d3a4-45a7-92cd-d0098079d4a8)
