### PR TITLE
feat(dbss): add new resource manages self built database bind DBSS instance

### DIFF
--- a/docs/resources/dbss_ecs_database.md
+++ b/docs/resources/dbss_ecs_database.md
@@ -1,0 +1,151 @@
+---
+subcategory: "Database Security Service (DBSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dbss_ecs_database"
+description: |-
+  Manage the resource of adding self built database to DBSS instance within HuaweiCloud.
+---
+
+# huaweicloud_dbss_ecs_database
+
+Manage the resource of adding self built database to DBSS instance within HuaweiCloud.
+
+-> Before adding the self built database to the DBSS instance, the DBSS instance `status` must be **ACTIVE**.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "name" {}
+variable "type" {}
+variable "version" {}
+variable "ip" {}
+variable "port" {}
+variable "os" {}
+
+resource "huaweicloud_dbss_ecs_database" "test" {
+  instance_id = var.instance_id
+  name        = var.name
+  type        = var.type
+  version     = var.version
+  ip          = var.ip
+  port        = var.port
+  os          = var.os
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the DBSS instance ID.
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the self built database name.
+  Changing this parameter will create a new resource.
+
+* `type` - (Required, String, ForceNew) Specifies the self built database type.
+  The valid values are as follows:
+  + **MYSQL**
+  + **ORACLE**
+  + **POSTGRESQL**
+  + **SQLSERVER**
+  + **DAMENG**
+  + **TAURUS**
+  + **DWS**
+  + **KINGBASE**
+  + **GAUSSDBOPENGAUSS**
+  + **GREENPLUM**
+  + **HIGHGO**
+  + **SHENTONG**
+  + **GBASE8A**
+  + **GBASE8S**
+  + **GBASEXDM**
+  + **MONGODB**
+  + **DDS**
+
+  Changing this parameter will create a new resource.
+
+* `version` - (Required, String, ForceNew) Specifies the self built database version.
+  Changing this parameter will create a new resource.
+
+* `ip` - (Required, String, ForceNew) Specifies the self built database IP address.
+  Changing this parameter will create a new resource.
+
+* `port` - (Required, String, ForceNew) Specifies the self built database port.
+  Changing this parameter will create a new resource.
+
+* `os` - (Required, String, ForceNew) Specifies the self built database operation system.
+  The valid values are as follows:
+  + **LINUX64**
+  + **WINDOWS64**
+  + **UNIX**
+
+  Changing this parameter will create a new resource.
+
+* `charset` - (Optional, String, ForceNew) Specifies the self built database character set.
+  The value can be **GBK** or **UTF8**. Defaults to **UTF8**
+
+  Changing this parameter will create a new resource.
+
+* `instance_name` - (Optional, String, ForceNew) Specifies the self built database instance name.
+  Changing this parameter will create a new resource.
+
+* `status` - (Optional, String) Specifies the audit status of the self built database.
+  The valid values are as follows:
+  + **ON**
+  + **OFF**
+
+  After a self built database is associated with the DBSS instance, the audit status is **OFF** by default.
+
+* `lts_audit_switch` - (Optional, Int) Specifies whether to disable LTS audit.
+  The valid values are as follows:
+  + `1`: Indicates disable.
+  + `0`: Remain unchanged. (In this case, the value can also be an integer other than `1`).
+
+  -> This parameter is used in the DWS database scenario. If you do not need to close it,
+    there is no need to set this field.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `audit_status` - The database running status.
+  The value can be **ACTIVE**, **SHUTOFF** or **ERROR**.
+
+* `agent_url` - The unique ID of the agent.
+
+* `db_classification` - The classification of the database.
+
+## Import
+
+The resource can be imported using the related `instance_id` and their `id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_dbss_ecs_database.test <instance_id>/<id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response.
+The missing attributes include: `lts_audit_switch`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the instance, or the resource definition should be updated to align
+with the instance. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_dbss_ecs_database" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      lts_audit_switch,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1461,6 +1461,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_css_logstash_custom_template":    css.ResourceLogstashCustomTemplate(),
 
 			"huaweicloud_dbss_audit_risk_rule_action": dbss.ResourceRiskRuleAction(),
+			"huaweicloud_dbss_ecs_database":           dbss.ResourceAddEcsDatabase(),
 			"huaweicloud_dbss_instance":               dbss.ResourceInstance(),
 			"huaweicloud_dbss_rds_database":           dbss.ResourceAddRdsDatabase(),
 

--- a/huaweicloud/services/acceptance/dbss/resource_huaweicloud_dbss_ecs_database_test.go
+++ b/huaweicloud/services/acceptance/dbss/resource_huaweicloud_dbss_ecs_database_test.go
@@ -1,0 +1,134 @@
+package dbss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dbss"
+)
+
+func getAddEcsDatabaseFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("dbss", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DBSS client: %s", err)
+	}
+	return dbss.GetDatabases(client, state.Primary.Attributes["instance_id"], state.Primary.ID)
+}
+
+func TestAccAddEcsDatabase_basic(t *testing.T) {
+	var (
+		addEcsDatabase interface{}
+		rName          = "huaweicloud_dbss_ecs_database.test"
+		name           = acceptance.RandomAccResourceName()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&addEcsDatabase,
+		getAddEcsDatabaseFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAddEcsDatabase_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id", "huaweicloud_dbss_instance.test", "instance_id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "type", "MYSQL"),
+					resource.TestCheckResourceAttr(rName, "version", "8"),
+					resource.TestCheckResourceAttr(rName, "ip", "192.168.0.88"),
+					resource.TestCheckResourceAttr(rName, "port", "3306"),
+					resource.TestCheckResourceAttr(rName, "os", "LINUX64"),
+					resource.TestCheckResourceAttr(rName, "charset", "UTF8"),
+					resource.TestCheckResourceAttr(rName, "instance_name", name),
+					resource.TestCheckResourceAttr(rName, "status", "ON"),
+					resource.TestCheckResourceAttrSet(rName, "db_classification"),
+				),
+			},
+			{
+				Config: testAccAddEcsDatabase_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "status", "OFF"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"lts_audit_switch",
+				},
+				ImportStateIdFunc: testAccAddEcsDatabaseImportState(rName),
+			},
+		},
+	})
+}
+
+func testAccAddEcsDatabase_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dbss_ecs_database" "test" {
+  instance_id   = huaweicloud_dbss_instance.test.instance_id
+  name          = "%[2]s"
+  type          = "MYSQL"
+  version       = "8"
+  ip            = "192.168.0.88"
+  port          = "3306"
+  os            = "LINUX64"
+  charset       = "UTF8"
+  instance_name = "%[2]s"
+  status        = "ON"
+}
+`, testInstance_basic(name), name)
+}
+
+func testAccAddEcsDatabase_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dbss_ecs_database" "test" {
+  instance_id   = huaweicloud_dbss_instance.test.instance_id
+  name          = "%[2]s"
+  type          = "MYSQL"
+  version       = "8"
+  ip            = "192.168.0.88"
+  port          = "3306"
+  os            = "LINUX64"
+  charset       = "UTF8"
+  instance_name = "%[2]s"
+  status        = "OFF"
+}
+`, testInstance_basic(name), name)
+}
+
+func testAccAddEcsDatabaseImportState(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var instanceId, databaseId string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", rName)
+		}
+
+		instanceId = rs.Primary.Attributes["instance_id"]
+		databaseId = rs.Primary.ID
+		if instanceId == "" || databaseId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<id>', but got '%s/%s'",
+				instanceId, databaseId)
+		}
+		return fmt.Sprintf("%s/%s", instanceId, databaseId), nil
+	}
+}

--- a/huaweicloud/services/dbss/resource_huaweicloud_dbss_ecs_database.go
+++ b/huaweicloud/services/dbss/resource_huaweicloud_dbss_ecs_database.go
@@ -1,0 +1,334 @@
+package dbss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DBSS POST /v1/{project_id}/{instance_id}/audit/databases
+// @API DBSS GET /v1/{project_id}/{instance_id}/dbss/audit/databases
+// @API DBSS POST /v2/{project_id}/{instance_id}/audit/databases/switch
+// @API DBSS DELETE /v2/{project_id}/{instance_id}/audit/databases/{db_id}
+func ResourceAddEcsDatabase() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAddEcsDatabaseCreate,
+		ReadContext:   resourceAddEcsDatabaseRead,
+		UpdateContext: resourceAddEcsDatabaseUpdate,
+		DeleteContext: resourceAddEcsDatabaseDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceAddEcsDatabaseImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ip": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"port": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"os": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"charset": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"lts_audit_switch": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"audit_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"agent_url": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"db_classification": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAddEcsDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	httpUrl := "v1/{project_id}/{instance_id}/audit/databases"
+	client, err := cfg.NewServiceClient("dbss", region)
+	if err != nil {
+		return diag.Errorf("error creating DBSS client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildAddEcsDatabaseParams(d),
+	}
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error adding self built database to the DBSS instance: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resourceId := utils.PathSearch("id", respBody, "").(string)
+	if resourceId == "" {
+		return diag.Errorf("error adding self built database to the DBSS instance: ID is not found in API response")
+	}
+
+	d.SetId(resourceId)
+
+	status := d.Get("status").(string)
+	if status == "ON" {
+		err = updateDatabaseAuditStatus(client, d, instanceId)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceAddEcsDatabaseRead(ctx, d, meta)
+}
+
+func buildAddEcsDatabaseParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"database": map[string]interface{}{
+			"db_classification": "ECS",
+			"name":              d.Get("name"),
+			"type":              d.Get("type"),
+			"version":           d.Get("version"),
+			"ip":                d.Get("ip"),
+			"port":              d.Get("port"),
+			"os":                d.Get("os"),
+			"charset":           utils.ValueIgnoreEmpty(d.Get("charset")),
+			"instance_name":     utils.ValueIgnoreEmpty(d.Get("instance_name")),
+		},
+	}
+
+	return params
+}
+
+func resourceAddEcsDatabaseRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dbss", region)
+	if err != nil {
+		return diag.Errorf("error creating DBSS client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	databaseInfo, err := GetDatabases(client, instanceId, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DBSS audit databases")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("instance_id", instanceId),
+		d.Set("name", utils.PathSearch("database.name", databaseInfo, nil)),
+		d.Set("type", utils.PathSearch("database.type", databaseInfo, nil)),
+		d.Set("version", utils.PathSearch("database.version", databaseInfo, nil)),
+		d.Set("ip", utils.PathSearch("database.ip", databaseInfo, nil)),
+		d.Set("port", utils.PathSearch("database.port", databaseInfo, nil)),
+		d.Set("os", utils.PathSearch("database.os", databaseInfo, nil)),
+		d.Set("status", utils.PathSearch("database.status", databaseInfo, nil)),
+		d.Set("charset", utils.PathSearch("database.charset", databaseInfo, nil)),
+		d.Set("instance_name", utils.PathSearch("database.instance_name", databaseInfo, nil)),
+		d.Set("audit_status", utils.PathSearch("database.audit_status", databaseInfo, nil)),
+		d.Set("agent_url", utils.PathSearch("database.agent_url", databaseInfo, nil)),
+		d.Set("db_classification", utils.PathSearch("database.db_classification", databaseInfo, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func GetDatabases(client *golangsdk.ServiceClient, instanceId, databaseId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/{instance_id}/dbss/audit/databases?limit=100"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	offset := 0
+	for {
+		getPathWithOffset := fmt.Sprintf("%s&offset=%d", getPath, offset)
+		resp, err := client.Request("GET", getPathWithOffset, &getOpts)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		databaseList := utils.PathSearch("databases", respBody, make([]interface{}, 0)).([]interface{})
+		if len(databaseList) == 0 {
+			break
+		}
+
+		database := utils.PathSearch(fmt.Sprintf("[?database.id=='%s']|[0]", databaseId), databaseList, nil)
+		if database != nil {
+			return database, nil
+		}
+		offset += len(databaseList)
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func updateDatabaseAuditStatus(client *golangsdk.ServiceClient, d *schema.ResourceData, instanceId string) error {
+	httpUrl := "v2/{project_id}/{instance_id}/audit/databases/switch"
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{instance_id}", instanceId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildAuditStatusBodyParams(d),
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return fmt.Errorf("error updating the database audit status: %s", err)
+	}
+
+	return nil
+}
+
+func buildAuditStatusBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"id":               d.Id(),
+		"status":           d.Get("status"),
+		"lts_audit_switch": utils.ValueIgnoreEmpty(d.Get("lts_audit_switch")),
+	}
+
+	return params
+}
+
+func resourceAddEcsDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dbss", region)
+	if err != nil {
+		return diag.Errorf("error creating DBSS client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+
+	if d.HasChanges("status", "lts_audit_switch") {
+		err := updateDatabaseAuditStatus(client, d, instanceId)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceAddEcsDatabaseRead(ctx, d, meta)
+}
+
+func resourceAddEcsDatabaseDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("dbss", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DBSS client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+
+	httpUrl := "v2/{project_id}/{instance_id}/audit/databases/{db_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceId)
+	deletePath = strings.ReplaceAll(deletePath, "{db_id}", d.Id())
+
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	_, err = client.Request("DELETE", deletePath, &deleteOpts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error removing the self built database from the DBSS instance")
+	}
+	return nil
+}
+
+func resourceAddEcsDatabaseImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<id>', but got '%s'",
+			importedId)
+	}
+	d.SetId(parts[1])
+
+	mErr := multierror.Append(nil,
+		d.Set("instance_id", parts[0]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource manages self built database bind DBSS instance

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support new resource manages self built database bind DBSS instance
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dbss" TESTARGS="-run TestAccAddEcsDatabase_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dbss -v -run TestAccAddEcsDatabase_basic -timeout 360m -parallel 4
=== RUN   TestAccAddEcsDatabase_basic
=== PAUSE TestAccAddEcsDatabase_basic
=== CONT  TestAccAddEcsDatabase_basic
--- PASS: TestAccAddEcsDatabase_basic (860.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dbss      860.355s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/5b7f60da-47f3-4399-a9d0-72748ac6eceb)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/4aaf1a89-7dae-4975-9be5-d0f9ca794c54)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
