### PR TITLE
feat(CSS): add css restore resource

### DIFF
--- a/docs/resources/css_restore.md
+++ b/docs/resources/css_restore.md
@@ -1,0 +1,79 @@
+---
+subcategory: "Cloud Search Service (CSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_css_restore"
+description: |-
+  Manages CSS cluster restore resource within HuaweiCloud
+---
+
+# huaweicloud_css_restore
+
+Manages CSS cluster restore resource within HuaweiCloud
+
+## Example Usage
+
+### restore by snapshot_id
+
+```hcl
+variable "target_cluster_id" {}
+variable "source_cluster_id" {}
+variable "snapshot_id" {}
+
+resource "huaweicloud_css_restore" "test" {
+  source_cluster_id     = var.target_cluster_id
+  target_cluster_id     = var.source_cluster_id
+  snapshot_id           = var.snapshot_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the css instance resource. If omitted, the
+  provider-level region will be used. Changing this creates a new resource.
+
+* `target_cluster_id` - (Required, String, ForceNew) Specifies the target cluster ID.
+
+  Changing this creates a new resource.
+
+* `source_cluster_id` - (Required, String, ForceNew) Specifies the source cluster ID.
+
+  Changing this creates a new resource.
+
+* `snapshot_id` - (Required, String, ForceNew) Specifies the ID of the snapshot to be restored.
+
+  Changing this creates a new resource.
+
+* `indices` - (Optional, Int, ForceNew) Name of an index to be restored. Multiple indexes are separated by commas (,).
+  By default, all indexes are restored.You can use \ * to match multiple indexes. For example, if you specify 2018-06*,
+  then the data of the indexes with the prefix 2018-06 will be restored.The value can contain 0 to 1,024 characters.
+  Uppercase letters, spaces, and the following special characters are not allowed: "\<|>/?.
+
+  Changing this creates a new resource.
+
+* `rename_pattern` - (Optional, Int, ForceNew) Rule for defining the indexes to be restored.The value can contain 0 to
+  1,024 characters. Uppercase letters, spaces, and the following special characters are not allowed: "\<|>/?. Indexes
+  that match this rule will be restored. The filtering condition must be a regular expression.
+
+  Changing this creates a new resource.
+
+* `rename_replacement` - (Optional, Int, ForceNew) Rule for renaming an index. The value can contain 0 to 1,024
+  characters. Uppercase letters, spaces, and the following special characters are not allowed: "\<|>/? For example,
+  restored_index_$1 indicates adding the restored_ prefix to the names of all the restored indexes.The
+  rename_replacement
+  parameter takes effect only if rename_pattern has been enabled.
+
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attribute is exported:
+
+* `id` - The resource ID. The value is the restore job ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.

--- a/docs/resources/css_restore.md
+++ b/docs/resources/css_restore.md
@@ -30,7 +30,7 @@ resource "huaweicloud_css_restore" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the css instance resource. If omitted, the
+* `region` - (Optional, String, ForceNew) The region in which to create the resource. If omitted, the
   provider-level region will be used. Changing this creates a new resource.
 
 * `target_cluster_id` - (Required, String, ForceNew) Specifies the target cluster ID.

--- a/docs/resources/css_restore.md
+++ b/docs/resources/css_restore.md
@@ -45,20 +45,20 @@ The following arguments are supported:
 
   Changing this creates a new resource.
 
-* `indices` - (Optional, Int, ForceNew) Name of an index to be restored. Multiple indexes are separated by commas (,).
+* `indices` - (Optional, String, ForceNew) Name of an index to be restored. Multiple indexes are separated by commas (,).
   By default, all indexes are restored.You can use \ * to match multiple indexes. For example, if you specify 2018-06*,
   then the data of the indexes with the prefix 2018-06 will be restored.The value can contain 0 to 1,024 characters.
   Uppercase letters, spaces, and the following special characters are not allowed: "\<|>/?.
 
   Changing this creates a new resource.
 
-* `rename_pattern` - (Optional, Int, ForceNew) Rule for defining the indexes to be restored.The value can contain 0 to
+* `rename_pattern` - (Optional, String, ForceNew) Rule for defining the indexes to be restored.The value can contain 0 to
   1,024 characters. Uppercase letters, spaces, and the following special characters are not allowed: "\<|>/?. Indexes
   that match this rule will be restored. The filtering condition must be a regular expression.
 
   Changing this creates a new resource.
 
-* `rename_replacement` - (Optional, Int, ForceNew) Rule for renaming an index. The value can contain 0 to 1,024
+* `rename_replacement` - (Optional, String, ForceNew) Rule for renaming an index. The value can contain 0 to 1,024
   characters. Uppercase letters, spaces, and the following special characters are not allowed: "\<|>/? For example,
   restored_index_$1 indicates adding the restored_ prefix to the names of all the restored indexes.The
   rename_replacement

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2228,6 +2228,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_cdm_cluster_v1": cdm.ResourceCdmCluster(),
 			"huaweicloud_css_cluster_v1": css.ResourceCssCluster(),
+			"huaweicloud_css_restore":    css.ResourceCssRestore(),
 			"huaweicloud_dis_stream_v2":  dis.ResourceDisStream(),
 
 			"huaweicloud_organizations_organization":            organizations.ResourceOrganization(),

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_restore_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_restore_test.go
@@ -1,0 +1,81 @@
+package css
+
+import (
+	"fmt"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccCssInstanceRestore_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCssInstanceRestoreConfig_basic(name),
+			},
+		},
+	})
+}
+
+func testAccCssInstanceRestoreConfig_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_obs_bucket" "cssObs" {
+  bucket        = "%s"
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "huaweicloud_css_cluster" "test" {
+  count			 = 2
+  name           = "%[2]s__${count.index}"
+  engine_version = "7.10.2"
+  security_mode  = true
+  password       = "Test@passw0rd"
+
+  ess_node_config {
+    flavor          = "ess.spec-4u8g"
+    instance_number = 1
+    volume {
+      volume_type = "HIGH"
+      size        = 40
+    }
+  }
+
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  vpc_id            = huaweicloud_vpc.test.id
+
+  backup_strategy {
+    keep_days   = 1
+    start_time  = "00:00 GMT+08:00"
+    prefix      = "snapshot"
+    bucket      = huaweicloud_obs_bucket.cssObs.bucket
+    agency      = "css_obs_agency"
+    backup_path = "css_repository/acctest"
+  }
+}
+resource "huaweicloud_css_snapshot" "snapshot" {
+  name        = "snapshot-%[2]s"
+  description = "a snapshot created by terraform acctest"
+  cluster_id  = huaweicloud_css_cluster.test[0].id
+}
+
+resource "huaweicloud_css_restore" "test" {
+  source_cluster_id 	= huaweicloud_css_cluster.test[0].id
+  target_cluster_id 	= huaweicloud_css_cluster.test[1].id
+  snapshot_id        	= huaweicloud_css_snapshot.snapshot.id
+}
+`, common.TestBaseNetwork(name), name)
+}

