### PR TITLE
feat(iotda/device_messages): support device messages dataSource

### DIFF
--- a/docs/data-sources/iotda_device_messages.md
+++ b/docs/data-sources/iotda_device_messages.md
@@ -1,0 +1,116 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_iotda_device_messages"
+description: |-
+  Use this data source to get the list of IoTDA device messages within HuaweiCloud.
+---
+
+# huaweicloud_iotda_device_messages
+
+Use this data source to get the list of IoTDA device messages within HuaweiCloud.
+
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify
+  the IoTDA service endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  *9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com*, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "device_id" {}
+
+data "huaweicloud_iotda_device_messages" "test" {
+  device_id = var.device_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the device messages.
+  If omitted, the provider-level region will be used.
+
+* `device_id` - (Required, String) Specifies the device ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `messages` - All device messages that match the filter parameters.
+  The [messages](#iotda_messages) structure is documented below.
+
+<a name="iotda_messages"></a>
+The `messages` block supports:
+
+* `id` - The message ID.
+
+* `name` - The message name.
+
+* `message` - The message content.
+
+* `encoding` - The encoding format for message content. The value can be **none** or **base64**.
+
+* `payload_format` - The payload format. The value can be **standard** or **raw**.
+
+* `topic` - The message topic.
+
+* `properties` - The attribute parameters of the message downstream to the device.
+  The [properties](#iotda_properties) structure is documented below.
+
+* `status` - The status of the message.  
+  The valid values are as follows:
+  + **PENDING**: The device is not online, the message is cached and will be issued after the device is online.
+  + **DELIVERED**: The message sent successfully.
+  + **FAILED**: The message sending failed.
+  + **TIMEOUT**: The message has not been sent to the device within the default time of the platform (`1` day).
+
+* `error_info` - The message delivery failure details.
+  The [error_info](#iotda_error_info) structure is documented below.
+
+* `created_time` - The creation time of the device message.
+  The format is **yyyyMMdd'T'HHmmss'Z'**, e.g. **20151212T121212Z**.
+
+* `finished_time` - The end time of the device message. Contains the time for the message to transition to the
+  **DELIVERED* and **TIMEOUT** status. The format is **yyyyMMdd'T'HHmmss'Z'**, e.g. **20151212T121212Z**.
+
+<a name="iotda_properties"></a>
+The `properties` block supports:
+
+* `correlation_data` - The relevant data in MQTT 5.0 request and response patterns.
+
+* `response_topic` - The response topic in MQTT 5.0 request and response patterns.
+
+* `user_properties` - The user-defined attributes.
+  The [user_properties](#iotda_user_properties) structure is documented below.
+
+<a name="iotda_user_properties"></a>
+The `user_properties` block supports:
+
+* `prop_key` - The custom attribute key.
+
+* `prop_value` - The custom attribute value.
+
+<a name="iotda_error_info"></a>
+The `error_info` block supports:
+
+* `error_code` - The abnormal information error code.  
+  The valid values are as follows:
+  + **IOTDA.014016**: Indicates that the device is not online.
+  + **IOTDA.014112**: Indicates that the device has not subscribed to the topic.
+
+* `error_msg` - The abnormal information explanation. Includes instructions for devices not online and devices not
+  subscribed to the topic.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -866,6 +866,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kps_running_tasks": dew.DataSourceDewKpsRunningTasks(),
 			"huaweicloud_kps_keypairs":      dew.DataSourceKeypairs(),
 
+			"huaweicloud_iotda_device_messages":            iotda.DataSourceDeviceMessages(),
 			"huaweicloud_iotda_device_proxies":             iotda.DataSourceDeviceProxies(),
 			"huaweicloud_iotda_device_binding_groups":      iotda.DataSourceDeviceBindingGroups(),
 			"huaweicloud_iotda_amqps":                      iotda.DataSourceAMQPQueues(),

--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_device_messages_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_device_messages_test.go
@@ -1,0 +1,92 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDeviceMessages_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_device_messages.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDeviceMessages_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "messages.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "messages.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "messages.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "messages.0.message"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "messages.0.encoding"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "messages.0.payload_format"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "messages.0.topic"),
+					resource.TestCheckResourceAttr(dataSourceName, "messages.0.properties.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "messages.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "messages.0.created_time"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDeviceMessages_derived(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_device_messages.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDeviceMessages_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "messages.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "messages.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "messages.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "messages.0.message"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "messages.0.encoding"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "messages.0.payload_format"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "messages.0.topic"),
+					resource.TestCheckResourceAttr(dataSourceName, "messages.0.properties.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "messages.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "messages.0.created_time"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDeviceMessages_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_iotda_device_messages" "test" {
+  depends_on = [
+    huaweicloud_iotda_device.test,
+    huaweicloud_iotda_device_message.test,
+  ]
+
+  device_id = huaweicloud_iotda_device.test.id
+}
+`, testDeviceMessage_basic(name))
+}

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_messages.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_messages.go
@@ -1,0 +1,190 @@
+package iotda
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API IoTDA GET /v5/iot/{project_id}/devices/{device_id}/messages
+func DataSourceDeviceMessages() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDeviceMessageRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"device_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"messages": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"message": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"encoding": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"payload_format": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"topic": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"properties": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"correlation_data": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"response_topic": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"user_properties": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"prop_key": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"prop_value": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"error_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"error_code": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"error_msg": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"created_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"finished_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDeviceMessageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+	)
+
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	listOpts := model.ListDeviceMessagesRequest{
+		DeviceId: d.Get("device_id").(string),
+	}
+
+	listResp, listErr := client.ListDeviceMessages(&listOpts)
+	if listErr != nil {
+		return diag.Errorf("error querying IoTDA device messages: %s", listErr)
+	}
+
+	uuID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(uuID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("messages", flattenDeviceMessages(listResp.Messages)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDeviceMessages(messages *[]model.DeviceMessage) []interface{} {
+	if messages == nil {
+		return nil
+	}
+
+	if len(*messages) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(*messages))
+	for _, v := range *messages {
+		rst = append(rst, map[string]interface{}{
+			"id":             v.MessageId,
+			"name":           v.Name,
+			"message":        v.Message,
+			"encoding":       v.Encoding,
+			"payload_format": v.PayloadFormat,
+			"topic":          v.Topic,
+			"properties":     flattenDeviceMessageProperties(v.Properties),
+			"status":         v.Status,
+			"error_info":     flattenDeviceMessageErrorInfo(v.ErrorInfo),
+			"created_time":   v.CreatedTime,
+			"finished_time":  v.FinishedTime,
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support device messages dataSource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Support device messages dataSource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

### Basic Test
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceMessages_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceMessages_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceMessages_basic
=== PAUSE TestAccDataSourceDeviceMessages_basic
=== CONT  TestAccDataSourceDeviceMessages_basic
--- PASS: TestAccDataSourceDeviceMessages_basic (11.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     11.256s

```

### Derived Test

```
$ export HW_IOTDA_ACCESS_ADDRESS=xxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceMessages_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceMessages_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceMessages_derived
=== PAUSE TestAccDataSourceDeviceMessages_derived
=== CONT  TestAccDataSourceDeviceMessages_derived
--- PASS: TestAccDataSourceDeviceMessages_derived (13.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     13.077s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
