### PR TITLE
feat(live): add new datasource to get the list of transcoding templates

### DIFF
--- a/docs/data-sources/live_transcodings.md
+++ b/docs/data-sources/live_transcodings.md
@@ -1,0 +1,96 @@
+---
+subcategory: "Live"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_live_transcodings"
+description: |-
+  Use this data source to get the list of the transcoding templates.
+---
+
+# huaweicloud_live_transcodings
+
+Use this data source to get the list of the transcoding templates.
+
+## Example Usage
+
+```hcl
+variable "domain_name" {}
+
+data "huaweicloud_live_transcodings" "test" {
+  domain_name = var.domain_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `domain_name` - (Required, String) Specifies the ingest domain name to which the transcoding templates blong.
+
+* `app_name` - (Optional, String) Specifies the application name of the transcoding template.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `templates` - The list of the transcoding templates.
+
+  The [templates](#templates_struct) structure is documented below.
+
+<a name="templates_struct"></a>
+The `templates` block supports:
+
+* `app_name` - The application name of the transcoding template.
+
+* `quality_info` - The video quality information.
+
+  The [quality_info](#templates_quality_info_struct) structure is documented below.
+
+<a name="templates_quality_info_struct"></a>
+The `quality_info` block supports:
+
+* `name` - The transcoding template name.
+
+* `quality` - The video quality.
+  The valid values are as follows:
+  + **lud**: Indicates ultra high definition.
+  + **lhd**: Indicates high definition.
+  + **lsd**: Indicates standard definition.
+  + **lld**: Indicates smooth.
+  + **userdefine**: Indicates customization of video quality.
+
+* `video_encoding` - The video encoding format.
+  The value can be **H264** or **H265**.
+
+* `width` - The video long edge (width of horizontal screen, height of vertical screen), in pixels.
+
+* `height` - The video short edge (horizontal screen height, vertical screen width), in pixels.
+
+* `bitrate` - The bitrate of the transcoding video, in Kbps.
+
+* `frame_rate` - The frame rate of transcoding video, in fps.
+
+* `protocol` - The protocol type of transcoding output.
+  The value can be **RTMP**.
+
+* `low_bitrate_hd` - Whether to enable high-definition and low bitrate.
+  The value can be **on** or **off**.
+
+* `gop` - The I frame interval, in seconds.
+
+* `bitrate_adaptive` - The adaptive bitrate.
+  The valid values are as follows:
+  + **off**: Turn off rate adaptation and output the target rate at the set rate.
+  + **minimum**: The target bitrate is output at the minimum value of the set bitrate and the source file bitrate.
+  + **adaptive**: The target bitrate is adaptively output based on source file bitrate.
+
+* `i_frame_interval` - The maximum I frame interval, in frame.
+
+* `i_frame_policy` - The encoding output I frame policy.
+  The valid values are as follows:
+  + **auto**: The I frame output according to the set `gop` duration.
+  + **strictSync**: The encoding output I frame is completely consistent with the source.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -892,7 +892,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_lb_certificate":  lb.DataSourceLBCertificateV2(),
 			"huaweicloud_lb_pools":        lb.DataSourcePools(),
 
-			"huaweicloud_live_domains": live.DataSourceLiveDomains(),
+			"huaweicloud_live_domains":      live.DataSourceLiveDomains(),
+			"huaweicloud_live_transcodings": live.DataSourceLiveTranscodings(),
 
 			"huaweicloud_lts_aom_accesses":                 lts.DataSourceAOMAccesses(),
 			"huaweicloud_lts_cce_accesses":                 lts.DataSourceCceAccesses(),

--- a/huaweicloud/services/acceptance/live/data_source_huaweicloud_live_transcodings_test.go
+++ b/huaweicloud/services/acceptance/live/data_source_huaweicloud_live_transcodings_test.go
@@ -1,0 +1,98 @@
+package live
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceLiveTranscodings_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_live_transcodings.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		domainName     = fmt.Sprintf("%s.huaweicloud.com", acceptance.RandomAccResourceNameWithDash())
+
+		byAppName   = "data.huaweicloud_live_transcodings.filter_by_app_name"
+		dcByAppName = acceptance.InitDataSourceCheck(byAppName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceLiveTranscodings_basic(domainName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "templates.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "templates.0.app_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "templates.0.quality_info.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "templates.0.quality_info.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "templates.0.quality_info.0.quality"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "templates.0.quality_info.0.video_encoding"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "templates.0.quality_info.0.width"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "templates.0.quality_info.0.height"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "templates.0.quality_info.0.bitrate"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "templates.0.quality_info.0.low_bitrate_hd"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "templates.0.quality_info.0.protocol"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "templates.0.quality_info.0.gop"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "templates.0.quality_info.0.bitrate_adaptive"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "templates.0.quality_info.0.i_frame_interval"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "templates.0.quality_info.0.i_frame_policy"),
+
+					dcByAppName.CheckResourceExists(),
+					resource.TestCheckOutput("app_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceLiveTranscodings_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_domain" "test" {
+  name = "%s"
+  type = "push"
+}
+
+resource "huaweicloud_live_transcoding" "test" {
+  domain_name    = huaweicloud_live_domain.test.name
+  app_name       = "live"
+  video_encoding = "H264"
+  low_bitrate_hd = true
+
+  templates {
+    name    = "temp"
+    width   = 640
+    height  = 360
+    bitrate = 400
+  }
+}
+
+data "huaweicloud_live_transcodings" "test" {
+  domain_name = huaweicloud_live_domain.test.name
+
+  depends_on = [huaweicloud_live_transcoding.test]
+}
+
+locals {
+  app_name = data.huaweicloud_live_transcodings.test.templates[0].app_name
+}
+
+data "huaweicloud_live_transcodings" "filter_by_app_name" {
+  domain_name = huaweicloud_live_domain.test.name
+  app_name    = local.app_name
+}
+
+output "app_name_filter_useful" {
+  value = length(data.huaweicloud_live_transcodings.filter_by_app_name.templates) > 0 && alltrue(
+    [for v in data.huaweicloud_live_transcodings.filter_by_app_name.templates[*].app_name : v == local.app_name]
+  )
+}
+`, name)
+}

