### PR TITLE
feat(cse/nacos): add new resource and data source for namespace

### DIFF
--- a/docs/data-sources/cse_nacos_namespaces.md
+++ b/docs/data-sources/cse_nacos_namespaces.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Cloud Service Engine (CSE)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cse_nacos_namespaces"
+description: |-
+  Use this data source to query available Nacos namespaces within HuaweiCloud.
+---
+
+# huaweicloud_cse_nacos_namespaces
+
+Use this data source to query available Nacos namespaces within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "nacos_engine_id" {}
+
+data "huaweicloud_cse_nacos_namespaces" "test" {
+  engine_id = var.nacos_engine_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the Nacos namespaces are located.  
+  If omitted, the provider-level region will be used.
+
+* `engine_id` - (Required, String) Specifies the ID of the Nacos microservice engine to which the namespaces belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `namespaces` - All queried Nacos namespaces.  
+  The [namespaces](#cse_nacos_namespaces) structure is documented below.
+
+<a name="cse_nacos_namespaces"></a>
+The `namespaces` block supports:
+
+* `id` - The ID of the Nacos namespace.
+
+  -> The reserved namespace (**public**) does not have the ID.
+
+* `name` - The name of the Nacos namespace.

--- a/docs/resources/cse_nacos_namespace.md
+++ b/docs/resources/cse_nacos_namespace.md
@@ -1,0 +1,50 @@
+---
+subcategory: "Cloud Service Engine (CSE)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cse_nacos_namespace"
+description: |-
+  Manages a namespace resource under CSE Nacos microservice engine within HuaweiCloud.
+---
+
+# huaweicloud_cse_nacos_namespace
+
+Manages a namespace resource under CSE Nacos microservice engine within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "nacos_engine_id" {}
+variable "namespace_name" {}
+
+resource "huaweicloud_cse_nacos_namespace" "test" {
+  engine_id = var.nacos_engine_id
+  name      = var.namespace_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the Nacos namespace is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `engine_id` - (Required, String, ForceNew) Specifies the ID of the Nacos microservice engine to which the namespace
+  belongs. Changing this will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the Nacos namespace.
+  The name can contain `1` to `128` characters, special characters `@#$%^&*` are not allowed.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+Nacos namespace can be imported using related `engine_id` and their `id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_cse_nacos_namespace.test <engine_id>/<id>
+```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20241204062359-3695be6b92d9
+	github.com/chnsz/golangsdk v0.0.0-20241209021804-a2c6b786dd27
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20241204062359-3695be6b92d9 h1:IcBRceM1kBXdX5i1oqRTrTJyXdzwkCIh1vJTLpOP1VA=
-github.com/chnsz/golangsdk v0.0.0-20241204062359-3695be6b92d9/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20241209021804-a2c6b786dd27 h1:qktzho3qYRW5AolHoIN6PwMTGiCKJCYjpwKTMzezih0=
+github.com/chnsz/golangsdk v0.0.0-20241209021804-a2c6b786dd27/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -591,6 +591,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_cse_microservice_engine_flavors": cse.DataSourceMicroserviceEngineFlavors(),
 			"huaweicloud_cse_microservice_engines":        cse.DataSourceMicroserviceEngines(),
+			"huaweicloud_cse_nacos_namespaces":            cse.DataSourceNacosNamespaces(),
 
 			"huaweicloud_csms_events":                   dew.DataSourceDewCsmsEvents(),
 			"huaweicloud_csms_secrets":                  dew.DataSourceDewCsmsSecrets(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1472,6 +1472,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cse_microservice_engine":               cse.ResourceMicroserviceEngine(),
 			"huaweicloud_cse_microservice_engine_configuration": cse.ResourceMicroserviceEngineConfiguration(),
 			"huaweicloud_cse_microservice_instance":             cse.ResourceMicroserviceInstance(),
+			"huaweicloud_cse_nacos_namespace":                   cse.ResourceNacosNamespace(),
 
 			"huaweicloud_csms_event":                dew.ResourceCsmsEvent(),
 			"huaweicloud_csms_secret":               dew.ResourceSecret(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -380,6 +380,7 @@ var (
 
 	HW_CSE_MICROSERVICE_ENGINE_ID             = os.Getenv("HW_CSE_MICROSERVICE_ENGINE_ID")
 	HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD = os.Getenv("HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD")
+	HW_CSE_NACOS_MICROSERVICE_ENGINE_ID       = os.Getenv("HW_CSE_NACOS_MICROSERVICE_ENGINE_ID")
 
 	HW_CSS_LOCAL_DISK_FLAVOR  = os.Getenv("HW_CSS_LOCAL_DISK_FLAVOR")
 	HW_CSS_ELB_AGENCY         = os.Getenv("HW_CSS_ELB_AGENCY")
@@ -2082,6 +2083,13 @@ func TestAccPreCheckCSEMicroserviceEngineID(t *testing.T) {
 func TestAccPreCheckCSEMicroserviceEngineAdminPassword(t *testing.T) {
 	if HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD == "" {
 		t.Skip("HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCSENacosMicroserviceEngineID(t *testing.T) {
+	if HW_CSE_NACOS_MICROSERVICE_ENGINE_ID == "" {
+		t.Skip("HW_CSE_NACOS_MICROSERVICE_ENGINE_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_nacos_namespaces_test.go
+++ b/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_nacos_namespaces_test.go
@@ -1,0 +1,79 @@
+package cse
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataNacosNamespaces_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_cse_nacos_namespaces.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCSENacosMicroserviceEngineID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataNacosNamespaces_basic_invalidEngine(),
+				ExpectError: regexp.MustCompile(`the Nacos engine \([0-9a-f-]+\) does not exist`),
+			},
+			{
+				Config: testAccDataNacosNamespaces_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "namespaces.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckOutput("all_custom_namespace_ids_set", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataNacosNamespaces_basic_invalidEngine() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_cse_nacos_namespaces" "test" {
+  engine_id = "%[1]s"
+}
+`, randUUID)
+}
+
+func testAccDataNacosNamespaces_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_cse_nacos_namespace" "test" {
+  engine_id = "%[1]s"
+  name      = "%[2]s"
+}
+
+data "huaweicloud_cse_nacos_namespaces" "test" {
+  depends_on = [huaweicloud_cse_nacos_namespace.test]
+
+  engine_id = "%[1]s"
+}
+
+# Check whether custom namespace ID is set
+locals {
+  namespace_id_validate_result = [
+    for o in data.huaweicloud_cse_nacos_namespaces.test.namespaces : o.id != "" if o.name != "public" 
+  ]
+}
+
+output "all_custom_namespace_ids_set" {
+  value = length(local.namespace_id_validate_result) > 0 && alltrue(local.namespace_id_validate_result)
+}
+`, acceptance.HW_CSE_NACOS_MICROSERVICE_ENGINE_ID, name)
+}

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_nacos_namespace_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_nacos_namespace_test.go
@@ -1,0 +1,101 @@
+package cse
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cse"
+)
+
+func getNacosNamespaceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("cse", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CSE client: %s", err)
+	}
+
+	return cse.GetNacosNamespaceById(client, state.Primary.Attributes["engine_id"], state.Primary.ID)
+}
+
+func TestAccNacosNamespace_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		uuid, _ = uuid.GenerateUUID()
+
+		resourceName = "huaweicloud_cse_nacos_namespace.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getNacosNamespaceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCSENacosMicroserviceEngineID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNacosNamespace_basic(uuid, name),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(`unable to create the namespace because the Nacos engine \(%s\) does not exist`, uuid)),
+			},
+			{
+				Config: testAccNacosNamespace_basic(acceptance.HW_CSE_NACOS_MICROSERVICE_ENGINE_ID, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+			{
+				Config: testAccNacosNamespace_basic(acceptance.HW_CSE_NACOS_MICROSERVICE_ENGINE_ID, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccNacosNamespaceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccNacosNamespaceImportStateIdFunc(resName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var engineId, namespaceId string
+		rs, ok := s.RootModule().Resources[resName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", resName)
+		}
+
+		engineId = rs.Primary.Attributes["engine_id"]
+		namespaceId = rs.Primary.ID
+
+		if engineId == "" || namespaceId == "" {
+			return "", fmt.Errorf("missing some attributes, want '<engine_id>/<id>', but got '%s/%s'", engineId, namespaceId)
+		}
+
+		return fmt.Sprintf("%s/%s", engineId, namespaceId), nil
+	}
+}
+
+func testAccNacosNamespace_basic(engineId, name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cse_nacos_namespace" "test" {
+  engine_id = "%[1]s"
+  name      = "%[2]s"
+}
+`, engineId, name)
+}

--- a/huaweicloud/services/cse/data_source_huaweicloud_cse_nacos_namespaces.go
+++ b/huaweicloud/services/cse/data_source_huaweicloud_cse_nacos_namespaces.go
@@ -1,0 +1,96 @@
+package cse
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CSE GET /v1/{project_id}/nacos/v1/console/namespaces
+func DataSourceNacosNamespaces() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNacosNamespacesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the Nacos namespaces are located.`,
+			},
+			"engine_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the Nacos microservice engine to which the namespaces belong.`,
+			},
+			"namespaces": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the Nacos namespace.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the Nacos namespace.`,
+						},
+					},
+				},
+				Description: `All queried Nacos namespaces.`,
+			},
+		},
+	}
+}
+
+func flattenNacosNamespaces(namespaces []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(namespaces))
+
+	for _, namespace := range namespaces {
+		result = append(result, map[string]interface{}{
+			"id":   utils.PathSearch("namespace", namespace, nil),
+			"name": utils.PathSearch("namespaceShowName", namespace, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceNacosNamespacesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		conf     = meta.(*config.Config)
+		region   = conf.GetRegion(d)
+		engineId = d.Get("engine_id").(string)
+	)
+	client, err := conf.NewServiceClient("cse", region)
+	if err != nil {
+		return diag.Errorf("error creating CSE client: %s", err)
+	}
+
+	namespaces, err := listNacosNamespaces(client, engineId)
+	if err != nil {
+		return diag.Errorf("error querying namespaces under Nacos engine (%s): %s", engineId, err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("namespaces", flattenNacosNamespaces(namespaces)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_nacos_namespace.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_nacos_namespace.go
@@ -1,0 +1,287 @@
+package cse
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CSE POST /v1/{project_id}/nacos/v1/console/namespaces
+// @API CSE GET /v1/{project_id}/nacos/v1/console/namespaces
+// @API CSE PUT /v1/{project_id}/nacos/v1/console/namespaces
+// @API CSE DELETE /v1/{project_id}/nacos/v1/console/namespaces
+func ResourceNacosNamespace() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNacosNamespaceCreate,
+		ReadContext:   resourceNacosNamespaceRead,
+		UpdateContext: resourceNacosNamespaceUpdate,
+		DeleteContext: resourceNacosNamespaceDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceNacosNamespaceImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the Nacos namespace is located.`,
+			},
+			"engine_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the Nacos microservice engine to which the namespace belongs.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the Nacos namespace.`,
+			},
+		},
+	}
+}
+
+func resourceNacosNamespaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/nacos/v1/console/namespaces?customNamespaceId={namespace_id}&namespaceName={namespace_name}"
+
+		engineId = d.Get("engine_id").(string)
+		name     = d.Get("name").(string)
+	)
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate resource ID for CSE Nacos namespace (%s): %s", name, err)
+	}
+
+	client, err := cfg.NewServiceClient("cse", region)
+	if err != nil {
+		return diag.Errorf("error creating CSE client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{namespace_id}", resourceId)
+	createPath = strings.ReplaceAll(createPath, "{namespace_name}", name)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"x-engine-id":  engineId,
+		},
+	}
+
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault502); ok {
+			// Bad gateway means Nacos engine does not exist.
+			return diag.Errorf("unable to create the namespace because the Nacos engine (%s) does not exist", engineId)
+		}
+		return diag.Errorf("error creating namespace under Nacos microservice engine (%s): %s", engineId, err)
+	}
+
+	d.SetId(resourceId)
+
+	return resourceNacosNamespaceRead(ctx, d, meta)
+}
+
+func listNacosNamespaces(client *golangsdk.ServiceClient, engineId string) ([]interface{}, error) {
+	httpUrl := "v1/{project_id}/nacos/v1/console/namespaces"
+
+	queryPath := client.Endpoint + httpUrl
+	queryPath = strings.ReplaceAll(queryPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"x-engine-id":  engineId,
+		},
+	}
+
+	requestResp, err := client.Request("GET", queryPath, &opt)
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault502); ok {
+			// Bad gateway means Nacos engine does not exist.
+			return nil, golangsdk.ErrDefault404{
+				ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+					Method:    "GET",
+					URL:       httpUrl,
+					RequestId: "NONE",
+					Body:      []byte(fmt.Sprintf("the Nacos engine (%s) does not exist", engineId)),
+				},
+			}
+		}
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func GetNacosNamespaceById(client *golangsdk.ServiceClient, engineId, namespaceId string) (interface{}, error) {
+	namespaces, err := listNacosNamespaces(client, engineId)
+	if err != nil {
+		return nil, err
+	}
+
+	namespace := utils.PathSearch(fmt.Sprintf("[?namespace=='%s']|[0]", namespaceId), namespaces, nil)
+	if namespace == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "v1/{project_id}/nacos/v1/console/namespaces",
+				RequestId: "NONE",
+				Body: []byte(fmt.Sprintf("the namespace (%s) has been removed from the Nacos microservice engine (%s)",
+					engineId, namespaceId)),
+			},
+		}
+	}
+	return namespace, nil
+}
+
+func resourceNacosNamespaceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		engineId    = d.Get("engine_id").(string)
+		namespaceId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("cse", region)
+	if err != nil {
+		return diag.Errorf("error creating CSE client: %s", err)
+	}
+
+	respBody, err := GetNacosNamespaceById(client, engineId, namespaceId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error querying Nacos namespace (%s)", namespaceId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("namespaceShowName", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceNacosNamespaceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/nacos/v1/console/namespaces?namespace={namespace_id}&namespaceShowName={namespace_name}"
+
+		engineId   = d.Get("engine_id").(string)
+		name       = d.Get("name").(string)
+		resourceId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("cse", region)
+	if err != nil {
+		return diag.Errorf("error creating CSE client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{namespace_id}", resourceId)
+	updatePath = strings.ReplaceAll(updatePath, "{namespace_name}", name)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"x-engine-id":  engineId,
+		},
+	}
+
+	_, err = client.Request("PUT", updatePath, &opt)
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault502); ok {
+			// Bad gateway means Nacos engine does not exist.
+			return diag.Errorf("unable to update the namespace because the Nacos engine (%s) does not exist", engineId)
+		}
+		return diag.Errorf("error updating namespace (%s) under the Nacos microservice engine (%s): %s", resourceId, engineId, err)
+	}
+
+	return resourceNacosNamespaceRead(ctx, d, meta)
+}
+
+func resourceNacosNamespaceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/nacos/v1/console/namespaces?namespaceId={namespace_id}"
+
+		engineId    = d.Get("engine_id").(string)
+		namespaceId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("cse", region)
+	if err != nil {
+		return diag.Errorf("error creating CSE client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{namespace_id}", namespaceId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"x-engine-id":  engineId,
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &opt)
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault502); ok {
+			// Bad gateway means Nacos engine has been removed and returns override the error with 404 status code.
+			err = golangsdk.ErrDefault404{
+				ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+					Method:    "DELETE",
+					URL:       httpUrl,
+					RequestId: "NONE",
+					Body:      []byte(fmt.Sprintf("unable to delete the namespace because the Nacos engine (%s) does not exist", engineId)),
+				},
+			}
+		}
+		// Delete method always return a 200 status code whether namespace is exist.
+		return common.CheckDeletedDiag(d, err,
+			fmt.Sprintf("error deleting namespace (%s) from the Nacos microserivce engine (%s)", namespaceId, engineId))
+	}
+	return nil
+}
+
+func resourceNacosNamespaceImportState(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<engine_id>/<id>', but got '%s'",
+			importedId)
+	}
+
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, d.Set("engine_id", parts[0])
+}

