### PR TITLE
feat(workspace/app): add new resource for custom storage permission policy

### DIFF
--- a/docs/resources/workspace_app_storage_policy.md
+++ b/docs/resources/workspace_app_storage_policy.md
@@ -1,0 +1,73 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_storage_policy"
+description: |-
+  Manages the custom storage permission policy of Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_storage_policy
+
+Manages the custom storage permission policy of Workspace APP within HuaweiCloud.
+
+-> **NOTE:** Deleting this resource will not initialize (restore) the permission policy configuration and just only
+   remove the tfstate record for this resource.
+
+## Example Usage
+
+### Read and write for server permission and allow upload and download permissions for client
+
+```hcl
+resource "huaweicloud_workspace_app_storage_policy" "test" {
+  server_actions = ["GetObject", "PutObject", "DeleteObject"]
+  client_actions = ["PutObject", "DeleteObject"]
+}
+```
+
+### Read-Only for server permission and deny upload and download permissions for client
+
+```hcl
+resource "huaweicloud_workspace_app_storage_policy" "test" {
+  server_actions = ["GetObject"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the custom storage permission policy is located.  
+  If omitted, the provider-level region will be used. Change this parameter will create a new resource.
+
+* `server_actions` - (Required, List) Specifies the collection of permissions that server can use to access storage.  
+  The valid configuration combinations are as follows:
+  + **GetObject**: Read-Only.
+  + **PutObject + GetObject + DeleteObject**: Read and Write.
+
+* `client_actions` - (Optional, List) Specifies the collection of permissions that client can use to access storage.  
+  The valid values are as follows:
+  + **GetObject**: Download permission only.
+  + **PutObject + DeleteObject**: Upload permission only.
+  + **GetObject + PutObject + DeleteObject**: Both download and upload permissions are allowed.
+
+  If omitted, both download and upload permissions are denied.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+Custom storage permission policy can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_workspace_app_storage_policy.test <id>
+```
+
+'NA' or other characters can be used to instead of the `id`.
+
+```bash
+$ terraform import huaweicloud_workspace_app_storage_policy.test NA
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2110,6 +2110,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_publishment":         workspace.ResourceAppPublishment(),
 			"huaweicloud_workspace_app_server_group":        workspace.ResourceAppServerGroup(),
 			"huaweicloud_workspace_app_server":              workspace.ResourceAppServer(),
+			"huaweicloud_workspace_app_storage_policy":      workspace.ResourceAppStoragePolicy(),
 			"huaweicloud_workspace_app_warehouse_app":       workspace.ResourceWarehouseApplication(),
 			"huaweicloud_workspace_user_group":              workspace.ResourceUserGroup(),
 			"huaweicloud_workspace_access_policy":           workspace.ResourceAccessPolicy(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_storage_policy_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_storage_policy_test.go
@@ -1,0 +1,124 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/workspace"
+)
+
+func getAppCustomStoragePolicyFunc(cfg *config.Config, _ *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("appstream", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Workspace APP client: %s", err)
+	}
+	return workspace.GetAppCustomStoragePolicy(client)
+}
+
+func TestAccAppStoragePolicy_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_workspace_app_storage_policy.test"
+
+		policy interface{}
+		rc     = acceptance.InitResourceCheck(resourceName, &policy, getAppCustomStoragePolicyFunc)
+	)
+
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppStoragePolicy_basic_step1,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "server_actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server_actions.0", "GetObject"),
+					resource.TestCheckResourceAttr(resourceName, "client_actions.#", "0"),
+				),
+			},
+			{
+				Config: testAccAppStoragePolicy_basic_step2,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "server_actions.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "client_actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_actions.0", "GetObject"),
+				),
+			},
+			{
+				Config: testAccAppStoragePolicy_basic_step3,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "server_actions.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "client_actions.#", "2"),
+				),
+			},
+			{
+				Config: testAccAppStoragePolicy_basic_step4,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "server_actions.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "client_actions.#", "3"),
+				),
+			},
+			// Import by ID.
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Import by other characters.
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAppCustomImportStateIdFunc(resourceName, "NA"),
+			},
+		},
+	})
+}
+
+func testAccAppCustomImportStateIdFunc(resourceName, customId string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		_, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("the resource (%s) is not found in the tfstate", resourceName)
+		}
+		return customId, nil
+	}
+}
+
+const testAccAppStoragePolicy_basic_step1 string = `
+resource "huaweicloud_workspace_app_storage_policy" "test" {
+  server_actions = ["GetObject"]
+}
+`
+
+const testAccAppStoragePolicy_basic_step2 string = `
+resource "huaweicloud_workspace_app_storage_policy" "test" {
+  server_actions = ["GetObject", "PutObject", "DeleteObject"]
+  client_actions = ["GetObject"]
+}
+`
+
+const testAccAppStoragePolicy_basic_step3 string = `
+resource "huaweicloud_workspace_app_storage_policy" "test" {
+  server_actions = ["GetObject", "PutObject", "DeleteObject"]
+  client_actions = ["PutObject", "DeleteObject"]
+}
+`
+
+const testAccAppStoragePolicy_basic_step4 string = `
+resource "huaweicloud_workspace_app_storage_policy" "test" {
+  server_actions = ["GetObject", "PutObject", "DeleteObject"]
+  client_actions = ["GetObject", "PutObject", "DeleteObject"]
+}
+`

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_storage_policy.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_storage_policy.go
@@ -1,0 +1,248 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace PUT /v1/{project_id}/storages-policy/actions/create-statements
+// @API Workspace GET /v1/{project_id}/storages-policy/actions/list-statements
+func ResourceAppStoragePolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppStoragePolicyCreate,
+		ReadContext:   resourceAppStoragePolicyRead,
+		UpdateContext: resourceAppStoragePolicyUpdate,
+		DeleteContext: resourceAppStoragePolicyDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceAppStoragePolicyImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the custom storage permission policy is located.",
+			},
+			"server_actions": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The collection of permissions that server can use to access storage.",
+			},
+			"client_actions": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The collection of permissions that client can use to access storage.",
+			},
+		},
+	}
+}
+
+func buildAppStoragePolicyCreateOpts(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"roam_actions": d.Get("server_actions").(*schema.Set).List(),
+		"actions":      d.Get("client_actions").(*schema.Set).List(),
+	}
+}
+
+func updateAppStoragePolicy(client *golangsdk.ServiceClient, d *schema.ResourceData) (string, error) {
+	httpUrl := "v1/{project_id}/storages-policy/actions/create-statements"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildAppStoragePolicyCreateOpts(d)),
+	}
+
+	requestResp, err := client.Request("PUT", createPath, &createOpt)
+	if err != nil {
+		return "", err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return "", err
+	}
+
+	policyId := utils.PathSearch("policy_statement_id", respBody, "").(string)
+	if policyId == "" {
+		return "", fmt.Errorf("unable to find the custom storage permission policy ID from the API response")
+	}
+	return policyId, nil
+}
+
+func resourceAppStoragePolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	policyId, err := updateAppStoragePolicy(client, d)
+	if err != nil {
+		return diag.Errorf("error creating custom storage permission policy of Workspace APP: %s", err)
+	}
+	d.SetId(policyId)
+
+	return resourceAppStoragePolicyRead(ctx, d, meta)
+}
+
+func listAppStoragePermissionPolicies(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/storages-policy/actions/list-statements?limit=100"
+		listOpt = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+		offset = 0
+		result = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, fmt.Errorf("error getting list of storage permission policies: %s", err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		items := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		if len(items) < 1 {
+			break
+		}
+		result = append(result, items...)
+		offset += len(items)
+	}
+	return result, nil
+}
+
+func GetAppCustomStoragePolicy(client *golangsdk.ServiceClient) (interface{}, error) {
+	policies, err := listAppStoragePermissionPolicies(client)
+	if err != nil {
+		return nil, err
+	}
+	policy := utils.PathSearch("[?!(contains(policy_statement_id, 'DEFAULT'))]|[0]", policies, nil)
+	if policy == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte("the custom storage permission policy has been removed from the Workspace APP service"),
+			},
+		}
+	}
+	return policy, nil
+}
+
+func resourceAppStoragePolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	policy, err := GetAppCustomStoragePolicy(client)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "Custom storage permission policy of Workspace APP")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("server_actions", utils.PathSearch("roam_actions", policy, nil)),
+		d.Set("client_actions", utils.PathSearch("actions", policy, nil)),
+	)
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("unable to setting resource fields of the custom storage permission policy: %s", err)
+	}
+	return nil
+}
+
+func resourceAppStoragePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	_, err = updateAppStoragePolicy(client, d)
+	if err != nil {
+		return diag.Errorf("error updating custom storage permission policy of Workspace APP: %s", err)
+	}
+
+	return resourceAppStoragePolicyRead(ctx, d, meta)
+}
+
+func resourceAppStoragePolicyDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `Deleting this resource will not initialize (restore) the policy configuration and just only remove the
+tfstate record for this resource.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}
+
+func resourceAppStoragePolicyImportState(_ context.Context, d *schema.ResourceData,
+	meta interface{}) ([]*schema.ResourceData, error) {
+	var (
+		re       = regexp.MustCompile(`^\d{18}$`)
+		importId = d.Id()
+		policyId string
+	)
+	if re.MatchString(importId) {
+		// The imported ID is custom storage permission ID.
+		policyId = importId
+	} else {
+		var (
+			cfg    = meta.(*config.Config)
+			region = cfg.GetRegion(d)
+		)
+		client, err := cfg.NewServiceClient("appstream", region)
+		if err != nil {
+			return nil, fmt.Errorf("error creating Workspace APP client: %s", err)
+		}
+
+		// Refresh the resource ID using field value of attribute 'policy_statement_id'.
+		policy, err := GetAppCustomStoragePolicy(client)
+		if err != nil {
+			return nil, err
+		}
+		policyId = utils.PathSearch("policy_statement_id", policy, "").(string)
+		if policyId == "" {
+			return nil, fmt.Errorf("unable to find the custom storage permission policy ID from the API response")
+		}
+	}
+
+	d.SetId(policyId)
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource to manage custom storage permission policy of Workspace APP.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource for custom storage permission policy.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccAppStoragePolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppStoragePolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccAppStoragePolicy_basic
=== PAUSE TestAccAppStoragePolicy_basic
=== CONT  TestAccAppStoragePolicy_basic
--- PASS: TestAccAppStoragePolicy_basic (35.93s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 35.980s coverage: 4.7% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
