### PR TITLE
feat(dms): support to restart kafka instance

### DIFF
--- a/docs/resources/dms_kafka_instance_restart.md
+++ b/docs/resources/dms_kafka_instance_restart.md
@@ -1,0 +1,44 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_instance_restart"
+description: |-
+  Manage DMS kafka instance restart resource within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_instance_restart
+
+Manage DMS kafka instance restart resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_dms_kafka_instance_restart" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the Kafka instance.
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1575,6 +1575,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_user":                      dms.ResourceDmsKafkaUser(),
 			"huaweicloud_dms_kafka_permissions":               dms.ResourceDmsKafkaPermissions(),
 			"huaweicloud_dms_kafka_instance":                  dms.ResourceDmsKafkaInstance(),
+			"huaweicloud_dms_kafka_instance_restart":          dms.ResourceDmsKafkaInstanceRestart(),
 			"huaweicloud_dms_kafka_topic":                     dms.ResourceDmsKafkaTopic(),
 			"huaweicloud_dms_kafka_message_produce":           dms.ResourceDmsKafkaMessageProduce(),
 			"huaweicloud_dms_kafka_partition_reassign":        dms.ResourceDmsKafkaPartitionReassign(),

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_restart_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_restart_test.go
@@ -1,0 +1,36 @@
+package dms
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccKafkaInstanceRestart_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKafkaInstanceRestart_basic(rName),
+			},
+		},
+	})
+}
+
+func testAccKafkaInstanceRestart_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dms_kafka_instance_restart" "test" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+}`, testAccKafkaInstance_newFormat(rName))
+}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_instance_restart.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_instance_restart.go
@@ -1,0 +1,71 @@
+package dms
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API Kafka POST /v2/{project_id}/instances/action
+// @API Kafka GET /v2/{project_id}/instances/{instance_id}
+func ResourceDmsKafkaInstanceRestart() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDmsKafkaInstanceRestartCreate,
+		ReadContext:   resourceDmsKafkaInstanceRestartRead,
+		DeleteContext: resourceDmsKafkaInstanceRestartDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the Kafka instance.`,
+			},
+		},
+	}
+}
+
+func resourceDmsKafkaInstanceRestartCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.DmsV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	if err = restartKafkaInstance(ctx, d.Timeout(schema.TimeoutCreate), client, instanceID); err != nil {
+		return diag.Errorf("error restarting instance: %s", err)
+	}
+
+	d.SetId(instanceID)
+
+	return nil
+}
+
+func resourceDmsKafkaInstanceRestartRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDmsKafkaInstanceRestartDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting resource is not supported. The resource is only removed from the state, the instance remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to restart kafka instance

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/dms" TESTARGS="-run TestAccKafkaInstanceRestart_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccKafkaInstanceRestart_basic -timeout 360m -parallel 4
=== RUN   TestAccKafkaInstanceRestart_basic
=== PAUSE TestAccKafkaInstanceRestart_basic
=== CONT  TestAccKafkaInstanceRestart_basic
--- PASS: TestAccKafkaInstanceRestart_basic (925.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       925.129s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