--- a/vendor/github.com/chnsz/golangsdk/errors.go
+++ b/vendor/github.com/chnsz/golangsdk/errors.go
@@ -106,6 +106,11 @@ type ErrDefault500 struct {
 	ErrUnexpectedResponseCode
 }
 
+// ErrDefault502 is the default error type returned on a 502 HTTP response code.
+type ErrDefault502 struct {
+	ErrUnexpectedResponseCode
+}
+
 // ErrDefault503 is the default error type returned on a 503 HTTP response code.
 type ErrDefault503 struct {
 	ErrUnexpectedResponseCode
@@ -167,6 +172,15 @@ func (e ErrDefault500) Error() string {
 	)
 	return e.choseErrString()
 }
+
+// HTTP bad gateway.
+func (e ErrDefault502) Error() string {
+	e.DefaultErrString = "Bad Gateway. Unable to receive a valid response from the upstream server while access the " +
+		"website or proxy server. It may be caused by the upstream server being temporarily unavailable, timing out, " +
+		"or returning a malformed response."
+	return e.choseErrString()
+}
+
 func (e ErrDefault503) Error() string {
 	return "The service is currently unable to handle the request due to a temporary" +
 		" overloading or maintenance. This is a temporary condition. Try again later."
@@ -218,6 +232,12 @@ type Err429er interface {
 // from a 500 error.
 type Err500er interface {
 	Error500(ErrUnexpectedResponseCode) error
+}
+
+// Err502er is the interface resource error types implement to override the error message
+// from a 502 error.
+type Err502er interface {
+	Error502(ErrUnexpectedResponseCode) error
 }
 
 // Err503er is the interface resource error types implement to override the error message

--- a/vendor/github.com/chnsz/golangsdk/provider_client.go
+++ b/vendor/github.com/chnsz/golangsdk/provider_client.go
@@ -446,6 +446,11 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 			if error500er, ok := errType.(Err500er); ok {
 				err = error500er.Error500(respErr)
 			}
+		case http.StatusBadGateway:
+			err = ErrDefault502{respErr}
+			if error502er, ok := errType.(Err502er); ok {
+				err = error502er.Error502(respErr)
+			}
 		case http.StatusServiceUnavailable:
 			err = ErrDefault503{respErr}
 			if error503er, ok := errType.(Err503er); ok {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20241204062359-3695be6b92d9
+# github.com/chnsz/golangsdk v0.0.0-20241209021804-a2c6b786dd27
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new resource to manage Nacos namespace resource.
Supports a new data source to query exist Nacos namespaces.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource for Nacos namespace management.
2. add new data source for Nacos namespaces query.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cse -f TestAccNacosNamespace_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccNacosNamespace_basic -timeout 360m -parallel 10
=== RUN   TestAccNacosNamespace_basic
=== PAUSE TestAccNacosNamespace_basic
=== CONT  TestAccNacosNamespace_basic
--- PASS: TestAccNacosNamespace_basic (18.24s)
PASS
coverage: 13.3% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       18.311s coverage: 13.3% of statements in ./huaweicloud/services/cse
```
```
./scripts/coverage.sh -o cse -f TestAccDataNacosNamespaces_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccDataNacosNamespaces_basic -timeout 360m -parallel 10
=== RUN   TestAccDataNacosNamespaces_basic
=== PAUSE TestAccDataNacosNamespaces_basic
=== CONT  TestAccDataNacosNamespaces_basic
--- PASS: TestAccDataNacosNamespaces_basic (8.58s)
PASS
coverage: 12.5% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       8.637s  coverage: 12.5% of statements in ./huaweicloud/services/cse
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![e7ed767e0022706d5558d87f698d797](https://github.com/user-attachments/assets/959a4791-e85c-4078-8a62-ba25d40d8324)

    ab. Related resources (parent resources) not found
    ![56eb6d68c6efc0abb57b7890c4d4540](https://github.com/user-attachments/assets/f88c159b-572a-4393-9ebb-9c9a0d355cd4)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![b60fa2403a0be5c29b7cc86fd467d07](https://github.com/user-attachments/assets/0fcfc2e6-86a0-48bb-b15b-04c94fd0d6e3)

    bb. Related resources (parent resources) not found
    ![5ac163c6046cf13c9ff552df2c630d2](https://github.com/user-attachments/assets/d829311c-b60b-4dda-b9e5-457b381f6b4e)
