### PR TITLE
feat(dms): support to resend rocketmq dead letter messages

### DIFF
--- a/docs/resources/dms_rocketmq_dead_letter_resend.md
+++ b/docs/resources/dms_rocketmq_dead_letter_resend.md
@@ -1,0 +1,60 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_rocketmq_dead_letter_resend"
+description: |-
+  Manages a DMS RocketMQ dead letter messages resend resource within HuaweiCloud.
+---
+
+# huaweicloud_dms_rocketmq_dead_letter_resend
+
+Manages a DMS RocketMQ dead letter messages resend resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "dead_letter_topic" {}
+variable "message_id_list" {}
+
+resource "huaweicloud_dms_rocketmq_dead_letter_resend" "test" {
+  instance_id     = var.instance_id
+  topic           = var.dead_letter_topic
+  message_id_list = var.message_id_list
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the instance ID.
+  Changing this creates a new resource.
+  
+* `topic` - (Required, String, ForceNew) Specifies the dead letter topic name.
+  Changing this creates a new resource.
+
+* `message_id_list` - (Required, List, ForceNew) Specifies the message ID list.
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `resend_results` - Indicates the resend results.
+  The [resend_results](#attrblock--resend_results) structure is documented below.
+
+<a name="attrblock--resend_results"></a>
+The `resend_results` block supports:
+
+* `message_id` - Indicates the message ID.
+
+* `error_code` - Indicates the error code.
+
+* `error_message` - Indicates the error message.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1563,6 +1563,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rocketmq_instance":             dms.ResourceDmsRocketMQInstance(),
 			"huaweicloud_dms_rocketmq_consumer_group":       dms.ResourceDmsRocketMQConsumerGroup(),
 			"huaweicloud_dms_rocketmq_message_offset_reset": dms.ResourceDmsRocketMQMessageOffsetReset(),
+			"huaweicloud_dms_rocketmq_dead_letter_resend":   dms.ResourceDmsRocketMQDeadLetterResend(),
 			"huaweicloud_dms_rocketmq_topic":                dms.ResourceDmsRocketMQTopic(),
 			"huaweicloud_dms_rocketmq_user":                 dms.ResourceDmsRocketMQUser(),
 			"huaweicloud_dms_rocketmq_migration_task":       dms.ResourceDmsRocketmqMigrationTask(),

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_dead_letter_resend_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_dead_letter_resend_test.go
@@ -1,0 +1,59 @@
+package dms
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccRocketMQDeadLetterResend_basic(t *testing.T) {
+	resourceName := "huaweicloud_dms_rocketmq_dead_letter_resend.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSRocketMQInstanceID(t)
+			acceptance.TestAccPreCheckDMSRocketMQGroupName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRocketMQDeadLetterResend_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "resend_results.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "resend_results.0.message_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "resend_results.0.error_code"),
+					resource.TestCheckResourceAttrSet(resourceName, "resend_results.0.error_message"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRocketMQDeadLetterResend_basic() string {
+	currentTime := time.Now()
+	startTime := time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 0, 0, 0, 0, currentTime.Location()).UnixMilli()
+	endTime := time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 23, 59, 59, 0, currentTime.Location()).UnixMilli()
+	return fmt.Sprintf(`
+data "huaweicloud_dms_rocketmq_messages" "test" {
+  instance_id = "%[1]s"
+  topic       = urlencode("%%DLQ%%%[2]s")
+  start_time  = %[3]v
+  end_time    = %[4]v
+}
+
+locals {
+  msg_id = data.huaweicloud_dms_rocketmq_messages.test.messages.0.message_id
+}
+
+resource "huaweicloud_dms_rocketmq_dead_letter_resend" "test" {
+  instance_id     = "%[1]s"
+  topic           = "%%DLQ%%%[2]s"
+  message_id_list = [local.msg_id]
+}`, acceptance.HW_DMS_ROCKETMQ_INSTANCE_ID, acceptance.HW_DMS_ROCKETMQ_GROUP_NAME, startTime, endTime)
+}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_dead_letter_resend.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_dead_letter_resend.go
@@ -1,0 +1,160 @@
+package dms
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RocketMQ POST /v2/{engine}/{project_id}/instances/{instance_id}/messages/deadletter-resend
+func ResourceDmsRocketMQDeadLetterResend() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDmsRocketMQDeadLetterResendCreate,
+		ReadContext:   resourceDmsRocketMQDeadLetterResendRead,
+		DeleteContext: resourceDmsRocketMQDeadLetterResendDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"topic": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"message_id_list": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"resend_results": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Indicates the resend results.`,
+				Elem:        rocketMQDeadLetterResendResultsSchema(),
+			},
+		},
+	}
+}
+
+func rocketMQDeadLetterResendResultsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"message_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the message ID.`,
+			},
+			"error_code": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the error code.`,
+			},
+			"error_message": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the error message.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceDmsRocketMQDeadLetterResendCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	createHttpUrl := "v2/{engine}/{project_id}/instances/{instance_id}/messages/deadletter-resend"
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{engine}", "reliability")
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", d.Get("instance_id").(string))
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildCreateRocketMQDeadLetterResendBodyParams(d),
+	}
+
+	// 200 even failed, have to return response body
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error resending RocketMQ dead letter messages: %s", err)
+	}
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("resend_results", flattenRocketMQMessageResendResults(
+			utils.PathSearch("resend_results", createRespBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRocketMQMessageResendResults(paramsList []interface{}) interface{} {
+	if len(paramsList) == 0 {
+		return nil
+	}
+	rst := make([]interface{}, 0, len(paramsList))
+	for _, params := range paramsList {
+		rst = append(rst, map[string]interface{}{
+			"message_id":    utils.PathSearch("msg_id", params, nil),
+			"error_code":    utils.PathSearch("error_code", params, nil),
+			"error_message": utils.PathSearch("error_message", params, nil),
+		})
+	}
+	return rst
+}
+
+func buildCreateRocketMQDeadLetterResendBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"topic":       d.Get("topic"),
+		"msg_id_list": d.Get("message_id_list"),
+	}
+	return bodyParams
+}
+
+func resourceDmsRocketMQDeadLetterResendRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDmsRocketMQDeadLetterResendDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to resend rocketmq dead letter messages

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/dms" TESTARGS="-run TestAccRocketMQDeadLetterResend_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccRocketMQDeadLetterResend_basic -timeout 360m -parallel 4
=== RUN   TestAccRocketMQDeadLetterResend_basic
=== PAUSE TestAccRocketMQDeadLetterResend_basic
=== CONT  TestAccRocketMQDeadLetterResend_basic
--- PASS: TestAccRocketMQDeadLetterResend_basic (21.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       21.873s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
