### PR TITLE
feat(live): add a new resource to manage URL validation

### DIFF
--- a/docs/resources/live_url_validation.md
+++ b/docs/resources/live_url_validation.md
@@ -1,0 +1,71 @@
+---
+subcategory: "Live"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_live_url_validation"
+description: |-
+  Manages an URL validation resource within HuaweiCloud.
+---
+
+# huaweicloud_live_url_validation
+
+Manages an URL validation resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "domain_name" {}
+variable "key" {}
+variable "auth_type" {}
+variable "timeout" {}
+
+resource "huaweicloud_live_url_validation" "test" {
+  domain_name = var.domain_name
+  key         = var.key
+  auth_type   = var.auth_type
+  timeout     = var.timeout
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `domain_name` - (Required, String, ForceNew) Specifies the domain name to which the URL validation belongs.
+  Including the ingest domain name and streaming domain name.
+  Changing this parameter will create a new resource.
+
+* `key` - (Required, String) Specifies the URL validation key value.
+  The valid length is `32` characters, only uppercase letters, lwercase letters and digits are allowed.
+  The value cannot contain only digits or letters.
+
+* `auth_type` - (Required, String) Specifies the signing method of the URL validation.
+  The valid values are as follows:
+  + **d_sha256**: Indicates signing method D, which uses the HMAC-SHA256 algorithm. This method is recommended.
+  + **c_aes**: Indicates signing method C, which uses the symmetric encryption algorithm.
+  + **b_md5**: Indicates signing method B, which uses the MD5 algorithm.
+  + **a_md5**: Indicates signing method A, which uses the MD5 algorithm.
+
+  -> The signing methods A, B and C have security risks. The signing method D is more secure and recommended.
+
+* `timeout` - (Required, Int) Specifies the timeout interval of URL validation.
+  The valid value ranges from `60` to `2,592,000`, in seconds.
+
+  -> This parameter is used to check whether the Live ingest URL or streaming URL has expired.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, UUID format.
+
+## Import
+
+The resource can be imported using `domain_name`, e.g.
+
+```bash
+$ terraform import huaweicloud_live_url_validation.test <domain_name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1816,12 +1816,13 @@ func Provider() *schema.Provider {
 			"huaweicloud_lb_pool":         lb.ResourcePoolV2(),
 			"huaweicloud_lb_whitelist":    lb.ResourceWhitelistV2(),
 
-			"huaweicloud_live_domain":               live.ResourceDomain(),
-			"huaweicloud_live_recording":            live.ResourceRecording(),
-			"huaweicloud_live_record_callback":      live.ResourceRecordCallback(),
-			"huaweicloud_live_transcoding":          live.ResourceTranscoding(),
-			"huaweicloud_live_snapshot":             live.ResourceLiveSnapshot(),
 			"huaweicloud_live_bucket_authorization": live.ResourceLiveBucketAuthorization(),
+			"huaweicloud_live_domain":               live.ResourceDomain(),
+			"huaweicloud_live_record_callback":      live.ResourceRecordCallback(),
+			"huaweicloud_live_recording":            live.ResourceRecording(),
+			"huaweicloud_live_snapshot":             live.ResourceLiveSnapshot(),
+			"huaweicloud_live_transcoding":          live.ResourceTranscoding(),
+			"huaweicloud_live_url_validation":       live.ResourceUrlValidation(),
 
 			"huaweicloud_lts_aom_access":                       lts.ResourceAOMAccess(),
 			"huaweicloud_lts_group":                            lts.ResourceLTSGroup(),

--- a/huaweicloud/services/acceptance/live/resource_huaweicloud_live_url_validation_test.go
+++ b/huaweicloud/services/acceptance/live/resource_huaweicloud_live_url_validation_test.go
@@ -1,0 +1,146 @@
+package live
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getUrlValidationFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Live client: %s", err)
+	}
+
+	getHttpUrl := "v1/{project_id}/guard/key-chain"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = fmt.Sprintf("%s?domain=%v", getPath, state.Primary.Attributes["domain_name"])
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving URL validation: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	key := utils.PathSearch("key", getRespBody, "").(string)
+	if key == "" {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return getRespBody, nil
+}
+
+func TestAccURLValidation_basic(t *testing.T) {
+	var (
+		urlValidationObj interface{}
+		rName            = "huaweicloud_live_url_validation.test"
+		domainName       = fmt.Sprintf("%s.huaweicloud.com", acceptance.RandomAccResourceNameWithDash())
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&urlValidationObj,
+		getUrlValidationFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUrlValidation_basic(domainName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "domain_name", "huaweicloud_live_domain.test", "name"),
+					resource.TestCheckResourceAttr(rName, "key", "IbBIzklRGCyMEd18oPV9sxAuuwNIzT81"),
+					resource.TestCheckResourceAttr(rName, "auth_type", "d_sha256"),
+					resource.TestCheckResourceAttr(rName, "timeout", "800"),
+				),
+			},
+			{
+				Config: testAccUrlValidation_update(domainName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "key", "IbBIzklRGCyMEd74oMS9sxAuuwNIzT59"),
+					resource.TestCheckResourceAttr(rName, "auth_type", "c_aes"),
+					resource.TestCheckResourceAttr(rName, "timeout", "1200"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateIdFunc: testAccUrlValidationImportState(rName),
+			},
+		},
+	})
+}
+
+func testAccUrlValidation_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_domain" "test" {
+  name = "%s"
+  type = "push"
+}
+
+resource "huaweicloud_live_url_validation" "test" {
+  domain_name = huaweicloud_live_domain.test.name
+  key         = "IbBIzklRGCyMEd18oPV9sxAuuwNIzT81"
+  auth_type   = "d_sha256"
+  timeout     = 800
+}
+`, name)
+}
+
+func testAccUrlValidation_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_domain" "test" {
+  name = "%s"
+  type = "push"
+}
+
+resource "huaweicloud_live_url_validation" "test" {
+  domain_name = huaweicloud_live_domain.test.name
+  key         = "IbBIzklRGCyMEd74oMS9sxAuuwNIzT59"
+  auth_type   = "c_aes"
+  timeout     = 1200
+}
+`, name)
+}
+
+func testAccUrlValidationImportState(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var domainName string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", rName)
+		}
+
+		domainName = rs.Primary.Attributes["domain_name"]
+		if domainName == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, 'domain_name' is empty")
+		}
+		return domainName, nil
+	}
+}

--- a/huaweicloud/services/live/resource_huaweicloud_live_url_validation.go
+++ b/huaweicloud/services/live/resource_huaweicloud_live_url_validation.go
@@ -1,0 +1,237 @@
+package live
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	domainNameNotExistsCode = "LIVE.100011001"
+)
+
+// @API Live PUT /v1/{project_id}/guard/key-chain
+// @API Live GET /v1/{project_id}/guard/key-chain
+// @API Live DELETE /v1/{project_id}/guard/key-chain
+func ResourceUrlValidation() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceUrlValidationCreate,
+		ReadContext:   resourceUrlValidationRead,
+		UpdateContext: resourceUrlValidationUpdate,
+		DeleteContext: resourceUrlValidationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceUrlValidationImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"domain_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the domain name to which the URL validation belongs.`,
+			},
+			"key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: `Specifies the URL validation key value.`,
+			},
+			"auth_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the signing method of the URL validation.`,
+			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the timeout interval of URL validation.`,
+			},
+		},
+	}
+}
+
+func resourceUrlValidationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		domainName = d.Get("domain_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	err = createOrUpdateUrlValidation(client, d, domainName)
+	if err != nil {
+		return diag.Errorf("error creating Live URL validation: %s", err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	return resourceUrlValidationRead(ctx, d, meta)
+}
+
+func createOrUpdateUrlValidation(client *golangsdk.ServiceClient, d *schema.ResourceData, domainName string) error {
+	validationHttpUrl := "v1/{project_id}/guard/key-chain"
+	validationPath := client.Endpoint + validationHttpUrl
+	validationPath = strings.ReplaceAll(validationPath, "{project_id}", client.ProjectID)
+	validationPath = fmt.Sprintf("%s?domain=%v", validationPath, domainName)
+
+	validationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildUrlValidationBodyParams(d)),
+	}
+
+	_, err := client.Request("PUT", validationPath, &validationOpt)
+	return err
+}
+
+func buildUrlValidationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"key":       d.Get("key"),
+		"auth_type": d.Get("auth_type"),
+		"timeout":   d.Get("timeout"),
+	}
+
+	return params
+}
+
+func resourceUrlValidationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		domainName = d.Get("domain_name").(string)
+		getHttpUrl = "v1/{project_id}/guard/key-chain"
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = fmt.Sprintf("%s?domain=%v", getPath, domainName)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", domainNameNotExistsCode),
+			"error retrieving URL validation")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	key := utils.PathSearch("key", getRespBody, "").(string)
+	if key == "" {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "URL validation")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("domain_name", domainName),
+		d.Set("key", utils.PathSearch("key", getRespBody, nil)),
+		d.Set("auth_type", utils.PathSearch("auth_type", getRespBody, nil)),
+		d.Set("timeout", utils.PathSearch("timeout", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceUrlValidationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		domainName = d.Get("domain_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	err = createOrUpdateUrlValidation(client, d, domainName)
+	if err != nil {
+		return diag.Errorf("error updating Live URL validation: %s", err)
+	}
+
+	return resourceUrlValidationRead(ctx, d, meta)
+}
+
+func resourceUrlValidationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		deleteHttpUrl = "v1/{project_id}/guard/key-chain"
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	deletePath := client.Endpoint + deleteHttpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = fmt.Sprintf("%s?domain=%v", deletePath, d.Get("domain_name"))
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", domainNameNotExistsCode),
+			"error deleting URL validation")
+	}
+
+	return nil
+}
+
+func resourceUrlValidationImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	if importedId == "" {
+		return nil, fmt.Errorf("invalid format specified for import ID, 'domain_name' is empty")
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("domain_name", importedId),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new resource to manage URL validation.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new resource to manage URL validation.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/live" TESTARGS="-run TestAccURLValidation_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/live -v -run TestAccURLValidation_basic -timeout 360m -parallel 4
=== RUN   TestAccURLValidation_basic
=== PAUSE TestAccURLValidation_basic
=== CONT  TestAccURLValidation_basic
--- PASS: TestAccURLValidation_basic (268.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      269.018s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/091bcf16-41e4-416b-9306-00c900368a71)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/user-attachments/assets/bbd2ef34-8e11-4b51-9cca-bed3500978f0)
    \>>>>>> Paste the screenshot here <<<<<<
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
