### PR TITLE
feat(cse): supports a new data source for engine flavors query

### DIFF
--- a/docs/data-sources/cse_microservice_engine_flavors.md
+++ b/docs/data-sources/cse_microservice_engine_flavors.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Cloud Service Engine (CSE)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cse_microservice_engine_flavors"
+description: |-
+  Use this data source to query available microservice engine flavors within HuaweiCloud.
+---
+
+# huaweicloud_cse_microservice_engine_flavors
+
+Use this data source to query available microservice engine flavors within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cse_microservice_engine_flavors" "test" {
+  version = "CSE2"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the microservice engine flavors are located.  
+  If omitted, the provider-level region will be used.
+
+* `version` - (Optional, String) Specifies the version that used to filter the microservice engine flavors.
+  + **CSE2**
+  + **Nacos2**
+  + **MicroGateway**
+
+  Defaults to **CSE2**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `flavors` - All microservice engine flavors that match the filter parameters.  
+  The [flavors](#cse_microservice_engine_flavors) structure is documented below.
+
+<a name="cse_microservice_engine_flavors"></a>
+The `flavors` block supports:
+
+* `id` - The ID of the microservice engine flavor.  
+  
+  -> For resource `huaweicloud_cse_microservice_engine`, the flavor of **Nacos2** need to declare the number of
+     capacity units (1 unit = 50 microservice instances) when reference. The format is as follows:  
+     **{flavor}.{capacity_units}**  
+     If you need to create an engine with 500 microservice instances, the flavor corresponding to
+     **cse.nacos2.c1.large** is **cse.nacos2.c1.large.10**.  
+     The specifications of **CSE2** can be used directly without special processing.
+
+* `spec` - The specification detail of the microservice engine flavor.  
+  The [spec](#cse_microservice_engine_flavor_spec) structure is documented below.
+
+<a name="cse_microservice_engine_flavor_spec"></a>
+The `spec` block supports:
+
+* `available_cpu_memory` - The CPU and memory combinations (each value separated by a hyphen) that the flavor is
+  allowed, in string format and separated by the commas (,).
+  For example, **2-4,4-8** means this flavors supports **2u4g** and **4u8g** instances create.
+
+* `linear` - Whether the microservice engine flavor is a linear flavor, in string format.
+  + **true**
+  + **false**
+
+* `available_prefix` - The flavor name prefix of the available node, e.g. **s,c,t**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -589,7 +589,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_cph_server_bandwidths":   cph.DataSourceCphServerBandwidths(),
 			"huaweicloud_cph_encode_servers":      cph.DataSourceCphEncodeServers(),
 
-			"huaweicloud_cse_microservice_engines": cse.DataSourceMicroserviceEngines(),
+			"huaweicloud_cse_microservice_engine_flavors": cse.DataSourceMicroserviceEngineFlavors(),
+			"huaweicloud_cse_microservice_engines":        cse.DataSourceMicroserviceEngines(),
 
 			"huaweicloud_csms_events":                   dew.DataSourceDewCsmsEvents(),
 			"huaweicloud_csms_secrets":                  dew.DataSourceDewCsmsSecrets(),

--- a/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservice_engine_flavors_test.go
+++ b/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservice_engine_flavors_test.go
@@ -1,0 +1,106 @@
+package cse
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataMicroserviceEngineFlavors_basic(t *testing.T) {
+	var (
+		withDefaultVersion   = "data.huaweicloud_cse_microservice_engine_flavors.version_omitted"
+		dcWithDefaultVersion = acceptance.InitDataSourceCheck(withDefaultVersion)
+
+		byVersion   = "data.huaweicloud_cse_microservice_engine_flavors.filter_by_version"
+		dcByVersion = acceptance.InitDataSourceCheck(byVersion)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataMicroserviceEngineFlavors_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dcWithDefaultVersion.CheckResourceExists(),
+					resource.TestMatchResourceAttr(withDefaultVersion, "flavors.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckOutput("all_flavor_ids_set", "true"),
+					resource.TestCheckOutput("is_available_cpu_memory_set_and_correct", "true"),
+					resource.TestCheckOutput("is_linear_set_and_correct", "true"),
+					resource.TestCheckOutput("is_available_prefix_set_and_correct", "true"),
+					dcByVersion.CheckResourceExists(),
+					resource.TestCheckOutput("is_version_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataMicroserviceEngineFlavors_basic string = `
+data "huaweicloud_cse_microservice_engine_flavors" "version_omitted" {}
+
+# Check whether flavor ID is set
+locals {
+  flavor_id_validate_result = [
+    for o in data.huaweicloud_cse_microservice_engine_flavors.version_omitted.flavors[*].id : o != ""
+  ]
+}
+
+output "all_flavor_ids_set" {
+  value = length(local.flavor_id_validate_result) > 0 && alltrue(local.flavor_id_validate_result)
+}
+
+# Check whether spec.available_cpu_memory is in expected format
+locals {
+  available_cpu_memory_filter_result = [
+    for o in data.huaweicloud_cse_microservice_engine_flavors.version_omitted.flavors : length(regexall("\\d+\\-\\d+",
+      o.spec[0].available_cpu_memory)) > 0
+  ]
+}
+
+output "is_available_cpu_memory_set_and_correct" {
+  value = length(local.available_cpu_memory_filter_result) > 0 && alltrue(local.available_cpu_memory_filter_result)
+}
+
+# Check whether spec.linear is in expected format
+locals {
+  linear_filter_result = [
+    for o in data.huaweicloud_cse_microservice_engine_flavors.version_omitted.flavors : contains(["true", "false"], o.spec[0].linear)
+  ]
+}
+
+output "is_linear_set_and_correct" {
+  value = length(local.linear_filter_result) > 0 && alltrue(local.linear_filter_result)
+}
+
+# Check whether spec.available_prefix is set
+locals {
+  available_prefix_filter_result = [
+    for o in data.huaweicloud_cse_microservice_engine_flavors.version_omitted.flavors : can(regex("[\\w,]+",
+      o.spec[0].available_prefix)) && length(split(",", o.spec[0].available_prefix))> 0
+  ]
+}
+
+output "is_available_prefix_set_and_correct" {
+  value = length(local.available_prefix_filter_result) > 0 && alltrue(local.available_prefix_filter_result)
+}
+
+data "huaweicloud_cse_microservice_engine_flavors" "filter_by_version" {
+  version = "Nacos2"
+}
+
+locals {
+  version_filter_result = [
+    for o in data.huaweicloud_cse_microservice_engine_flavors.filter_by_version.flavors : strcontains(o.id, "nacos2")
+  ]
+}
+
+output "is_version_filter_useful" {
+  value = length(local.version_filter_result) > 0 && alltrue(local.version_filter_result)
+}
+`

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_test.go
@@ -48,7 +48,8 @@ func TestAccMicroserviceEngine_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", randName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform test"),
-					resource.TestCheckResourceAttr(resourceName, "flavor", "cse.s1.small2"),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor",
+						"data.huaweicloud_cse_microservice_engine_flavors.test", "flavors.0.id"),
 					resource.TestCheckResourceAttrPair(resourceName, "network_id", "huaweicloud_vpc_subnet.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "auth_type", "RBAC"),
 					resource.TestCheckResourceAttrSet(resourceName, "admin_pass"),
@@ -76,6 +77,10 @@ func TestAccMicroserviceEngine_basic(t *testing.T) {
 func testAccMicroserviceEngine_base(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_cse_microservice_engine_flavors" "test" {
+  version = "CSE2"
+}
 
 resource "huaweicloud_vpc" "test" {
   name = "%[1]s"
@@ -111,7 +116,7 @@ func testAccMicroserviceEngine_basic(rName string) string {
 resource "huaweicloud_cse_microservice_engine" "test" {
   name                  = "%[2]s"
   description           = "Created by terraform test"
-  flavor                = "cse.s1.small2"
+  flavor                = data.huaweicloud_cse_microservice_engine_flavors.test.flavors[0].id
   network_id            = huaweicloud_vpc_subnet.test.id
   eip_id                = huaweicloud_vpc_eip.test.id
   enterprise_project_id = "0"
@@ -151,7 +156,8 @@ func TestAccMicroserviceEngine_withEpsId(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", randName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform test"),
-					resource.TestCheckResourceAttr(resourceName, "flavor", "cse.s1.small2"),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor",
+						"data.huaweicloud_cse_microservice_engine_flavors.test", "flavors.0.id"),
 					resource.TestCheckResourceAttrPair(resourceName, "network_id", "huaweicloud_vpc_subnet.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "auth_type", "RBAC"),
 					resource.TestCheckResourceAttrSet(resourceName, "admin_pass"),
@@ -200,7 +206,7 @@ func testAccMicroserviceEngine_withEpsId(name string) string {
 resource "huaweicloud_cse_microservice_engine" "test" {
   name                  = "%[2]s"
   description           = "Created by terraform test"
-  flavor                = "cse.s1.small2"
+  flavor                = data.huaweicloud_cse_microservice_engine_flavors.test.flavors[0].id
   network_id            = huaweicloud_vpc_subnet.test.id
   eip_id                = huaweicloud_vpc_eip.test.id
   enterprise_project_id = "%[3]s"
@@ -238,7 +244,7 @@ func TestAccMicroserviceEngine_nacos(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", randName),
-					resource.TestCheckResourceAttr(resourceName, "flavor", "cse.nacos2.c1.large.10"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavor"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttrPair(resourceName, "network_id", "huaweicloud_vpc_subnet.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "auth_type", "NONE"),
@@ -255,11 +261,16 @@ func TestAccMicroserviceEngine_nacos(t *testing.T) {
 
 func testAccMicroserviceEngine_nacos_step1(rName string) string {
 	return fmt.Sprintf(`
+data "huaweicloud_cse_microservice_engine_flavors" "test" {
+  version = "Nacos2"
+}
+
 %[1]s
 
 resource "huaweicloud_cse_microservice_engine" "test" {
   name       = "%[2]s"
-  flavor     = "cse.nacos2.c1.large.10"
+  # 10 capacity units (500 microservice instances)
+  flavor     = format("%%s.10", data.huaweicloud_cse_microservice_engine_flavors.test.flavors[0].id)
   network_id = huaweicloud_vpc_subnet.test.id
   auth_type  = "NONE"
   version    = "Nacos2"

--- a/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_engine_flavors.go
+++ b/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_engine_flavors.go
@@ -1,0 +1,155 @@
+package cse
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CSE GET /v2/{project_id}/enginemgr/flavors
+func DataSourceMicroserviceEngineFlavors() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceMicroserviceEngineFlavorsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the microservice engine flavors are located.`,
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The version that used to filter the microservice engine flavors.`,
+			},
+			"flavors": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the microservice engine flavor.`,
+						},
+						"spec": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"available_cpu_memory": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The CPU and memory combinations that the flavor is allowed.`,
+									},
+									"linear": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `Whether the microservice engine flavor is a linear flavor.`,
+									},
+									"available_prefix": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The flavor name prefix of the available node.`,
+									},
+								},
+							},
+							Description: `The specification detail of the microservice engine flavor.`,
+						},
+					},
+				},
+				Description: `All microservice engine flavors that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func queryMicroserviceEngineFlavors(client *golangsdk.ServiceClient, specType string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/enginemgr/flavors"
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	if specType != "" {
+		listPath = fmt.Sprintf("%s?specType=%s", listPath, specType)
+	}
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+	return utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenMicroserviceEngineFlavorSpec(spec interface{}) []map[string]interface{} {
+	if spec == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"available_cpu_memory": utils.PathSearch("availableCpuMemory", spec, nil),
+			"linear":               utils.PathSearch("linear", spec, nil),
+			"available_prefix":     utils.PathSearch("availablePrefix", spec, nil),
+		},
+	}
+}
+
+func flattenMicroserviceEngineFlavors(flavors []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(flavors))
+
+	for _, flavor := range flavors {
+		result = append(result, map[string]interface{}{
+			"id":   utils.PathSearch("flavor", flavor, nil),
+			"spec": flattenMicroserviceEngineFlavorSpec(utils.PathSearch("spec", flavor, nil)),
+		})
+	}
+
+	return result
+}
+
+func dataSourceMicroserviceEngineFlavorsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	client, err := conf.NewServiceClient("cse", region)
+	if err != nil {
+		return diag.Errorf("error creating CSE client: %s", err)
+	}
+
+	flavors, err := queryMicroserviceEngineFlavors(client, d.Get("version").(string))
+	if err != nil {
+		return diag.Errorf("error querying microservice engine flavors: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("flavors", flattenMicroserviceEngineFlavors(flavors)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data source that used to query microservice engine flavors.
With a filter parameter 'version' and with a default value 'CSE2'.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports a new data source for engine flavors query.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cse -f TestAccDataMicroserviceEngineFlavors_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccDataMicroserviceEngineFlavors_basic -timeout 360m -parallel 10
=== RUN   TestAccDataMicroserviceEngineFlavors_basic
=== PAUSE TestAccDataMicroserviceEngineFlavors_basic
=== CONT  TestAccDataMicroserviceEngineFlavors_basic
--- PASS: TestAccDataMicroserviceEngineFlavors_basic (7.01s)
PASS
coverage: 7.7% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       7.064s  coverage: 7.7% of statements in ./huaweicloud/services/cse
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
