### PR TITLE
feat(iotda/data_backlog_policies): support data backlog policies dataSource

### DIFF
--- a/docs/data-sources/iotda_data_backlog_policies.md
+++ b/docs/data-sources/iotda_data_backlog_policies.md
@@ -1,0 +1,70 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_iotda_data_backlog_policies"
+description: |-
+  Use this data source to get the list of IoTDA data backlog policies within HuaweiCloud.
+---
+
+# huaweicloud_iotda_data_backlog_policies
+
+Use this data source to get the list of IoTDA data backlog policies within HuaweiCloud.
+
+-> Currently, data backlog policy resources are only supported on IoTDA **standard** or **enterprise** edition
+  instance. When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify
+  the IoTDA service endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  **9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "policy_name" {}
+
+data "huaweicloud_iotda_data_backlog_policies" "test" {
+  policy_name = var.policy_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data backlog policies.
+  If omitted, the provider-level region will be used.
+
+* `policy_name` - (Optional, String) Specifies the name of the data backlog policy.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `policies` - All data backlog policies that match the filter parameters.
+  The [policies](#iotda_policies) structure is documented below.
+
+<a name="iotda_policies"></a>
+The `policies` block supports:
+
+* `id` - The ID of the data backlog policy.
+
+* `name` - The name of the data backlog policy.
+
+* `description` - The description of the data backlog policy.
+
+* `backlog_size` - The size of data backlog in bytes. The range of valid values is integers from `0` to
+  `1,073,741,823` (`1` GB), `0` means no backlog.
+
+* `backlog_time` - The data backlog time in seconds. The range of valid values is integers from `0` to
+  `86,399` (`1` day), `0` means no backlog.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -863,6 +863,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_batchtasks":                 iotda.DataSourceBatchTasks(),
 			"huaweicloud_iotda_dataforwarding_rules":       iotda.DataSourceDataForwardingRules(),
 			"huaweicloud_iotda_data_flow_control_policies": iotda.DataSourceDataFlowControlPolicies(),
+			"huaweicloud_iotda_data_backlog_policies":      iotda.DataSourceDataBacklogPolicies(),
 			"huaweicloud_iotda_devices":                    iotda.DataSourceDevices(),
 			"huaweicloud_iotda_device_certificates":        iotda.DataSourceDeviceCertificates(),
 			"huaweicloud_iotda_device_groups":              iotda.DataSourceDeviceGroups(),

--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_data_backlog_policies_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_data_backlog_policies_test.go
@@ -1,0 +1,81 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDataBacklogPolicies_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_data_backlog_policies.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This resource only supports standard and enterprise version IoTDA instances.
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDataBacklogPolicies_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "policies.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.description"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.backlog_size"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.backlog_time"),
+
+					resource.TestCheckOutput("is_policy_name_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDataBacklogPolicies_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_iotda_data_backlog_policies" "test" {
+  depends_on = [
+    huaweicloud_iotda_data_backlog_policy.test,
+  ]
+}
+
+# Filter using policy_name.
+locals {
+  policy_name = data.huaweicloud_iotda_data_backlog_policies.test.policies[0].name
+}
+
+data "huaweicloud_iotda_data_backlog_policies" "policy_name_filter" {
+  policy_name = local.policy_name
+}
+
+output "is_policy_name_filter_useful" {
+  value = length(data.huaweicloud_iotda_data_backlog_policies.policy_name_filter.policies) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_data_backlog_policies.policy_name_filter.policies[*].name : v == local.policy_name]
+  )
+}
+
+# Filter using non existent name.
+data "huaweicloud_iotda_data_backlog_policies" "not_found" {
+  policy_name = "resource_not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_iotda_data_backlog_policies.not_found.policies) == 0
+}
+`, testDataBacklogPolicy_basic(name))
+}

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_data_backlog_policies.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_data_backlog_policies.go
@@ -1,0 +1,139 @@
+package iotda
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IoTDA GET /v5/iot/{project_id}/routing-rule/backlog-policy
+func DataSourceDataBacklogPolicies() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDataBacklogPoliciesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"policy_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"policies": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"backlog_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"backlog_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDataBacklogPoliciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+	)
+
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	var (
+		allPolicies []model.BacklogPolicyInfo
+		limit       = int32(50)
+		offset      int32
+	)
+
+	for {
+		listOpts := model.ListRoutingBacklogPolicyRequest{
+			PolicyName: utils.StringIgnoreEmpty(d.Get("policy_name").(string)),
+			Limit:      utils.Int32(limit),
+			Offset:     &offset,
+		}
+
+		listResp, listErr := client.ListRoutingBacklogPolicy(&listOpts)
+		if listErr != nil {
+			return diag.Errorf("error querying IoTDA data backlog policies: %s", listErr)
+		}
+
+		if listResp == nil || listResp.BacklogPolicies == nil {
+			break
+		}
+
+		if len(*listResp.BacklogPolicies) == 0 {
+			break
+		}
+
+		allPolicies = append(allPolicies, *listResp.BacklogPolicies...)
+		//nolint:gosec
+		offset += int32(len(*listResp.BacklogPolicies))
+	}
+
+	uuID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(uuID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("policies", flattenDataBacklogPolicies(allPolicies)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDataBacklogPolicies(policies []model.BacklogPolicyInfo) []interface{} {
+	if len(policies) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(policies))
+	for _, v := range policies {
+		rst = append(rst, map[string]interface{}{
+			"id":           v.PolicyId,
+			"name":         v.PolicyName,
+			"description":  v.Description,
+			"backlog_size": v.BacklogSize,
+			"backlog_time": v.BacklogTime,
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support data backlog policies dataSource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Support data backlog policies dataSource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ export HW_IOTDA_ACCESS_ADDRESS=xxxxxxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDataBacklogPolicies_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDataBacklogPolicies_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDataBacklogPolicies_basic
=== PAUSE TestAccDataSourceDataBacklogPolicies_basic
=== CONT  TestAccDataSourceDataBacklogPolicies_basic
--- PASS: TestAccDataSourceDataBacklogPolicies_basic (16.67s)
PASS

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
