### PR TITLE
feat(dbss): the DBSS instance resource supports new API

### DIFF
--- a/docs/resources/dbss_instance.md
+++ b/docs/resources/dbss_instance.md
@@ -111,6 +111,17 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies the description of the instance.
 
+* `action` - (Optional, String) Specifies operation the DBSS instance status.
+  The valid values are as follows:
+  + **start**: Indicates enable the DBSS instance.
+  + **stop**: Indicates disable the DBSS instance.
+  + **reboot**: Indicates restart the DBSS instance.
+
+  -> 1.After a DBSS instance created, the default status is **start**.
+  <br/>2.The same operation cannot be performed repeatedly.
+  <br/>3.The **stop** or **reboot** operation can only be performed when the DBSS instance has no tasks
+  and is in **start** status.
+
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the instance.
 
 ## Attribute Reference
@@ -147,6 +158,7 @@ In addition to all arguments above, the following attributes are exported:
 This resource provides the following timeouts configuration options:
 
 * `create` - Default is 20 minutes.
+* `update` - Default is 10 minutes.
 * `delete` - Default is 20 minutes.
 
 ## Import
@@ -159,7 +171,8 @@ $ terraform import huaweicloud_dbss_instance.test <id>
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response. The missing attributes include: `charging_mode`, `enterprise_project_id`, `flavor`, `period`,
-`period_unit`, `product_spec_desc` and `tags`. It is generally recommended running `terraform plan` after importing an instance.
+`period_unit`, `product_spec_desc`, `tags` and `action`.
+It is generally recommended running `terraform plan` after importing an instance.
 You can then decide if changes should be applied to the instance, or the resource definition should be updated to align
 with the instance. Also, you can ignore changes as below.
 
@@ -169,7 +182,7 @@ resource "huaweicloud_dbss_instance" "test" {
 
   lifecycle {
     ignore_changes = [
-      charging_mode, enterprise_project_id, flavor, period, period_unit, product_spec_desc, tags
+      charging_mode, enterprise_project_id, flavor, period, period_unit, product_spec_desc, tags, action,
     ]
   }
 }

--- a/huaweicloud/services/dbss/resource_huaweicloud_dbss_instance.go
+++ b/huaweicloud/services/dbss/resource_huaweicloud_dbss_instance.go
@@ -36,6 +36,10 @@ import (
 // @API DBSS POST /v1/{project_id}/{resource_type}/{resource_id}/tags/create
 // @API DBSS DELETE /v1/{project_id}/{resource_type}/{resource_id}/tags/delete
 // @API DBSS PUT /v1/{project_id}/dbss/audit/instances/{instance_id}
+// @API DBSS POST /v1/{project_id}/dbss/audit/security-group
+// @API DBSS POST /v1/{project_id}/dbss/audit/instance/start
+// @API DBSS POST /v1/{project_id}/dbss/audit/instance/stop
+// @API DBSS POST /v1/{project_id}/dbss/audit/instance/reboot
 func ResourceInstance() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceInstanceCreate,
@@ -47,6 +51,7 @@ func ResourceInstance() *schema.Resource {
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
@@ -156,6 +161,13 @@ func ResourceInstance() *schema.Resource {
 				ForceNew:    true,
 				Description: `Specifies the IP address.`,
 			},
+			"action": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"start", "stop", "reboot",
+				}, false),
+			},
 			"tags": common.TagsSchema(),
 			"connect_ip": {
 				Type:        schema.TypeString,
@@ -256,6 +268,25 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	if err != nil {
 		return diag.Errorf("error waiting for the instance (%s) creation to complete: %s", d.Id(), err)
 	}
+
+	action := d.Get("action").(string)
+	if action == "stop" || action == "reboot" {
+		resp, err := QueryTargetDBSSInstance(client, d.Id())
+		if err != nil {
+			return diag.Errorf("error retrieving DBSS instance")
+		}
+
+		instanceId := utils.PathSearch("id", resp, "").(string)
+		if instanceId == "" {
+			return diag.Errorf("failed to operation the DBSS instance: 'instance_id' is not found in API response")
+		}
+
+		err = operateDbssInstance(ctx, d, client, action, instanceId)
+		if err != nil {
+			return diag.Errorf("error '%s' the DBSS instance in creation: %s", action, err)
+		}
+	}
+
 	return resourceInstanceRead(ctx, d, meta)
 }
 
