### PR TITLE
feat(workspace/app): add new resource for shared folder management

### DIFF
--- a/docs/resources/workspace_app_shared_folder.md
+++ b/docs/resources/workspace_app_shared_folder.md
@@ -1,0 +1,64 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_shared_folder"
+description: |-
+  Manages a shared folder resource of Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_shared_folder
+
+Manages a shared folder resource of Workspace APP within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "nas_storage_id" {}
+variable "shared_folder_name" {}
+
+resource "huaweicloud_workspace_app_shared_folder" "test" {
+  storage_id = var.nas_storage_id
+  name       = var.shared_folder_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the shared folder is located.  
+  If omitted, the provider-level region will be used. Change this parameter will create a new resource.
+
+* `storage_id` - (Required, String, ForceNew) Specifies the NAS storage ID to which the shared folder belongs.  
+  Change this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the shared folder.  
+  The valid length is limited from `1` to `32`, only letters, digits, spaces, underscores (_) and hyphens (-) are
+  allowed, but cannot be all spaces or start with the space.  
+  Change this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The shared folder ID.
+
+* `delimiter` - The delimiter that the shared folder path used.
+
+* `path` - The path of the shared folder, the usual format is: **{root_path}{delimiter}{folder_name}{delimiter}**,
+  such as **shares/xxx/**.  
+
+## Import
+
+Shared folders can be imported using their related `storage_id` and `id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_workspace_app_shared_folder.test <storage_id>/<id>
+```
+
+If the NAS storage ID or shared folder ID is unknow, its corresponding name can be used as an alternative to ID.  
+The NAS storage name can be obtained through the console or data source (`huaweicloud_workspace_app_nas_storages`).
+
+```bash
+$ terraform import huaweicloud_workspace_app_shared_folder.test <storage_name>/<name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2124,6 +2124,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_publishment":         workspace.ResourceAppPublishment(),
 			"huaweicloud_workspace_app_server_group":        workspace.ResourceAppServerGroup(),
 			"huaweicloud_workspace_app_server":              workspace.ResourceAppServer(),
+			"huaweicloud_workspace_app_shared_folder":       workspace.ResourceAppSharedFolder(),
 			"huaweicloud_workspace_app_storage_policy":      workspace.ResourceAppStoragePolicy(),
 			"huaweicloud_workspace_app_warehouse_app":       workspace.ResourceWarehouseApplication(),
 			"huaweicloud_workspace_user_group":              workspace.ResourceUserGroup(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -512,8 +512,8 @@ var (
 	HW_DMS_ROCKETMQ_TOPIC_NAME  = os.Getenv("HW_DMS_ROCKETMQ_TOPIC_NAME")
 	HW_DMS_ROCKETMQ_GROUP_NAME  = os.Getenv("HW_DMS_ROCKETMQ_GROUP_NAME")
 
-	HW_SFS_TURBO_BACKUP_ID  = os.Getenv("HW_SFS_TURBO_BACKUP_ID")
-	HW_SFS_FILE_SYSTEM_NAME = os.Getenv("HW_SFS_FILE_SYSTEM_NAME")
+	HW_SFS_TURBO_BACKUP_ID   = os.Getenv("HW_SFS_TURBO_BACKUP_ID")
+	HW_SFS_FILE_SYSTEM_NAMES = os.Getenv("HW_SFS_FILE_SYSTEM_NAMES")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -2682,9 +2682,9 @@ func TestAccPrecheckSFSTurboBackupId(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPrecheckSfsFileSystemName(t *testing.T) {
-	if HW_SFS_FILE_SYSTEM_NAME == "" {
-		t.Skip("HW_SFS_FILE_SYSTEM_NAME must be set for the acceptance test")
+func TestAccPrecheckSfsFileSystemNames(t *testing.T) {
+	if len(strings.Split(HW_SFS_FILE_SYSTEM_NAMES, ",")) < 1 {
+		t.Skip("At least one of user must be configured in the HW_SFS_FILE_SYSTEM_NAMES, and separated by commas")
 	}
 }
 

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_personal_folders_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_personal_folders_test.go
@@ -45,7 +45,7 @@ func TestAccAppPersonalFolders_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPrecheckSfsFileSystemName(t)
+			acceptance.TestAccPrecheckSfsFileSystemNames(t)
 			acceptance.TestAccPrecheckWorkspaceUserNames(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
@@ -84,7 +84,7 @@ resource "huaweicloud_workspace_app_nas_storage" "test" {
   name = "%[1]s"
 
   storage_metadata {
-    storage_handle = "%[2]s"
+    storage_handle = element(split(",", "%[2]s"), 0)
     storage_class  = "sfs"
   }
 }
@@ -107,5 +107,5 @@ resource "huaweicloud_workspace_app_personal_folders" "test" {
     }
   }
 }
-`, name, acceptance.HW_SFS_FILE_SYSTEM_NAME, acceptance.HW_WORKSPACE_USER_NAMES)
+`, name, acceptance.HW_SFS_FILE_SYSTEM_NAMES, acceptance.HW_WORKSPACE_USER_NAMES)
 }

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_shared_folder_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_shared_folder_test.go
@@ -1,0 +1,125 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/workspace"
+)
+
+func getAppSharedFolderFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("appstream", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Workspace APP client: %s", err)
+	}
+	return workspace.GetAppSharedFolderById(client, state.Primary.Attributes["storage_id"], state.Primary.ID)
+}
+
+func TestAccAppSharedFolder_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_workspace_app_shared_folder.test"
+		name         = acceptance.RandomAccResourceName()
+
+		sharedFolder interface{}
+		rc           = acceptance.InitResourceCheck(resourceName, &sharedFolder, getAppSharedFolderFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckSfsFileSystemNames(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppSharedFolder_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "storage_id",
+						"huaweicloud_workspace_app_nas_storage.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "path", fmt.Sprintf("shares/%s/", name)),
+					resource.TestCheckResourceAttr(resourceName, "delimiter", "/"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The format of import ID is <storage_id>/<shared_folder_id>.
+				ImportStateIdFunc: testAccAppSharedFolderImportStateIdFunc(resourceName),
+				ImportStateVerifyIgnore: []string{
+					"name",
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The format of import ID is <storage_name>/<shared_folder_id>.
+				ImportStateIdFunc: testAccAppSharedFolderImportStateIdFunc(resourceName, name),
+				ImportStateVerifyIgnore: []string{
+					"name",
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The format of import ID is <storage_name>/<shared_folder_name>.
+				ImportStateIdFunc: testAccAppSharedFolderImportStateIdFunc(resourceName, name, name),
+				ImportStateVerifyIgnore: []string{
+					"name",
+				},
+			},
+		},
+	})
+}
+
+func testAccAppSharedFolderImportStateIdFunc(resourceName string, names ...string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("the resource (%s) is not found in the tfstate", resourceName)
+		}
+
+		switch len(names) {
+		case 0:
+			return fmt.Sprintf("%s/%s", rs.Primary.Attributes["storage_id"], rs.Primary.ID), nil
+		case 1:
+			// Related NAS storage ID is unknow, using storage name instead of storage ID.
+			// The ID format is: <storage_name>/<shared_folder_id>
+			return fmt.Sprintf("%s/%s", names[0], rs.Primary.ID), nil
+		case 2:
+			// Bosth related NAS storage ID and shared folder ID are unknow, using their names instead of IDs.
+			// The ID format is: <storage_name>/<shared_folder_name>
+			return fmt.Sprintf("%s/%s", names[0], names[1]), nil
+		}
+
+		return "", fmt.Errorf("invalid length of the names input, most two IDs are allowed")
+	}
+}
+
+func testAccAppSharedFolder_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_app_nas_storage" "test" {
+  name = "%[1]s"
+
+  storage_metadata {
+    storage_handle = element(split(",", "%[2]s"), 0)
+    storage_class  = "sfs"
+  }
+}
+
+resource "huaweicloud_workspace_app_shared_folder" "test" {
+  storage_id = huaweicloud_workspace_app_nas_storage.test.id
+  name       = "%[1]s"
+}
+`, name, acceptance.HW_SFS_FILE_SYSTEM_NAMES)
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_shared_folder.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_shared_folder.go
@@ -1,0 +1,293 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace POST /v1/{project_id}/persistent-storages/{storage_id}/actions/create-share-folder
+// @API Workspace GET /v1/{project_id}/persistent-storages/actions/list-share-folders
+// @API Workspace POST /v1/{project_id}/persistent-storages/{storage_id}/actions/delete-storage-claim
+func ResourceAppSharedFolder() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppSharedFolderCreate,
+		ReadContext:   resourceAppSharedFolderRead,
+		DeleteContext: resourceAppSharedFolderDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceAppSharedFolderImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the shared folder is located.",
+			},
+			"storage_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The NAS storage ID to which the shared folder belongs.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the shared folder.",
+			},
+			"delimiter": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The delimiter that the shared folder path used.",
+			},
+			"path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The path of the shared folder.",
+			},
+		},
+	}
+}
+
+func buildAppSharedFolderCreateJsonBody(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"folder_name": d.Get("name").(string),
+	}
+}
+
+func resourceAppSharedFolderCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		httpUrl   = "v1/{project_id}/persistent-storages/{storage_id}/actions/create-share-folder"
+		storageId = d.Get("storage_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{storage_id}", storageId)
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildAppSharedFolderCreateJsonBody(d)),
+	}
+	requestResp, err := client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return diag.Errorf("error creating shared folder of Workspace APP: %s", err)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	sharedFolderId := utils.PathSearch("storage_claim_id", respBody, "").(string)
+	if sharedFolderId == "" {
+		return diag.Errorf("unable to find the shared folder ID from the API response")
+	}
+	d.SetId(sharedFolderId)
+
+	return resourceAppSharedFolderRead(ctx, d, meta)
+}
+
+func listAppSharedFolders(client *golangsdk.ServiceClient, storageId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/persistent-storages/actions/list-share-folders?storage_id={storage_id}&limit=100"
+		listOpt = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+		offset = 0
+		result = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{storage_id}", storageId)
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, fmt.Errorf("error getting list of shared folders: %s", err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		items := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		if len(items) < 1 {
+			break
+		}
+		result = append(result, items...)
+		offset += len(items)
+	}
+	return result, nil
+}
+
+func GetAppSharedFolderById(client *golangsdk.ServiceClient, storageId, sharedFolderId string) (interface{}, error) {
+	sharedFolders, err := listAppSharedFolders(client, storageId)
+	if err != nil {
+		return nil, err
+	}
+
+	sharedFolder := utils.PathSearch(fmt.Sprintf("[?storage_claim_id=='%s']|[0]", sharedFolderId), sharedFolders, nil)
+	if sharedFolder == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte("the shared folder has been removed from the Workspace APP service"),
+			},
+		}
+	}
+	return sharedFolder, nil
+}
+
+func resourceAppSharedFolderRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		storageId      = d.Get("storage_id").(string)
+		sharedFolderId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	sharedFolder, err := GetAppSharedFolderById(client, storageId, sharedFolderId)
+	if err != nil {
+		// If NAS storage not exist or the service has been closed, the API request will fail and returns a 404 error.
+		return common.CheckDeletedDiag(d, err, "Shared folder of Workspace APP")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("delimiter", utils.PathSearch("delimiter", sharedFolder, nil)),
+		d.Set("path", utils.PathSearch("folder_path", sharedFolder, nil)),
+	)
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("unable to setting resource fields of the shared folder: %s", err)
+	}
+	return nil
+}
+
+func resourceAppSharedFolderDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		httpUrl        = "v1/{project_id}/persistent-storages/{storage_id}/actions/delete-storage-claim"
+		storageId      = d.Get("storage_id").(string)
+		sharedFolderId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{storage_id}", storageId)
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"items": []interface{}{sharedFolderId},
+		},
+	}
+	_, err = client.Request("POST", deletePath, &deleteOpts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting shared folder (%s) of Workspace APP", sharedFolderId))
+	}
+	return nil
+}
+
+func retrieveAppNasStorageId(client *golangsdk.ServiceClient, importId string) (string, error) {
+	re := regexp.MustCompile(`^\d{18}$`)
+	if re.MatchString(importId) {
+		// The imported ID is NAS storage ID.
+		return importId, nil
+	}
+
+	// The imported ID is NAS storage name or other meaningless characters, which are all queried as names.
+	storages, err := listAppNasStorages(client)
+	if err != nil {
+		return "", err
+	}
+	storageId := utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0].id", importId), storages, "").(string)
+	if storageId == "" {
+		return "", fmt.Errorf("unable to find the NAS storage ID using its name (%s)", storageId)
+	}
+	return storageId, nil
+}
+
+func retrieveAppSharedFolderId(client *golangsdk.ServiceClient, storageId, importId string) (string, error) {
+	re := regexp.MustCompile(`^\d{18}$`)
+	if re.MatchString(importId) {
+		// The imported ID is shared folder ID.
+		return importId, nil
+	}
+
+	// The imported ID is shared folder name.
+	sharedFolders, err := listAppSharedFolders(client, storageId)
+	if err != nil {
+		return "", err
+	}
+
+	delimiter := utils.PathSearch("[0].delimiter", sharedFolders, "").(string)
+	sharedFolderId := utils.PathSearch(fmt.Sprintf("[?contains(folder_path, '%s%s%s')]|[0].storage_claim_id",
+		delimiter, importId, delimiter), sharedFolders, "").(string)
+	if sharedFolderId == "" {
+		return "", fmt.Errorf("unable to find the shared folder ID using its name (%s)", sharedFolderId)
+	}
+	return sharedFolderId, nil
+}
+
+func resourceAppSharedFolderImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	var (
+		storageId, sharedFolderId string
+		importId                  = d.Id()
+		cfg                       = meta.(*config.Config)
+		region                    = cfg.GetRegion(d)
+	)
+
+	parts := strings.Split(importId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<storage_name>/<name>' or '<storage_id>/<id>', but got '%s'", importId)
+	}
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	storageId, err = retrieveAppNasStorageId(client, parts[0])
+	if err != nil {
+		return nil, err
+	}
+
+	sharedFolderId, err = retrieveAppSharedFolderId(client, storageId, parts[1])
+	if err != nil {
+		return nil, err
+	}
+
+	d.SetId(sharedFolderId)
+	return []*schema.ResourceData{d}, d.Set("storage_id", storageId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new resource for shared folder management.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports a new resource for shared folder management.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccAppSharedFolder_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppSharedFolder_basic -timeout 360m -parallel 10
=== RUN   TestAccAppSharedFolder_basic
=== PAUSE TestAccAppSharedFolder_basic
=== CONT  TestAccAppSharedFolder_basic
--- PASS: TestAccAppSharedFolder_basic (17.74s)
PASS
coverage: 9.7% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 17.806s coverage: 9.7% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
