### PR TITLE
feat(dms): support to reset kafka message offset

### DIFF
--- a/docs/resources/dms_kafka_message_diagnosis_task.md
+++ b/docs/resources/dms_kafka_message_diagnosis_task.md
@@ -3,12 +3,12 @@ subcategory: "Distributed Message Service (DMS)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_dms_kafka_message_diagnosis_task"
 description: |-
-  Manage DMS kafka smart message diagnosis task resource within HuaweiCloud.
+  Manage DMS kafka message diagnosis task resource within HuaweiCloud.
 ---
 
 # huaweicloud_dms_kafka_message_diagnosis_task
 
-Manage DMS kafka smart message diagnosis task resource within HuaweiCloud.
+Manage DMS kafka message diagnosis task resource within HuaweiCloud.
 
 ## Example Usage
 

--- a/docs/resources/dms_kafka_message_offset_reset.md
+++ b/docs/resources/dms_kafka_message_offset_reset.md
@@ -1,0 +1,111 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_message_offset_reset"
+description: |-
+  Manage DMS kafka message offset reset resource within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_message_offset_reset
+
+Manage DMS kafka message offset reset resource within HuaweiCloud.
+
+## Example Usage
+
+### Reset message offset for all topic with timestamp
+
+```hcl
+variable "instance_id" {}
+variable "group" {}
+
+resource "huaweicloud_dms_kafka_message_offset_reset" "test" {
+  instance_id = var.instance_id
+  group       = var.group
+  topic       = ""
+  partition   = -1
+  timestamp   = 0
+}
+```
+
+### Reset message offset for all partition under specific topic with timestamp
+
+```hcl
+variable "instance_id" {}
+variable "group" {}
+variable "topic" {}
+
+resource "huaweicloud_dms_kafka_message_offset_reset" "test" {
+  instance_id = var.instance_id
+  group       = var.group
+  topic       = var.topic
+  partition   = -1
+  timestamp   = 0
+}
+```
+
+### Reset message offset for all partition under specific topic with message offset
+
+```hcl
+variable "instance_id" {}
+variable "group" {}
+variable "topic" {}
+
+resource "huaweicloud_dms_kafka_message_offset_reset" "test" {
+  instance_id    = var.instance_id
+  group          = var.group
+  topic          = var.topic
+  partition      = -1
+  message_offset = 0
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the instance ID.
+  Changing this creates a new resource.
+
+* `group` - (Required, String, ForceNew) Specifies the group name.
+  Changing this creates a new resource.
+
+* `partition` - (Required, Int, ForceNew) Specifies the partiton number.
+  + If value is **-1**, reset all partitions. When `topic` is empty, only support reset all partitions.
+  + If value is specific number, reset that partiton only.
+
+  Changing this creates a new resource.
+
+* `topic` - (Optional, String, ForceNew) Specifies the topic name. If it is empty, reset all topic.
+  Changing this creates a new resource.
+
+* `message_offset` - (Optional, String, ForceNew) Specifies the message offset.
+  + If this offset is earlier than the current earliest offset, the offset will be reset to the earliest offset.
+  + If this offset is later than the current largest offset, the offset will be reset to the latest offset.
+
+  Changing this creates a new resource.
+
+* `timestamp` - (Optional, String, ForceNew) Specifies the time that the offset is to be reset to.
+  The value is a Unix timestamp, in millisecond.
+  + If this time is earlier than the current earliest timestamp, the offset will be reset to the earliest timestamp.
+  + If this time is later than the current largest timestamp, the offset will be reset to the latest timestamp.
+
+  Changing this creates a new resource.
+
+-> Exactly one of `message_offset` and `timestamp` should be specified, when `topic` is empty, only support to reset
+  with `timestamp`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1558,6 +1558,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_message_produce":           dms.ResourceDmsKafkaMessageProduce(),
 			"huaweicloud_dms_kafka_partition_reassign":        dms.ResourceDmsKafkaPartitionReassign(),
 			"huaweicloud_dms_kafka_consumer_group":            dms.ResourceDmsKafkaConsumerGroup(),
+			"huaweicloud_dms_kafka_message_offset_reset":      dms.ResourceDmsKafkaMessageOffsetReset(),
 			"huaweicloud_dms_kafka_smart_connect":             dms.ResourceDmsKafkaSmartConnect(),
 			"huaweicloud_dms_kafka_smart_connect_task":        dms.ResourceDmsKafkaSmartConnectTask(),
 			"huaweicloud_dms_kafkav2_smart_connect_task":      dms.ResourceDmsKafkav2SmartConnectTask(),

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_message_offset_reset_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_message_offset_reset_test.go
@@ -1,0 +1,38 @@
+package dms
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccKafkaMessageOffsetReset_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
+			acceptance.TestAccPreCheckDMSKafkaConsumerGroupName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKafkaMessageOffsetReset_basic(),
+			},
+		},
+	})
+}
+
+func testAccKafkaMessageOffsetReset_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_message_offset_reset" "test" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+  topic       = ""
+  partition   = -1
+  timestamp   = 0
+}`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, acceptance.HW_DMS_KAFKA_CONSUMER_GROUP_NAME)
+}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_message_offset_reset.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_message_offset_reset.go
@@ -1,0 +1,159 @@
+package dms
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Kafka POST /v2/kafka/{project_id}/instances/{instance_id}/groups/{group}/reset-message-offset
+// @API Kafka GET /v2/{project_id}/instances/{instance_id}/tasks
+func ResourceDmsKafkaMessageOffsetReset() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDmsKafkaMessageOffsetResetCreate,
+		ReadContext:   resourceDmsKafkaMessageOffsetResetRead,
+		DeleteContext: resourceDmsKafkaMessageOffsetResetDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the instance ID.`,
+			},
+			"group": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the consumer group.`,
+			},
+			"partition": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the partition number.`,
+			},
+			"topic": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the topic name.`,
+			},
+			"message_offset": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ExactlyOneOf: []string{"timestamp"},
+				Description:  `Specifies the message offset.`,
+			},
+			"timestamp": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the message offset. The value is a Unix timestamp, in millisecond`,
+			},
+		},
+	}
+}
+
+func resourceDmsKafkaMessageOffsetResetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	createHttpUrl := "v2/kafka/{project_id}/instances/{instance_id}/groups/{group}/reset-message-offset"
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", d.Get("instance_id").(string))
+	createPath = strings.ReplaceAll(createPath, "{group}", d.Get("group").(string))
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateKafkaMessageOffsetResetBodyParams(d)),
+		OkCodes: []int{
+			204,
+		},
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error resetting Kafka message offset: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	// when topic is empty string, reset all topic, and a job will be created
+	if _, ok := d.GetOk("topic"); !ok {
+		stateConf := &resource.StateChangeConf{
+			Pending:      []string{"CREATED"},
+			Target:       []string{"SUCCESS"},
+			Refresh:      filterTaskRefreshFunc(client, d.Get("instance_id").(string), "kafkaResetConsumerOffset"),
+			Timeout:      d.Timeout(schema.TimeoutCreate),
+			Delay:        5 * time.Second,
+			PollInterval: 5 * time.Second,
+		}
+
+		task, err := stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			if taskID := utils.PathSearch("id", task, ""); taskID != "" {
+				return diag.Errorf("error waiting for job (%s) to be done: %s", taskID, err)
+			}
+			return diag.Errorf("error waiting for job to be done: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func buildCreateKafkaMessageOffsetResetBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		// when topic is empty string, reset all topic
+		"topic":          d.Get("topic"),
+		"partition":      d.Get("partition"),
+		"message_offset": utils.ValueIgnoreEmpty(d.Get("message_offset")),
+		"timestamp":      utils.ValueIgnoreEmpty(d.Get("timestamp")),
+	}
+	return bodyParams
+}
+
+func resourceDmsKafkaMessageOffsetResetRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDmsKafkaMessageOffsetResetDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to reset kafka message offset

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/dms" TESTARGS="-run TestAccKafkaMessageOffsetReset_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccKafkaMessageOffsetReset_basic -timeout 360m -parallel 4
=== RUN   TestAccKafkaMessageOffsetReset_basic
=== PAUSE TestAccKafkaMessageOffsetReset_basic
=== CONT  TestAccKafkaMessageOffsetReset_basic
--- PASS: TestAccKafkaMessageOffsetReset_basic (20.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       20.446s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
