### PR TITLE
feat(workspace/app): add resource to manage private image

### DIFF
--- a/docs/resources/workspace_app_image.md
+++ b/docs/resources/workspace_app_image.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_image"
+description: |-
+  Manages a private image resource of Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_image
+
+Manages a private image resource of Workspace APP within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "image_server_id" {}
+variable "generated_image_name" {}
+variable "generated_image_description" {}
+
+resource "huaweicloud_workspace_app_image" "test" {
+  server_id   = var.image_server_id
+  name        = var.generated_image_name
+  description = var.generated_image_description
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `server_id` - (Required, String, ForceNew) Specifies the image server ID for generating a private image.
+  Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the image.
+  Changing this creates a new resource.  
+  The name valid length is limited from `1` to `128` characters. Only Chinese and English characters, digits, spaces and
+  special characters (-._) and are allowed, and the first and last characters cannot be spaces.
+
+* `description` - (Optional, String, ForceNew) Specifies the description of the image.
+  Changing this creates a new resource.  
+  The description contain a maximum of `1,024` characters. The carriage return characters and angle brackets (< and >) are
+  not allowed, and the first character cannot be space.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the image belongs.
+  Changing this creates a new resource.  
+  This parameter is only valid for enterprise users, if omitted, default enterprise project will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2118,6 +2118,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_group_authorization": workspace.ResourceAppGroupAuthorization(),
 			"huaweicloud_workspace_app_group":               workspace.ResourceWorkspaceAppGroup(),
 			"huaweicloud_workspace_app_image_server":        workspace.ResourceAppImageServer(),
+			"huaweicloud_workspace_app_image":               workspace.ResourceAppImage(),
 			"huaweicloud_workspace_app_nas_storage":         workspace.ResourceAppNasStorage(),
 			"huaweicloud_workspace_app_personal_folders":    workspace.ResourceAppPersonalFolders(),
 			"huaweicloud_workspace_app_policy_group":        workspace.ResourceAppPolicyGroup(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_image_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_image_test.go
@@ -1,0 +1,81 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceAppImage_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_workspace_app_image.test"
+		name         = acceptance.RandomAccResourceName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+			acceptance.TestAccPreCheckWorkspaceAppImageSpecCode(t)
+			acceptance.TestAccPrecheckWorkspaceUserNames(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceAppImage_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "Workspace APP genereted image"),
+				),
+			},
+		},
+	})
+}
+
+func testResourceAppImage_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_app_image_server" "test" {
+  name                    = "%[1]s"
+  flavor_id               = "%[2]s"
+  vpc_id                  = "%[3]s"
+  subnet_id               = "%[4]s"
+  image_id                = "%[5]s"
+  image_type              = "gold"
+  image_source_product_id = "%[6]s"
+  spec_code               = "%[7]s"
+
+  # Currently only one user can be set.
+  authorize_accounts {
+    account = split(",", "%[8]s")[0]
+    type    = "USER"
+  }
+
+  root_volume {
+    type = "SAS"
+    size = 80
+  }
+
+  is_vdi                         = true
+  enterprise_project_id          = "%[9]s"
+  is_delete_associated_resources = true
+}
+
+resource "huaweicloud_workspace_app_image" "test" {
+  server_id             = huaweicloud_workspace_app_image_server.test.id
+  name                  = "%[1]s"
+  description           = "Workspace APP genereted image"
+  enterprise_project_id = "%[9]s"
+}
+`, name, acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
+		acceptance.HW_WORKSPACE_AD_VPC_ID,
+		acceptance.HW_WORKSPACE_AD_NETWORK_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_SPEC_CODE,
+		acceptance.HW_WORKSPACE_USER_NAMES,
+		acceptance.HW_ENTERPRISE_PROJECT_ID_TEST,
+	)
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_image.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_image.go
@@ -1,0 +1,203 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace POST /v1/{project_id}/image-servers/{server_id}/actions/recreate-image
+// @API Workspace GET /v1/{project_id}/image-server-jobs/{job_id}
+// @API IMS GET /v2/cloudimages
+// @API IMS DELETE /v2/images/{image_id}
+func ResourceAppImage() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppImageCreate,
+		ReadContext:   resourceAppImageRead,
+		DeleteContext: resourceAppImageDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"server_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The image server ID for generating a private image.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the image.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The description of the image.",
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The enterprise project ID to which the image belongs.",
+			},
+		},
+	}
+}
+
+func buildAppImageCreateOpts(name, description interface{}, epsId string) map[string]interface{} {
+	return map[string]interface{}{
+		"name":                  name,
+		"description":           utils.ValueIgnoreEmpty(description),
+		"enterprise_project_id": utils.ValueIgnoreEmpty(epsId),
+	}
+}
+
+func resourceAppImageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		httpUrl       = "v1/{project_id}/image-servers/{server_id}/actions/recreate-image"
+		imageServerId = d.Get("server_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{server_id}", imageServerId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildAppImageCreateOpts(d.Get("name"), d.Get("description"), cfg.GetEnterpriseProjectID(d))),
+	}
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating private image from image server (%s): %s", imageServerId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// The job ID consists of 18 digits, e.g. `773698274006671360`.
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find job ID from API response")
+	}
+	// Set the resource ID in advance to avoid dirty data when the image task fails.
+	d.SetId(jobId)
+
+	serverResp, err := waitForImageServerJobCompleted(ctx, client, d.Timeout(schema.TimeoutCreate), jobId)
+	if err != nil {
+		return diag.Errorf("error waiting for creating image job (%s) completed: %s", jobId, err)
+	}
+
+	imageId := utils.PathSearch("sub_jobs|[0].job_resource_info.resource_id", serverResp, "").(string)
+	if imageId == "" {
+		return diag.Errorf("unable to find generated image ID from API response")
+	}
+
+	d.SetId(imageId)
+
+	return resourceAppImageRead(ctx, d, meta)
+}
+
+func resourceAppImageRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppImageDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/images/{image_id}"
+		imageId = d.Id()
+	)
+
+	imsClient, err := cfg.NewServiceClient("ims", region)
+	if err != nil {
+		return diag.Errorf("error creating IMS client: %s", err)
+	}
+	deletePath := imsClient.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", imsClient.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{image_id}", imageId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	// If the image creation fails, the resource ID consists of 18 digits, e.g. `773698274006671360`.
+	// At this time, the deletion interface response status code is still 204.
+	_, err = imsClient.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting generated image (%s)", imageId))
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"DELETED"},
+		Refresh:      refreshImageStatusFunc(imsClient, imageId),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        10 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for deleting generated image (%s) completed: %s", imageId, err)
+	}
+
+	return nil
+}
+
+func refreshImageStatusFunc(client *golangsdk.ServiceClient, imageId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		httpUrl := "v2/cloudimages?id={image_id}"
+		listPath := client.Endpoint + httpUrl
+		listPath = strings.ReplaceAll(listPath, "{image_id}", imageId)
+		getOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+
+		resp, err := client.Request("GET", listPath, &getOpt)
+		if err != nil {
+			return resp, "ERROR", err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return resp, "ERROR", err
+		}
+
+		images := utils.PathSearch("images", respBody, make([]interface{}, 0)).([]interface{})
+		if len(images) < 1 {
+			return "", "DELETED", nil
+		}
+		return images, "PENDING", nil
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to manage a private image.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new reource to generate a private image from image server.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccResourceAppImage_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceAppImage_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceAppImage_basic
=== PAUSE TestAccResourceAppImage_basic
=== CONT  TestAccResourceAppImage_basic
--- PASS: TestAccResourceAppImage_basic (1697.59s)
PASS
coverage: 7.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 1697.647s       coverage: 7.0% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
