### PR TITLE
feat(dsc): add new resource to manage DSC alarm notification

### DIFF
--- a/docs/resources/dsc_alarm_notification.md
+++ b/docs/resources/dsc_alarm_notification.md
@@ -1,0 +1,72 @@
+---
+subcategory: "Data Security Center (DSC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dsc_alarm_notification"
+description: |-
+  Manages a DSC alarm notification resource within HuaweiCloud.
+---
+
+# huaweicloud_dsc_alarm_notification
+
+Manages a DSC alarm notification resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "alarm_topic_id" {}
+variable "topic_urn" {}
+
+resource "huaweicloud_dsc_alarm_notification" "test" {
+  alarm_topic_id = var.alarm_topic_id
+  topic_urn      = var.topic_urn
+  status         = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create new resource.
+
+* `alarm_topic_id` - (Required, String, ForceNew) Specifies the alarm topic ID.
+
+  Changing this will create new resource.
+
+* `topic_urn` - (Required, String) Specifies the unique resource identifier of an SMN topic.
+
+* `status` - (Required, Int) Specifies the alarm notification status. Valid values are:
+  + `0`: Close alarm notification.
+  + `1`: Open alarm notification.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (same as `alarm_topic_id`).
+
+## Import
+
+DSC alarm notification resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_dsc_alarm_notification.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include: `status`. It is generally recommended running `terraform plan` after
+importing the resource. You can then decide if changes should be applied to the resource, or the resource
+definition should be updated to align with the cloud. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_dsc_alarm_notification" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      status,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2092,8 +2092,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_codearts_inspector_website":      codearts.ResourceInspectorWebsite(),
 			"huaweicloud_codearts_inspector_website_scan": codearts.ResourceInspectorWebsiteScan(),
 
-			"huaweicloud_dsc_instance":  dsc.ResourceDscInstance(),
-			"huaweicloud_dsc_asset_obs": dsc.ResourceAssetObs(),
+			"huaweicloud_dsc_instance":           dsc.ResourceDscInstance(),
+			"huaweicloud_dsc_asset_obs":          dsc.ResourceAssetObs(),
+			"huaweicloud_dsc_alarm_notification": dsc.ResourceAlarmNotification(),
 
 			// internal only
 			"huaweicloud_apm_aksk":                apm.ResourceApmAkSk(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -254,7 +254,8 @@ var (
 	HW_DC_VIRTUAL_INTERFACE_ID = os.Getenv("HW_DC_VIRTUAL_INTERFACE_ID")
 	HW_DC_ENABLE_FLAG          = os.Getenv("HW_DC_ENABLE_FLAG")
 
-	HW_DSC_INSTANCE_ID = os.Getenv("HW_DSC_INSTANCE_ID")
+	HW_DSC_INSTANCE_ID    = os.Getenv("HW_DSC_INSTANCE_ID")
+	HW_DSC_ALARM_TOPIC_ID = os.Getenv("HW_DSC_ALARM_TOPIC_ID")
 
 	HW_CES_START_TIME = os.Getenv("HW_CES_START_TIME")
 	HW_CES_END_TIME   = os.Getenv("HW_CES_END_TIME")
@@ -2560,6 +2561,13 @@ func TestAccPrecheckDcFlag(t *testing.T) {
 func TestAccPrecheckDscInstance(t *testing.T) {
 	if HW_DSC_INSTANCE_ID == "" {
 		t.Skip("HW_DSC_INSTANCE_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPrecheckDscAlarmTopicID(t *testing.T) {
+	if HW_DSC_ALARM_TOPIC_ID == "" {
+		t.Skip("HW_DSC_ALARM_TOPIC_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_alarm_notification_test.go
+++ b/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_alarm_notification_test.go
@@ -1,0 +1,131 @@
+package dsc
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getResourceDscAlarmNotificationFunc(cfg *config.Config, _ *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dsc", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v1/{project_id}/sdg/smn/topics"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DSC alarm notification: %s", err)
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func TestAccResourceDscAlarmNotification_basic(t *testing.T) {
+	var (
+		obj          interface{}
+		randName     = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_dsc_alarm_notification.test"
+		alarmTopicID = acceptance.HW_DSC_ALARM_TOPIC_ID
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getResourceDscAlarmNotificationFunc,
+	)
+
+	// Avoid CheckDestroy
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please create a DSC instance in advance.
+			acceptance.TestAccPrecheckDscInstance(t)
+			// Please configure the alarm topic ID into the environment variable in advance.
+			// Currently, it can only be obtained through F12 on the console.
+			acceptance.TestAccPrecheckDscAlarmTopicID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceDscAlarmNotification_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "alarm_topic_id", alarmTopicID),
+					resource.TestCheckResourceAttr(resourceName, "status", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "topic_urn",
+						"huaweicloud_smn_topic.test1", "topic_urn"),
+				),
+			},
+			{
+				Config: testResourceDscAlarmNotification_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "alarm_topic_id", alarmTopicID),
+					resource.TestCheckResourceAttr(resourceName, "status", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "topic_urn",
+						"huaweicloud_smn_topic.test2", "topic_urn"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"status"},
+			},
+		},
+	})
+}
+
+func testResourceDscAlarmNotification_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test1" {
+  name         = "smn-%[1]s-1"
+  display_name = "The display name of smn topic 1"
+}
+
+resource "huaweicloud_smn_topic" "test2" {
+  name         = "smn-%[1]s-2"
+  display_name = "The display name of smn topic 2"
+}
+`, name)
+}
+
+func testResourceDscAlarmNotification_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dsc_alarm_notification" "test" {
+  alarm_topic_id = "%[2]s"
+  status         = 0
+  topic_urn      = huaweicloud_smn_topic.test1.topic_urn
+}
+`, testResourceDscAlarmNotification_base(name), acceptance.HW_DSC_ALARM_TOPIC_ID)
+}
+
+func testResourceDscAlarmNotification_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dsc_alarm_notification" "test" {
+  alarm_topic_id = "%[2]s"
+  status         = 1
+  topic_urn      = huaweicloud_smn_topic.test2.topic_urn
+}
+`, testResourceDscAlarmNotification_base(name), acceptance.HW_DSC_ALARM_TOPIC_ID)
+}

--- a/huaweicloud/services/dsc/resource_huaweicloud_dsc_alarm_notification.go
+++ b/huaweicloud/services/dsc/resource_huaweicloud_dsc_alarm_notification.go
@@ -1,0 +1,201 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DSC PUT /v1/{project_id}/sdg/smn/topic
+// @API DSC GET /v1/{project_id}/sdg/smn/topics
+func ResourceAlarmNotification() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAlarmNotificationCreate,
+		ReadContext:   resourceAlarmNotificationRead,
+		UpdateContext: resourceAlarmNotificationUpdate,
+		DeleteContext: resourceAlarmNotificationDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"alarm_topic_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The alarm topic ID.`,
+			},
+			"topic_urn": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The unique resource identifier of an SMN topic.`,
+			},
+			"status": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The alarm notification status.`,
+			},
+		},
+	}
+}
+
+func buildConfigAlarmNotificationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"id":        d.Get("alarm_topic_id"),
+		"topic_urn": d.Get("topic_urn"),
+		"status":    d.Get("status"),
+	}
+}
+
+func updateAlarmNotification(client *golangsdk.ServiceClient, requestBody map[string]interface{}) error {
+	requestPath := client.Endpoint + "v1/{project_id}/sdg/smn/topic"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         requestBody,
+	}
+
+	resp, err := client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return err
+	}
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	status := utils.PathSearch("status", respBody, "").(string)
+	if status != "success" {
+		return fmt.Errorf("got an unexcept status (%s) in API response", status)
+	}
+	return nil
+}
+
+func resourceAlarmNotificationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dsc"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestBody := buildConfigAlarmNotificationBodyParams(d)
+	if err := updateAlarmNotification(client, requestBody); err != nil {
+		return diag.Errorf("error configuring DSC alarm notification in creation operation: %s", err)
+	}
+
+	d.SetId(d.Get("alarm_topic_id").(string))
+
+	return resourceAlarmNotificationRead(ctx, d, meta)
+}
+
+func resourceAlarmNotificationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		product = "dsc"
+		httpUrl = "v1/{project_id}/sdg/smn/topics"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DSC alarm notification: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	alarmTopicID := utils.PathSearch("id", respBody, "").(string)
+	if alarmTopicID == "" {
+		// Normally, this logic cannot be tested.
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("alarm_topic_id", alarmTopicID),
+		d.Set("topic_urn", utils.PathSearch("default_topic_urn", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceAlarmNotificationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dsc"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestBody := buildConfigAlarmNotificationBodyParams(d)
+	if err := updateAlarmNotification(client, requestBody); err != nil {
+		return diag.Errorf("error configuring DSC alarm notification in update operation: %s", err)
+	}
+
+	return resourceAlarmNotificationRead(ctx, d, meta)
+}
+
+func buildDeleteAlarmNotificationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"id":        d.Get("alarm_topic_id"),
+		"topic_urn": d.Get("topic_urn"),
+		"status":    0,
+	}
+}
+
+func resourceAlarmNotificationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dsc"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DSC client: %s", err)
+	}
+
+	requestBody := buildDeleteAlarmNotificationBodyParams(d)
+	if err := updateAlarmNotification(client, requestBody); err != nil {
+		return diag.Errorf("error disabling DSC alarm notification in deletion operation: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add new resource to manage DSC alarm notification.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/dsc' TESTARGS='-run TestAccResourceDscAlarmNotification_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dsc -v -run TestAccResourceDscAlarmNotification_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDscAlarmNotification_basic
=== PAUSE TestAccResourceDscAlarmNotification_basic
=== CONT  TestAccResourceDscAlarmNotification_basic
--- PASS: TestAccResourceDscAlarmNotification_basic (22.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       22.181s
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
