### PR TITLE
feat(worksapce/app): add new resource for personal folder assignment

### DIFF
--- a/docs/resources/workspace_app_nas_storage.md
+++ b/docs/resources/workspace_app_nas_storage.md
@@ -72,7 +72,13 @@ The `storage_metadata` block supports:
 
 ## Import
 
-NAS storages can be imported using their `name`, e.g.
+NAS storages can be imported using their `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_workspace_app_nas_storage.test <id>
+```
+
+If the NAS storage ID is unknow, the NAS storage name can be used as an alternative to ID.  
 
 ```bash
 $ terraform import huaweicloud_workspace_app_nas_storage.test <name>

--- a/docs/resources/workspace_app_personal_folders.md
+++ b/docs/resources/workspace_app_personal_folders.md
@@ -1,0 +1,84 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_personal_folders"
+description: |-
+  Using this resource to assign or manages the personal folders under NAS storage of Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_personal_folders
+
+Using this resource to assign or manages the personal folders under NAS storage of Workspace APP within HuaweiCloud.
+
+## Example Usage
+
+### Create a personal folder for each user with the same permission policy
+
+```hcl
+variable "workspace_app_nas_storage_id" {}
+variable "workspace_app_storage_policy_id" {}
+variable "workspace_user_names" {
+  type = list(string)
+}
+
+resource "huaweicloud_workspace_app_personal_folders" "test" {
+  storage_id = var.workspace_app_nas_storage_id
+
+  dynamic "assignments" {
+    for_each = var.workspace_user_names
+
+    content {
+      policy_statement_id = var.workspace_app_storage_policy_id
+      attach              = assignments.value
+      attach_type         = "USER"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the personal folders are located.  
+  If omitted, the provider-level region will be used. Change this parameter will create a new resource.
+
+* `storage_id` - (Required, String, ForceNew) Specifies the NAS storage ID to which the personal folders belong.  
+  Change this parameter will create a new resource.
+
+* `assignments` - (Required, List, ForceNew) Specifies the assignment configuration of personal folders.  
+  The [assignments](#workspace_app_personal_folder_assignment) structure is documented below.
+
+<a name="workspace_app_personal_folder_assignment"></a>
+The `assignments` block supports:
+
+* `policy_statement_id` - (Required, String, ForceNew) Specifies the ID of the storage permission policy.  
+  Change this parameter will create a new resource.
+
+* `attach` - (Required, String, ForceNew) Specifies the object name of personal folder assignment.  
+  Change this parameter will create a new resource.
+
+* `attach_type` - (Optional, String, ForceNew) Specifies the type of personal folder assignment.  
+  The valid value is **USER** (also default value).  
+  Change this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also `storage_id`.
+
+## Import
+
+Personal folders can be imported using resource `id`, also ID of NAS storage to which personal folders belong, e.g.
+
+```bash
+$ terraform import huaweicloud_workspace_app_personal_folders.test <id>
+```
+
+If the NAS storage ID is unknow, the NAS storage name can be used as an alternative to ID.  
+The NAS storage name can be obtained through the console or data source (`huaweicloud_workspace_app_nas_storages`).
+
+```bash
+$ terraform import huaweicloud_workspace_app_personal_folders.test <storage_name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2106,6 +2106,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_group":               workspace.ResourceWorkspaceAppGroup(),
 			"huaweicloud_workspace_app_image_server":        workspace.ResourceAppImageServer(),
 			"huaweicloud_workspace_app_nas_storage":         workspace.ResourceAppNasStorage(),
+			"huaweicloud_workspace_app_personal_folders":    workspace.ResourceAppPersonalFolders(),
 			"huaweicloud_workspace_app_policy_group":        workspace.ResourceAppPolicyGroup(),
 			"huaweicloud_workspace_app_publishment":         workspace.ResourceAppPublishment(),
 			"huaweicloud_workspace_app_server_group":        workspace.ResourceAppServerGroup(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_nas_storage_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_nas_storage_test.go
@@ -51,6 +51,13 @@ func TestAccAppNasStorage_basic(t *testing.T) {
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
+			// Import by ID.
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Import by name.
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_personal_folders_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_personal_folders_test.go
@@ -1,0 +1,111 @@
+package workspace
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/workspace"
+)
+
+func getAppPersonalFoldersFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("appstream", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Workspace APP client: %s", err)
+	}
+	assignments, err := workspace.ListAppPersonalFolders(client, state.Primary.ID)
+	if len(assignments) < 1 {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte("All personal folders have been removed from the Workspace APP service"),
+			},
+		}
+	}
+	return assignments, err
+}
+
+func TestAccAppPersonalFolders_basic(t *testing.T) {
+	var (
+		resourceName        = "huaweicloud_workspace_app_personal_folders.test"
+		storageResourceName = "huaweicloud_workspace_app_nas_storage.test"
+		name                = acceptance.RandomAccResourceName()
+
+		personalFolders interface{}
+		rc              = acceptance.InitResourceCheck(resourceName, &personalFolders, getAppPersonalFoldersFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckSfsFileSystemName(t)
+			acceptance.TestAccPrecheckWorkspaceUserNames(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppPersonalFolders_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "storage_id",
+						"huaweicloud_workspace_app_nas_storage.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "assignments.#",
+						strconv.Itoa(len(strings.Split(acceptance.HW_WORKSPACE_USER_NAMES, ",")))),
+				),
+			},
+			// Import by ID (also NAS storage ID).
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Import by NAS storage name.
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAppNasStorageImportStateIdFunc(storageResourceName),
+			},
+		},
+	})
+}
+
+func testAccAppPersonalFolders_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_app_nas_storage" "test" {
+  name = "%[1]s"
+
+  storage_metadata {
+    storage_handle = "%[2]s"
+    storage_class  = "sfs"
+  }
+}
+
+resource "huaweicloud_workspace_app_storage_policy" "test" {
+  server_actions = ["GetObject", "PutObject", "DeleteObject"]
+  client_actions = ["GetObject", "PutObject", "DeleteObject"]
+}
+
+resource "huaweicloud_workspace_app_personal_folders" "test" {
+  storage_id = huaweicloud_workspace_app_nas_storage.test.id
+
+  dynamic "assignments" {
+    for_each = split(",", "%[3]s")
+
+    content {
+      policy_statement_id = huaweicloud_workspace_app_storage_policy.test.id
+      attach              = assignments.value
+      attach_type         = "USER"
+    }
+  }
+}
+`, name, acceptance.HW_SFS_FILE_SYSTEM_NAME, acceptance.HW_WORKSPACE_USER_NAMES)
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_personal_folders.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_personal_folders.go
@@ -1,0 +1,294 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace POST /v1/{project_id}/persistent-storages/{storage_id}/actions/assign-folder
+// @API Workspace GET /v1/{project_id}/persistent-storages/actions/list-attachments
+// @API Workspace POST /v1/{project_id}/persistent-storages/{storage_id}/actions/delete-user-attachment
+func ResourceAppPersonalFolders() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppPersonalFoldersCreate,
+		ReadContext:   resourceAppPersonalFoldersRead,
+		DeleteContext: resourceAppPersonalFoldersDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceAppPersonalFolderImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the personal folders are located.",
+			},
+			"storage_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The NAS storage ID to which the personal folders belong.",
+			},
+			"assignments": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"policy_statement_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+							Description: "The ID of the storage permission policy.",
+						},
+						"attach": {
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+							Description: "The object name of personal folder assignment.",
+						},
+						"attach_type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							ForceNew:    true,
+							Description: "The type of personal folder assignment.",
+						},
+					},
+				},
+				Description: "The assignment configuration of personal folders.",
+			},
+		},
+	}
+}
+
+func buildAppPersonalFoldersCreateJsonBody(d *schema.ResourceData) map[string]interface{} {
+	assignments := d.Get("assignments").(*schema.Set)
+	items := make([]interface{}, 0, assignments.Len())
+
+	for _, assignment := range assignments.List() {
+		items = append(items, map[string]interface{}{
+			"policy_statement_id": utils.PathSearch("policy_statement_id", assignment, nil),
+			"attach":              utils.PathSearch("attach", assignment, nil),
+			"attach_type":         utils.ValueIgnoreEmpty(utils.PathSearch("attach_type", assignment, nil)),
+		})
+	}
+
+	return map[string]interface{}{
+		"items": items,
+	}
+}
+
+func resourceAppPersonalFoldersCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		httpUrl   = "v1/{project_id}/persistent-storages/{storage_id}/actions/assign-folder"
+		storageId = d.Get("storage_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{storage_id}", storageId)
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildAppPersonalFoldersCreateJsonBody(d)),
+	}
+	_, err = client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return diag.Errorf("error assigning personal folders of Workspace APP: %s", err)
+	}
+
+	d.SetId(storageId)
+
+	return resourceAppPersonalFoldersRead(ctx, d, meta)
+}
+
+func ListAppPersonalFolders(client *golangsdk.ServiceClient, storageId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/persistent-storages/actions/list-attachments?claim_mode=USER&storage_id={storage_id}&limit=100"
+		listOpt = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+		offset = 0
+		result = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{storage_id}", storageId)
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, fmt.Errorf("error getting list of personal folders: %s", err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		items := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		if len(items) < 1 {
+			break
+		}
+		result = append(result, items...)
+		offset += len(items)
+	}
+	return result, nil
+}
+
+func flattenAppPersonalFolderAssignments(assignments []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(assignments))
+
+	for _, assignment := range assignments {
+		result = append(result, map[string]interface{}{
+			"policy_statement_id": utils.PathSearch("policy_statement.policy_statement_id", assignment, nil),
+			"attach":              utils.PathSearch("attachment.attach", assignment, nil),
+			"attach_type":         utils.PathSearch("attachment.attach_type", assignment, nil),
+		})
+	}
+
+	return result
+}
+
+func resourceAppPersonalFoldersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		storageId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	assignments, err := ListAppPersonalFolders(client, storageId)
+	if err != nil {
+		// If NAS storage not exist or the service has been closed, the API request will fail and returns a 404 error.
+		return common.CheckDeletedDiag(d, err, "Personal folders of Workspace APP")
+	}
+	if len(assignments) < 1 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte("All personal folders have been removed from the Workspace APP service"),
+			},
+		}, "")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("assignments", flattenAppPersonalFolderAssignments(assignments)),
+	)
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("unable to setting resource fields of the personal folders: %s", err)
+	}
+	return nil
+}
+
+func buildAppPersonalFoldersDeleteJsonBody(client *golangsdk.ServiceClient, storageId string) (map[string]interface{}, error) {
+	// The assignments is empey if resource is tainted.
+	assignments, err := ListAppPersonalFolders(client, storageId)
+	if err != nil {
+		return nil, err
+	}
+
+	items := utils.PathSearch("items[*].attachment.attach", assignments, make([]interface{}, 0)).([]interface{})
+	if len(items) < 1 {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte("all personal folders removed from the NAS storage for Workspace APP"),
+			},
+		}
+	}
+	return map[string]interface{}{
+		"items": items,
+	}, nil
+}
+
+func resourceAppPersonalFoldersDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		httpUrl   = "v1/{project_id}/persistent-storages/{storage_id}/actions/delete-user-attachment"
+		storageId = d.Get("storage_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	deleteItems, err := buildAppPersonalFoldersDeleteJsonBody(client, storageId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "Personal folders query before delete")
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{storage_id}", storageId)
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(deleteItems),
+	}
+	_, err = client.Request("POST", deletePath, &deleteOpts)
+	if err != nil {
+		return diag.Errorf("error deleting personal folders of Workspace APP: %s", err)
+	}
+	return nil
+}
+
+func resourceAppPersonalFolderImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	var (
+		storageId string
+		importId  = d.Id()
+		re        = regexp.MustCompile(`^\d{18}$`)
+	)
+
+	if re.MatchString(d.Id()) {
+		// The imported ID is NAS storage ID.
+		storageId = importId
+	} else {
+		// The imported ID is NAS storage name or other meaningless characters, which are all queried as names.
+		cfg := meta.(*config.Config)
+		region := cfg.GetRegion(d)
+
+		client, err := cfg.NewServiceClient("appstream", region)
+		if err != nil {
+			return nil, fmt.Errorf("error creating Workspace APP client: %s", err)
+		}
+
+		storages, err := listAppNasStorages(client)
+		if err != nil {
+			return nil, err
+		}
+		storageId = utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0].id", importId), storages, "").(string)
+		if storageId == "" {
+			return nil, fmt.Errorf("unable to find the NAS storage using its name (%s): %s", importId, err)
+		}
+	}
+
+	d.SetId(storageId)
+	return []*schema.ResourceData{d}, d.Set("storage_id", storageId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports new resource to manage personal folders under NAS storage.
Refactor the NAS storage resource that the import ID supports as name.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource for personal folder assignment.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccAppPersonalFolders_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppPersonalFolders_basic -timeout 360m -parallel 10
=== RUN   TestAccAppPersonalFolders_basic
=== PAUSE TestAccAppPersonalFolders_basic
=== CONT  TestAccAppPersonalFolders_basic
--- PASS: TestAccAppPersonalFolders_basic (16.08s)
PASS
coverage: 10.8% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 16.125s coverage: 10.8% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/3b1a7d03-bd53-49e5-9e50-fbe2b2089dd8)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![image](https://github.com/user-attachments/assets/bdb97fe1-f8eb-47a2-abba-1d7ace6f498f)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
