### PR TITLE
feat(iotda/data_backlog_policy): support data backlog policy resource

### DIFF
--- a/docs/resources/iotda_data_backlog_policy.md
+++ b/docs/resources/iotda_data_backlog_policy.md
@@ -1,0 +1,84 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_iotda_data_backlog_policy"
+description: |-
+  Manages an IoTDA data backlog policy resource within HuaweiCloud.
+---
+
+# huaweicloud_iotda_data_backlog_policy
+
+Manages an IoTDA data backlog policy resource within HuaweiCloud.
+
+-> 1. A single tenant can create up to one data backlog policy under a single IoTDA instance.
+  <br/>2. Before creating a data backlog policy, it is necessary to ensure that there is a data forwarding rule under
+  the current IoTDA instance.
+  <br/>3. After the successful creation of the data backlog policy, it will take effect for all data forwarding rules,
+  covering the default backlog size (`1` GB) and default backlog time (`1` day) of all forwarding rules.
+  <br/>4. When the maximum backlog (cache) size or backlog (cache) time is exceeded, the earliest unprocessed flow data
+  will be discarded until the backlog (cache) size and time limits are met. Please consider carefully before using a
+  data backlog policy and configuring a reasonable backlog size and time.
+
+-> Currently, data backlog policy resources are only supported on IoTDA **standard** or **enterprise** edition
+  instance. When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify
+  the IoTDA service endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  **9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "name" {}
+
+resource "huaweicloud_iotda_data_backlog_policy" "test" {
+  name  = var.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Optional, String) Specifies the name of the data backlog policy. The length must not exceed `256`, and
+  only Chinese characters, letters, numbers, and the following characters are allowed: `_?'#().,&%@!-`.
+
+* `description` - (Optional, String) Specifies the description of the data backlog policy. The length must not exceed
+  `256`, and only Chinese characters, letters, numbers, and the following characters are allowed: `_?'#().,&%@!-`.
+
+* `backlog_size` - (Optional, String) Specifies the size of data backlog in bytes. The range of valid values is integers
+  from `0` to `1,073,741,823`, defaults to `1,073,741,823` (`1` GB).
+  + When `backlog_size` is set to `0`, it means there is no backlog.
+
+* `backlog_time` - (Optional, String) Specifies the data backlog time in seconds. The range of valid values is integers
+  from `0` to `86,399`, defaults to `86,399` (`1` day).
+  + When `backlog_time` is set to `0`, it means there is no backlog.
+
+-> If both `backlog_size` and `backlog_time` dimensions are configured, the dimension that reaches the threshold first
+   shall prevail.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The data backlog policy can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_iotda_data_backlog_policy.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1743,6 +1743,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_batchtask":                iotda.ResourceBatchTask(),
 			"huaweicloud_iotda_dataforwarding_rule":      iotda.ResourceDataForwardingRule(),
 			"huaweicloud_iotda_data_flow_control_policy": iotda.ResourceDataFlowControlPolicy(),
