### PR TITLE
feat(lts/log_group): the log group supports enterprise_project_id

### DIFF
--- a/docs/data-sources/lts_groups.md
+++ b/docs/data-sources/lts_groups.md
@@ -44,4 +44,6 @@ The `groups` block supports:
 
 * `tags` - The key/value pairs to associate with the log group.
 
+* `enterprise_project_id` - The enterprise project ID to which the log group belongs.
+
 * `created_at` - The creation time of the log group, in RFC3339 format.

--- a/docs/resources/lts_group.md
+++ b/docs/resources/lts_group.md
@@ -24,15 +24,19 @@ resource "huaweicloud_lts_group" "test" {
 The following arguments are supported:
 
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the log group resource. If omitted, the
-  provider-level region will be used. Changing this creates a new log group resource.
+  provider-level region will be used. Changing this parameter will create a new resource.
 
-* `group_name` - (Required, String, ForceNew) Specifies the log group name. Changing this parameter will create a new
-  resource.
+* `group_name` - (Required, String, ForceNew) Specifies the log group name. Changing this parameter will create a new resource.
 
 * `ttl_in_days` - (Required, Int) Specifies the log expiration time(days).  
   The value is range from `1` to `365`.
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the log group.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the log group belongs.
+  Changing this parameter will create a new resource.  
+  This parameter is valid only when the enterprise project function is enabled, if omitted, default enterprise project
+  will be used.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_groups_test.go
+++ b/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_groups_test.go
@@ -34,6 +34,7 @@ func TestAccDataSourceGroups_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(dataSource, "groups.0.created_at",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 					resource.TestCheckOutput("is_exist_log_group", "true"),
+					resource.TestCheckOutput("is_eps_return_and_matched", "true"),
 				),
 			},
 		},
@@ -52,6 +53,15 @@ data "huaweicloud_lts_groups" "test" {
 
 output "is_exist_log_group" {
   value = contains(data.huaweicloud_lts_groups.test.groups[*].id, huaweicloud_lts_group.test.id)
+}
+
+locals {
+  eps_filter_result = [for v in data.huaweicloud_lts_groups.test.groups :
+  v.enterprise_project_id == huaweicloud_lts_group.test.enterprise_project_id if v.id == huaweicloud_lts_group.test.id]
+}
+
+output "is_eps_return_and_matched" {
+  value = length(local.eps_filter_result) > 0 && alltrue(local.eps_filter_result)
 }
 `, testAccLtsGroup_basic(name, 30))
 }

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_group_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_group_test.go
@@ -46,6 +46,13 @@ func getLtsGroupResourceFunc(cfg *config.Config, state *terraform.ResourceState)
 	return groupResult, nil
 }
 
+func getAcceptanceEpsId() string {
+	if acceptance.HW_ENTERPRISE_PROJECT_ID_TEST == "" {
+		return "0"
+	}
+	return acceptance.HW_ENTERPRISE_PROJECT_ID_TEST
+}
+
 func TestAccLtsGroup_basic(t *testing.T) {
 	var (
 		group        interface{}
@@ -68,7 +75,9 @@ func TestAccLtsGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "group_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "ttl_in_days", "30"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform")),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", getAcceptanceEpsId()),
+				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -105,15 +114,21 @@ func TestAccLtsGroup_basic(t *testing.T) {
 
 func testAccLtsGroup_basic(name string, ttl int) string {
 	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  default = "%[1]s"
+}
+
 resource "huaweicloud_lts_group" "test" {
-  group_name  = "%s"
+  group_name  = "%[2]s"
   ttl_in_days = %d
 
   tags = {
     owner = "terraform"
   }
+
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 }
-`, name, ttl)
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name, ttl)
 }
 
 func testAccLtsGroup_step3(name string, ttl int) string {

--- a/huaweicloud/services/lts/data_source_huaweicloud_lts_groups.go
+++ b/huaweicloud/services/lts/data_source_huaweicloud_lts_groups.go
@@ -54,6 +54,11 @@ func DataSourceLtsGroups() *schema.Resource {
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Description: `The key/value pairs to associate with the log group.`,
 						},
+						"enterprise_project_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The enterprise project ID to which the log group belongs.`,
+						},
 						"created_at": {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -124,8 +129,11 @@ func (w *GroupsDSWrapper) listLogGroupsToSchema(body *gjson.Result) error {
 					"id":          groups.Get("log_group_id").Value(),
 					"name":        groups.Get("log_group_name").Value(),
 					"ttl_in_days": groups.Get("ttl_in_days").Value(),
-					"tags":        w.setLogGroupsTag(groups),
-					"created_at":  w.setLogGroCreTime(groups),
+					// Using the `delete` method in the `ignoreSysEpsTag` method will change the original value,
+					// so assign a value to `enterprise_project_id` parmater before assigning a value to `tags` parmater.
+					"enterprise_project_id": groups.Get("tag._sys_enterprise_project_id").Value(),
+					"tags":                  w.setLogGroupsTag(groups),
+					"created_at":            w.setLogGroCreTime(groups),
 				}
 			},
 		)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add **enterprise_project_id** parameter for log group resource and DataSource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. the log group resource and DataSource supports enterprise_project_id parameter.
2. supports correponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/lts TESTARGS='-run TestAccLtsGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccLtsGroup -timeout 360m -parallel 4
=== RUN   TestAccLtsGroup_basic
=== PAUSE TestAccLtsGroup_basic
=== RUN   TestAccLtsGroup_withEpsId
=== PAUSE TestAccLtsGroup_withEpsId
=== CONT  TestAccLtsGroup_basic
=== CONT  TestAccLtsGroup_withEpsId
--- PASS: TestAccLtsGroup_withEpsId (36.22s)
--- PASS: TestAccLtsGroup_basic (99.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       99.278s

make testacc TEST=./huaweicloud/services/acceptance/lts TESTARGS='-run TestAccDataSourceGroups_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccDataSourceGroups_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceGroups_basic
=== PAUSE TestAccDataSourceGroups_basic
=== CONT  TestAccDataSourceGroups_basic
--- PASS: TestAccDataSourceGroups_basic (42.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       42.890s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
