### PR TITLE
feat(workspace/app): add new datasource to query storage policies

### DIFF
--- a/docs/data-sources/workspace_app_storage_policies.md
+++ b/docs/data-sources/workspace_app_storage_policies.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_storage_policies"
+description: |-
+  Use this data source to get the list of storage permission policies for Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_storage_policies
+
+Use this data source to get the list of storage permission policies for Workspace APP within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_workspace_app_storage_policies" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the custom storage permission policies are located.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `policies` - The list of the storage permission policies.  
+  The [policies](#workspace_app_storage_policies) structure is documented below.
+
+<a name="workspace_app_storage_policies"></a>
+The `policies` block supports:
+
+* `id` - The ID of the storage permission policy.
+
+* `server_actions` - The collection of permissions that server can use to access storage.
+
+* `client_actions` - The collection of permissions that client can use to access storage.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1166,8 +1166,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_workload_queue_associated_users": dws.DataSourceDwsWorkloadQueueAssociatedUsers(),
 			"huaweicloud_dws_workload_queues":                 dws.DataSourceWorkloadQueues(),
 
-			"huaweicloud_workspace_desktops": workspace.DataSourceDesktops(),
-			"huaweicloud_workspace_flavors":  workspace.DataSourceWorkspaceFlavors(),
+			"huaweicloud_workspace_app_storage_policies": workspace.DataSourceAppStoragePolicies(),
+			"huaweicloud_workspace_desktops":             workspace.DataSourceDesktops(),
+			"huaweicloud_workspace_flavors":              workspace.DataSourceWorkspaceFlavors(),
 
 			// Legacy
 			"huaweicloud_images_image_v2":        ims.DataSourceImagesImageV2(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_storage_policies_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_storage_policies_test.go
@@ -1,0 +1,64 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAppStoragePolicies_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_workspace_app_storage_policies.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAppStoragePolicies_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_system_policy_exist", "true"),
+					resource.TestCheckOutput("is_policy_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAppStoragePolicies_basic string = `
+resource "huaweicloud_workspace_app_storage_policy" "test" {
+  server_actions = ["GetObject"]
+}
+
+data "huaweicloud_workspace_app_storage_policies" "test" {
+  depends_on = [huaweicloud_workspace_app_storage_policy.test]
+}
+
+// Filter all system policies
+locals {
+  system_policies = [for o in data.huaweicloud_workspace_app_storage_policies.test.policies: o if strcontains(o.id, "DEFAULT")]
+}
+
+output "is_system_policy_exist" {
+  value = length(local.system_policies) > 0
+}
+
+// Filter by storage permission policy ID, in manual
+locals {
+  policy_id = huaweicloud_workspace_app_storage_policy.test.id
+
+  policy_id_filter_result = [for o in data.huaweicloud_workspace_app_storage_policies.test.policies: o if o.id == local.policy_id]
+}
+
+output "is_policy_id_filter_useful" {
+  value = length(local.policy_id_filter_result) == 1
+}
+`

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_storage_policies.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_storage_policies.go
@@ -1,0 +1,101 @@
+package workspace
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/storages-policy/actions/list-statements
+func DataSourceAppStoragePolicies() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppStoragePoliciesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The region where the custom storage permission policies are located.",
+			},
+			"policies": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the storage permission policy.",
+						},
+						"server_actions": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "The collection of permissions that server can use to access storage.",
+						},
+						"client_actions": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "The collection of permissions that client can use to access storage.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func flattenAppStoragePolicies(policies []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(policies))
+
+	for _, val := range policies {
+		result = append(result, map[string]interface{}{
+			"id":             utils.PathSearch("policy_statement_id", val, nil),
+			"server_actions": utils.PathSearch("roam_actions", val, make([]interface{}, 0)),
+			"client_actions": utils.PathSearch("actions", val, make([]interface{}, 0)),
+		})
+	}
+
+	return result
+}
+
+func dataSourceAppStoragePoliciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	policies, err := listAppStoragePermissionPolicies(client)
+	if err != nil {
+		// API error already formated in the list method.
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate data source ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("policies", flattenAppStoragePolicies(policies)),
+	)
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("unable to setting data source fields of the storage permission policies: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New data source supported:
data.huaweicloud_workspace_app_storage_policies

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query storage policies.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataSourceAppStoragePolicies_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataSourceAppStoragePolicies_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAppStoragePolicies_basic
=== PAUSE TestAccDataSourceAppStoragePolicies_basic
=== CONT  TestAccDataSourceAppStoragePolicies_basic
--- PASS: TestAccDataSourceAppStoragePolicies_basic (8.55s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 8.624s  coverage: 4.5% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.
