### PR TITLE
feat(iotda/device_message): support device message delivery resource

### DIFF
--- a/docs/resources/iotda_device_message.md
+++ b/docs/resources/iotda_device_message.md
@@ -1,0 +1,167 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_iotda_device_message"
+description: |-
+  Manages a device message delivery resource within HuaweiCloud.
+---
+
+# huaweicloud_iotda_device_message
+
+Manages a device message delivery resource within HuaweiCloud.
+
+-> 1.This resource is only a one-time action resource for doing API action. Deleting this resource will not clear
+  the corresponding request record, but will only remove the resource information from the tfstate file.
+  <br>2.Currently, this resource is only supported deliver message to MQTT devices.
+  <br>3.After the resource is created, please pay attention to the message delivery result through `status` attribute,
+  you can execute the **terraform plan** command at regular intervals to monitor `status` attribute changes.
+
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+  endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  **9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "device_id"{}
+variable "message"{}
+
+resource "huaweicloud_iotda_device_message" "test" {
+  device_id = var.device_id
+  message   = var.message
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `device_id` - (Required, String, ForceNew) Specifies the ID of the device to which the message is delivered.
+  Changing this parameter will create a new resource.
+
+* `message` - (Required, String, ForceNew) Specifies message content, supporting string and json formats.
+  Changing this parameter will create a new resource.
+
+* `message_id` - (Optional, String, ForceNew) Specifies the message ID, it is recommended to use UUID, which is unique
+  within the same device. The length should not exceed `128`, and only combinations of letters, numbers,
+  underscores (_), and hyphens (-) are allowed. Changing this parameter will create a new resource.
+  + If the message ID filled in is not unique within the device, an error will be returned.
+  + If left blank, the system will generate a random ID.
+
+* `name` - (Optional, String, ForceNew) Specifies the message name. The length should not exceed `128`, and only
+  Chinese, letters, numbers, and the following characters are allowed: `_?'#().,&%@!-`.
+  Changing this parameter will create a new resource.
+
+* `properties` - (Optional, List, ForceNew) Specifies the attribute parameters of the message downstream to the device.
+  Changing this parameter will create a new resource.
+  The [properties](#iotda_properties) structure is documented below.
+
+* `encoding` - (Optional, String, ForceNew) Specifies the encoding format for message content.
+  Changing this parameter will create a new resource.  
+  The valid values are as follows:
+  + **none**
+  + **base64**
+
+  Defaults to **none**.
+
+* `payload_format` - (Optional, String, ForceNew) Specifies the payload format. This parameter is valid only `encoding`
+  is set to **none**. Changing this parameter will create a new resource.  
+  The valid values are as follows:
+  + **standard**: Standard format for platform encapsulation.
+  + **raw**: Directly distribute the message content as a payload.
+
+  Defaults to **standard**.
+
+* `topic` - (Optional, String, ForceNew) Specifies the custom topic suffix for message downstream to the device.
+  Only topics configured on the tenant product interface can be filled in, otherwise the verification will not pass.
+  If the topic is specified, the message will be directed to the device through that topic. If not specified, the
+  message will be directed to the device through the system's default topic.
+  Changing this parameter will create a new resource.
+
+* `topic_full_name` - (Optional, String, ForceNew) Specifies the complete topic name for the message to be sent to the
+  device. When it is necessary to issue a custom topic to the device, this parameter can be used to specify the complete
+  topic name. The IoT platform does not verify whether the topic is defined on the platform and directly transmits it to
+  the device. The device needs to subscribe to the topic in advance.
+  Changing this parameter will create a new resource.
+
+-> Only one of parameters `topic` and `topic_full_name` can be set.
+
+* `ttl` - (Optional, String, ForceNew) Specifies the aging time of the message in the platform cache, in minutes.
+  Changing this parameter will create a new resource.
+  + The valid value must be a multiple of `5`.
+  + When specified as `0`, it means that the message is not cached, and the default maximum caching time is `1,440`.
+
+  Defaults to `1,440`.
+
+<a name="iotda_properties"></a>
+The `properties` block supports:
+
+* `correlation_data` - (Optional, String, ForceNew) Specifies relevant data in MQTT 5.0 request and response patterns.
+  The length should not exceed `128`, and only combinations of letters, numbers, underscores (_), and hyphens (-) are
+  allowed. Changing this parameter will create a new resource.
+
+* `response_topic` - (Optional, String, ForceNew) Specifies response topic in MQTT 5.0 request and response patterns.
+  The length should not exceed 128, and only letters, numbers, and the following characters are allowed: `_-?=$#+/`.
+  Changing this parameter will create a new resource.
+
+* `user_properties` - (Optional, List, ForceNew) Specifies user-defined attributes. The maximum number that can be
+  configured is `20`. Changing this parameter will create a new resource.
+  The [user_properties](#iotda_user_properties) structure is documented below.
+
+<a name="iotda_user_properties"></a>
+The `user_properties` block supports:
+
+* `prop_key` - (Optional, String, ForceNew) Specifies custom attribute key. The length should not exceed `128`, and only
+  combinations of letters, numbers, underscores (_), and hyphens (-) are allowed.
+  Changing this parameter will create a new resource.
+
+* `prop_value` - (Optional, String, ForceNew) Specifies custom attribute value. The length should not exceed `128`, and
+  only Chinese, letters, numbers, and the following characters are allowed: `_? '#().,&%@!-`.
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `message_id`.
+
+* `status` - The status of the message.  
+  The valid values are as follows:
+  + **PENDING**: The device is not online, the message is cached and will be issued after the device is online.
+  + **DELIVERED**: The message sent successfully.
+  + **FAILED**: The message sending failed.
+  + **TIMEOUT**: The message has not been sent to the device within the default time of the platform (`1` day).
+
+* `error_info` - The message delivery failure details.
+  The [error_info](#iotda_error_info) structure is documented below.
+
+* `created_time` - The creation time of the device message.
+  The format is **yyyyMMdd'T'HHmmss'Z'**, e.g. **20151212T121212Z**.
+
+* `finished_time` - The end time of the device message. Contains the time for the message to transition to the
+  **DELIVERED* and **TIMEOUT** status. The format is **yyyyMMdd'T'HHmmss'Z'**, e.g. **20151212T121212Z**.
+
+<a name="iotda_error_info"></a>
+The `error_info` block supports:
+
+* `error_code` - The abnormal information error code.  
+  The valid values are as follows:
+  + **IOTDA.014016**: Indicates that the device is not online.
+  + **IOTDA.014112**: Indicates that the device has not subscribed to the topic.
+
+* `error_msg` - The abnormal information explanation. Includes instructions for devices not online and devices not
+  subscribed to the topic.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1771,6 +1771,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_dataforwarding_rule":      iotda.ResourceDataForwardingRule(),
 			"huaweicloud_iotda_data_flow_control_policy": iotda.ResourceDataFlowControlPolicy(),
 			"huaweicloud_iotda_data_backlog_policy":      iotda.ResourceDataBacklogPolicy(),
+			"huaweicloud_iotda_device_message":           iotda.ResourceDeviceMessage(),
 			"huaweicloud_iotda_device":                   iotda.ResourceDevice(),
 			"huaweicloud_iotda_device_async_command":     iotda.ResourceDeviceAsyncCommand(),
 			"huaweicloud_iotda_device_certificate":       iotda.ResourceDeviceCertificate(),

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_message_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_message_test.go
@@ -1,0 +1,169 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getDeviceMessageResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, WithDerivedAuth())
+	if err != nil {
+		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	queryOpts := &model.ShowDeviceMessageRequest{
+		DeviceId:  state.Primary.Attributes["device_id"],
+		MessageId: state.Primary.ID,
+	}
+	return client.ShowDeviceMessage(queryOpts)
+}
+
+func TestAccDeviceMessage_basic(t *testing.T) {
+	var (
+		obj   model.ShowDeviceMessageResponse
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_iotda_device_message.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeviceMessageResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDeviceMessage_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "device_id", "huaweicloud_iotda_device.test", "id"),
+					resource.TestCheckResourceAttr(rName, "message", "message_content"),
+					resource.TestCheckResourceAttr(rName, "message_id", name),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "encoding", "none"),
+					resource.TestCheckResourceAttr(rName, "payload_format", "standard"),
+					resource.TestCheckResourceAttr(rName, "topic_full_name", "topic_test"),
+					resource.TestCheckResourceAttr(rName, "properties.#", "1"),
+					resource.TestCheckResourceAttr(rName, "properties.0.correlation_data", "data_test"),
+					resource.TestCheckResourceAttr(rName, "properties.0.response_topic", "resp_test"),
+					resource.TestCheckResourceAttr(rName, "properties.0.user_properties.#", "2"),
+					resource.TestCheckResourceAttr(rName, "properties.0.user_properties.0.prop_key", "test_key1"),
+					resource.TestCheckResourceAttr(rName, "properties.0.user_properties.0.prop_value", "test_val1"),
+					resource.TestCheckResourceAttr(rName, "properties.0.user_properties.1.prop_key", "test_key2"),
+					resource.TestCheckResourceAttr(rName, "properties.0.user_properties.1.prop_value", "test_val2"),
+					resource.TestCheckResourceAttrSet(rName, "created_time"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDeviceMessage_derived(t *testing.T) {
+	var (
+		obj   model.ShowDeviceMessageResponse
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_iotda_device_message.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeviceMessageResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDeviceMessage_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "device_id", "huaweicloud_iotda_device.test", "id"),
+					resource.TestCheckResourceAttr(rName, "message", "message_content"),
+					resource.TestCheckResourceAttr(rName, "message_id", name),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "encoding", "none"),
+					resource.TestCheckResourceAttr(rName, "payload_format", "standard"),
+					resource.TestCheckResourceAttr(rName, "topic_full_name", "topic_test"),
+					resource.TestCheckResourceAttr(rName, "properties.#", "1"),
+					resource.TestCheckResourceAttr(rName, "properties.0.correlation_data", "data_test"),
+					resource.TestCheckResourceAttr(rName, "properties.0.response_topic", "resp_test"),
+					resource.TestCheckResourceAttr(rName, "properties.0.user_properties.#", "2"),
+					resource.TestCheckResourceAttr(rName, "properties.0.user_properties.0.prop_key", "test_key1"),
+					resource.TestCheckResourceAttr(rName, "properties.0.user_properties.0.prop_value", "test_val1"),
+					resource.TestCheckResourceAttr(rName, "properties.0.user_properties.1.prop_key", "test_key2"),
+					resource.TestCheckResourceAttr(rName, "properties.0.user_properties.1.prop_value", "test_val2"),
+					resource.TestCheckResourceAttrSet(rName, "created_time"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+				),
+			},
+		},
+	})
+}
+
+func testDeviceMessage_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
+resource "huaweicloud_iotda_device" "test" {
+  node_id    = "%[3]s"
+  name       = "%[3]s"
+  space_id   = huaweicloud_iotda_space.test.id
+  product_id = huaweicloud_iotda_product.test.id
+  secret     = "1234567890"
+}
+`, buildIoTDAEndpoint(), testAccDevice_base(name), name)
+}
+
+func testDeviceMessage_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_iotda_device_message" "test" {
+  device_id       = huaweicloud_iotda_device.test.id
+  message         = "message_content"
+  message_id      = "%[2]s"
+  name            = "%[2]s"
+  encoding        = "none"
+  payload_format  = "standard"
+  topic_full_name = "topic_test"
+  ttl             = "100"
+
+  properties {
+    correlation_data = "data_test"
+    response_topic   = "resp_test"
+
+    user_properties {
+      prop_key   = "test_key1"
+      prop_value = "test_val1"
+    }
+
+    user_properties {
+      prop_key   = "test_key2"
+      prop_value = "test_val2"
+    }
+  }
+}
+`, testDeviceMessage_base(name), name)
+}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_data_backlog_policy.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_data_backlog_policy.go
@@ -61,7 +61,7 @@ func ResourceDataBacklogPolicy() *schema.Resource {
 	}
 }
 
