### PR TITLE
fix: chore(dns): Ignore suffix character of domain name that changes happen

### DIFF
--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_recordset_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_recordset_test.go
@@ -67,15 +67,14 @@ func getDNSRecordsetResourceFunc(cfg *config.Config, state *terraform.ResourceSt
 }
 
 func TestAccDNSRecordset_basic(t *testing.T) {
-	var obj interface{}
+	var (
+		obj interface{}
 
-	name := fmt.Sprintf("acpttest-recordset-%s.com.", acctest.RandString(5))
-	rName := "huaweicloud_dns_recordset.test"
+		rName = "huaweicloud_dns_recordset.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getDNSRecordsetResourceFunc)
 
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getDNSRecordsetResourceFunc,
+		name              = fmt.Sprintf("acpttest-recordset-%s.com", acctest.RandString(5))
+		nameWithDotSuffix = fmt.Sprintf("%s.", name)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -87,7 +86,7 @@ func TestAccDNSRecordset_basic(t *testing.T) {
 				Config: testDNSRecordset_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "name", nameWithDotSuffix),
 					resource.TestCheckResourceAttr(rName, "type", "A"),
 					resource.TestCheckResourceAttr(rName, "description", "a recordset description"),
 					resource.TestCheckResourceAttr(rName, "status", "ENABLE"),
@@ -105,7 +104,7 @@ func TestAccDNSRecordset_basic(t *testing.T) {
 				Config: testDNSRecordset_basic_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("update.%s", name)),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("update.%s", nameWithDotSuffix)),
 					resource.TestCheckResourceAttr(rName, "type", "TXT"),
 					resource.TestCheckResourceAttr(rName, "description", "a recordset description update"),
 					resource.TestCheckResourceAttr(rName, "status", "DISABLE"),
@@ -126,15 +125,14 @@ func TestAccDNSRecordset_basic(t *testing.T) {
 }
 
 func TestAccDNSRecordset_publicZone(t *testing.T) {
-	var obj interface{}
+	var (
+		obj interface{}
 
-	name := fmt.Sprintf("acpttest-recordset-%s.com.", acctest.RandString(5))
-	rName := "huaweicloud_dns_recordset.test"
+		rName = "huaweicloud_dns_recordset.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getDNSRecordsetResourceFunc)
 
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getDNSRecordsetResourceFunc,
+		name              = fmt.Sprintf("acpttest-recordset-%s.com", acctest.RandString(5))
+		nameWithDotSuffix = fmt.Sprintf("%s.", name)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -146,7 +144,7 @@ func TestAccDNSRecordset_publicZone(t *testing.T) {
 				Config: testDNSRecordset_publicZone(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "name", nameWithDotSuffix),
 					resource.TestCheckResourceAttr(rName, "type", "A"),
 					resource.TestCheckResourceAttr(rName, "description", "a record set"),
 					resource.TestCheckResourceAttr(rName, "status", "ENABLE"),
@@ -162,7 +160,7 @@ func TestAccDNSRecordset_publicZone(t *testing.T) {
 				Config: testDNSRecordset_publicZone_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("update.%s", name)),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("update.%s", nameWithDotSuffix)),
 					resource.TestCheckResourceAttr(rName, "type", "TXT"),
 					resource.TestCheckResourceAttr(rName, "description", "an updated record set"),
 					resource.TestCheckResourceAttr(rName, "status", "DISABLE"),
@@ -177,15 +175,14 @@ func TestAccDNSRecordset_publicZone(t *testing.T) {
 }
 
 func TestAccDNSRecordset_privateZone(t *testing.T) {
-	var obj interface{}
+	var (
+		obj interface{}
 
-	name := fmt.Sprintf("acpttest-recordset-%s.com.", acctest.RandString(5))
-	rName := "huaweicloud_dns_recordset.test"
+		rName = "huaweicloud_dns_recordset.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getDNSRecordsetResourceFunc)
 
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getDNSRecordsetResourceFunc,
+		name              = fmt.Sprintf("acpttest-recordset-%s.com", acctest.RandString(5))
+		nameWithDotSuffix = fmt.Sprintf("%s.", name)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -197,7 +194,7 @@ func TestAccDNSRecordset_privateZone(t *testing.T) {
 				Config: testDNSRecordset_privateZone(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "name", nameWithDotSuffix),
 					resource.TestCheckResourceAttr(rName, "type", "A"),
 					resource.TestCheckResourceAttr(rName, "description", "a private record set"),
 					resource.TestCheckResourceAttr(rName, "status", "DISABLE"),
@@ -213,7 +210,7 @@ func TestAccDNSRecordset_privateZone(t *testing.T) {
 				Config: testDNSRecordset_privateZone_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("update.%s", name)),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("update.%s", nameWithDotSuffix)),
 					resource.TestCheckResourceAttr(rName, "type", "TXT"),
 					resource.TestCheckResourceAttr(rName, "description", "a private record set update"),
 					resource.TestCheckResourceAttr(rName, "status", "ENABLE"),

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_recordset_v2_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_recordset_v2_test.go
@@ -32,14 +32,14 @@ func getDNSV2RecordsetResourceFunc(c *config.Config, state *terraform.ResourceSt
 }
 
 func TestAccDNSV2RecordSet_basic(t *testing.T) {
-	var recordset recordsets.RecordSet
-	resourceName := "huaweicloud_dns_recordset_v2.recordset_1"
-	name := fmt.Sprintf("acpttest-recordset-%s.com.", acctest.RandString(5))
+	var (
+		obj interface{}
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&recordset,
-		getDNSV2RecordsetResourceFunc,
+		resourceName = "huaweicloud_dns_recordset_v2.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getDNSV2RecordsetResourceFunc)
+
+		name              = fmt.Sprintf("acpttest-recordset-%s.com", acctest.RandString(5))
+		nameWithDotSuffix = fmt.Sprintf("%s.", name)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -51,7 +51,7 @@ func TestAccDNSV2RecordSet_basic(t *testing.T) {
 				Config: testAccDNSV2RecordSet_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "name", nameWithDotSuffix),
 					resource.TestCheckResourceAttr(resourceName, "description", "a record set"),
 					resource.TestCheckResourceAttr(resourceName, "type", "A"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "3000"),
@@ -61,7 +61,7 @@ func TestAccDNSV2RecordSet_basic(t *testing.T) {
 			{
 				Config: testAccDNSV2RecordSet_tags(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "name", nameWithDotSuffix),
 					resource.TestCheckResourceAttr(resourceName, "description", "a record set"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "3000"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
@@ -86,14 +86,13 @@ func TestAccDNSV2RecordSet_basic(t *testing.T) {
 }
 
 func TestAccDNSV2RecordSet_readTTL(t *testing.T) {
-	var recordset recordsets.RecordSet
-	resourceName := "huaweicloud_dns_recordset_v2.recordset_1"
-	name := fmt.Sprintf("acpttest-recordset-%s.com.", acctest.RandString(5))
+	var (
+		obj interface{}
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&recordset,
-		getDNSV2RecordsetResourceFunc,
+		resourceName = "huaweicloud_dns_recordset_v2.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getDNSV2RecordsetResourceFunc)
+
+		name = fmt.Sprintf("acpttest-recordset-%s.com", acctest.RandString(5))
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -114,14 +113,14 @@ func TestAccDNSV2RecordSet_readTTL(t *testing.T) {
 }
 
 func TestAccDNSV2RecordSet_private(t *testing.T) {
-	var recordset recordsets.RecordSet
-	resourceName := "huaweicloud_dns_recordset_v2.recordset_1"
-	name := fmt.Sprintf("acpttest-recordset-%s.com.", acctest.RandString(5))
+	var (
+		obj interface{}
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&recordset,
-		getDNSV2RecordsetResourceFunc,
+		resourceName = "huaweicloud_dns_recordset_v2.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getDNSV2RecordsetResourceFunc)
+
+		name              = fmt.Sprintf("acpttest-recordset-%s.com", acctest.RandString(5))
+		nameWithDotSuffix = fmt.Sprintf("%s.", name)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -133,7 +132,7 @@ func TestAccDNSV2RecordSet_private(t *testing.T) {
 				Config: testAccDNSV2RecordSet_private(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "name", nameWithDotSuffix),
 					resource.TestCheckResourceAttr(resourceName, "description", "a private record set"),
 					resource.TestCheckResourceAttr(resourceName, "type", "A"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "3000"),
@@ -160,7 +159,7 @@ func testAccDNSV2RecordSet_basic(zoneName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_dns_recordset_v2" "recordset_1" {
+resource "huaweicloud_dns_recordset_v2" "test" {
   zone_id     = huaweicloud_dns_zone.zone_1.id
   name        = "%s"
   type        = "A"
@@ -175,7 +174,7 @@ func testAccDNSV2RecordSet_tags(zoneName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_dns_recordset_v2" "recordset_1" {
+resource "huaweicloud_dns_recordset_v2" "test" {
   zone_id     = huaweicloud_dns_zone.zone_1.id
   name        = "%s"
   type        = "A"
@@ -195,7 +194,7 @@ func testAccDNSV2RecordSet_update(zoneName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_dns_recordset_v2" "recordset_1" {
+resource "huaweicloud_dns_recordset_v2" "test" {
   zone_id     = huaweicloud_dns_zone.zone_1.id
   name        = "%s"
   type        = "A"
@@ -215,7 +214,7 @@ func testAccDNSV2RecordSet_readTTL(zoneName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_dns_recordset_v2" "recordset_1" {
+resource "huaweicloud_dns_recordset_v2" "test" {
   zone_id = huaweicloud_dns_zone.zone_1.id
   name    = "%s"
   type    = "A"
@@ -241,7 +240,7 @@ resource "huaweicloud_dns_zone" "zone_1" {
   }
 }
 
-resource "huaweicloud_dns_recordset_v2" "recordset_1" {
+resource "huaweicloud_dns_recordset_v2" "test" {
   zone_id     = huaweicloud_dns_zone.zone_1.id
   name        = "%s"
   type        = "A"

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_test.go
@@ -29,14 +29,14 @@ func getDNSZoneResourceFunc(c *config.Config, state *terraform.ResourceState) (i
 }
 
 func TestAccDNSZone_basic(t *testing.T) {
-	var zone zones.Zone
-	resourceName := "huaweicloud_dns_zone.zone_1"
-	name := fmt.Sprintf("acpttest-zone-%s.com.", acctest.RandString(5))
+	var (
+		obj interface{}
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&zone,
-		getDNSZoneResourceFunc,
+		resourceName = "huaweicloud_dns_zone.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getDNSZoneResourceFunc)
+
+		name              = fmt.Sprintf("acpttest-zone-%s.com", acctest.RandString(5))
+		nameWithDotSuffix = fmt.Sprintf("%s.", name)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -48,7 +48,7 @@ func TestAccDNSZone_basic(t *testing.T) {
 				Config: testAccDNSZone_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "name", nameWithDotSuffix),
 					resource.TestCheckResourceAttr(resourceName, "zone_type", "public"),
 					resource.TestCheckResourceAttr(resourceName, "description", "a zone"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "300"),
@@ -79,15 +79,15 @@ func TestAccDNSZone_basic(t *testing.T) {
 }
 
 func TestAccDNSZone_private(t *testing.T) {
-	var zone zones.Zone
-	resourceName := "huaweicloud_dns_zone.test"
-	name := fmt.Sprintf("acpttest-zone-%s.com.", acctest.RandString(5))
-	vpcName := acceptance.RandomAccResourceName()
+	var (
+		obj interface{}
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&zone,
-		getDNSZoneResourceFunc,
+		resourceName = "huaweicloud_dns_zone.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getDNSZoneResourceFunc)
+
+		name              = fmt.Sprintf("acpttest-zone-%s.com", acctest.RandString(5))
+		nameWithDotSuffix = fmt.Sprintf("%s.", name)
+		baseConfig        = testAccDNSZone_private_base(acceptance.RandomAccResourceName())
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -96,10 +96,10 @@ func TestAccDNSZone_private(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSZone_private_step1(name, vpcName),
+				Config: testAccDNSZone_private_step1(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "name", nameWithDotSuffix),
 					resource.TestCheckResourceAttr(resourceName, "zone_type", "private"),
 					resource.TestCheckResourceAttr(resourceName, "description", "a private zone"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "300"),
@@ -110,10 +110,10 @@ func TestAccDNSZone_private(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDNSZone_private_step2(name, vpcName),
+				Config: testAccDNSZone_private_step2(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "name", nameWithDotSuffix),
 					resource.TestCheckOutput("valid_route_id", "true"),
 					resource.TestCheckResourceAttr(resourceName, "router.#", "2"),
 				),
@@ -123,14 +123,13 @@ func TestAccDNSZone_private(t *testing.T) {
 }
 
 func TestAccDNSZone_readTTL(t *testing.T) {
-	var zone zones.Zone
-	resourceName := "huaweicloud_dns_zone.zone_1"
-	name := fmt.Sprintf("acpttest-zone-%s.com.", acctest.RandString(5))
+	var (
+		obj interface{}
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&zone,
-		getDNSZoneResourceFunc,
+		resourceName = "huaweicloud_dns_zone.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getDNSZoneResourceFunc)
+
+		name = fmt.Sprintf("acpttest-zone-%s.com", acctest.RandString(5))
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -150,14 +149,14 @@ func TestAccDNSZone_readTTL(t *testing.T) {
 }
 
 func TestAccDNSZone_withEpsId(t *testing.T) {
-	var zone zones.Zone
-	resourceName := "huaweicloud_dns_zone.zone_1"
-	name := fmt.Sprintf("acpttest-zone-%s.com.", acctest.RandString(5))
+	var (
+		obj interface{}
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&zone,
-		getDNSZoneResourceFunc,
+		resourceName = "huaweicloud_dns_zone.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getDNSZoneResourceFunc)
+
+		name              = fmt.Sprintf("acpttest-zone-%s.com", acctest.RandString(5))
+		nameWithDotSuffix = fmt.Sprintf("%s.", name)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -169,7 +168,7 @@ func TestAccDNSZone_withEpsId(t *testing.T) {
 				Config: testAccDNSZone_withEpsId(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "name", nameWithDotSuffix),
 					resource.TestCheckResourceAttr(resourceName, "zone_type", "private"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
@@ -180,7 +179,7 @@ func TestAccDNSZone_withEpsId(t *testing.T) {
 
 func testAccDNSZone_basic(zoneName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dns_zone" "zone_1" {
+resource "huaweicloud_dns_zone" "test" {
   name        = "%s"
   description = "a zone"
   ttl         = 300
@@ -196,7 +195,7 @@ resource "huaweicloud_dns_zone" "zone_1" {
 
 func testAccDNSZone_update(zoneName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dns_zone" "zone_1" {
+resource "huaweicloud_dns_zone" "test" {
   name        = "%s"
   description = "an updated zone"
   ttl         = 600
@@ -212,23 +211,29 @@ resource "huaweicloud_dns_zone" "zone_1" {
 
 func testAccDNSZone_readTTL(zoneName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dns_zone" "zone_1" {
+resource "huaweicloud_dns_zone" "test" {
   name  = "%s"
   email = "email1@example.com"
 }
 `, zoneName)
 }
 
-func testAccDNSZone_private_step1(zoneName, vpcName string) string {
+func testAccDNSZone_private_base(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "test" {
   count = 3
-  name  = "%s_${count.index}"
-  cidr  = "192.168.0.0/16"
+
+  name = "%s_${count.index}"
+  cidr = cidrsubnet("192.168.0.0/16", 4, count.index)
+}`, name)
 }
 
+func testAccDNSZone_private_step1(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
 resource "huaweicloud_dns_zone" "test" {
-  name        = "%s"
+  name        = "%[2]s"
   email       = "email@example.com"
   description = "a private zone"
   zone_type   = "private"
@@ -246,19 +251,15 @@ resource "huaweicloud_dns_zone" "test" {
     owner     = "terraform"
   }
 }
-`, vpcName, zoneName)
+`, baseConfig, name)
 }
 
-func testAccDNSZone_private_step2(zoneName, vpcName string) string {
+func testAccDNSZone_private_step2(baseConfig, name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_vpc" "test" {
-  count = 3
-  name  = "%s_${count.index}"
-  cidr  = "192.168.0.0/16"
-}
+%[1]s
 
 resource "huaweicloud_dns_zone" "test" {
-  name        = "%s"
+  name        = "%[2]s"
   email       = "email@example.com"
   description = "a private zone"
   zone_type   = "private"
@@ -284,7 +285,7 @@ locals {
 output "valid_route_id" {
   value = contains(local.router_ids, huaweicloud_vpc.test[1].id) && contains(local.router_ids, huaweicloud_vpc.test[2].id)
 }
-`, vpcName, zoneName)
+`, baseConfig, name)
 }
 
 func testAccDNSZone_withEpsId(zoneName string) string {
@@ -293,7 +294,7 @@ data "huaweicloud_vpc" "default" {
   name = "vpc-default"
 }
 
-resource "huaweicloud_dns_zone" "zone_1" {
+resource "huaweicloud_dns_zone" "test" {
   name                  = "%s"
   email                 = "email@example.com"
   description           = "a private zone"

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_ptrrecord.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_ptrrecord.go
@@ -50,6 +50,9 @@ func ResourceDNSPtrRecord() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+				DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+					return strings.TrimSuffix(oldVal, ".") == strings.TrimSuffix(newVal, ".")
+				},
 			},
 			"floatingip_id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_recordset.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_recordset.go
@@ -63,6 +63,9 @@ func ResourceDNSRecordset() *schema.Resource {
 				Required: true,
 				Description: `Specifies the name of the record set. The name suffixed with a zone name, which is a
 complete host name ended with a dot.`,
+				DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+					return strings.TrimSuffix(oldVal, ".") == strings.TrimSuffix(newVal, ".")
+				},
 			},
 			"type": {
 				Type:     schema.TypeString,

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_recordset_v2.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_recordset_v2.go
@@ -60,6 +60,9 @@ func ResourceDNSRecordSetV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+					return strings.TrimSuffix(oldVal, ".") == strings.TrimSuffix(newVal, ".")
+				},
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_zone.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_zone.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -59,6 +60,9 @@ func ResourceDNSZone() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+					return strings.TrimSuffix(oldVal, ".") == strings.TrimSuffix(newVal, ".")
+				},
 			},
 			"email": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Ignore suffix character of domain name that changes happen.

After creation complete, the domain name will trigger this change:
```
// For example, the domain name set with the demo.example.com
demo.example.com. -> demo.example.com
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. resource name which domain name or name suffix can ignore dot character at the end.
2. using new value that without dot suffix of check items for acceptance test case.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccDNSZone
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDNSZone -timeout 360m -parallel 10
=== RUN   TestAccDNSZone_basic
=== PAUSE TestAccDNSZone_basic
=== RUN   TestAccDNSZone_private
=== PAUSE TestAccDNSZone_private
=== RUN   TestAccDNSZone_readTTL
=== PAUSE TestAccDNSZone_readTTL
=== RUN   TestAccDNSZone_withEpsId
=== PAUSE TestAccDNSZone_withEpsId
=== CONT  TestAccDNSZone_basic
=== CONT  TestAccDNSZone_private
=== CONT  TestAccDNSZone_readTTL
=== CONT  TestAccDNSZone_withEpsId
--- PASS: TestAccDNSZone_readTTL (36.32s)
--- PASS: TestAccDNSZone_withEpsId (41.64s)
--- PASS: TestAccDNSZone_basic (56.70s)
--- PASS: TestAccDNSZone_private (81.17s)
PASS
coverage: 16.2% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       81.216s coverage: 16.2% of statements in ./huaweicloud/services/dns
```
```
./scripts/coverage.sh -o dns -f TestAccDNSPtrRecord
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDNSPtrRecord -timeout 360m -parallel 10
=== RUN   TestAccDNSPtrRecord_basic
=== PAUSE TestAccDNSPtrRecord_basic
=== RUN   TestAccDNSPtrRecord_withEpsId
=== PAUSE TestAccDNSPtrRecord_withEpsId
=== CONT  TestAccDNSPtrRecord_basic
=== CONT  TestAccDNSPtrRecord_withEpsId
--- PASS: TestAccDNSPtrRecord_withEpsId (42.66s)
--- PASS: TestAccDNSPtrRecord_basic (60.32s)
PASS
coverage: 6.5% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       60.368s coverage: 6.5% of statements in ./huaweicloud/services/dns
```
```
./scripts/coverage.sh -o dns -f TestAccDNSRecordset
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDNSRecordset -timeout 360m -parallel 10
=== RUN   TestAccDNSRecordset_basic
=== PAUSE TestAccDNSRecordset_basic
=== RUN   TestAccDNSRecordset_publicZone
=== PAUSE TestAccDNSRecordset_publicZone
=== RUN   TestAccDNSRecordset_privateZone
=== PAUSE TestAccDNSRecordset_privateZone
=== CONT  TestAccDNSRecordset_basic
=== CONT  TestAccDNSRecordset_privateZone
=== CONT  TestAccDNSRecordset_publicZone
--- PASS: TestAccDNSRecordset_publicZone (75.38s)
--- PASS: TestAccDNSRecordset_basic (79.91s)
--- PASS: TestAccDNSRecordset_privateZone (94.48s)
PASS
coverage: 18.6% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       94.535s coverage: 18.6% of statements in ./huaweicloud/services/dns
```
```
./scripts/coverage.sh -o dns -f TestAccDNSV2RecordSet
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDNSV2RecordSet -timeout 360m -parallel 10
=== RUN   TestAccDNSV2RecordSet_basic
=== PAUSE TestAccDNSV2RecordSet_basic
=== RUN   TestAccDNSV2RecordSet_readTTL
=== PAUSE TestAccDNSV2RecordSet_readTTL
=== RUN   TestAccDNSV2RecordSet_private
=== PAUSE TestAccDNSV2RecordSet_private
=== CONT  TestAccDNSV2RecordSet_basic
=== CONT  TestAccDNSV2RecordSet_private
=== CONT  TestAccDNSV2RecordSet_readTTL
--- PASS: TestAccDNSV2RecordSet_readTTL (47.56s)
--- PASS: TestAccDNSV2RecordSet_private (53.25s)
--- PASS: TestAccDNSV2RecordSet_basic (78.87s)
PASS
coverage: 14.9% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       78.936s coverage: 14.9% of statements in ./huaweicloud/services/dns
```

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
