### PR TITLE
feat(dns): add resource to manage endpoint

### DIFF
--- a/docs/resources/dns_endpoint_assignment.md
+++ b/docs/resources/dns_endpoint_assignment.md
@@ -1,0 +1,104 @@
+---
+subcategory: "Domain Name Service (DNS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dns_endpoint_assignment"
+description: |-
+  Manages a DNS endpoint assignment resource within HuaweiCloud.
+---
+
+# huaweicloud_dns_endpoint_assignment
+
+Manages a DNS endpoint assignment resource within HuaweiCloud.
+
+-> For the same subnet, only one of the `huaweicloud_dns_endpoint` and `huaweicloud_dns_endpoint_assignment` resources
+   is allowed to manage an endpoint. We recommend using this resource to replace the `huaweicloud_dns_endpoint` resource.
+
+## Example Usage
+
+### Create an endpoint in the same subnet
+
+```hcl
+variable "endpoint_name" {}
+variable "subnet_id" {}
+variable "ip_addresses" {
+  type = list(string)
+}
+
+resource "huaweicloud_dns_endpoint_assignment" "test" {
+  name      = var.endpoint_name
+  direction = "inbound"
+
+  dynamic "assignments" {
+    for_each = range(length(var.ip_addresses))
+    content {
+      subnet_id  = var.subnet_id
+      ip_address = var.ip_addresses[assignments.key]
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `name` - (Required, String) Specifies the name of the endpoint.  
+  The name valid length is limited from `1` to `64` characters. Only Chinese and English characters, digits and
+  special characters (-._) are allowed.
+
+* `direction` - (Required, String, ForceNew) Specifies the direction of the endpoint.
+  Changing this creates a new resource.  
+  The valid values are as follows:
+  + **inbound**
+  + **outbound**
+  
+* `assignments` - (Required, List) Specifies the list of the IP addresses of the endpoint.
+  The valid length of the `assignments` ranges from `2` to `6`.  
+  The [assignments](#endpoint_assignments) structure is documented below.
+
+<a name="endpoint_assignments"></a>
+The `assignments` block supports:
+
+* `subnet_id` - (Required, String) Specifies the subnet ID to which the IP address belongs.
+
+* `ip_address` - (Required, String) Specifies the IP address associated with the endpoint.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also endpoint ID.
+
+* `assignments` - The list of the IP addresses of the endpoint.
+  The [assignments](#endpoint_attr_assignments) structure is documented below.
+
+* `vpc_id` - The VPC ID associated with the endpoint.
+
+* `status` - The current status of the endpoint.
+
+* `created_at` - The creation time of the endpoint, in RFC3339 format.
+
+<a name="endpoint_attr_assignments"></a>
+The `assignments` block supports:
+
+* `ip_address_id` - The ID of the IP address associated with the endpoint.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The DNS endpoint resource can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_dns_endpoint_assignment.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1605,6 +1605,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_ptrrecord":               dns.ResourceDNSPtrRecord(),
 			"huaweicloud_dns_recordset":               dns.ResourceDNSRecordset(),
 			"huaweicloud_dns_zone":                    dns.ResourceDNSZone(),
+			"huaweicloud_dns_endpoint_assignment":     dns.ResourceEndpointAssignment(),
 			"huaweicloud_dns_endpoint":                dns.ResourceDNSEndpoint(),
 			"huaweicloud_dns_resolver_rule":           dns.ResourceDNSResolverRule(),
 			"huaweicloud_dns_resolver_rule_associate": dns.ResourceDNSResolverRuleAssociate(),

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_endpoint_assignment_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_endpoint_assignment_test.go
@@ -1,0 +1,142 @@
+package dns
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dns"
+)
+
+func getEndpointAssignmentResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("dns", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DNS client: %s", err)
+	}
+
+	return dns.GetEntpointById(client, state.Primary.ID)
+}
+
+func TestAccEndpointAssignment_basic(t *testing.T) {
+	var (
+		endpoint   interface{}
+		rName      = "huaweicloud_dns_endpoint_assignment.test"
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+	)
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&endpoint,
+		getEndpointAssignmentResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testEndpointAssignment_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "direction", "inbound"),
+					resource.TestCheckResourceAttr(rName, "assignments.#", "5"),
+					resource.TestCheckResourceAttrSet(rName, "assignments.0.subnet_id"),
+					resource.TestCheckResourceAttrSet(rName, "assignments.0.ip_address"),
+					resource.TestCheckResourceAttrSet(rName, "assignments.0.ip_address_id"),
+					resource.TestCheckResourceAttrSet(rName, "vpc_id"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testEndpointAssignment_basic_step2(name, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "assignments.#", "6"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testEndpointAssignment_base(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  count      = 2
+  name       = "%[1]s${count.index}"
+  vpc_id     = huaweicloud_vpc.test.id
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 4, count.index)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, count.index), 1)
+}`, rName)
+}
+
+func testEndpointAssignment_basic_step1(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dns_endpoint_assignment" "test" {
+  name      = "%[2]s"
+  direction = "inbound"
+
+  dynamic "assignments" {
+    for_each = range(4)
+    content {
+      subnet_id  = huaweicloud_vpc_subnet.test[0].id
+      ip_address = cidrhost(huaweicloud_vpc_subnet.test[0].cidr, assignments.key + 100)
+    }
+  }
+
+  assignments {
+    subnet_id  = huaweicloud_vpc_subnet.test[1].id
+    ip_address = cidrhost(huaweicloud_vpc_subnet.test[1].cidr, 100)
+  }
+}`, testEndpointAssignment_base(rName), rName)
+}
+
+func testEndpointAssignment_basic_step2(rName, updateName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dns_endpoint_assignment" "test" {
+  name      = "%[2]s"
+  direction = "inbound"
+
+  dynamic "assignments" {
+    for_each = range(4)
+    content {
+      subnet_id  = huaweicloud_vpc_subnet.test[0].id
+      ip_address = cidrhost(huaweicloud_vpc_subnet.test[0].cidr, assignments.key + 100)
+    }
+  }
+
+  assignments {
+    subnet_id  = huaweicloud_vpc_subnet.test[1].id
+    ip_address = cidrhost(huaweicloud_vpc_subnet.test[1].cidr, 102)
+  }
+  assignments {
+    subnet_id  = huaweicloud_vpc_subnet.test[1].id
+    ip_address = cidrhost(huaweicloud_vpc_subnet.test[1].cidr, 103)
+  }
+}`, testEndpointAssignment_base(rName), updateName)
+}

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_endpoint_assignment.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_endpoint_assignment.go
@@ -1,0 +1,496 @@
+package dns
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DNS POST /v2.1/endpoints
+// @API DNS GET /v2.1/endpoints/{endpoint_id}
+// @API DNS GET /v2.1/endpoints/{endpoint_id}/ipaddresses
+// @API VPC GET /v1/{project_id}/subnets
+// @API DNS PUT /v2.1/endpoints/{endpoint_id}
+// @API DNS POST /v2.1/endpoints/{endpoint_id}/ipaddresses
+// @API DNS DELETE /v2.1/endpoints/{endpoint_id}/ipaddresses/{ipaddress_id}
+// @API DNS DELETE /v2.1/endpoints/{endpoint_id}
+func ResourceEndpointAssignment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceEndpointAssignmentCreate,
+		ReadContext:   resourceEndpointAssignmentRead,
+		UpdateContext: resourceEndpointAssignmentUpdate,
+		DeleteContext: resourceEndpointAssignmentDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the endpoint.`,
+			},
+			"direction": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The direction of the endpoint.`,
+			},
+			"assignments": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MaxItems: 6,
+				MinItems: 2,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"subnet_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The subnet ID to which the IP address belongs.`,
+						},
+						"ip_address": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The IP address associated with the endpoint.`,
+						},
+						"ip_address_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the IP address associated with the endpoint.`,
+						},
+					},
+				},
+				Description: `The list of the IP addresses of the endpoint.`,
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The VPC ID associated with the endpoint.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current status of the endpoint.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the endpoint, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func buildCreateEndpointOpts(d *schema.ResourceData, region string) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"direction":   d.Get("direction"),
+		"region":      region,
+		"ipaddresses": buildEndpointAssignments(d.Get("assignments").(*schema.Set).List()),
+	}
+}
+
+func buildEndpointAssignments(assignments []interface{}) []interface{} {
+	rst := make([]interface{}, len(assignments))
+	for i, v := range assignments {
+		rst[i] = map[string]interface{}{
+			"subnet_id": utils.PathSearch("subnet_id", v, nil),
+			"ip":        utils.PathSearch("ip_address", v, nil),
+		}
+	}
+	return rst
+}
+
+func resourceEndpointAssignmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		conf    = meta.(*config.Config)
+		region  = conf.GetRegion(d)
+		httpUrl = "v2.1/endpoints"
+	)
+
+	client, err := conf.NewServiceClient("dns", region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateEndpointOpts(d, region)),
+	}
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating DNS endpoint: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	endpointId := utils.PathSearch("endpoint.id", respBody, "").(string)
+	if endpointId == "" {
+		return diag.Errorf("unable to find endpoint ID from API response")
+	}
+	d.SetId(endpointId)
+
+	stateConf := &resource.StateChangeConf{
+		Target:       []string{"ACTIVE"},
+		Pending:      []string{"PENDING"},
+		Refresh:      refreshEndpointStatus(client, endpointId),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for DNS endpoint (%s) creation to completed: %s", endpointId, err)
+	}
+
+	return resourceEndpointAssignmentRead(ctx, d, meta)
+}
+
+func refreshEndpointStatus(client *golangsdk.ServiceClient, endpointId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		endPoint, err := GetEntpointById(client, endpointId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return "Resource Not Found", "DELETED", nil
+			}
+			return nil, "ERROR", err
+		}
+
+		return endPoint, parseStatus(utils.PathSearch("status", endPoint, "").(string)), nil
+	}
+}
+
+// GetEntpointById is a method used to get endpoint detail by specified endpoint ID.
+func GetEntpointById(client *golangsdk.ServiceClient, endpointId string) (interface{}, error) {
+	httpUrl := "v2.1/endpoints/{endpoint_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{endpoint_id}", endpointId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	return utils.PathSearch("endpoint", respBody, nil), err
+}
+
+func resourceEndpointAssignmentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		conf       = meta.(*config.Config)
+		region     = conf.GetRegion(d)
+		endpointId = d.Id()
+	)
+	client, err := conf.NewServiceClient("dns", region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	endpointInfo, err := GetEntpointById(client, endpointId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DNS endpoint")
+	}
+
+	reqResp, err := getEndpointIpAdressesById(client, endpointId)
+	if err != nil {
+		return diag.Errorf("error retrieving IP addresses under specified endpoint (%s): %s", endpointId, err)
+	}
+
+	vpcId := utils.PathSearch("vpc_id", endpointInfo, "").(string)
+	subnetClient, err := conf.NewServiceClient("vpc", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
+	}
+
+	subnets, err := getSubnetsByVpcId(subnetClient, vpcId)
+	if err != nil {
+		return diag.Errorf("error retrieving subnets under specified VPC (%s): %s", vpcId, err)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", endpointInfo, nil)),
+		d.Set("direction", utils.PathSearch("direction", endpointInfo, nil)),
+		d.Set("assignments",
+			flattenAssignments(utils.PathSearch("ipaddresses", reqResp, make([]interface{}, 0)).([]interface{}), subnets)),
+		d.Set("vpc_id", utils.PathSearch("vpc_id", endpointInfo, nil)),
+		d.Set("status", utils.PathSearch("status", endpointInfo, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(
+			utils.PathSearch("create_time", endpointInfo, "").(string), "2006-01-02T15:04:05.000")/1000, false)),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.FromErr(mErr.ErrorOrNil())
+	}
+
+	return nil
+}
+
+func getEndpointIpAdressesById(client *golangsdk.ServiceClient, endpointId string) (interface{}, error) {
+	httpUrl := "v2.1/endpoints/{endpoint_id}/ipaddresses"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{endpoint_id}", endpointId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func getSubnetsByVpcId(client *golangsdk.ServiceClient, vpcId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/subnets?limit=100&vpcId={vpc_id}"
+		listOpt = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+		marker = ""
+		result = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{vpc_id}", vpcId)
+
+	for {
+		listPathWithMarker := listPath
+		if marker != "" {
+			listPathWithMarker = fmt.Sprintf("%s&marker=%v", listPath, marker)
+		}
+
+		requestResp, err := client.Request("GET", listPathWithMarker, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		subnets := utils.PathSearch("subnets", respBody, make([]interface{}, 0)).([]interface{})
+		if len(subnets) < 1 {
+			break
+		}
+		result = append(result, subnets...)
+		marker = utils.PathSearch("[-1].id", subnets, "").(string)
+	}
+
+	return result, nil
+}
+
+func flattenAssignments(ipAddresses, subnets []interface{}) []map[string]interface{} {
+	rst := make([]map[string]interface{}, len(ipAddresses))
+	for i, v := range ipAddresses {
+		rst[i] = map[string]interface{}{
+			"ip_address":    utils.PathSearch("ip", v, nil),
+			"ip_address_id": utils.PathSearch("id", v, nil),
+		}
+
+		for _, subnet := range subnets {
+			if utils.PathSearch("subnet_id", v, "").(string) == utils.PathSearch("neutron_subnet_id", subnet, "").(string) {
+				rst[i]["subnet_id"] = utils.PathSearch("id", subnet, nil)
+				break
+			}
+		}
+	}
+
+	return rst
+}
+
+func resourceEndpointAssignmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	endpointId := d.Id()
+	client, err := conf.NewServiceClient("dns", region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	if d.HasChange("name") {
+		if err = updateEndpointName(client, endpointId, d.Get("name").(string)); err != nil {
+			return diag.Errorf("error updating the name of the endpoint (%s): %s", endpointId, err)
+		}
+	}
+
+	if d.HasChange("assignments") {
+		err = updateEndpointAssignments(client, d, endpointId)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		stateConf := &resource.StateChangeConf{
+			Target:       []string{"ACTIVE"},
+			Pending:      []string{"PENDING"},
+			Refresh:      refreshEndpointStatus(client, d.Id()),
+			Timeout:      d.Timeout(schema.TimeoutUpdate),
+			Delay:        5 * time.Second,
+			PollInterval: 5 * time.Second,
+		}
+
+		_, err = stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			return diag.Errorf("error waiting for DNS endpoint (%s) update to completed: %s", d.Id(), err)
+		}
+	}
+
+	return resourceEndpointAssignmentRead(ctx, d, meta)
+}
+
+func updateEndpointName(client *golangsdk.ServiceClient, endpointId, name string) error {
+	httpUrl := "v2.1/endpoints/{endpoint_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{endpoint_id}", endpointId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"name": name,
+		},
+	}
+
+	_, err := client.Request("PUT", updatePath, &getOpt)
+	return err
+}
+
+func updateEndpointAssignments(client *golangsdk.ServiceClient, d *schema.ResourceData, endpointId string) error {
+	var (
+		oldRaws, newRaws = d.GetChange("assignments")
+		addRaws          = newRaws.(*schema.Set).Difference(oldRaws.(*schema.Set)).List()
+		removeRaws       = oldRaws.(*schema.Set).Difference(newRaws.(*schema.Set)).List()
+		// The `originNum` indicates the actual number of IP addresses obtained in the interface.
+		originNum = oldRaws.(*schema.Set).Len()
+		err       error
+	)
+
+	// Since the assignment length ranges from `2` to `6`, the logic is to handle the critical value.
+	for len(addRaws) > 0 || len(removeRaws) > 0 {
+		// If the number of IP address mappings does not reach the upper limit, add an IP address mapping first.
+		if originNum < 6 && len(addRaws) > 0 {
+			addRaws, err = addEndpointIpAddress(client, addRaws, endpointId)
+			if err != nil {
+				return err
+			}
+			originNum++
+			continue
+		}
+
+		if removeRaws, err = removeEndpointIpAddress(client, removeRaws, endpointId); err != nil {
+			return err
+		}
+		originNum--
+	}
+	return nil
+}
+
+func addEndpointIpAddress(client *golangsdk.ServiceClient, addIpAddresses []interface{}, endpointId string) ([]interface{}, error) {
+	httpUrl := "v2.1/endpoints/{endpoint_id}/ipaddresses"
+	addPath := client.Endpoint + httpUrl
+	addPath = strings.ReplaceAll(addPath, "{endpoint_id}", endpointId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"ipaddress": map[string]interface{}{
+				"subnet_id": utils.PathSearch("subnet_id", addIpAddresses[0], nil),
+				"ip":        utils.PathSearch("ip_address", addIpAddresses[0], nil),
+			},
+		},
+	}
+
+	_, err := client.Request("POST", addPath, &opt)
+	if err != nil {
+		return nil, fmt.Errorf("error adding IP addresss for endpoint (%s): %s", endpointId, err)
+	}
+	return addIpAddresses[1:], nil
+}
+
+func removeEndpointIpAddress(client *golangsdk.ServiceClient, rmIpAddresses []interface{}, endpointId string) ([]interface{}, error) {
+	httpUrl := "v2.1/endpoints/{endpoint_id}/ipaddresses/{ipaddress_id}"
+	addPath := client.Endpoint + httpUrl
+	addPath = strings.ReplaceAll(addPath, "{endpoint_id}", endpointId)
+	addPath = strings.ReplaceAll(addPath, "{ipaddress_id}", utils.PathSearch("ip_address_id", rmIpAddresses[0], "").(string))
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err := client.Request("DELETE", addPath, &opt)
+	if err != nil {
+		// The status code is 404 when unbinding a non-existent IP address.
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			return rmIpAddresses[1:], nil
+		}
+		return nil, fmt.Errorf("error removing IP addresss from endpoint (%s): %s", endpointId, err)
+	}
+	return rmIpAddresses[1:], nil
+}
+
+func resourceEndpointAssignmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		conf       = meta.(*config.Config)
+		region     = conf.GetRegion(d)
+		httplUr    = "v2.1/endpoints/{endpoint_id}"
+		endpointId = d.Id()
+	)
+	client, err := conf.NewServiceClient("dns", region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httplUr
+	deletePath = strings.ReplaceAll(deletePath, "{endpoint_id}", endpointId)
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &opts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting DNS endpoint (%s): %s", endpointId, err))
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Target: []string{"DELETED"},
+		// Endpoints with status "ERROR" are allowed to be deleted.
+		Pending:      []string{"ACTIVE", "PENDING", "ERROR"},
+		Refresh:      refreshEndpointStatus(client, endpointId),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for DNS endpoint (%s) deletion to completed: %s", d.Id(), err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add an new resource `huaweicloud_dns_endpoint_assignment`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.  add resource to manage endpoint.
2. add corresponding documnet and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccEndpointAssignment_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccEndpointAssignment_basic -timeout 360m -parallel 10
=== RUN   TestAccEndpointAssignment_basic
=== PAUSE TestAccEndpointAssignment_basic
=== CONT  TestAccEndpointAssignment_basic
--- PASS: TestAccEndpointAssignment_basic (241.79s)
PASS
coverage: 10.1% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       241.907s        coverage: 10.1% of statements in ./huaweicloud/services/dns
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/509d2912-418f-473b-b04b-e524864b16a8)

  
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
   ![image](https://github.com/user-attachments/assets/976f7140-02dd-4a95-96cd-68685183fca5)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