-func convertBacklogValueToInt32(value string) *int32 {
+func convertStringValueToInt32(value string) *int32 {
 	if value == "0" {
 		return utils.Int32(0)
 	}
@@ -79,8 +79,8 @@ func buildDataBacklogPolicyCreateParams(d *schema.ResourceData) *model.CreateRou
 	createOptsBody := model.AddBacklogPolicy{
 		PolicyName:  utils.StringIgnoreEmpty(d.Get("name").(string)),
 		Description: utils.StringIgnoreEmpty(d.Get("description").(string)),
-		BacklogSize: convertBacklogValueToInt32(d.Get("backlog_size").(string)),
-		BacklogTime: convertBacklogValueToInt32(d.Get("backlog_time").(string)),
+		BacklogSize: convertStringValueToInt32(d.Get("backlog_size").(string)),
+		BacklogTime: convertStringValueToInt32(d.Get("backlog_time").(string)),
 	}
 
 	return &model.CreateRoutingBacklogPolicyRequest{
@@ -159,8 +159,8 @@ func buildDataBacklogPolicyUpdateParams(d *schema.ResourceData) *model.UpdateRou
 	updateOptsBody := model.UpdateBacklogPolicy{
 		PolicyName:  utils.StringIgnoreEmpty(d.Get("name").(string)),
 		Description: utils.StringIgnoreEmpty(d.Get("description").(string)),
-		BacklogSize: convertBacklogValueToInt32(d.Get("backlog_size").(string)),
-		BacklogTime: convertBacklogValueToInt32(d.Get("backlog_time").(string)),
+		BacklogSize: convertStringValueToInt32(d.Get("backlog_size").(string)),
+		BacklogTime: convertStringValueToInt32(d.Get("backlog_time").(string)),
 	}
 
 	return &model.UpdateRoutingBacklogPolicyRequest{

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_message.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_message.go
@@ -1,0 +1,352 @@
+package iotda
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IoTDA POST /v5/iot/{project_id}/devices/{device_id}/messages
+// @API IoTDA GET /v5/iot/{project_id}/devices/{device_id}/messages/{message_id}
+func ResourceDeviceMessage() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDeviceMessageCreate,
+		ReadContext:   resourceDeviceMessageRead,
+		DeleteContext: resourceDeviceMessageDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"device_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"message": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"message_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"properties": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"correlation_data": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"response_topic": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"user_properties": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"prop_key": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"prop_value": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"encoding": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"payload_format": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"topic": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"topic_full_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"ttl": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"error_info": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"error_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"error_msg": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"created_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"finished_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildDeviceMessagePropertiesParams(properties []interface{}) *model.PropertiesDto {
+	if len(properties) == 0 {
+		return nil
+	}
+
+	propertiesMap := properties[0].(map[string]interface{})
+	propertiesParams := &model.PropertiesDto{
+		CorrelationData: utils.StringIgnoreEmpty(propertiesMap["correlation_data"].(string)),
+		ResponseTopic:   utils.StringIgnoreEmpty(propertiesMap["response_topic"].(string)),
+	}
+
+	if userPropertiesList := propertiesMap["user_properties"].([]interface{}); len(userPropertiesList) > 0 {
+		userPropertiesParams := make([]model.UserPropDto, 0, len(userPropertiesList))
+		for _, v := range userPropertiesList {
+			userPropMap := v.(map[string]interface{})
+			userProperties := model.UserPropDto{
+				PropKey:   utils.StringIgnoreEmpty(userPropMap["prop_key"].(string)),
+				PropValue: utils.StringIgnoreEmpty(userPropMap["prop_value"].(string)),
+			}
+			userPropertiesParams = append(userPropertiesParams, userProperties)
+		}
+		if len(userPropertiesParams) > 0 {
+			propertiesParams.UserProperties = &userPropertiesParams
+		}
+	}
+
+	return propertiesParams
+}
+
+func buildDeviceMessageBodyParams(d *schema.ResourceData) *model.CreateMessageRequest {
+	message := d.Get("message")
+	bodyParams := model.CreateMessageRequest{
+		DeviceId: d.Get("device_id").(string),
+		Body: &model.DeviceMessageRequest{
+			MessageId:     utils.StringIgnoreEmpty(d.Get("message_id").(string)),
+			Name:          utils.StringIgnoreEmpty(d.Get("name").(string)),
+			Message:       &message,
+			Properties:    buildDeviceMessagePropertiesParams(d.Get("properties").([]interface{})),
+			Encoding:      utils.StringIgnoreEmpty(d.Get("encoding").(string)),
+			PayloadFormat: utils.StringIgnoreEmpty(d.Get("payload_format").(string)),
+			Topic:         utils.StringIgnoreEmpty(d.Get("topic").(string)),
+			TopicFullName: utils.StringIgnoreEmpty(d.Get("topic_full_name").(string)),
+			Ttl:           convertStringValueToInt32(d.Get("ttl").(string)),
+		},
+	}
+
+	return &bodyParams
+}
+
+func resourceDeviceMessageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+	)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	createOpts := buildDeviceMessageBodyParams(d)
+	resp, err := client.CreateMessage(createOpts)
+	if err != nil {
+		return diag.Errorf("error creating device message: %s", err)
+	}
+
+	if resp == nil || resp.MessageId == nil {
+		return diag.Errorf("error creating device message: ID is not found in API response")
+	}
+
+	d.SetId(*resp.MessageId)
+
+	return resourceDeviceMessageRead(ctx, d, meta)
+}
+
+func buildDeviceMessageQueryParams(d *schema.ResourceData) *model.ShowDeviceMessageRequest {
+	return &model.ShowDeviceMessageRequest{
+		DeviceId:  d.Get("device_id").(string),
+		MessageId: d.Id(),
+	}
+}
+
+func resourceDeviceMessageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+	)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	// When the parent resource (device_id) does not exist, query API will return `404` error code.
+	response, err := client.ShowDeviceMessage(buildDeviceMessageQueryParams(d))
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving IoTDA device message")
+	}
+
+	// When the resource does not exist, query API will return `200` status code.
+	// Therefore, it is necessary to check whether the message ID is returned in the response body.
+	if response == nil || response.MessageId == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving IoTDA device message")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("message_id", response.MessageId),
+		d.Set("name", response.Name),
+		d.Set("message", response.Message),
+		d.Set("properties", flattenDeviceMessageProperties(response.Properties)),
+		d.Set("encoding", response.Encoding),
+		d.Set("payload_format", response.PayloadFormat),
+		d.Set("status", response.Status),
+		d.Set("error_info", flattenDeviceMessageErrorInfo(response.ErrorInfo)),
+		d.Set("created_time", response.CreatedTime),
+		d.Set("finished_time", response.FinishedTime),
+	)
+
+	// The values of parameters `topic` and `topic_full_name` correspond to the `topic` field in the query API response.
+	if response.Topic != nil {
+		topicStr := *response.Topic
+		if strings.HasPrefix(topicStr, "$oc/devices") {
+			mErr = multierror.Append(mErr, d.Set("topic", flattenDeviceMessageTopicOrTopicFullName(topicStr)))
+		} else {
+			mErr = multierror.Append(mErr, d.Set("topic_full_name", flattenDeviceMessageTopicOrTopicFullName(topicStr)))
+		}
+	}
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+// The topic prefix added to the platform field is: $oc/devices/{device_id}/user/
+func flattenDeviceMessageTopicOrTopicFullName(topic string) string {
+	index := strings.Index(topic, "user/")
+	if index != -1 {
+		// For `topic` parameter, We need to extract the suffix here.
+		return topic[index+len("user/"):]
+	}
+
+	return topic
+}
+
+func flattenDeviceMessageProperties(properties *model.PropertiesDto) []interface{} {
+	if properties == nil {
+		return nil
+	}
+
+	propertiesMap := map[string]interface{}{
+		"correlation_data": properties.CorrelationData,
+		"response_topic":   properties.ResponseTopic,
+		"user_properties":  flattenDeviceMessageUserProperties(properties.UserProperties),
+	}
+
+	return []interface{}{propertiesMap}
+}
+
+func flattenDeviceMessageUserProperties(userProperties *[]model.UserPropDto) []interface{} {
+	if userProperties == nil {
+		return nil
+	}
+
+	result := make([]interface{}, len(*userProperties))
+	for i, v := range *userProperties {
+		result[i] = map[string]interface{}{
+			"prop_key":   v.PropKey,
+			"prop_value": v.PropValue,
+		}
+	}
+
+	return result
+}
+
+func flattenDeviceMessageErrorInfo(errorInfo *model.ErrorInfoDto) []interface{} {
+	if errorInfo == nil {
+		return nil
+	}
+
+	errorInfoMap := map[string]interface{}{
+		"error_code": errorInfo.ErrorCode,
+		"error_msg":  errorInfo.ErrorMsg,
+	}
+
+	return []interface{}{errorInfoMap}
+}
+
+func resourceDeviceMessageDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Delete()' method because the resource is an action resource.
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support device message delivery resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Support device message delivery resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

### Basic Test
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDeviceMessage_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceMessage_basic -timeout 360m -parallel 4
=== RUN   TestAccDeviceMessage_basic
--- PASS: TestAccDeviceMessage_basic (14.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     14.657s

```

### Derived Test
```
$ export HW_IOTDA_ACCESS_ADDRESS=xxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDeviceMessage_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceMessage_derived -timeout 360m -parallel 4
=== RUN   TestAccDeviceMessage_derived
--- PASS: TestAccDeviceMessage_derived (10.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     10.638s

```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/1c62af54-f585-4a7c-9e7e-8e41552015ab)

    ab. Related resources (parent resources) not found
![image](https://github.com/user-attachments/assets/545b5135-27a5-446e-b6d0-cdd170452f6a)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->