### PR TITLE
refactor(network): deprecate resource acl and acl_rule

### DIFF
--- a/docs/resources/network_acl.md
+++ b/docs/resources/network_acl.md
@@ -1,11 +1,13 @@
 ---
-subcategory: "Network ACL"
+subcategory: "Deprecated"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_network_acl"
 description: ""
 ---
 
 # huaweicloud_network_acl
+
+!> **WARNING:** It has been deprecated, use `huaweicloud_vpc_network_acl` instead.
 
 Manages a network ACL resource within HuaweiCloud.
 

--- a/docs/resources/network_acl_rule.md
+++ b/docs/resources/network_acl_rule.md
@@ -1,11 +1,13 @@
 ---
-subcategory: "Network ACL"
+subcategory: "Deprecated"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_network_acl_rule"
 description: ""
 ---
 
 # huaweicloud_network_acl_rule
+
+!> **WARNING:** It has been deprecated, use `huaweicloud_vpc_network_acl` instead.
 
 Manages a network ACL rule resource within HuaweiCloud.
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1899,8 +1899,6 @@ func Provider() *schema.Provider {
 			"huaweicloud_nat_private_snat_rule":  nat.ResourcePrivateSnatRule(),
 			"huaweicloud_nat_private_transit_ip": nat.ResourcePrivateTransitIp(),
 
-			"huaweicloud_network_acl":              ResourceNetworkACL(),
-			"huaweicloud_network_acl_rule":         ResourceNetworkACLRule(),
 			"huaweicloud_networking_secgroup":      vpc.ResourceNetworkingSecGroup(),
 			"huaweicloud_networking_secgroup_rule": vpc.ResourceNetworkingSecGroupRule(),
 			"huaweicloud_networking_vip":           vpc.ResourceNetworkingVip(),
@@ -2260,6 +2258,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_csbs_backup_policy_v1":          deprecated.ResourceCSBSBackupPolicyV1(),
 			"huaweicloud_csbs_backup_v1":                 deprecated.ResourceCSBSBackupV1(),
 			"huaweicloud_fgs_trigger":                    deprecated.ResourceFunctionGraphTrigger(),
+			"huaweicloud_network_acl":                    deprecated.ResourceNetworkACL(),
+			"huaweicloud_network_acl_rule":               deprecated.ResourceNetworkACLRule(),
 			"huaweicloud_networking_network_v2":          deprecated.ResourceNetworkingNetworkV2(),
 			"huaweicloud_networking_subnet_v2":           deprecated.ResourceNetworkingSubnetV2(),
 			"huaweicloud_networking_floatingip_v2":       deprecated.ResourceNetworkingFloatingIPV2(),

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_network_acl_rule_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_network_acl_rule_test.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package deprecated
 
 import (
 	"fmt"
@@ -12,6 +12,7 @@ import (
 	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/fwaas_v2/rules"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
@@ -20,9 +21,9 @@ func TestAccNetworkACLRule_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNetworkACLRuleDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheckDeprecated(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkACLRule_basic_1(rName),
@@ -76,9 +77,9 @@ func TestAccNetworkACLRule_anyProtocol(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNetworkACLRuleDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheckDeprecated(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkACLRule_anyProtocol(rName),
@@ -96,8 +97,8 @@ func TestAccNetworkACLRule_anyProtocol(t *testing.T) {
 }
 
 func testAccCheckNetworkACLRuleDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	fwClient, err := config.FwV2Client(HW_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	fwClient, err := config.FwV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud fw client: %s", err)
 	}
@@ -128,8 +129,8 @@ func testAccCheckNetworkACLRuleExists(key string) resource.TestCheckFunc {
 			return fmtp.Errorf("No ID is set in %s", key)
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		fwClient, err := config.FwV2Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		fwClient, err := config.FwV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud fw client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_network_acl_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_network_acl_test.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package deprecated
 
 import (
 	"fmt"
@@ -12,6 +12,7 @@ import (
 	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/fwaas_v2/firewall_groups"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
@@ -21,9 +22,9 @@ func TestAccNetworkACL_basic(t *testing.T) {
 	var fwGroup FirewallGroup
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNetworkACLDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheckDeprecated(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkACL_basic(rName),
@@ -56,9 +57,9 @@ func TestAccNetworkACL_no_subnets(t *testing.T) {
 	var fwGroup FirewallGroup
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNetworkACLDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheckDeprecated(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkACL_no_subnets(rName),
@@ -80,9 +81,9 @@ func TestAccNetworkACL_remove(t *testing.T) {
 	var fwGroup FirewallGroup
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNetworkACLDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheckDeprecated(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkACL_basic_update(rName),
@@ -113,8 +114,8 @@ func TestAccNetworkACL_remove(t *testing.T) {
 }
 
 func testAccCheckNetworkACLDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	fwClient, err := config.FwV2Client(HW_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	fwClient, err := config.FwV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud fw client: %s", err)
 	}
@@ -145,8 +146,8 @@ func testAccCheckNetworkACLExists(n string, fwGroup *FirewallGroup) resource.Tes
 			return fmtp.Errorf("No ID is set in %s", n)
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		fwClient, err := config.FwV2Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		fwClient, err := config.FwV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud fw client: %s", err)
 		}
@@ -162,16 +163,6 @@ func testAccCheckNetworkACLExists(n string, fwGroup *FirewallGroup) resource.Tes
 		}
 
 		*fwGroup = found
-
-		return nil
-	}
-}
-
-func testAccCheckFWFirewallPortCount(firewall_group *FirewallGroup, expected int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if len(firewall_group.PortIDs) != expected {
-			return fmtp.Errorf("Expected %d Ports, got %d", expected, len(firewall_group.PortIDs))
-		}
 
 		return nil
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/deprecated' TESTARGS='-run TestAccNetworkACL'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/deprecated -v -run TestAccNetworkACL -timeout 360m -parallel 4
=== RUN   TestAccNetworkACLRule_basic
=== PAUSE TestAccNetworkACLRule_basic
=== RUN   TestAccNetworkACLRule_anyProtocol
=== PAUSE TestAccNetworkACLRule_anyProtocol
=== RUN   TestAccNetworkACL_basic
=== PAUSE TestAccNetworkACL_basic
=== RUN   TestAccNetworkACL_no_subnets
=== PAUSE TestAccNetworkACL_no_subnets
=== RUN   TestAccNetworkACL_remove
=== PAUSE TestAccNetworkACL_remove
=== CONT  TestAccNetworkACLRule_basic
=== CONT  TestAccNetworkACL_no_subnets
=== CONT  TestAccNetworkACL_basic
=== CONT  TestAccNetworkACLRule_anyProtocol
--- PASS: TestAccNetworkACL_no_subnets (30.82s)
=== CONT  TestAccNetworkACL_remove
--- PASS: TestAccNetworkACLRule_anyProtocol (33.06s)
--- PASS: TestAccNetworkACLRule_basic (68.71s)
--- PASS: TestAccNetworkACL_basic (174.59s)
--- PASS: TestAccNetworkACL_remove (174.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/deprecated        205.449s
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