@@ -551,9 +582,8 @@ func resourceInstanceRead(_ context.Context, d *schema.ResourceData, meta interf
 
 func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg        = meta.(*config.Config)
-		region     = cfg.GetRegion(d)
-		instanceId = d.Id()
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
 	)
 
 	client, err := cfg.NewServiceClient("dbss", region)
@@ -569,7 +599,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 	if d.HasChange("enterprise_project_id") {
 		migrateOpts := config.MigrateResourceOpts{
-			ResourceId:   instanceId,
+			ResourceId:   d.Id(),
 			ResourceType: "auditInstance",
 			RegionId:     region,
 			ProjectId:    cfg.GetProjectID(region),
@@ -603,6 +633,20 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	if d.HasChange("security_group_id") {
 		if err := updateSecurityGroupID(client, d); err != nil {
 			return diag.Errorf("error updating DBSS security group: %s", err)
+		}
+	}
+
+	if d.HasChange("action") {
+		action := d.Get("action").(string)
+		instanceId := d.Get("instance_id").(string)
+		if instanceId == "" {
+			return diag.Errorf("editing action is currently not supported because of a failure in getting instance_id")
+		}
+		if action != "" {
+			err = operateDbssInstance(ctx, d, client, action, instanceId)
+			if err != nil {
+				return diag.Errorf("error '%s' the DBSS instance in update: %s", action, err)
+			}
 		}
 	}
 
@@ -758,4 +802,62 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	return nil
+}
+
+func operateDbssInstance(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient,
+	action, instanceId string) error {
+	httpUrl := "v1/{project_id}/dbss/audit/instance/{action}"
+	actionPath := client.Endpoint + httpUrl
+	actionPath = strings.ReplaceAll(actionPath, "{project_id}", client.ProjectID)
+	actionPath = strings.ReplaceAll(actionPath, "{action}", action)
+
+	actionOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"instance_id": instanceId,
+		},
+	}
+
+	_, err := client.Request("POST", actionPath, &actionOpts)
+	if err != nil {
+		return err
+	}
+
+	err = waitingForOperationInstanceCompleted(ctx, d, client, d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return fmt.Errorf("error waiting for the instance '%s' to complete: %s", action, err)
+	}
+
+	return nil
+}
+
+func waitingForOperationInstanceCompleted(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient,
+	t time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			respBody, err := QueryTargetDBSSInstance(client, d.Id())
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			task := utils.PathSearch("task", respBody, "").(string)
+			if task == "" {
+				return nil, "ERROR", fmt.Errorf("the 'task' is not found in API response")
+			}
+
+			if task == "NO_TASK" {
+				return respBody, "COMPLETED", nil
+			}
+
+			return respBody, "PENDING", nil
+		},
+		Timeout:      t,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+
+	return err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The DBSS instance resource supports new API.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dbss" TESTARGS="-run TestAccInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dbss -v -run TestAccInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== CONT  TestAccInstance_basic
--- PASS: TestAccInstance_basic (1999.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dbss      1999.248s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/dbss" TESTARGS="-run TestAccInstance_updateWithEpsId"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dbss -v -run TestAccInstance_updateWithEpsId -timeout 360m -parallel 4
=== RUN   TestAccInstance_updateWithEpsId
=== PAUSE TestAccInstance_updateWithEpsId
=== CONT  TestAccInstance_updateWithEpsId
--- PASS: TestAccInstance_updateWithEpsId (1229.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dbss      1229.710s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
