### PR TITLE
feat(cdn): domain resource supports using SCM certificate ID

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -2,7 +2,8 @@
 subcategory: "Content Delivery Network (CDN)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_cdn_domain"
-description: ""
+description: |-
+  Manages a CDN domain resource within HuaweiCloud.
 ---
 
 # huaweicloud_cdn_domain
@@ -17,7 +18,7 @@ Manages a CDN domain resource within HuaweiCloud.
 variable "domain_name" {}
 variable "origin_server" {}
 
-resource "huaweicloud_cdn_domain" "domain_1" {
+resource "huaweicloud_cdn_domain" "test" {
   name         = var.domain_name
   type         = "web"
   service_area = "mainland_china"
@@ -41,7 +42,7 @@ resource "huaweicloud_cdn_domain" "domain_1" {
 variable "domain_name" {}
 variable "origin_server" {}
 
-resource "huaweicloud_cdn_domain" "domain_1" {
+resource "huaweicloud_cdn_domain" "test" {
   name         = var.domain_name
   type         = "web"
   service_area = "mainland_china"
@@ -71,7 +72,7 @@ variable "domain_name" {}
 variable "origin_server" {}
 variable "ip_or_domain" {}
 
-resource "huaweicloud_cdn_domain" "domain_1" {
+resource "huaweicloud_cdn_domain" "test" {
   name         = var.domain_name
   type         = "web"
   service_area = "mainland_china"
@@ -204,6 +205,38 @@ resource "huaweicloud_cdn_domain" "domain_1" {
       type          = "white"
       value         = "*.common.com,192.187.2.43,www.test.top:4990"
       include_empty = false
+    }
+  }
+}
+```
+
+### Create a CDN domain with SCM certificate HTTPS configs
+
+```hcl
+variable "domain_name" {}
+variable "origin_server" {}
+variable "certificate_name" {}
+variable "scm_certificate_id" {}
+
+resource "huaweicloud_cdn_domain" "test" {
+  name         = var.domain_name
+  type         = "web"
+  service_area = "mainland_china"
+
+  sources {
+    origin      = var.origin_server
+    origin_type = "ipaddr"
+    active      = 1
+  }
+
+  configs {
+    https_settings {
+      certificate_source = 2
+      certificate_name   = var.certificate_name
+      scm_certificate_id = var.scm_certificate_id
+      certificate_type   = "server"
+      http2_enabled      = true
+      https_enabled      = true
     }
   }
 }
@@ -435,14 +468,22 @@ The `https_settings` block support:
 * `certificate_name` - (Optional, String) Specifies the certificate name. The value contains `3` to `32` characters.
   This parameter is mandatory when a certificate is configured.
 
+* `certificate_source` - (Optional, Int) Specifies the certificate source. Valid values are:
+  + `0`: Your own certificate.
+  + `2`: SCM certificate. Please enable SCM delegation authorization to access SCM service.
+
+  Defaults to `0`.
+
 * `certificate_body` - (Optional, String) Specifies the content of the certificate used by the HTTPS protocol.
   This parameter is mandatory when a certificate is configured. The value is in PEM format.
+  This field is required when `certificate_source` is set to `0`.
 
 * `private_key` - (Optional, String) Specifies the private key used by the HTTPS protocol. This parameter is mandatory
   when a certificate is configured. The value is in PEM format.
+  This field is required when `certificate_source` is set to `0`.
 
-* `certificate_source` - (Optional, Int) Specifies the certificate source. Currently, only **0** is supported, which means
-  your own certificate. Defaults to **0**.
+* `scm_certificate_id` - (Optional, String) Specifies the SCM certificate ID.
+  This field is required when `certificate_source` is set to `2`.
 
 * `certificate_type` - (Optional, String) Specifies the certificate type. Currently, only **server** is supported, which
   means international certificate. Defaults to **server**.

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -54,6 +54,11 @@ var httpsConfig = schema.Schema{
 				Optional: true,
 				Computed: true,
 			},
+			"scm_certificate_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"certificate_type": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -1314,6 +1319,7 @@ func flattenHTTPSAttributes(configResp interface{}, privateKey, certificateBody 
 		"certificate_body":     certificateBody,
 		"private_key":          privateKey,
 		"certificate_source":   httpsMap["certificate_source"],
+		"scm_certificate_id":   httpsMap["scm_certificate_id"],
 		"certificate_type":     httpsMap["certificate_type"],
 		"http2_status":         httpsMap["http2_status"],
 		"tls_version":          httpsMap["tls_version"],
@@ -1991,6 +1997,7 @@ func buildCdnDomainHTTPSOpts(rawHTTPS []interface{}) map[string]interface{} {
 		"certificate_value":    utils.ValueIgnoreEmpty(https["certificate_body"]),
 		"private_key":          utils.ValueIgnoreEmpty(https["private_key"]),
 		"certificate_source":   https["certificate_source"],
+		"scm_certificate_id":   utils.ValueIgnoreEmpty(https["scm_certificate_id"]),
 		"certificate_type":     utils.ValueIgnoreEmpty(https["certificate_type"]),
 		"http2_status":         utils.ValueIgnoreEmpty(buildCdnDomainHTTP2StatusOpts(https["http2_enabled"].(bool))),
 		"tls_version":          utils.ValueIgnoreEmpty(https["tls_version"]),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

CDN domain resource supports using SCM certificate ID.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_ -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== RUN   TestAccCdnDomain_configHttpSettings
=== PAUSE TestAccCdnDomain_configHttpSettings
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== RUN   TestAccCdnDomain_epsID_migrate
=== PAUSE TestAccCdnDomain_epsID_migrate
=== CONT  TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_epsID_migrate
=== CONT  TestAccCdnDomain_configHttpSettings
--- PASS: TestAccCdnDomain_epsID_migrate (366.29s)
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configTypeWholeSite (525.26s)
--- PASS: TestAccCdnDomain_basic (604.92s)
--- PASS: TestAccCdnDomain_configHttpSettings (771.19s)
--- PASS: TestAccCdnDomain_configs (879.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       1245.363s
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
