### PR TITLE
feat(dms): support to get rocketmq consumers

### DIFF
--- a/docs/data-sources/dms_rocketmq_consumers.md
+++ b/docs/data-sources/dms_rocketmq_consumers.md
@@ -1,0 +1,75 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_rocketmq_consumers"
+description: |-
+  Use this data source to get the list of RocketMQ consumers.
+---
+
+# huaweicloud_dms_rocketmq_consumers
+
+Use this data source to get the list of RocketMQ consumers.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "group" {}
+
+data "huaweicloud_dms_rocketmq_consumers" "test" {
+  instance_id = var.instance_id
+  group       = var.group
+  is_detail   = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the instance ID.
+
+* `group` - (Required, String) Specifies the consumer group name.
+
+* `is_detail` - (Optional, Bool) Specifies whether to query the consumer details.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `clients` - Indicates the list of consumer subscription details.
+
+  The [clients](#clients_struct) structure is documented below.
+
+* `online` - Indicates whether the consumer group is online.
+
+* `subscription_consistency` - Indicates whether subscriptions are consistent.
+
+<a name="clients_struct"></a>
+The `clients` block supports:
+
+* `subscriptions` - Indicates the subscription list.
+
+  The [subscriptions](#clients_subscriptions_struct) structure is documented below.
+
+* `language` - Indicates the client language.
+
+* `version` - Indicates the client version.
+
+* `client_id` - Indicates the client ID.
+
+* `client_address` - Indicates the client address.
+
+<a name="clients_subscriptions_struct"></a>
+The `subscriptions` block supports:
+
+* `topic` - Indicates the name of the subscribed topic.
+
+* `type` - Indicates the subscription type. The value can be **TAG** and **SQL92**.
+
+* `expression` - Indicates the subscription tag.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -716,6 +716,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rocketmq_topics":                dms.DataSourceDmsRocketMQTopics(),
 			"huaweicloud_dms_rocketmq_users":                 dms.DataSourceDmsRocketMQUsers(),
 			"huaweicloud_dms_rocketmq_consumer_groups":       dms.DataSourceDmsRocketMQConsumerGroups(),
+			"huaweicloud_dms_rocketmq_consumers":             dms.DataSourceDmsRocketmqConsumers(),
 			"huaweicloud_dms_rocketmq_flavors":               dms.DataSourceRocketMQFlavors(),
 			"huaweicloud_dms_rocketmq_migration_tasks":       dms.DataSourceDmsRocketmqMigrationTasks(),
 			"huaweicloud_dms_rocketmq_topic_consumer_groups": dms.DataSourceDmsRocketmqTopicConsumerGroups(),

--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_rocketmq_consumers_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_rocketmq_consumers_test.go
@@ -1,0 +1,65 @@
+package dms
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDmsRocketmqConsumers_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_dms_rocketmq_consumers.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSRocketMQInstanceID(t)
+			acceptance.TestAccPreCheckDMSKafkaConsumerGroupName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDmsRocketmqConsumers_basic(true),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "clients.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "clients.0.language"),
+					resource.TestCheckResourceAttrSet(dataSource, "clients.0.version"),
+					resource.TestCheckResourceAttrSet(dataSource, "clients.0.client_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "clients.0.client_address"),
+					resource.TestCheckResourceAttrSet(dataSource, "clients.0.subscriptions.0.topic"),
+					resource.TestCheckResourceAttrSet(dataSource, "clients.0.subscriptions.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "clients.0.subscriptions.0.expression"),
+					resource.TestCheckResourceAttrSet(dataSource, "online"),
+					resource.TestCheckResourceAttrSet(dataSource, "subscription_consistency"),
+				),
+			},
+			{
+				Config: testDataSourceDmsRocketmqConsumers_basic(false),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "clients.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "clients.0.language"),
+					resource.TestCheckResourceAttrSet(dataSource, "clients.0.version"),
+					resource.TestCheckResourceAttrSet(dataSource, "clients.0.client_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "clients.0.client_address"),
+					resource.TestCheckResourceAttrSet(dataSource, "online"),
+					resource.TestCheckResourceAttrSet(dataSource, "subscription_consistency"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDmsRocketmqConsumers_basic(detail bool) string {
+	return fmt.Sprintf(`
+data "huaweicloud_dms_rocketmq_consumers" "test" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+  is_detail   = %t
+}
+`, acceptance.HW_DMS_ROCKETMQ_INSTANCE_ID, acceptance.HW_DMS_ROCKETMQ_GROUP_NAME, detail)
+}

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_message_offset_reset_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_message_offset_reset_test.go
@@ -13,6 +13,9 @@ func TestAccRocketMQMessageOffsetReset_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSRocketMQInstanceID(t)
+			acceptance.TestAccPreCheckDMSKafkaConsumerGroupName(t)
+			acceptance.TestAccPreCheckDMSRocketMQTopicName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      nil,

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_rocketmq_consumers.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_rocketmq_consumers.go
@@ -1,0 +1,204 @@
+package dms
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RocketMQ GET /v2/rocketmq/{project_id}/instances/{instance_id}/groups/{group}/clients
+func DataSourceDmsRocketmqConsumers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDmsRocketmqConsumersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the instance ID.`,
+			},
+			"group": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the consumer group name.`,
+			},
+			"is_detail": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Specifies whether to query the consumer details.`,
+			},
+			"clients": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Indicates the list of consumer subscription details.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"subscriptions": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `Indicates the subscription list.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"topic": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `Indicates the name of the subscribed topic.`,
+									},
+									"type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `Indicates the subscription type.`,
+									},
+									"expression": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `Indicates the subscription tag.`,
+									},
+								},
+							},
+						},
+						"language": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the client language.`,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the client version.`,
+						},
+						"client_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the client ID.`,
+						},
+						"client_address": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the client address.`,
+						},
+					},
+				},
+			},
+			"online": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the consumer group is online.`,
+			},
+			"subscription_consistency": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether subscriptions are consistent.`,
+			},
+		},
+	}
+}
+
+func dataSourceDmsRocketmqConsumersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	listHttpUrl := "v2/rocketmq/{project_id}/instances/{instance_id}/groups/{group}/clients"
+	listPath := client.Endpoint + listHttpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", d.Get("instance_id").(string))
+	listPath = strings.ReplaceAll(listPath, "{group}", d.Get("group").(string))
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	// pagelimit is `10`
+	listPath += fmt.Sprintf("?limit=%v", pageLimit)
+	listPath += fmt.Sprintf("&is_detail=%v", d.Get("is_detail"))
+
+	var offset int
+	var online bool
+	var subscriptionConsistency bool
+	results := make([]map[string]interface{}, 0)
+	for {
+		currentPath := listPath + fmt.Sprintf("&offset=%d", offset)
+		listResp, err := client.Request("GET", currentPath, &listOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving consumers: %s", err)
+		}
+		listRespBody, err := utils.FlattenResponse(listResp)
+		if err != nil {
+			return diag.Errorf("error flatten response: %s", err)
+		}
+
+		consumers := utils.PathSearch("clients", listRespBody, make([]interface{}, 0)).([]interface{})
+		for _, consumer := range consumers {
+			results = append(results, map[string]interface{}{
+				"language":       utils.PathSearch("language", consumer, nil),
+				"version":        utils.PathSearch("version", consumer, nil),
+				"client_id":      utils.PathSearch("client_id", consumer, nil),
+				"client_address": utils.PathSearch("client_addr", consumer, nil),
+				"subscriptions": flattenRocketMQConsumersClientSubscriptions(
+					utils.PathSearch("subscriptions", consumer, make([]interface{}, 0)).([]interface{})),
+			})
+		}
+
+		// `-1` means to the end
+		nextOffset := utils.PathSearch("next_offset", listRespBody, float64(-1)).(float64)
+		if int(nextOffset) == -1 {
+			online = utils.PathSearch("online", listRespBody, false).(bool)
+			subscriptionConsistency = utils.PathSearch("subscription_consistency", listRespBody, false).(bool)
+
+			break
+		}
+
+		offset = int(nextOffset)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("clients", results),
+		d.Set("online", online),
+		d.Set("subscription_consistency", subscriptionConsistency),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRocketMQConsumersClientSubscriptions(paramsList []interface{}) interface{} {
+	if len(paramsList) == 0 {
+		return nil
+	}
+	rst := make([]interface{}, 0, len(paramsList))
+	for _, params := range paramsList {
+		rst = append(rst, map[string]interface{}{
+			"topic":      utils.PathSearch("topic", params, nil),
+			"type":       utils.PathSearch("type", params, nil),
+			"expression": utils.PathSearch("expression", params, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to get rocketmq consumers


## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/dms" TESTARGS="-run TestAccDataSourceDmsRocketmqConsumers_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDataSourceDmsRocketmqConsumers_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDmsRocketmqConsumers_basic
=== PAUSE TestAccDataSourceDmsRocketmqConsumers_basic
=== CONT  TestAccDataSourceDmsRocketmqConsumers_basic
--- PASS: TestAccDataSourceDmsRocketmqConsumers_basic (25.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       25.254s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
