### PR TITLE
refactor(vpc): ignore tags error in data_source subnets

### DIFF
--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnets.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnets.go
@@ -226,7 +226,7 @@ func dataSourceVpcSubnetsRead(_ context.Context, d *schema.ResourceData, meta in
 			}
 			subnet["tags"] = tagmap
 		} else {
-			return diag.Errorf("error query tags of subnets (%s): %s", item.ID, err)
+			log.Printf("[WARN] error query tags of subnets (%s): %s", item.ID, err)
 		}
 
 		subnets = append(subnets, subnet)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcSubnetsDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcSubnetsDataSource -timeout 360m -parallel 4
=== RUN   TestAccVpcSubnetsDataSource_basic
=== PAUSE TestAccVpcSubnetsDataSource_basic
=== RUN   TestAccVpcSubnetsDataSource_ipv4ByCidr
=== PAUSE TestAccVpcSubnetsDataSource_ipv4ByCidr
=== RUN   TestAccVpcSubnetsDataSource_ipv4ByName
=== PAUSE TestAccVpcSubnetsDataSource_ipv4ByName
=== RUN   TestAccVpcSubnetsDataSource_ipv4ByVpcId
=== PAUSE TestAccVpcSubnetsDataSource_ipv4ByVpcId
=== RUN   TestAccVpcSubnetsDataSource_ipv6Basic
=== PAUSE TestAccVpcSubnetsDataSource_ipv6Basic
=== CONT  TestAccVpcSubnetsDataSource_basic
=== CONT  TestAccVpcSubnetsDataSource_ipv4ByVpcId
=== CONT  TestAccVpcSubnetsDataSource_ipv6Basic
=== CONT  TestAccVpcSubnetsDataSource_ipv4ByName
--- PASS: TestAccVpcSubnetsDataSource_ipv6Basic (96.25s)
=== CONT  TestAccVpcSubnetsDataSource_ipv4ByCidr
--- PASS: TestAccVpcSubnetsDataSource_basic (99.95s)
--- PASS: TestAccVpcSubnetsDataSource_ipv4ByName (102.77s)
--- PASS: TestAccVpcSubnetsDataSource_ipv4ByVpcId (104.30s)
--- PASS: TestAccVpcSubnetsDataSource_ipv4ByCidr (74.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       171.187s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
