### PR TITLE
feat(dms): support to reset message offset for rocketmq

### DIFF
--- a/docs/resources/dms_rocketmq_message_offset_reset.md
+++ b/docs/resources/dms_rocketmq_message_offset_reset.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_rocketmq_message_offset_reset"
+description: |-
+  Manages a DMS RocketMQ message offset reset resource within HuaweiCloud.
+---
+
+# huaweicloud_dms_rocketmq_message_offset_reset
+
+Manages a DMS RocketMQ message offset reset resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "group" {}
+variable "topic" {}
+
+resource "huaweicloud_dms_rocketmq_message_offset_reset" "test" {
+  instance_id = var.instance_id
+  group       = var.group
+  topic       = var.topic
+  timestamp   = 0
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the instance ID.
+  Changing this creates a new resource.
+
+* `group` - (Required, String, ForceNew) Specifies the group name.
+  Changing this creates a new resource.
+
+* `topic` - (Required, String, ForceNew) Specifies the topic name.
+  Changing this creates a new resource.
+
+* `timestamp` - (Required, String, ForceNew) Specifies the timestamp.
+  + If it is specified as **0**, reset to earliset.
+  + If it is specified as **-1**, reset to latest.
+  + If it is specified as a timestamp in milliseconds, reset to specific time.
+
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1552,11 +1552,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rabbitmq_exchange_associate":  dms.ResourceDmsRabbitmqExchangeAssociate(),
 			"huaweicloud_dms_rabbitmq_user":                dms.ResourceDmsRabbitmqUser(),
 
-			"huaweicloud_dms_rocketmq_instance":       dms.ResourceDmsRocketMQInstance(),
-			"huaweicloud_dms_rocketmq_consumer_group": dms.ResourceDmsRocketMQConsumerGroup(),
-			"huaweicloud_dms_rocketmq_topic":          dms.ResourceDmsRocketMQTopic(),
-			"huaweicloud_dms_rocketmq_user":           dms.ResourceDmsRocketMQUser(),
-			"huaweicloud_dms_rocketmq_migration_task": dms.ResourceDmsRocketmqMigrationTask(),
+			"huaweicloud_dms_rocketmq_instance":             dms.ResourceDmsRocketMQInstance(),
+			"huaweicloud_dms_rocketmq_consumer_group":       dms.ResourceDmsRocketMQConsumerGroup(),
+			"huaweicloud_dms_rocketmq_message_offset_reset": dms.ResourceDmsRocketMQMessageOffsetReset(),
+			"huaweicloud_dms_rocketmq_topic":                dms.ResourceDmsRocketMQTopic(),
+			"huaweicloud_dms_rocketmq_user":                 dms.ResourceDmsRocketMQUser(),
+			"huaweicloud_dms_rocketmq_migration_task":       dms.ResourceDmsRocketmqMigrationTask(),
 
 			"huaweicloud_dns_custom_line":             dns.ResourceDNSCustomLine(),
 			"huaweicloud_dns_ptrrecord":               dns.ResourceDNSPtrRecord(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -500,6 +500,7 @@ var (
 
 	HW_DMS_ROCKETMQ_INSTANCE_ID = os.Getenv("HW_DMS_ROCKETMQ_INSTANCE_ID")
 	HW_DMS_ROCKETMQ_TOPIC_NAME  = os.Getenv("HW_DMS_ROCKETMQ_TOPIC_NAME")
+	HW_DMS_ROCKETMQ_GROUP_NAME  = os.Getenv("HW_DMS_ROCKETMQ_GROUP_NAME")
 
 	HW_SFS_TURBO_BACKUP_ID = os.Getenv("HW_SFS_TURBO_BACKUP_ID")
 )
@@ -2484,6 +2485,13 @@ func TestAccPreCheckDMSKafkaConsumerGroupName(t *testing.T) {
 func TestAccPreCheckDMSRocketMQInstanceID(t *testing.T) {
 	if HW_DMS_ROCKETMQ_INSTANCE_ID == "" {
 		t.Skip("HW_DMS_ROCKETMQ_INSTANCE_ID must be set for DMS acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDMSRocketMQGroupName(t *testing.T) {
+	if HW_DMS_ROCKETMQ_GROUP_NAME == "" {
+		t.Skip("HW_DMS_ROCKETMQ_GROUP_NAME must be set for DMS acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_message_offset_reset_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_message_offset_reset_test.go
@@ -1,0 +1,35 @@
+package dms
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccRocketMQMessageOffsetReset_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRocketMQMessageOffsetReset_basic(),
+			},
+		},
+	})
+}
+
+func testAccRocketMQMessageOffsetReset_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_rocketmq_message_offset_reset" "test" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+  topic       = "%[3]s"
+  timestamp   = 0
+}`, acceptance.HW_DMS_ROCKETMQ_INSTANCE_ID, acceptance.HW_DMS_ROCKETMQ_GROUP_NAME, acceptance.HW_DMS_ROCKETMQ_TOPIC_NAME)
+}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_message_offset_reset.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_message_offset_reset.go
@@ -1,0 +1,108 @@
+package dms
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API RocketMQ POST /v2/{engine}/{project_id}/instances/{instance_id}/groups/{group_id}/reset-message-offset
+func ResourceDmsRocketMQMessageOffsetReset() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDmsRocketMQMessageOffsetResetCreate,
+		ReadContext:   resourceDmsRocketMQMessageOffsetResetRead,
+		DeleteContext: resourceDmsRocketMQMessageOffsetResetDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"group": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"topic": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"timestamp": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceDmsRocketMQMessageOffsetResetCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	createHttpUrl := "v2/{engine}/{project_id}/instances/{instance_id}/groups/{group_id}/reset-message-offset"
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{engine}", "reliability")
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", d.Get("instance_id").(string))
+	createPath = strings.ReplaceAll(createPath, "{group_id}", d.Get("group").(string))
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildCreateRocketMQMessageOffsetResetBodyParams(d),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error resetting RocketMQ message offset: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	return nil
+}
+
+func buildCreateRocketMQMessageOffsetResetBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"topic":     d.Get("topic"),
+		"timestamp": d.Get("timestamp"),
+	}
+	return bodyParams
+}
+
+func resourceDmsRocketMQMessageOffsetResetRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDmsRocketMQMessageOffsetResetDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to reset message offset for rocketmq

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/dms" TESTARGS="-run TestAccRocketMQMessageOffsetReset_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccRocketMQMessageOffsetReset_basic -timeout 360m -parallel 4
=== RUN   TestAccRocketMQMessageOffsetReset_basic
=== PAUSE TestAccRocketMQMessageOffsetReset_basic
=== CONT  TestAccRocketMQMessageOffsetReset_basic
--- PASS: TestAccRocketMQMessageOffsetReset_basic (15.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       15.877s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
