### PR TITLE
feat(live): add a new datasource to get the list of recording rules

### DIFF
--- a/docs/data-sources/live_recordings.md
+++ b/docs/data-sources/live_recordings.md
@@ -1,0 +1,130 @@
+---
+subcategory: "Live"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_live_recordings"
+description: |-
+  Use this data source to get the list of recording rules.
+---
+
+# huaweicloud_live_recordings
+
+Use this datasource to get the list of recording rules.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_live_recordings" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `domain_name` - (Optional, String) Specifies the ingest domain name to which the recording rules belong.
+
+* `app_name` - (Optional, String) Specifies the application name of the recording rule.
+
+* `stream_name` - (Optional, String) Specifies the stream name of the recording rule.
+
+* `type` - (Optional, String) Specifies the recording type of the recording rule.
+  The valid values are as follows:
+  + **CONTINUOUS_RECORD**: Indicates continuous recording.
+  + **COMMAND_RECORD**: Indicates command recording.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `rules` - The list of the recording rules.
+
+  The [rules](#rules_struct) structure is documented below.
+
+<a name="rules_struct"></a>
+The `rules` block supports:
+
+* `id` - The recording rule ID.
+
+* `domain_name` - The ingest domain name to which the recording rule belongs.
+
+* `app_name` - The application name of the recording rule.
+
+* `stream_name` - The stream name of the recording rule.
+
+* `type` - The recording type of the recording rule.
+
+* `default_record_config` - The default recording configuration rule.
+
+  The [default_record_config](#rules_default_record_config_struct) structure is documented below.
+
+* `created_at` - The creation time of the recording rule.
+  The format is **yyyy-mm-ddThh:mm:ssZ**. e.g. **2024-09-01T15:30:20Z**.
+
+* `updated_at` - The lasted update time of the recording rule.
+  The format is **yyyy-mm-ddThh:mm:ssZ**. e.g. **2024-09-01T15:30:20Z**.
+
+<a name="rules_default_record_config_struct"></a>
+The `default_record_config` block supports:
+
+* `record_format` - The recording format.
+  The valid values are **HLS**, **FLV** and **MP4**.
+
+* `obs` - The OBS bucket information for storing recordings.
+
+  The [obs](#default_record_config_obs_struct) structure is documented below.
+
+* `hls` - The HLS configuration rule.
+
+  The [hls](#default_record_config_hls_struct) structure is documented below.
+
+* `flv` - The FLV configuration rule.
+
+  The [flv](#default_record_config_flv_struct) structure is documented below.
+
+* `mp4` - The MP4 configuration rule.
+
+  The [mp4](#default_record_config_mp4_struct) structure is documented below.
+
+<a name="default_record_config_obs_struct"></a>
+The `obs` block supports:
+
+* `bucket` - The OBS bucket name.
+
+* `region` - The region to which the OBS bucket belongs.
+
+* `object` - The OBS object storage path.
+
+<a name="default_record_config_hls_struct"></a>
+The `hls` block supports:
+
+* `recording_length` - The periodic recording duration, in seconds.
+
+* `file_naming` - The file path and file name prefix of the recorded M3U8 file.
+
+* `ts_file_naming` - The file name prefix of recorded TS file.
+
+* `record_slice_duration` - The TS slicing duration during HLS recording, in seconds.
+
+* `max_stream_pause_length` - The recording HLS file concatenation duration, in seconds.
+
+<a name="default_record_config_flv_struct"></a>
+The `flv` block supports:
+
+* `recording_length` - The periodic recording duration, in seconds.
+
+* `file_naming` - The file path and file name prefix of the recorded FLV file.
+
+* `max_stream_pause_length` - The recording FLV file concatenation duration, in seconds.
+
+<a name="default_record_config_mp4_struct"></a>
+The `mp4` block supports:
+
+* `recording_length` - The periodic recording duration, in seconds.
+
+* `file_naming` - The file path and file name prefix of the recorded MP4 file.
+
+* `max_stream_pause_length` - The recording MP4 file concatenation duration, in seconds.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -898,6 +898,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_lb_pools":        lb.DataSourcePools(),
 
 			"huaweicloud_live_domains":      live.DataSourceLiveDomains(),
+			"huaweicloud_live_recordings":   live.DataSourceLiveRecordings(),
 			"huaweicloud_live_transcodings": live.DataSourceLiveTranscodings(),
 
 			"huaweicloud_lts_aom_accesses":                 lts.DataSourceAOMAccesses(),

--- a/huaweicloud/services/acceptance/live/data_source_huaweicloud_live_recordings_test.go
+++ b/huaweicloud/services/acceptance/live/data_source_huaweicloud_live_recordings_test.go
@@ -1,0 +1,177 @@
+package live
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceLiveRecordings_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_live_recordings.test"
+		randInt        = acctest.RandInt()
+		domainName     = fmt.Sprintf("%s.huaweicloud.com", acceptance.RandomAccResourceNameWithDash())
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byDomainName   = "data.huaweicloud_live_recordings.filter_by_domain_name"
+		dcByDomainName = acceptance.InitDataSourceCheck(byDomainName)
+
+		byAppName   = "data.huaweicloud_live_recordings.filter_by_app_name"
+		dcByAppName = acceptance.InitDataSourceCheck(byAppName)
+
+		byStreamName   = "data.huaweicloud_live_recordings.filter_by_stream_name"
+		dcByStreamName = acceptance.InitDataSourceCheck(byStreamName)
+
+		byType   = "data.huaweicloud_live_recordings.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceLiveRecordings_basic(domainName, randInt),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.domain_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.app_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.stream_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.default_record_config.0.obs.0.bucket"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.default_record_config.0.obs.0.region"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.default_record_config.0.hls.0.recording_length"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.default_record_config.0.hls.0.file_naming"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.default_record_config.0.hls.0.record_slice_duration"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.updated_at"),
+
+					dcByDomainName.CheckResourceExists(),
+					resource.TestCheckOutput("domain_name_filter_useful", "true"),
+
+					dcByAppName.CheckResourceExists(),
+					resource.TestCheckOutput("app_name_filter_useful", "true"),
+
+					dcByStreamName.CheckResourceExists(),
+					resource.TestCheckOutput("stream_name_filter_useful", "true"),
+
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("type_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceLiveRecordings_base(name string, randInt int) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_domain" "test" {
+  name = "%[1]s"
+  type = "push"
+}
+
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "tf-bucket-%[2]d"
+  storage_class = "STANDARD"
+  acl           = "private"
+}
+
+resource "huaweicloud_live_bucket_authorization" "test" {
+  bucket = huaweicloud_obs_bucket.test.bucket
+}
+
+resource "huaweicloud_live_recording" "test" {
+  domain_name = huaweicloud_live_domain.test.name
+  app_name    = "live"
+  stream_name = "stream"
+  type        = "CONTINUOUS_RECORD"
+
+  obs {
+    region = huaweicloud_obs_bucket.test.region
+    bucket = huaweicloud_obs_bucket.test.bucket
+  }
+
+  hls {
+    recording_length = 120
+  }
+
+  depends_on = [huaweicloud_live_bucket_authorization.test]
+}
+`, name, randInt)
+}
+
+func testDataSourceLiveRecordings_basic(name string, randInt int) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_live_recordings" "test" {
+  depends_on = [
+    huaweicloud_live_recording.test
+  ]
+}
+
+locals {
+  domain_name = data.huaweicloud_live_recordings.test.rules[0].domain_name
+}
+
+data "huaweicloud_live_recordings" "filter_by_domain_name" {
+  domain_name = local.domain_name
+}
+
+output "domain_name_filter_useful" {
+  value = length(data.huaweicloud_live_recordings.filter_by_domain_name.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_live_recordings.filter_by_domain_name.rules[*].domain_name : v == local.domain_name]
+  )
+}
+
+locals {
+  app_name = data.huaweicloud_live_recordings.test.rules[0].app_name
+}
+
+data "huaweicloud_live_recordings" "filter_by_app_name" {
+  app_name = local.app_name
+}
+
+output "app_name_filter_useful" {
+  value = length(data.huaweicloud_live_recordings.filter_by_app_name.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_live_recordings.filter_by_app_name.rules[*].app_name : v == local.app_name]
+  )
+}
+
+locals {
+  stream_name = data.huaweicloud_live_recordings.test.rules[0].stream_name
+}
+
+data "huaweicloud_live_recordings" "filter_by_stream_name" {
+  stream_name = local.stream_name
+}
+
+output "stream_name_filter_useful" {
+  value = length(data.huaweicloud_live_recordings.filter_by_stream_name.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_live_recordings.filter_by_stream_name.rules[*].stream_name : v == local.stream_name]
+  )
+}
+
+locals {
+  type = data.huaweicloud_live_recordings.test.rules[0].type
+}
+
+data "huaweicloud_live_recordings" "filter_by_type" {
+  type = local.type
+}
+
+output "type_filter_useful" {
+  value = length(data.huaweicloud_live_recordings.filter_by_type.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_live_recordings.filter_by_type.rules[*].type : v == local.type]
+  )
+}
+`, testDataSourceLiveRecordings_base(name, randInt))
+}

--- a/huaweicloud/services/live/data_source_huaweicloud_live_recordings.go
+++ b/huaweicloud/services/live/data_source_huaweicloud_live_recordings.go
@@ -1,0 +1,417 @@
+package live
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API LIVE GET /v1/{project_id}/record/rules
+func DataSourceLiveRecordings() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceLiveRecordingsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"domain_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the ingest domain name to which the recording rules belong.`,
+			},
+			"app_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the application name of the recording rule.`,
+			},
+			"stream_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the stream name of the recording rule.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the recording type of the recording rule.`,
+			},
+			"rules": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the recording rules.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The recording rule ID.`,
+						},
+						"domain_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ingest domain name to which the recording rule belongs.`,
+						},
+						"app_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The application name of the recording rule.`,
+						},
+						"stream_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The stream name of the recording rule.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The recording type of the recording rule.`,
+						},
+						"default_record_config": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The default recording configuration rule.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"record_format": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: `The recording format.`,
+									},
+									"obs": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: `The OBS bucket information for storing recordings.`,
+										Elem:        rulesDefaultRecordConfigObsElem(),
+									},
+									"hls": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: `The HLS configuration rule.`,
+										Elem:        rulesDefaultRecordConfigHlsElem(),
+									},
+									"flv": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: `The FLV configuration rule.`,
+										Elem:        rulesDefaultRecordConfigFlvElem(),
+									},
+									"mp4": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: `The MP4 configuration rule.`,
+										Elem:        rulesDefaultRecordConfigMp4Elem(),
+									},
+								},
+							},
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the recording rule.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The lasted update time of the recording rule.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func rulesDefaultRecordConfigObsElem() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The OBS bucket name.`,
+			},
+			"region": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The region to which the OBS bucket belongs.`,
+			},
+			"object": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The OBS object storage path.`,
+			},
+		},
+	}
+}
+
+func rulesDefaultRecordConfigHlsElem() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"recording_length": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The periodic recording duration, in seconds.`,
+			},
+			"file_naming": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The file path and file name prefix of the recorded M3U8 file.`,
+			},
+			"ts_file_naming": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The file name prefix of recorded TS file.`,
+			},
+			"record_slice_duration": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The TS slicing duration during HLS recording, in seconds.`,
+			},
+			"max_stream_pause_length": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The recording HLS file concatenation duration, in seconds.`,
+			},
+		},
+	}
+}
+
+func rulesDefaultRecordConfigFlvElem() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"recording_length": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The periodic recording duration, in seconds.`,
+			},
+			"file_naming": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The file path and file name prefix of the recorded FLV file.`,
+			},
+			"max_stream_pause_length": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The recording FLV file concatenation duration, in seconds.`,
+			},
+		},
+	}
+}
+
+func rulesDefaultRecordConfigMp4Elem() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"recording_length": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The periodic recording duration, in seconds.`,
+			},
+			"file_naming": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The file path and file name prefix of the recorded MP4 file.`,
+			},
+			"max_stream_pause_length": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The recording MP4 file concatenation duration, in seconds.`,
+			},
+		},
+	}
+}
+
+func dataSourceLiveRecordingsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	recordings, err := queryLiveRecordings(d, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("rules", flattenLiveRecordings(recordings)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func queryLiveRecordings(d *schema.ResourceData, client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/record/rules?limit=100"
+		page    = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildRecordingsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		// The offset indicates the page number.
+		// The default value is 0, which represents the first page.
+		listPathWithPage := fmt.Sprintf("%s&offset=%d", listPath, page)
+		requestResp, err := client.Request("GET", listPathWithPage, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving recordings: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		recording := utils.PathSearch("record_config", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, recording...)
+		if len(recording) == 0 {
+			break
+		}
+		page++
+	}
+	return result, nil
+}
+
+func buildRecordingsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if domainName, ok := d.GetOk("domain_name"); ok {
+		res = fmt.Sprintf("%s&publish_domain=%v", res, domainName)
+	}
+	if appName, ok := d.GetOk("app_name"); ok {
+		res = fmt.Sprintf("%s&app=%v", res, appName)
+	}
+	if streamName, ok := d.GetOk("stream_name"); ok {
+		res = fmt.Sprintf("%s&stream=%v", res, streamName)
+	}
+	if recordType, ok := d.GetOk("type"); ok {
+		res = fmt.Sprintf("%s&record_type=%v", res, recordType)
+	}
+	return res
+}
+
+func flattenLiveRecordings(recordings []interface{}) []map[string]interface{} {
+	if len(recordings) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(recordings))
+	for i, v := range recordings {
+		result[i] = map[string]interface{}{
+			"id":          utils.PathSearch("id", v, nil),
+			"domain_name": utils.PathSearch("publish_domain", v, nil),
+			"app_name":    utils.PathSearch("app", v, nil),
+			"stream_name": utils.PathSearch("stream", v, nil),
+			"type":        utils.PathSearch("record_type", v, nil),
+			"created_at":  utils.PathSearch("create_time", v, nil),
+			"updated_at":  utils.PathSearch("update_time", v, nil),
+			"default_record_config": flattenDefaultRecordConfig(
+				utils.PathSearch("default_record_config", v, make(map[string]interface{})).(map[string]interface{})),
+		}
+	}
+	return result
+}
+
+func flattenDefaultRecordConfig(recordCofig interface{}) []map[string]interface{} {
+	if recordCofig == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"record_format": utils.PathSearch("record_format", recordCofig, nil),
+			"obs": flattenObsCofig(
+				utils.PathSearch("obs_addr", recordCofig, make(map[string]interface{})).(map[string]interface{})),
+			"hls": flattenHlsCofig(
+				utils.PathSearch("hls_config", recordCofig, make(map[string]interface{})).(map[string]interface{})),
+			"flv": flattenFlvCofig(
+				utils.PathSearch("flv_config", recordCofig, make(map[string]interface{})).(map[string]interface{})),
+			"mp4": flattenMp4Cofig(
+				utils.PathSearch("mp4_config", recordCofig, make(map[string]interface{})).(map[string]interface{})),
+		},
+	}
+}
+
+func flattenObsCofig(obsConfig interface{}) []map[string]interface{} {
+	if obsConfig == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"bucket": utils.PathSearch("bucket", obsConfig, nil),
+			"region": utils.PathSearch("location", obsConfig, nil),
+			"object": utils.PathSearch("object", obsConfig, nil),
+		},
+	}
+}
+
+func flattenHlsCofig(hlsConfig interface{}) []map[string]interface{} {
+	if hlsConfig == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"recording_length":        utils.PathSearch("record_cycle", hlsConfig, nil),
+			"file_naming":             utils.PathSearch("record_prefix", hlsConfig, nil),
+			"ts_file_naming":          utils.PathSearch("record_ts_prefix", hlsConfig, nil),
+			"record_slice_duration":   utils.PathSearch("record_slice_duration", hlsConfig, nil),
+			"max_stream_pause_length": utils.PathSearch("record_max_duration_to_merge_file", hlsConfig, nil),
+		},
+	}
+}
+
+func flattenFlvCofig(flvConfig interface{}) []map[string]interface{} {
+	if flvConfig == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"recording_length":        utils.PathSearch("record_cycle", flvConfig, nil),
+			"file_naming":             utils.PathSearch("record_prefix", flvConfig, nil),
+			"max_stream_pause_length": utils.PathSearch("record_max_duration_to_merge_file", flvConfig, nil),
+		},
+	}
+}
+
+func flattenMp4Cofig(mp4Config interface{}) []map[string]interface{} {
+	if mp4Config == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"recording_length":        utils.PathSearch("record_cycle", mp4Config, nil),
+			"file_naming":             utils.PathSearch("record_prefix", mp4Config, nil),
+			"max_stream_pause_length": utils.PathSearch("record_max_duration_to_merge_file", mp4Config, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source to get the list of recording rules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new datasource to get the list of recording rules.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/live" TESTARGS="-run TestAccDataSourceLiveRecordings_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/live -v -run TestAccDataSourceLiveRecordings_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceLiveRecordings_basic
=== PAUSE TestAccDataSourceLiveRecordings_basic
=== CONT  TestAccDataSourceLiveRecordings_basic
--- PASS: TestAccDataSourceLiveRecordings_basic (329.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      329.476s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
