### PR TITLE
feat(workspace/app): supports new nas storage resource

### DIFF
--- a/docs/resources/workspace_app_nas_storage.md
+++ b/docs/resources/workspace_app_nas_storage.md
@@ -1,0 +1,79 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_nas_storage"
+description: |-
+  Manages a NAS storage resource of Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_nas_storage
+
+Manages a NAS storage resource of Workspace APP within HuaweiCloud.
+
+## Example Usage
+
+### Create a NAS storage via SFS (3.0) file system
+
+```hcl
+variable "nas_storage_name" {}
+variable "sfs_file_system_name" {}
+
+resource "huaweicloud_workspace_app_nas_storage" "test" {
+  name = var.nas_storage_name
+
+  storage_metadata {
+    storage_handle = var.sfs_file_system_name
+    storage_class  = "sfs"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the NAS storage is located.  
+  If omitted, the provider-level region will be used. Change this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the NAS storage.  
+  The valid length is limited from `1` to `128`, and allows visible characters or spaces, but cannot be all spaces.
+  Change this parameter will create a new resource.
+
+* `storage_metadata` - (Required, List, ForceNew) Specifies the metadata of the corresponding storage.  
+  The [storage_metadata](#workspace_app_nas_storage_metadata) structure is documented below.
+
+<a name="workspace_app_nas_storage_metadata"></a>
+The `storage_metadata` block supports:
+
+* `storage_handle` - (Required, String, ForceNew) Specifies the storage name.  
+  Change this parameter will create a new resource.
+
+* `storage_class` - (Required, String, ForceNew) Specifies the storage type.  
+  The valid values are as follows:
+  + **sfs**: SFS file system with v3.0 framework.
+
+  Change this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The NAS storage ID.
+
+* `storage_metadata` - The metadata of the corresponding storage.  
+  The [storage_metadata](#workspace_app_nas_storage_metadata) structure is documented below.
+
+* `created_at` - The creation time of the NAS storage.
+
+<a name="workspace_app_nas_storage_metadata"></a>
+The `storage_metadata` block supports:
+
+* `export_location` - The storage access URL.
+
+## Import
+
+NAS storages can be imported using their `name`, e.g.
+
+```bash
+$ terraform import huaweicloud_workspace_app_nas_storage.test <name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2071,6 +2071,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_workspace_app_group_authorization": workspace.ResourceAppGroupAuthorization(),
 			"huaweicloud_workspace_app_group":               workspace.ResourceWorkspaceAppGroup(),
