### PR TITLE
fix(workspace/service): fix the invalid ad_domain reference

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -199,11 +199,11 @@ var (
 	HW_AAD_INSTANCE_ID = os.Getenv("HW_AAD_INSTANCE_ID")
 	HW_AAD_IP_ADDRESS  = os.Getenv("HW_AAD_IP_ADDRESS")
 
-	HW_WORKSPACE_AD_DOMAIN_NAME = os.Getenv("HW_WORKSPACE_AD_DOMAIN_NAME") // Domain name, e.g. "example.com".
-	HW_WORKSPACE_AD_SERVER_PWD  = os.Getenv("HW_WORKSPACE_AD_SERVER_PWD")  // The password of AD server.
-	HW_WORKSPACE_AD_DOMAIN_IP   = os.Getenv("HW_WORKSPACE_AD_DOMAIN_IP")   // Active domain IP, e.g. "192.168.196.3".
-	HW_WORKSPACE_AD_VPC_ID      = os.Getenv("HW_WORKSPACE_AD_VPC_ID")      // The VPC ID to which the AD server and desktops belongs.
-	HW_WORKSPACE_AD_NETWORK_ID  = os.Getenv("HW_WORKSPACE_AD_NETWORK_ID")  // The network ID to which the AD server belongs.
+	HW_WORKSPACE_AD_DOMAIN_NAMES = os.Getenv("HW_WORKSPACE_AD_DOMAIN_NAMES") // Domain name, e.g. "example.com".
+	HW_WORKSPACE_AD_SERVER_PWD   = os.Getenv("HW_WORKSPACE_AD_SERVER_PWD")   // The password of AD server.
+	HW_WORKSPACE_AD_DOMAIN_IPS   = os.Getenv("HW_WORKSPACE_AD_DOMAIN_IPS")   // Active domain IP, e.g. "192.168.196.3".
+	HW_WORKSPACE_AD_VPC_ID       = os.Getenv("HW_WORKSPACE_AD_VPC_ID")       // The VPC ID to which the AD server and desktops belongs.
+	HW_WORKSPACE_AD_NETWORK_ID   = os.Getenv("HW_WORKSPACE_AD_NETWORK_ID")   // The network ID to which the AD server belongs.
 	// The internet access port to which the Workspace service.
 	HW_WORKSPACE_INTERNET_ACCESS_PORT              = os.Getenv("HW_WORKSPACE_INTERNET_ACCESS_PORT")
 	HW_WORKSPACE_APP_SERVER_GROUP_ID               = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_ID")
@@ -1488,10 +1488,24 @@ func TestAccPreCheckCtsTimeRange(t *testing.T) {
 }
 
 // lintignore:AT003
+func TestAccPreCheckWorkspaceADDomainNames(t *testing.T) {
+	if len(strings.Split(HW_WORKSPACE_AD_DOMAIN_NAMES, ",")) != 2 {
+		t.Skip(`The Workspace AD service need domain name configurations for both master and standby servers, plesse config them in the
+HW_WORKSPACE_AD_DOMAIN_NAMES environment variable, separated by a comma (,).`)
+	}
+}
+
+// lintignore:AT003
 func TestAccPreCheckWorkspaceAD(t *testing.T) {
-	if HW_WORKSPACE_AD_DOMAIN_NAME == "" || HW_WORKSPACE_AD_SERVER_PWD == "" || HW_WORKSPACE_AD_DOMAIN_IP == "" ||
-		HW_WORKSPACE_AD_VPC_ID == "" || HW_WORKSPACE_AD_NETWORK_ID == "" {
-		t.Skip("The configuration of AD server is not completed for Workspace service acceptance test.")
+	TestAccPreCheckWorkspaceADDomainNames(t)
+
+	if len(strings.Split(HW_WORKSPACE_AD_DOMAIN_IPS, ",")) != 2 {
+		t.Skip(`The Workspace AD service need IP address configurations for both master and standby servers, plesse config them in the
+HW_WORKSPACE_AD_DOMAIN_IPS environment variable, separated by a comma (,).`)
+	}
+	if HW_WORKSPACE_AD_SERVER_PWD == "" || HW_WORKSPACE_AD_VPC_ID == "" || HW_WORKSPACE_AD_NETWORK_ID == "" {
+		t.Skip(`The configuration of AD server is not completed for Workspace service acceptance test, please check your inputs for
+HW_WORKSPACE_AD_SERVER_PWD, HW_WORKSPACE_AD_VPC_ID and HW_WORKSPACE_AD_NETWORK_ID.`)
 	}
 }
 

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_image_server_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_image_server_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -48,6 +49,7 @@ func TestAccResourceAppImageServer_basic(t *testing.T) {
 			acceptance.TestAccPreCheckWorkspaceAppImageSpecCode(t)
 			acceptance.TestAccPrecheckWorkspaceUserNames(t)
 			acceptance.TestAccPreCheckWorkspaceOUName(t)
+			acceptance.TestAccPreCheckWorkspaceADDomainNames(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -59,7 +61,8 @@ func TestAccResourceAppImageServer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "authorize_accounts.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "authorize_accounts.0.type", "USER"),
-					resource.TestCheckResourceAttr(resourceName, "authorize_accounts.0.domain", acceptance.HW_WORKSPACE_AD_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(resourceName, "authorize_accounts.0.domain",
+						retrieveActiveDomainName(strings.Split(acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES, ","))),
 					resource.TestCheckResourceAttr(resourceName, "image_id", acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID),
 					resource.TestCheckResourceAttr(resourceName, "image_type", "gold"),
 					resource.TestCheckResourceAttr(resourceName, "spec_code",
@@ -120,7 +123,7 @@ resource "huaweicloud_workspace_app_image_server" "test" {
   authorize_accounts {
     account = split(",", "%[8]s")[0]
     type    = "USER"
-    domain  = "%[9]s"
+    domain  = element(split("%[9]s", ","), 0)
   }
 
   root_volume {
@@ -155,7 +158,7 @@ resource "huaweicloud_workspace_app_image_server" "test" {
 		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID,
 		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_SPEC_CODE,
 		acceptance.HW_WORKSPACE_USER_NAMES,
-		acceptance.HW_WORKSPACE_AD_DOMAIN_NAME,
+		acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES,
 		description,
 		acceptance.HW_WORKSPACE_OU_NAME,
 		acceptance.HW_ENTERPRISE_PROJECT_ID_TEST,

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_service_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_service_test.go
@@ -2,6 +2,9 @@ package workspace
 
 import (
 	"fmt"
+	"log"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -152,11 +155,55 @@ func TestAccService_internetAccessPort(t *testing.T) {
 	})
 }
 
+func retrieveAdDomain(domainNames []string) string {
+	if len(domainNames) < 1 {
+		return ""
+	}
+
+	re := regexp.MustCompile(`^[^.]+\.(.*)$`)
+	match := re.FindStringSubmatch(domainNames[0])
+	if len(match) < 2 {
+		log.Printf("[ERROR] No match found for the AD domain: %s", domainNames[0])
+		return ""
+	}
+
+	return match[1]
+}
+
+// These method are parsed before precheck.
+// To avoid subscript out of bounds, the length is checked before the value is taken.
+func retrieveActiveDomainIpAddress(ipAddresses []string) string {
+	if len(ipAddresses) > 0 {
+		return ipAddresses[0]
+	}
+	return ""
+}
+
+func retrieveStandbyDomainIpAddress(ipAddresses []string) string {
+	if len(ipAddresses) > 1 {
+		return ipAddresses[1]
+	}
+	return ""
+}
+
+func retrieveActiveDomainName(domainNames []string) string {
+	if len(domainNames) > 0 {
+		return domainNames[0]
+	}
+	return ""
+}
+
+func retrieveStandbyDomainName(domainNames []string) string {
+	if len(domainNames) > 1 {
+		return domainNames[1]
+	}
+	return ""
+}
+
 func TestAccService_localAD(t *testing.T) {
 	var (
 		service      services.Service
 		resourceName = "huaweicloud_workspace_service.test"
-		rName        = acceptance.RandomAccResourceNameWithDash()
 	)
 
 	rc := acceptance.InitResourceCheck(
@@ -174,17 +221,20 @@ func TestAccService_localAD(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccService_localAD_step1(rName),
+				Config: testAccService_localAD_step1(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "auth_type", "LOCAL_AD"),
-					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.name", acceptance.HW_WORKSPACE_AD_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.name",
+						retrieveAdDomain(strings.Split(acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES, ","))),
 					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.admin_account", "Administrator"),
 					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.password", acceptance.HW_WORKSPACE_AD_SERVER_PWD),
-					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.active_domain_ip", acceptance.HW_WORKSPACE_AD_DOMAIN_IP),
 					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.active_domain_name",
-						fmt.Sprintf("server.%s", acceptance.HW_WORKSPACE_AD_DOMAIN_NAME)),
-					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.active_dns_ip", acceptance.HW_WORKSPACE_AD_DOMAIN_IP),
+						retrieveActiveDomainName(strings.Split(acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES, ","))),
+					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.active_domain_ip",
+						retrieveActiveDomainIpAddress(strings.Split(acceptance.HW_WORKSPACE_AD_DOMAIN_IPS, ","))),
+					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.active_dns_ip",
+						retrieveActiveDomainIpAddress(strings.Split(acceptance.HW_WORKSPACE_AD_DOMAIN_IPS, ","))),
 					resource.TestCheckResourceAttr(resourceName, "access_mode", "INTERNET"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_id", acceptance.HW_WORKSPACE_AD_VPC_ID),
 					resource.TestCheckResourceAttr(resourceName, "network_ids.0", acceptance.HW_WORKSPACE_AD_NETWORK_ID),
@@ -197,22 +247,23 @@ func TestAccService_localAD(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccService_localAD_step2(rName),
+				Config: testAccService_localAD_step2(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "network_ids.0", acceptance.HW_WORKSPACE_AD_NETWORK_ID),
-					resource.TestCheckResourceAttrPair(resourceName, "network_ids.1",
-						"huaweicloud_vpc_subnet.master", "id"),
-					resource.TestCheckResourceAttrPair(resourceName, "network_ids.2",
-						"huaweicloud_vpc_subnet.standby", "id"),
+					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.standby_domain_name",
+						retrieveStandbyDomainName(strings.Split(acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES, ","))),
+					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.standby_domain_ip",
+						retrieveStandbyDomainIpAddress(strings.Split(acceptance.HW_WORKSPACE_AD_DOMAIN_IPS, ","))),
+					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.standby_dns_ip",
+						retrieveStandbyDomainIpAddress(strings.Split(acceptance.HW_WORKSPACE_AD_DOMAIN_IPS, ","))),
 					resource.TestCheckResourceAttrSet(resourceName, "internet_access_address"),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_id", rName),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_id", "custom-workspace-service"),
 					resource.TestCheckResourceAttr(resourceName, "otp_config_info.0.enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "otp_config_info.0.receive_mode", "VMFA"),
 				),
 			},
 			{
-				Config: testAccService_localAD_step3(rName),
+				Config: testAccService_localAD_step3(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "otp_config_info.0.rule_type", "ACCESS_MODE"),
@@ -235,7 +286,6 @@ func TestAccService_internetAccessPort_localAD(t *testing.T) {
 	var (
 		service      services.Service
 		resourceName = "huaweicloud_workspace_service.test"
-		rName        = acceptance.RandomAccResourceNameWithDash()
 	)
 
 	rc := acceptance.InitResourceCheck(
@@ -254,14 +304,14 @@ func TestAccService_internetAccessPort_localAD(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccService_localAD_step1(rName),
+				Config: testAccService_localAD_step1(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(resourceName, "internet_access_port"),
 				),
 			},
 			{
-				Config: testAccService_localAD_internetAccessPort_update(rName),
+				Config: testAccService_localAD_internetAccessPort_update(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "internet_access_port", acceptance.HW_WORKSPACE_INTERNET_ACCESS_PORT),
@@ -356,122 +406,85 @@ resource "huaweicloud_workspace_service" "test" {
 `, testAccService_base(rName), rName)
 }
 
-func testAccService_localAD_base(rName string) string {
+func testAccService_localAD_step1() string {
 	return fmt.Sprintf(`
-data "huaweicloud_vpc" "test" {
-  id = "%[1]s"
-}
-
-resource "huaweicloud_vpc_subnet" "master" {
-  vpc_id = "%[1]s"
-
-  name       = "%[2]s-master"
-  cidr       = cidrsubnet(data.huaweicloud_vpc.test.cidr, 4, 1)
-  gateway_ip = cidrhost(cidrsubnet(data.huaweicloud_vpc.test.cidr, 4, 1), 1)
-}
-
-resource "huaweicloud_vpc_subnet" "standby" {
-  vpc_id = "%[1]s"
-
-  name       = "%[2]s-standby"
-  cidr       = cidrsubnet(data.huaweicloud_vpc.test.cidr, 4, 2)
-  gateway_ip = cidrhost(cidrsubnet(data.huaweicloud_vpc.test.cidr, 4, 2), 1)
-}
-`, acceptance.HW_WORKSPACE_AD_VPC_ID, rName)
-}
-
-func testAccService_localAD_step1(rName string) string {
-	return fmt.Sprintf(`
-%[1]s
-
 resource "huaweicloud_workspace_service" "test" {
   ad_domain {
-    name               = "%[2]s"
+    name               = try(element(regexall("\\w+\\.(.*)", element(split(",", "%[1]s"), 0))[0], 0), "")
     admin_account      = "Administrator"
-    password           = "%[3]s"
-    active_domain_ip   = "%[4]s"
-    active_domain_name = "server.%[2]s"
-    active_dns_ip      = "%[4]s"
+    password           = "%[2]s"
+    active_domain_name = element(split(",", "%[1]s"), 0)
+    active_domain_ip   = element(split(",", "%[3]s"), 0)
+    active_dns_ip      = element(split(",", "%[3]s"), 0)
   }
 
   auth_type   = "LOCAL_AD"
   access_mode = "INTERNET"
-  vpc_id      = "%[5]s"
-  network_ids = ["%[6]s"]
+  vpc_id      = "%[4]s"
+  network_ids = ["%[5]s"]
 }
-`, testAccService_localAD_base(rName), acceptance.HW_WORKSPACE_AD_DOMAIN_NAME, acceptance.HW_WORKSPACE_AD_SERVER_PWD,
-		acceptance.HW_WORKSPACE_AD_DOMAIN_IP, acceptance.HW_WORKSPACE_AD_VPC_ID, acceptance.HW_WORKSPACE_AD_NETWORK_ID)
+`, acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES,
+		acceptance.HW_WORKSPACE_AD_SERVER_PWD,
+		acceptance.HW_WORKSPACE_AD_DOMAIN_IPS,
+		acceptance.HW_WORKSPACE_AD_VPC_ID,
+		acceptance.HW_WORKSPACE_AD_NETWORK_ID)
 }
 
-func testAccService_localAD_step2(rName string) string {
+func testAccService_localAD_step2() string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "huaweicloud_workspace_service" "test" {
-  depends_on = [
-    huaweicloud_vpc_subnet.master,
-	huaweicloud_vpc_subnet.standby,
-  ]
-
   ad_domain {
-    name               = "%[2]s"
-    admin_account      = "Administrator"
-    password           = "%[3]s"
-    active_domain_ip   = "%[4]s"
-    active_domain_name = "server.%[2]s"
-    active_dns_ip      = "%[4]s"
+    name                = try(element(regexall("\\w+\\.(.*)", element(split(",", "%[1]s"), 0))[0], 0), "")
+    admin_account       = "Administrator"
+    password            = "%[2]s"
+    active_domain_name  = element(split(",", "%[1]s"), 0)
+    active_domain_ip    = element(split(",", "%[3]s"), 0)
+    active_dns_ip       = element(split(",", "%[3]s"), 0)
+    standby_domain_name = element(split(",", "%[1]s"), 1)
+    standby_domain_ip   = element(split(",", "%[3]s"), 1)
+    standby_dns_ip      = element(split(",", "%[3]s"), 1)
   }
 
   auth_type   = "LOCAL_AD"
   access_mode = "INTERNET"
-  vpc_id      = "%[5]s"
-  network_ids = [
-    "%[6]s",
-    huaweicloud_vpc_subnet.master.id,
-    huaweicloud_vpc_subnet.standby.id,
-  ]
+  vpc_id      = "%[4]s"
+  network_ids = ["%[5]s"]
 
-  enterprise_id        = "%[7]s"
+  enterprise_id = "custom-workspace-service"
 
   otp_config_info {
     enable       = true
     receive_mode = "VMFA"
   }
 }
-`, testAccService_localAD_base(rName), acceptance.HW_WORKSPACE_AD_DOMAIN_NAME, acceptance.HW_WORKSPACE_AD_SERVER_PWD,
-		acceptance.HW_WORKSPACE_AD_DOMAIN_IP, acceptance.HW_WORKSPACE_AD_VPC_ID, acceptance.HW_WORKSPACE_AD_NETWORK_ID,
-		rName)
+`, acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES,
+		acceptance.HW_WORKSPACE_AD_SERVER_PWD,
+		acceptance.HW_WORKSPACE_AD_DOMAIN_IPS,
+		acceptance.HW_WORKSPACE_AD_VPC_ID,
+		acceptance.HW_WORKSPACE_AD_NETWORK_ID)
 }
 
-func testAccService_localAD_step3(rName string) string {
+func testAccService_localAD_step3() string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "huaweicloud_workspace_service" "test" {
-  depends_on = [
-    huaweicloud_vpc_subnet.master,
-	huaweicloud_vpc_subnet.standby,
-  ]
-
   ad_domain {
-    name               = "%[2]s"
-    admin_account      = "Administrator"
-    password           = "%[3]s"
-    active_domain_ip   = "%[4]s"
-    active_domain_name = "server.%[2]s"
-    active_dns_ip      = "%[4]s"
+    name                = try(element(regexall("\\w+\\.(.*)", element(split(",", "%[1]s"), 0))[0], 0), "")
+    admin_account       = "Administrator"
+    password            = "%[2]s"
+    active_domain_name  = element(split(",", "%[1]s"), 0)
+    active_domain_ip    = element(split(",", "%[3]s"), 0)
+    active_dns_ip       = element(split(",", "%[3]s"), 0)
+    standby_domain_name = element(split(",", "%[1]s"), 1)
+    standby_domain_ip   = element(split(",", "%[3]s"), 1)
+    standby_dns_ip      = element(split(",", "%[3]s"), 1)
   }
 
   auth_type   = "LOCAL_AD"
   access_mode = "INTERNET"
-  vpc_id      = "%[5]s"
-  network_ids = [
-    "%[6]s",
-    huaweicloud_vpc_subnet.master.id,
-    huaweicloud_vpc_subnet.standby.id,
-  ]
+  vpc_id      = "%[4]s"
+  network_ids = ["%[5]s"]
 
-  enterprise_id        = "%[7]s"
+  enterprise_id = "custom-workspace-service"
 
   otp_config_info {
     enable       = true
@@ -480,9 +493,11 @@ resource "huaweicloud_workspace_service" "test" {
     rule         = "PRIVATE"
   }
 }
-`, testAccService_localAD_base(rName), acceptance.HW_WORKSPACE_AD_DOMAIN_NAME, acceptance.HW_WORKSPACE_AD_SERVER_PWD,
-		acceptance.HW_WORKSPACE_AD_DOMAIN_IP, acceptance.HW_WORKSPACE_AD_VPC_ID, acceptance.HW_WORKSPACE_AD_NETWORK_ID,
-		rName)
+`, acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES,
+		acceptance.HW_WORKSPACE_AD_SERVER_PWD,
+		acceptance.HW_WORKSPACE_AD_DOMAIN_IPS,
+		acceptance.HW_WORKSPACE_AD_VPC_ID,
+		acceptance.HW_WORKSPACE_AD_NETWORK_ID)
 }
 
 func testAccService_internetAccessPort_update(rName string) string {
@@ -503,38 +518,30 @@ resource "huaweicloud_workspace_service" "test" {
 `, testAccService_base(rName), acceptance.HW_WORKSPACE_INTERNET_ACCESS_PORT, rName)
 }
 
-func testAccService_localAD_internetAccessPort_update(rName string) string {
+func testAccService_localAD_internetAccessPort_update() string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "huaweicloud_workspace_service" "test" {
-  depends_on = [
-    huaweicloud_vpc_subnet.master,
-	huaweicloud_vpc_subnet.standby,
-  ]
-
   ad_domain {
-    name               = "%[2]s"
+    name               = try(element(regexall("\\w+\\.(.*)", element(split(",", "%[1]s"), 0))[0], 0), "")
     admin_account      = "Administrator"
-    password           = "%[3]s"
-    active_domain_ip   = "%[4]s"
-    active_domain_name = "server.%[2]s"
-    active_dns_ip      = "%[4]s"
+    password           = "%[2]s"
+    active_domain_name = element(split(",", "%[1]s"), 0)
+    active_domain_ip   = element(split(",", "%[3]s"), 0)
+    active_dns_ip      = element(split(",", "%[3]s"), 0)
   }
 
   auth_type   = "LOCAL_AD"
   access_mode = "INTERNET"
-  vpc_id      = "%[5]s"
-  network_ids = [
-    "%[6]s",
-    huaweicloud_vpc_subnet.master.id,
-    huaweicloud_vpc_subnet.standby.id,
-  ]
+  vpc_id      = "%[4]s"
+  network_ids = ["%[5]s"]
 
-  internet_access_port = "%[7]s"
-  enterprise_id        = "%[8]s"
+  internet_access_port = "%[6]s"
+  enterprise_id        = "custom-workspace-service"
 }
-`, testAccService_localAD_base(rName), acceptance.HW_WORKSPACE_AD_DOMAIN_NAME, acceptance.HW_WORKSPACE_AD_SERVER_PWD,
-		acceptance.HW_WORKSPACE_AD_DOMAIN_IP, acceptance.HW_WORKSPACE_AD_VPC_ID, acceptance.HW_WORKSPACE_AD_NETWORK_ID,
-		acceptance.HW_WORKSPACE_INTERNET_ACCESS_PORT, rName)
+`, acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES,
+		acceptance.HW_WORKSPACE_AD_SERVER_PWD,
+		acceptance.HW_WORKSPACE_AD_DOMAIN_IPS,
+		acceptance.HW_WORKSPACE_AD_VPC_ID,
+		acceptance.HW_WORKSPACE_AD_NETWORK_ID,
+		acceptance.HW_WORKSPACE_INTERNET_ACCESS_PORT)
 }

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_service.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_service.go
@@ -654,7 +654,7 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("error creating Workspace v2 client: %s", err)
 	}
 
-	if d.HasChanges("ad_domains", "access_mode", "dedicated_subnets") {
+	if d.HasChanges("ad_domain", "access_mode", "dedicated_subnets") {
 		if err = updateServiceConnection(ctx, client, d); err != nil {
 			return diag.Errorf("error updating connection parameters of service: %s", err)
 		}

--- a/vendor/github.com/chnsz/golangsdk/openstack/workspace/v2/services/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/workspace/v2/services/requests.go
@@ -49,16 +49,16 @@ type Domain struct {
 	AcitveDomainName string `json:"active_domain_name,omitempty"`
 	// The IP address of the standby domain controller.
 	// It needs to be configured when the domain type is LOCAL_AD and the standby node is configured.
-	StandyDomainIp string `json:"standy_domain_ip,omitempty"`
+	StandyDomainIp string `json:"standby_domain_ip,omitempty"`
 	// The name of the standby domain controller.
 	// It needs to be configured when the domain type is LOCAL_AD and the standby node is configured.
-	StandyDomainName string `json:"standy_domain_name,omitempty"`
+	StandyDomainName string `json:"standby_domain_name,omitempty"`
 	// Primary DNS IP address.
 	// It needs to be configured when the domain type is LOCAL_AD.
 	ActiveDnsIp string `json:"active_dns_ip,omitempty"`
 	// Backup DNS IP address.
 	// It needs to be configured when the domain type is LOCAL_AD and the standby node is configured.
-	StandyDnsIp string `json:"standy_dns_ip,omitempty"`
+	StandyDnsIp string `json:"standby_dns_ip,omitempty"`
 	// Whether to delete the corresponding computer object on AD while deleting the desktop.
 	// + 0 means not delete
 	// + 1 means delete.

--- a/vendor/github.com/chnsz/golangsdk/openstack/workspace/v2/services/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/workspace/v2/services/results.go
@@ -123,16 +123,16 @@ type DomainResp struct {
 	AcitveDomainName string `json:"active_domain_name"`
 	// The IP address of the standby domain controller.
 	// It needs to be configured when the domain type is LOCAL_AD and the standby node is configured.
-	StandyDomainIp string `json:"standy_domain_ip"`
+	StandyDomainIp string `json:"standby_domain_ip"`
 	// The name of the standby domain controller.
 	// It needs to be configured when the domain type is LOCAL_AD and the standby node is configured.
-	StandyDomainName string `json:"standy_domain_name"`
+	StandyDomainName string `json:"standby_domain_name"`
 	// Primary DNS IP address.
 	// It needs to be configured when the domain type is LOCAL_AD.
 	ActiveDnsIp string `json:"active_dns_ip"`
 	// Backup DNS IP address.
 	// It needs to be configured when the domain type is LOCAL_AD and the standby node is configured.
-	StandyDnsIp string `json:"standy_dns_ip"`
+	StandyDnsIp string `json:"standby_dns_ip"`
 	// Whether to delete the corresponding computer object on AD while deleting the desktop.
 	// + 0 means not delete
 	// + 1 means delete.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix the invalid ad_domain reference: d.GetChanges('ad_domains', ...)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fix the invalid ad_domain reference
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccService_localAD
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccService_localAD -timeout 360m -parallel 10
=== RUN   TestAccService_localAD
--- PASS: TestAccService_localAD (506.69s)
PASS
coverage: 8.8% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 506.739s        coverage: 8.8% of statements in ./huaweicloud/services/workspace
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
