### PR TITLE
feat(dms): support to verify rocketmq consumption

### DIFF
--- a/docs/resources/dms_rocketmq_consumption_verify.md
+++ b/docs/resources/dms_rocketmq_consumption_verify.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_rocketmq_consumption_verify"
+description: |-
+  Manages a DMS RocketMQ consumption verify resource within HuaweiCloud.
+---
+
+# huaweicloud_dms_rocketmq_consumption_verify
+
+Manages a DMS RocketMQ consumption verify resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "group" {}
+variable "topic" {}
+variable "client_id" {}
+variable "message_id_list" {}
+
+resource "huaweicloud_dms_rocketmq_consumption_verify" "test" {
+  instance_id     = var.instance_id
+  group           = var.group
+  topic           = var.topic
+  client_id       = var.client_id
+  message_id_list = var.message_id_list
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the instance ID.
+  Changing this creates a new resource.
+
+* `group` - (Optional, String, ForceNew) Specifies the group name.
+  Changing this creates a new resource.
+
+* `topic` - (Optional, String, ForceNew) Specifies the topic name.
+  Changing this creates a new resource.
+
+* `client_id` - (Optional, String, ForceNew) Specifies the client ID.
+  Changing this creates a new resource.
+
+* `message_id_list` - (Optional, List, ForceNew) Specifies the message ID list.
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `resend_results` - Indicates the verify results.
+  The [resend_results](#attrblock--resend_results) structure is documented below.
+
+<a name="attrblock--resend_results"></a>
+The `resend_results` block supports:
+
+* `error_code` - Indicates the error code.
+
+* `error_message` - Indicates the error message.
+
+* `message_id` - Indicates the message ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1576,6 +1576,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_dms_rocketmq_instance":             dms.ResourceDmsRocketMQInstance(),
 			"huaweicloud_dms_rocketmq_consumer_group":       dms.ResourceDmsRocketMQConsumerGroup(),
+			"huaweicloud_dms_rocketmq_consumption_verify":   dms.ResourceDmsRocketMQConsumptionVerify(),
 			"huaweicloud_dms_rocketmq_message_offset_reset": dms.ResourceDmsRocketMQMessageOffsetReset(),
 			"huaweicloud_dms_rocketmq_dead_letter_resend":   dms.ResourceDmsRocketMQDeadLetterResend(),
 			"huaweicloud_dms_rocketmq_topic":                dms.ResourceDmsRocketMQTopic(),

--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_rocketmq_consumers_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_rocketmq_consumers_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceDmsRocketmqConsumers_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckDMSRocketMQInstanceID(t)
-			acceptance.TestAccPreCheckDMSKafkaConsumerGroupName(t)
+			acceptance.TestAccPreCheckDMSRocketMQGroupName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_consumption_verify_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_consumption_verify_test.go
@@ -1,0 +1,62 @@
+package dms
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccRocketMQConsumptionVerify_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSRocketMQInstanceID(t)
+			acceptance.TestAccPreCheckDMSRocketMQGroupName(t)
+			acceptance.TestAccPreCheckDMSRocketMQTopicName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRocketMQConsumptionVerify_basic(),
+			},
+		},
+	})
+}
+
+func testAccRocketMQConsumptionVerify_basic() string {
+	currentTime := time.Now()
+	startTime := time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 0, 0, 0, 0, currentTime.Location()).UnixMilli()
+	endTime := time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 23, 59, 59, 0, currentTime.Location()).UnixMilli()
+	return fmt.Sprintf(`
+data "huaweicloud_dms_rocketmq_messages" "test" {
+  instance_id = "%[1]s"
+  topic       = "%[3]s"
+  start_time  = %[4]v
+  end_time    = %[5]v
+}
+
+data "huaweicloud_dms_rocketmq_consumers" "test" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+  is_detail   = true
+}
+
+locals {
+  msg_id    = data.huaweicloud_dms_rocketmq_messages.test.messages.0.message_id
+  client_id = data.huaweicloud_dms_rocketmq_consumers.test.clients.0.client_id
+}
+
+resource "huaweicloud_dms_rocketmq_consumption_verify" "test" {
+  instance_id     = "%[1]s"
+  group           = "%[2]s"
+  topic           = "%[3]s"
+  client_id       = local.client_id
+  message_id_list = [local.msg_id]
+}`, acceptance.HW_DMS_ROCKETMQ_INSTANCE_ID, acceptance.HW_DMS_ROCKETMQ_GROUP_NAME, acceptance.HW_DMS_ROCKETMQ_TOPIC_NAME,
+		startTime, endTime)
+}

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_message_offset_reset_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_message_offset_reset_test.go
@@ -14,7 +14,7 @@ func TestAccRocketMQMessageOffsetReset_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckDMSRocketMQInstanceID(t)
-			acceptance.TestAccPreCheckDMSKafkaConsumerGroupName(t)
+			acceptance.TestAccPreCheckDMSRocketMQGroupName(t)
 			acceptance.TestAccPreCheckDMSRocketMQTopicName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_consumption_verify.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_consumption_verify.go
@@ -1,0 +1,135 @@
+package dms
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RocketMQ POST /v2/{engine}/{project_id}/instances/{instance_id}/messages/resend
+func ResourceDmsRocketMQConsumptionVerify() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDmsRocketMQConsumptionVerifyCreate,
+		ReadContext:   resourceDmsRocketMQConsumptionVerifyRead,
+		DeleteContext: resourceDmsRocketMQConsumptionVerifyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"group": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"client_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"topic": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"message_id_list": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				ForceNew: true,
+			},
+			"resend_results": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Indicates the verify results.`,
+				Elem:        rocketMQDeadLetterResendResultsSchema(),
+			},
+		},
+	}
+}
+
+func resourceDmsRocketMQConsumptionVerifyCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	createHttpUrl := "v2/{engine}/{project_id}/instances/{instance_id}/messages/resend"
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{engine}", "reliability")
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", d.Get("instance_id").(string))
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateRocketMQConsumptionVerifyBodyParams(d)),
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	// return 200 even failed, the error message is in response body
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating RocketMQ consumption verify: %s", err)
+	}
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("resend_results", flattenRocketMQMessageResendResults(
+			utils.PathSearch("resend_results", createRespBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildCreateRocketMQConsumptionVerifyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"group":       utils.ValueIgnoreEmpty(d.Get("group")),
+		"topic":       utils.ValueIgnoreEmpty(d.Get("topic")),
+		"client_id":   utils.ValueIgnoreEmpty(d.Get("client_id")),
+		"msg_id_list": utils.ValueIgnoreEmpty(d.Get("message_id_list")),
+	}
+	return bodyParams
+}
+
+func resourceDmsRocketMQConsumptionVerifyRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDmsRocketMQConsumptionVerifyDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to verify rocketmq consumption

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/dms" TESTARGS="-run TestAccRocketMQConsumptionVerify_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccRocketMQConsumptionVerify_basic -timeout 360m -parallel 4
=== RUN   TestAccRocketMQConsumptionVerify_basic
=== PAUSE TestAccRocketMQConsumptionVerify_basic
=== CONT  TestAccRocketMQConsumptionVerify_basic
--- PASS: TestAccRocketMQConsumptionVerify_basic (25.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       25.932s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
