### PR TITLE
fix(nat): Fixed the issue that some region enterprise projects do not support null

### DIFF
--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_gateway_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_gateway_test.go
@@ -52,7 +52,6 @@ func TestAccPublicGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "spec", string(nat.PublicSpecTypeSmall)),
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
 					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
-					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
 				),
@@ -65,7 +64,6 @@ func TestAccPublicGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "spec", string(nat.PublicSpecTypeMedium)),
 					resource.TestCheckResourceAttr(rName, "description", ""),
 					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
-					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "baaar"),
 					resource.TestCheckResourceAttr(rName, "tags.newkey", "value"),
 				),
@@ -84,13 +82,12 @@ func testAccPublicGateway_basic_step_1(name, relatedConfig string) string {
 %[1]s
 
 resource "huaweicloud_nat_gateway" "test" {
-  name                  = "%[2]s"
-  spec                  = "1"
-  description           = "Created by acc test"
-  ngport_ip_address     = "192.168.0.101"
-  vpc_id                = huaweicloud_vpc.test.id
-  subnet_id             = huaweicloud_vpc_subnet.test.id
-  enterprise_project_id = "0"
+  name              = "%[2]s"
+  spec              = "1"
+  description       = "Created by acc test"
+  ngport_ip_address = "192.168.0.101"
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
 
   tags = {
     foo = "bar"
@@ -105,12 +102,11 @@ func testAccPublicGateway_basic_step_2(name, relatedConfig string) string {
 %[1]s
 
 resource "huaweicloud_nat_gateway" "test" {
-  name                  = "%[2]s"
-  spec                  = "2"
-  ngport_ip_address     = "192.168.0.101"
-  vpc_id                = huaweicloud_vpc.test.id
-  subnet_id             = huaweicloud_vpc_subnet.test.id
-  enterprise_project_id = "0"
+  name              = "%[2]s"
+  spec              = "2"
+  ngport_ip_address = "192.168.0.101"
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
 
   tags = {
     foo    = "baaar"

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_gateway.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_gateway.go
@@ -225,7 +225,7 @@ func resourcePublicGatewayCreate(ctx context.Context, d *schema.ResourceData, me
 	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
 	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         buildCreatePublicGatewayBodyParams(d, cfg),
+		JSONBody:         utils.RemoveNil(buildCreatePublicGatewayBodyParams(d, cfg)),
 	}
 	createResp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {


### PR DESCRIPTION
… support null

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fixed the issue that some region enterprise projects do not support null.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

- The error message before repair is as follows：
```
make testacc TEST='./huaweicloud/services/acceptance/nat' TESTARGS='-run TestAccPublicGateway_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccPublicGateway_basic
=== PAUSE TestAccPublicGateway_basic
=== CONT  TestAccPublicGateway_basic
    resource_huaweicloud_nat_gateway_test.go:40: Step 1/3 error: Error running apply: exit status 1

        Error: error creating NAT gateway: Bad request with: [POST https://nat.cn-east-4.myhuaweicloud.com/v2/bf2bc85c1ee64f03b7a9a5491babdaf0/nat_gateways], request_id: 3f2c22a3e5a9c71a3c0ec32ed7048fd7, error message: {"message":"invalid  enterprise project id:null","code":"SYS.0400","request_id":"3f2c22a3e5a9c71a3c0ec32ed7048fd7"}

          with huaweicloud_nat_gateway.test,
          on terraform_plugin_test.tf line 27, in resource "huaweicloud_nat_gateway" "test":
          27: resource "huaweicloud_nat_gateway" "test" {

--- FAIL: TestAccPublicGateway_basic (40.93s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       40.981s
FAIL
make: *** [GNUmakefile:21: testacc] Error 1
```

- After the repair, the test case can be executed correctly：
```
make testacc TEST='./huaweicloud/services/acceptance/nat' TESTARGS='-run TestAccPublicGateway_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccPublicGateway_basic
=== PAUSE TestAccPublicGateway_basic
=== CONT  TestAccPublicGateway_basic
--- PASS: TestAccPublicGateway_basic (81.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       81.924s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