--- a/huaweicloud/services/live/data_source_huaweicloud_live_transcodings.go
+++ b/huaweicloud/services/live/data_source_huaweicloud_live_transcodings.go
@@ -1,0 +1,241 @@
+package live
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API LIVE GET /v1/{project_id}/template/transcodings
+func DataSourceLiveTranscodings() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceLiveTranscodingsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"domain_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ingest domain name to which the transcoding templates blong.`,
+			},
+			"app_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the application name of the transcoding template.`,
+			},
+			"templates": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the transcoding templates.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"app_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The application name of the transcoding template.`,
+						},
+						"quality_info": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The video quality information.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The transcoding template name.`,
+									},
+									"quality": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The video quality.`,
+									},
+									"video_encoding": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The video encoding format.`,
+									},
+									"width": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The video long edge (width of horizontal screen, height of vertical screen), in pixels.`,
+									},
+									"height": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The video short edge (horizontal screen height, vertical screen width), in pixels.`,
+									},
+									"bitrate": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The bitrate of the transcoding video, in Kbps.`,
+									},
+									"frame_rate": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The frame rate of transcoding video, in fps.`,
+									},
+									"protocol": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The protocol type of transcoding output.`,
+									},
+									"low_bitrate_hd": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `Whether to enable high-definition and low bitrate.`,
+									},
+									"gop": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The I frame interval, in seconds.`,
+									},
+									"bitrate_adaptive": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The adaptive bitrate.`,
+									},
+									"i_frame_interval": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The maximum I frame interval, in frame.`,
+									},
+									"i_frame_policy": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The encoding output I frame policy.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceLiveTranscodingsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	transcodings, err := queryLiveTranscodings(d, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("templates", flattenLiveTranscodings(transcodings)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func queryLiveTranscodings(d *schema.ResourceData, client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/template/transcodings?size=100"
+		page    = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = fmt.Sprintf("%s&domain=%v", listPath, d.Get("domain_name"))
+	if v, ok := d.GetOk("app_name"); ok {
+		listPath = fmt.Sprintf("%s&app_name=%v", listPath, v)
+	}
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		// The page indicates the page number.
+		// The default value is 0, which represents the first page.
+		listPathWithPage := fmt.Sprintf("%s&page=%d", listPath, page)
+		requestResp, err := client.Request("GET", listPathWithPage, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving transcodings: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		transcoding := utils.PathSearch("templates", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, transcoding...)
+		if len(transcoding) == 0 {
+			break
+		}
+		page++
+	}
+	return result, nil
+}
+
+func flattenLiveTranscodings(transcodings []interface{}) []map[string]interface{} {
+	if len(transcodings) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(transcodings))
+	for i, v := range transcodings {
+		result[i] = map[string]interface{}{
+			"app_name":     utils.PathSearch("app_name", v, nil),
+			"quality_info": flattenQualityInfos(utils.PathSearch("quality_info", v, make([]interface{}, 0)).([]interface{})),
+		}
+	}
+	return result
+}
+
+func flattenQualityInfos(qualityInfos []interface{}) []map[string]interface{} {
+	if len(qualityInfos) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(qualityInfos))
+	for i, v := range qualityInfos {
+		result[i] = map[string]interface{}{
+			"name":             utils.PathSearch("templateName", v, nil),
+			"quality":          utils.PathSearch("quality", v, nil),
+			"video_encoding":   utils.PathSearch("codec", v, nil),
+			"width":            utils.PathSearch("width", v, nil),
+			"height":           utils.PathSearch("height", v, nil),
+			"bitrate":          utils.PathSearch("bitrate", v, nil),
+			"frame_rate":       utils.PathSearch("video_frame_rate", v, nil),
+			"protocol":         utils.PathSearch("protocol", v, nil),
+			"low_bitrate_hd":   utils.PathSearch("hdlb", v, nil),
+			"gop":              utils.PathSearch("gop", v, nil),
+			"bitrate_adaptive": utils.PathSearch("bitrate_adaptive", v, nil),
+			"i_frame_interval": utils.PathSearch("iFrameInterval", v, nil),
+			"i_frame_policy":   utils.PathSearch("i_frame_policy", v, nil),
+		}
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new datasource to get the list of transcoding templates.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new datasource to get the list of transcoding templates.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/live" TESTARGS="-run TestAccDataSourceLiveTranscodings_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/live -v -run TestAccDataSourceLiveTranscodings_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceLiveTranscodings_basic
=== PAUSE TestAccDataSourceLiveTranscodings_basic
=== CONT  TestAccDataSourceLiveTranscodings_basic
--- PASS: TestAccDataSourceLiveTranscodings_basic (269.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      269.696s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