+			"huaweicloud_iotda_data_backlog_policy":      iotda.ResourceDataBacklogPolicy(),
 			"huaweicloud_iotda_device":                   iotda.ResourceDevice(),
 			"huaweicloud_iotda_device_async_command":     iotda.ResourceDeviceAsyncCommand(),
 			"huaweicloud_iotda_device_certificate":       iotda.ResourceDeviceCertificate(),

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_data_backlog_policy_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_data_backlog_policy_test.go
@@ -1,0 +1,136 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getDataBacklogPolicyResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, WithDerivedAuth())
+	if err != nil {
+		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	return client.ShowRoutingBacklogPolicy(&model.ShowRoutingBacklogPolicyRequest{PolicyId: state.Primary.ID})
+}
+
+func TestAccDataBacklogPolicy_basic(t *testing.T) {
+	var (
+		obj   model.ShowRoutingBacklogPolicyResponse
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_iotda_data_backlog_policy.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDataBacklogPolicyResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This resource only supports standard and enterprise version IoTDA instances.
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDataBacklogPolicy_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "description_test"),
+					// The `backlog_size` field default value is `1073741823`.
+					resource.TestCheckResourceAttr(rName, "backlog_size", "1073741823"),
+					// The `backlog_time` field default value is `86399`.
+					resource.TestCheckResourceAttr(rName, "backlog_time", "86399"),
+				),
+			},
+			{
+				Config: testDataBacklogPolicy_update1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
+					resource.TestCheckResourceAttr(rName, "description", "description_update"),
+					resource.TestCheckResourceAttr(rName, "backlog_size", "100"),
+					resource.TestCheckResourceAttr(rName, "backlog_time", "100"),
+				),
+			},
+			{
+				Config: testDataBacklogPolicy_update2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
+					resource.TestCheckResourceAttr(rName, "description", "description_update"),
+					resource.TestCheckResourceAttr(rName, "backlog_size", "0"),
+					resource.TestCheckResourceAttr(rName, "backlog_time", "0"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testDataBacklogPolicy_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_iotda_data_backlog_policy" "test" {
+  # Before creating a data backlog policy, it is necessary to ensure that there is a data forwarding rule in place.
+  depends_on = [
+    huaweicloud_iotda_dataforwarding_rule.test
+  ]
+
+  name        = "%[2]s"
+  description = "description_test"
+}
+`, testDataForwardingRule_basic(name), name)
+}
+
+func testDataBacklogPolicy_update1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_iotda_data_backlog_policy" "test" {
+  depends_on = [
+    huaweicloud_iotda_dataforwarding_rule.test
+  ]
+
+  name         = "%[2]s_update"
+  description  = "description_update"
+  backlog_size = "100"
+  backlog_time = "100"
+}
+`, testDataForwardingRule_basic(name), name)
+}
+
+func testDataBacklogPolicy_update2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_iotda_data_backlog_policy" "test" {
+  depends_on = [
+    huaweicloud_iotda_dataforwarding_rule.test
+  ]
+
+  name         = "%[2]s_update"
+  description  = "description_update"
+  backlog_size = "0"
+  backlog_time = "0"
+}
+`, testDataForwardingRule_basic(name), name)
+}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_data_backlog_policy.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_data_backlog_policy.go
@@ -1,0 +1,215 @@
+package iotda
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IoTDA POST /v5/iot/{project_id}/routing-rule/backlog-policy
+// @API IoTDA GET /v5/iot/{project_id}/routing-rule/backlog-policy/{policy_id}
+// @API IoTDA PUT /v5/iot/{project_id}/routing-rule/backlog-policy/{policy_id}
+// @API IoTDA DELETE /v5/iot/{project_id}/routing-rule/backlog-policy/{policy_id}
+func ResourceDataBacklogPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDataBacklogPolicyCreate,
+		ReadContext:   resourceDataBacklogPolicyRead,
+		UpdateContext: resourceDataBacklogPolicyUpdate,
+		DeleteContext: resourceDataBacklogPolicyDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"backlog_size": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"backlog_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func convertBacklogValueToInt32(value string) *int32 {
+	if value == "0" {
+		return utils.Int32(0)
+	}
+
+	parsedValue := utils.StringToInt(&value)
+	if parsedValue != nil {
+		//nolint:gosec
+		return utils.Int32IgnoreEmpty(int32(*parsedValue))
+	}
+
+	return nil
+}
+
+func buildDataBacklogPolicyCreateParams(d *schema.ResourceData) *model.CreateRoutingBacklogPolicyRequest {
+	createOptsBody := model.AddBacklogPolicy{
+		PolicyName:  utils.StringIgnoreEmpty(d.Get("name").(string)),
+		Description: utils.StringIgnoreEmpty(d.Get("description").(string)),
+		BacklogSize: convertBacklogValueToInt32(d.Get("backlog_size").(string)),
+		BacklogTime: convertBacklogValueToInt32(d.Get("backlog_time").(string)),
+	}
+
+	return &model.CreateRoutingBacklogPolicyRequest{
+		Body: &createOptsBody,
+	}
+}
+
+func resourceDataBacklogPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+	)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	resp, err := client.CreateRoutingBacklogPolicy(buildDataBacklogPolicyCreateParams(d))
+	if err != nil {
+		return diag.Errorf("error creating IoTDA data backlog policy: %s", err)
+	}
+
+	if resp == nil || resp.PolicyId == nil {
+		return diag.Errorf("error creating IoTDA data backlog policy: ID is not found in API response")
+	}
+
+	d.SetId(*resp.PolicyId)
+
+	return resourceDataBacklogPolicyRead(ctx, d, meta)
+}
+
+func buildDataBacklogPolicyQueryParams(d *schema.ResourceData) *model.ShowRoutingBacklogPolicyRequest {
+	return &model.ShowRoutingBacklogPolicyRequest{
+		PolicyId: d.Id(),
+	}
+}
+
+func resourceDataBacklogPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+	)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	resp, err := client.ShowRoutingBacklogPolicy(buildDataBacklogPolicyQueryParams(d))
+	// When the resource does not exist, query API will return `404` error code.
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving IoTDA data backlog policy")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("name", resp.PolicyName),
+		d.Set("description", resp.Description),
+		d.Set("backlog_size", parseBacklogValueToString(resp.BacklogSize)),
+		d.Set("backlog_time", parseBacklogValueToString(resp.BacklogTime)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func parseBacklogValueToString(value *int32) string {
+	if value != nil {
+		return fmt.Sprintf("%v", *value)
+	}
+
+	return ""
+}
+
+func buildDataBacklogPolicyUpdateParams(d *schema.ResourceData) *model.UpdateRoutingBacklogPolicyRequest {
+	updateOptsBody := model.UpdateBacklogPolicy{
+		PolicyName:  utils.StringIgnoreEmpty(d.Get("name").(string)),
+		Description: utils.StringIgnoreEmpty(d.Get("description").(string)),
+		BacklogSize: convertBacklogValueToInt32(d.Get("backlog_size").(string)),
+		BacklogTime: convertBacklogValueToInt32(d.Get("backlog_time").(string)),
+	}
+
+	return &model.UpdateRoutingBacklogPolicyRequest{
+		PolicyId: d.Id(),
+		Body:     &updateOptsBody,
+	}
+}
+
+func resourceDataBacklogPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+	)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	_, err = client.UpdateRoutingBacklogPolicy(buildDataBacklogPolicyUpdateParams(d))
+	if err != nil {
+		return diag.Errorf("error updating IoTDA data backlog policy: %s", err)
+	}
+
+	return resourceDataBacklogPolicyRead(ctx, d, meta)
+}
+
+func buildDataBacklogPolicyDeleteParams(d *schema.ResourceData) *model.DeleteRoutingBacklogPolicyRequest {
+	return &model.DeleteRoutingBacklogPolicyRequest{
+		PolicyId: d.Id(),
+	}
+}
+
+func resourceDataBacklogPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+	)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	_, err = client.DeleteRoutingBacklogPolicy(buildDataBacklogPolicyDeleteParams(d))
+	// When the resource does not exist, delete API will return `404` error code.
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting IoTDA data backlog policy")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support data backlog policy resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Support data backlog policy resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ export HW_IOTDA_ACCESS_ADDRESS=xxxxxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataBacklogPolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataBacklogPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccDataBacklogPolicy_basic
--- PASS: TestAccDataBacklogPolicy_basic (27.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     27.927s

```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/d26a4fdc-89cb-4c4f-a0d6-9ae0ff5ffa4d)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/user-attachments/assets/7b64944d-2a66-41e5-b857-8df0f301afff)