--- a/huaweicloud/services/css/resource_huaweicloud_css_restore.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_restore.go
@@ -1,0 +1,137 @@
+package css
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CSS POST /v1.0/{project_id}/clusters/{cluster_id}/index_snapshot/{snapshot_id}/restore
+// @API CSS GET /v1.0/{project_id}/clusters
+func ResourceCssRestore() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCssRestoreCreate,
+		ReadContext:   resourceCssRestoreRead,
+		DeleteContext: resourceCssRestoreDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"source_cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the source cluster ID.`,
+			},
+			"snapshot_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the snapshot to be restored.`,
+			},
+			"target_cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the target cluster ID.`,
+			},
+			"indices": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Name of an index to be restored.`,
+			},
+			"rename_pattern": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Rule for defining the indexes to be restored.`,
+			},
+			"rename_replacement": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Rule for renaming an index.`,
+			},
+		},
+	}
+}
+
+func resourceCssRestoreCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	cssV1Client, err := cfg.CssV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CSS V1 client: %s", err)
+	}
+	hcCssV1Client, err := cfg.HcCssV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CSS V1 client: %s", err)
+	}
+
+	restoreCssCreateHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/index_snapshot/{snapshot_id}/restore"
+
+	targetClusterID := d.Get("target_cluster_id").(string)
+	backupId := d.Get("snapshot_id").(string)
+	clusterId := d.Get("source_cluster_id").(string)
+	restoreCssCreatePath := cssV1Client.Endpoint + restoreCssCreateHttpUrl
+	restoreCssCreatePath = strings.ReplaceAll(restoreCssCreatePath, "{project_id}", cssV1Client.ProjectID)
+	restoreCssCreatePath = strings.ReplaceAll(restoreCssCreatePath, "{cluster_id}", clusterId)
+	restoreCssCreatePath = strings.ReplaceAll(restoreCssCreatePath, "{snapshot_id}", backupId)
+
+	restoreCssCreateOpt := golangsdk.RequestOpts{KeepResponseBody: true}
+	restoreCssCreateOpt.JSONBody = utils.RemoveNil(buildCreateRestoreBodyParams(d))
+
+	_, err = cssV1Client.Request("POST", restoreCssCreatePath, &restoreCssCreateOpt)
+	if err != nil {
+		return diag.Errorf("error restore CSS cluster snapshot extend, cluster_id: %s, error: %s", d.Id(), err)
+	}
+
+	err = checkClusterOperationCompleted(ctx, hcCssV1Client, targetClusterID, d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(backupId)
+
+	return resourceCssRestoreRead(ctx, d, meta)
+}
+
+func buildCreateRestoreBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"targetCluster":     d.Get("target_cluster_id"),
+		"indices":           utils.ValueIgnoreEmpty(d.Get("indices")),
+		"renamePattern":     utils.ValueIgnoreEmpty(d.Get("rename_pattern")),
+		"renameReplacement": utils.ValueIgnoreEmpty(d.Get("rename_replacement")),
+	}
+	return bodyParams
+}
+
+func resourceCssRestoreRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceCssRestoreDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting restoration record is not supported. The restoration record is only removed from the state," +
+		" but it remains in the cloud. And the instance doesn't return to the state before restoration."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}

--- a/huaweicloud/services/css/resource_huaweicloud_css_restore.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_restore.go
@@ -102,7 +102,7 @@ func resourceCssRestoreCreate(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("error restore CSS cluster snapshot extend, cluster_id: %s, error: %s", d.Id(), err)
 	}
 
-	err = checkClusterOperationCompleted(ctx, hcCssV1Client, targetClusterID, d.Timeout(schema.TimeoutUpdate))
+	err = checkClusterOperationCompleted(ctx, hcCssV1Client, targetClusterID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```release-note
add css restore resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed
```
make testacc TEST=./huaweicloud/services/acceptance/css/ TESTARGS='-run TestAccCssInstanceRestore_' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css/ -v -run TestAccCssInstanceRestore_ -timeout 360m -parallel 4
=== RUN   TestAccCssInstanceRestore_basic
=== PAUSE TestAccCssInstanceRestore_basic
=== CONT  TestAccCssInstanceRestore_basic
--- PASS: TestAccCssInstanceRestore_basic (1213.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1213.591s
```