+			"huaweicloud_workspace_app_nas_storage":         workspace.ResourceAppNasStorage(),
 			"huaweicloud_workspace_app_policy_group":        workspace.ResourceAppPolicyGroup(),
 			"huaweicloud_workspace_app_publishment":         workspace.ResourceAppPublishment(),
 			"huaweicloud_workspace_app_server_group":        workspace.ResourceAppServerGroup(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -501,7 +501,8 @@ var (
 	HW_DMS_ROCKETMQ_INSTANCE_ID = os.Getenv("HW_DMS_ROCKETMQ_INSTANCE_ID")
 	HW_DMS_ROCKETMQ_TOPIC_NAME  = os.Getenv("HW_DMS_ROCKETMQ_TOPIC_NAME")
 
-	HW_SFS_TURBO_BACKUP_ID = os.Getenv("HW_SFS_TURBO_BACKUP_ID")
+	HW_SFS_TURBO_BACKUP_ID  = os.Getenv("HW_SFS_TURBO_BACKUP_ID")
+	HW_SFS_FILE_SYSTEM_NAME = os.Getenv("HW_SFS_FILE_SYSTEM_NAME")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -2589,6 +2590,13 @@ func TestAccPrecheckCDNAnalytics(t *testing.T) {
 func TestAccPrecheckSFSTurboBackupId(t *testing.T) {
 	if HW_SFS_TURBO_BACKUP_ID == "" {
 		t.Skip("HW_SFS_TURBO_BACKUP_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPrecheckSfsFileSystemName(t *testing.T) {
+	if HW_SFS_FILE_SYSTEM_NAME == "" {
+		t.Skip("HW_SFS_FILE_SYSTEM_NAME must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_nas_storage_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_nas_storage_test.go
@@ -1,0 +1,90 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/workspace"
+)
+
+func getAppNasStorageFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("appstream", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Workspace APP client: %s", err)
+	}
+	return workspace.GetAppNasStorageById(client, state.Primary.ID)
+}
+
+func TestAccAppNasStorage_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_workspace_app_nas_storage.test"
+		name         = acceptance.RandomAccResourceName()
+
+		appGroup interface{}
+		rc       = acceptance.InitResourceCheck(resourceName, &appGroup, getAppNasStorageFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckSfsFileSystemName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppNasStorage_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "storage_metadata.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_metadata.0.storage_handle", acceptance.HW_SFS_FILE_SYSTEM_NAME),
+					resource.TestCheckResourceAttr(resourceName, "storage_metadata.0.storage_class", "sfs"),
+					resource.TestCheckResourceAttrSet(resourceName, "storage_metadata.0.export_location"),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAppNasStorageImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccAppNasStorageImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var storageName string
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("the resource (%s) is not found in the tfstate", resourceName)
+		}
+		storageName = rs.Primary.Attributes["name"]
+		if storageName == "" {
+			return "", fmt.Errorf("the NAS storage name is missing")
+		}
+		return storageName, nil
+	}
+}
+
+func testAccAppNasStorage_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_app_nas_storage" "test" {
+  name = "%[1]s"
+
+  storage_metadata {
+    storage_handle = "%[2]s"
+    storage_class  = "sfs"
+  }
+}
+`, name, acceptance.HW_SFS_FILE_SYSTEM_NAME)
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_nas_storage.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_nas_storage.go
@@ -1,0 +1,292 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace POST /v1/{project_id}/persistent-storages
+// @API Workspace GET /v1/{project_id}/persistent-storages
+// @API Workspace DELETE /v1/{project_id}/persistent-storages/{storage_id}
+func ResourceAppNasStorage() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppNasStorageCreate,
+		ReadContext:   resourceAppNasStorageRead,
+		DeleteContext: resourceAppNasStorageDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceAppNasStorageImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the NAS storage is located.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the NAS storage.",
+			},
+			"storage_metadata": {
+				Type:        schema.TypeList,
+				Required:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Description: `The metadata of the corresponding storage.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"storage_handle": {
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+							Description: "The storage name.",
+						},
+						"storage_class": {
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+							Description: "The storage type.",
+						},
+						"export_location": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The storage access URL.",
+						},
+					},
+				},
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildAppNasStorageMetadata(metadataConfigs []interface{}) map[string]interface{} {
+	if len(metadataConfigs) < 1 {
+		return nil
+	}
+
+	metadata := metadataConfigs[0]
+	return map[string]interface{}{
+		"storage_handle": utils.PathSearch("storage_handle", metadata, nil),
+		"storage_class":  utils.PathSearch("storage_class", metadata, nil),
+	}
+}
+
+func buildAppNasStorageCreateOpts(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":             d.Get("name").(string),
+		"storage_metadata": buildAppNasStorageMetadata(d.Get("storage_metadata").([]interface{})),
+	}
+}
+
+func resourceAppNasStorageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/persistent-storages"
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildAppNasStorageCreateOpts(d)),
+	}
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating NAS storage of Workspace APP: %s", err)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	storageId := utils.PathSearch("id", respBody, "").(string)
+	if storageId == "" {
+		return diag.Errorf("unable to find the storage ID from the API response")
+	}
+	d.SetId(storageId)
+
+	return resourceAppNasStorageRead(ctx, d, meta)
+}
+
+func flattenStorageMetadata(metadata interface{}) []map[string]interface{} {
+	if metadata != nil {
+		return []map[string]interface{}{
+			{
+				"storage_handle":  utils.PathSearch("storage_handle", metadata, nil),
+				"storage_class":   utils.PathSearch("storage_class", metadata, nil),
+				"export_location": utils.PathSearch("export_location", metadata, nil),
+			},
+		}
+	}
+	return nil
+}
+
+func GetAppNasStorageById(client *golangsdk.ServiceClient, storageId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/persistent-storages?storage_id={storage_id}"
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{storage_id}", storageId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving NAS storage (%s): %s", storageId, err)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+	storageConfig := utils.PathSearch("items|[0]", respBody, nil)
+	if storageConfig == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte("the NAS storage has been removed from the Workspace APP service"),
+			},
+		}
+	}
+	return storageConfig, nil
+}
+
+func resourceAppNasStorageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		storageId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	storageConfig, err := GetAppNasStorageById(client, storageId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "NAS Storage of Workspace APP")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", storageConfig, nil)),
+		d.Set("storage_metadata", flattenStorageMetadata(utils.PathSearch("storage_metadata", storageConfig, nil))),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("create_time",
+			storageConfig, "").(string))/1000, false)),
+	)
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("unable to setting resource fields of the NAS storage: %s", err)
+	}
+	return nil
+}
+
+func resourceAppNasStorageDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		httpUrl   = "v1/{project_id}/persistent-storages/{storage_id}"
+		storageId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{storage_id}", storageId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		// Although the deletion result of the main region shows that the interface returns a 200 status code when
+		// deleting a non-existent NAS storage, in order to avoid the possible return of a 404 status code in the
+		// future, the CheckDeleted design is retained here.
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting NAS storage (%s)", storageId))
+	}
+	return nil
+}
+
+func listAppNasStorages(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/persistent-storages?limit=100"
+		listOpt = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+		offset = 0
+		result = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, fmt.Errorf("error getting list of NAS storages: %s", err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		items := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		if len(items) < 1 {
+			break
+		}
+		result = append(result, items...)
+		offset += len(items)
+	}
+
+	return result, nil
+}
+
+func resourceAppNasStorageImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		storageName = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	storages, err := listAppNasStorages(client)
+	if err != nil {
+		return nil, err
+	}
+
+	d.SetId(utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0].id", storageName), storages, "").(string))
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource support, and names 'huaweicloud_workspace_app_nas_storage‘.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Workspace APP supports new resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccAppNasStorage_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppNasStorage_basic -timeout 360m -parallel 10
=== RUN   TestAccAppNasStorage_basic
=== PAUSE TestAccAppNasStorage_basic
=== CONT  TestAccAppNasStorage_basic
--- PASS: TestAccAppNasStorage_basic (8.79s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 8.844s  coverage: 4.5% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/2cb3f0f0-06d3-4f13-916c-57ae3539c3d7)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![image](https://github.com/user-attachments/assets/6bfe2a0e-5fd1-4699-8dd8-c668e8e25236)


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
