### PR TITLE
feat(cce): change data_volumes to optional and add subnet_list in node pool

### DIFF
--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -290,8 +290,9 @@ The following arguments are supported:
   This parameter can be plain or salted and is alternative to `key_pair`.
   Changing this parameter will create a new resource.
 
-* `subnet_id` - (Optional, String, ForceNew) Specifies the ID of the subnet to which the NIC belongs.
-  Changing this parameter will create a new resource.
+* `subnet_id` - (Optional, String) Specifies the ID of the subnet to which the NIC belongs.
+
+* `subnet_list` - (Optional, List) Specifies the ID list of the subnet to which the NIC belongs.
 
 * `ecs_group_id` - (Optional, String, ForceNew) Specifies the ECS group ID. If specified, the node will be created under
   the cloud server group. Changing this parameter will create a new resource.
@@ -607,7 +608,7 @@ $ terraform import huaweicloud_cce_node_pool.my_node_pool <cluster_id>/<id>
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include:
-`password`, `subnet_id`, `extend_params`, `taints`, `initial_node_count`, `pod_security_groups` and `extension_scale_groups`.
+`password`, `extend_params`, `taints`, `initial_node_count`, `pod_security_groups` and `extension_scale_groups`.
 It is generally recommended running `terraform plan` after importing a node pool.
 You can then decide if changes should be applied to the node pool, or the resource
 definition should be updated to align with the node pool. Also you can ignore changes as below.
