### PR TITLE
feat(workspace/service): supports any charachters instead of import ID

### DIFF
--- a/docs/resources/workspace_service.md
+++ b/docs/resources/workspace_service.md
@@ -236,7 +236,13 @@ This resource provides the following timeouts configuration options:
 Service can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_workspace_service.test fd3f81cb-d95f-43ce-b342-81b6b5dcadda
+$ terraform import huaweicloud_workspace_service.test <id>
+```
+
+'NA' or other characters can be used to instead of the `id`.
+
+```bash
+$ terraform import huaweicloud_workspace_service.test NA
 ```
 
 ## Appendix

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_service_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_service_test.go
@@ -93,8 +93,24 @@ func TestAccService_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCustomImportStateIdFunc(resourceName, "NA"),
+			},
 		},
 	})
+}
+
+func testAccCustomImportStateIdFunc(resourceName, customId string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		_, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("the resource (%s) is not found in the tfstate", resourceName)
+		}
+		return customId, nil
+	}
 }
 
 func TestAccService_internetAccessPort(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Import ID of Workspace service supports any characters, such as 'NA'.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. workspace service supports any charachters instead of import ID.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccService_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccService_basic -timeout 360m -parallel 10
=== RUN   TestAccService_basic
--- PASS: TestAccService_basic (134.00s)
PASS
coverage: 8.9% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 134.046s        coverage: 8.9% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