@@ -618,7 +619,7 @@ resource "huaweicloud_cce_node_pool" "my_node_pool" {
 
   lifecycle {
     ignore_changes = [
-      password, subnet_id,
+      password, extend_params,
     ]
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20241115032204-66a489c3683b
+	github.com/chnsz/golangsdk v0.0.0-20241127043958-16cdf11d688f
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20241115032204-66a489c3683b h1:TjfiRI6vtL4cW896+VU2Dk9EAVFC6FcZdpEIcMX40Os=
-github.com/chnsz/golangsdk v0.0.0-20241115032204-66a489c3683b/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20241127043958-16cdf11d688f h1:BLAsiVZd+F7hgBVok1bjLbModDeqaBzBY4/lbCMCILE=
+github.com/chnsz/golangsdk v0.0.0-20241127043958-16cdf11d688f/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/cce/common.go
+++ b/huaweicloud/services/cce/common.go
@@ -274,8 +274,12 @@ func resourceNodeRootVolume() *schema.Schema {
 func resourceNodeDataVolume() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
-		Required: true,
+		Optional: true,
+		Computed: true,
 		ForceNew: true,
+		Description: utils.SchemaDesc("", utils.SchemaDescInput{
+			Required: true,
+		}),
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"size": {

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/requests.go
@@ -249,7 +249,7 @@ type UpdateNodeTemplate struct {
 	// Number of nodes when creating in batch
 	Count int `json:"count,omitempty"`
 	// The node nic spec
-	NodeNicSpec *nodes.NodeNicSpec `json:"nodeNicSpec,omitempty"`
+	NodeNicSpecUpdate nodes.NodeNicSpec `json:"nodeNicSpecUpdate,omitempty"`
 	// Extended parameter
 	ExtendParam map[string]interface{} `json:"extendParam,omitempty"`
 	// UUID of an ECS group

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodes/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodes/results.go
@@ -56,7 +56,7 @@ type Spec struct {
 	// System disk parameter of the node
 	RootVolume VolumeSpec `json:"rootVolume" required:"true"`
 	// The data disk parameter of the node must currently be a disk
-	DataVolumes []VolumeSpec `json:"dataVolumes" required:"true"`
+	DataVolumes []VolumeSpec `json:"dataVolumes,omitempty"`
 	// Disk initialization configuration management parameters
 	// If omit, disk management is performed according to the DockerLVMConfigOverride parameter in extendParam
 	Storage *StorageSpec `json:"storage,omitempty"`
@@ -104,6 +104,8 @@ type PrimaryNic struct {
 	SubnetId string `json:"subnetId,omitempty"`
 	// Fixed ips of the primary Nic
 	FixedIps []string `json:"fixedIps,omitempty"`
+	// Subnet list of the primary Nic
+	SubnetList []string `json:"subnetList,omitempty"`
 }
 
 type ExtNic struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20241115032204-66a489c3683b
+# github.com/chnsz/golangsdk v0.0.0-20241127043958-16cdf11d688f
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. change data_volumes to optional in node and node pool
2. add subnet_list in node pool
3. support updating subnet_id in node pool
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccNode'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccNode -timeout 360m -parallel 4
# github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dataarts
runtime: failed to create new OS thread (have 7 already; errno=12)
fatal error: newosproc
=== RUN   TestAccNodeDataSource_basic
=== PAUSE TestAccNodeDataSource_basic
=== RUN   TestAccNodesDataSource_basic
=== PAUSE TestAccNodesDataSource_basic
=== RUN   TestAccNodeAttach_basic
=== PAUSE TestAccNodeAttach_basic
=== RUN   TestAccNodeAttach_prePaid
=== PAUSE TestAccNodeAttach_prePaid
=== RUN   TestAccNodePool_basic
=== PAUSE TestAccNodePool_basic
=== RUN   TestAccNodePool_tagsLabelsTaints
=== PAUSE TestAccNodePool_tagsLabelsTaints
=== RUN   TestAccNodePool_volume_encryption
=== PAUSE TestAccNodePool_volume_encryption
=== RUN   TestAccNodePool_prePaid
=== PAUSE TestAccNodePool_prePaid
=== RUN   TestAccNodePool_SecurityGroups
=== PAUSE TestAccNodePool_SecurityGroups
=== RUN   TestAccNodePool_serverGroup
=== PAUSE TestAccNodePool_serverGroup
=== RUN   TestAccNodePool_storage
=== PAUSE TestAccNodePool_storage
=== RUN   TestAccNodePool_extensionScaleGroups
=== PAUSE TestAccNodePool_extensionScaleGroups
=== RUN   TestAccNode_basic
=== PAUSE TestAccNode_basic
=== RUN   TestAccNode_eip
=== PAUSE TestAccNode_eip
=== RUN   TestAccNode_volume_encryption
=== PAUSE TestAccNode_volume_encryption
=== RUN   TestAccNode_prePaid
=== PAUSE TestAccNode_prePaid
=== RUN   TestAccNode_password
=== PAUSE TestAccNode_password
=== RUN   TestAccNode_storage
=== PAUSE TestAccNode_storage
=== CONT  TestAccNodeDataSource_basic
=== CONT  TestAccNodePool_tagsLabelsTaints
=== CONT  TestAccNodePool_serverGroup
=== CONT  TestAccNode_volume_encryption
    acceptance.go:1398: This environment does not support KMS tests
--- SKIP: TestAccNode_volume_encryption (0.00s)
=== CONT  TestAccNode_eip
--- PASS: TestAccNodePool_serverGroup (725.44s)
=== CONT  TestAccNode_basic
--- PASS: TestAccNodeDataSource_basic (843.73s)
=== CONT  TestAccNodePool_extensionScaleGroups
--- PASS: TestAccNodePool_tagsLabelsTaints (914.31s)
=== CONT  TestAccNodePool_storage
=== CONT  TestAccNode_storage
--- PASS: TestAccNode_eip (1188.08s)
--- PASS: TestAccNode_basic (839.30s)
=== CONT  TestAccNodePool_basic
--- PASS: TestAccNodePool_storage (743.22s)
=== CONT  TestAccNodeAttach_basic
--- PASS: TestAccNodePool_extensionScaleGroups (913.53s)
=== CONT  TestAccNodesDataSource_basic
--- PASS: TestAccNode_storage (807.81s)
=== CONT  TestAccNode_password
--- PASS: TestAccNodesDataSource_basic (776.41s)
=== CONT  TestAccNodePool_prePaid
    acceptance.go:994: This environment does not support prepaid tests
--- SKIP: TestAccNodePool_prePaid (0.02s)
=== CONT  TestAccNodePool_SecurityGroups
--- PASS: TestAccNodePool_basic (1230.92s)
=== CONT  TestAccNode_prePaid
    acceptance.go:994: This environment does not support prepaid tests
--- SKIP: TestAccNode_prePaid (0.11s)
=== CONT  TestAccNodePool_volume_encryption
    acceptance.go:1398: This environment does not support KMS tests
--- SKIP: TestAccNodePool_volume_encryption (0.09s)
=== CONT  TestAccNodeAttach_prePaid
    acceptance.go:994: This environment does not support prepaid tests
--- SKIP: TestAccNodeAttach_prePaid (0.09s)
--- PASS: TestAccNode_password (867.19s)
--- PASS: TestAccNodeAttach_basic (1217.38s)
--- PASS: TestAccNodePool_SecurityGroups (839.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       3373.314s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
