### PR TITLE
feat(apig): add new resource for orchestration rules management

### DIFF
--- a/docs/resources/apig_orchestration_rule.md
+++ b/docs/resources/apig_orchestration_rule.md
@@ -1,0 +1,355 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_orchestration_rule"
+description: |-
+  Manages an orchestration rule under the dedicated instance within HuaweiCloud.
+---
+
+# huaweicloud_apig_orchestration_rule
+
+Manages an orchestration rule under the dedicated instance within HuaweiCloud.
+
+## Example Usage
+
+### Manages an orchestration rule with list type and no preprocessing
+
+```hcl
+variable "instance_id" {}
+variable "orchestration_rule_name" {}
+
+resource "huaweicloud_apig_orchestration_rule" "test" {
+  instance_id = var.instance_id
+  name        = var.orchestration_rule_name
+  strategy    = "list"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "listParam",
+    "mapped_param_type": "string",
+    "mapped_param_location": "header"
+  })
+
+  map = [
+    jsonencode({
+      # First priority
+      # All input values ​​in the list are mapped to 'ValueAA'.
+      "mapped_param_value": "ValueAA",
+      "map_param_list": ["ValueA"]
+    }),
+    jsonencode({
+      # Second priority
+      "mapped_param_value": "ValueBB",
+      "map_param_list": ["ValueB"]
+    })
+  ]
+}
+```
+
+### Manages an preprocessing orchestration rule with list type
+
+```hcl
+variable "instance_id" {}
+variable "orchestration_rule_name" {}
+
+resource "huaweicloud_apig_orchestration_rule" "test" {
+  instance_id      = var.instance_id
+  name             = var.orchestration_rule_name
+  strategy         = "list"
+  is_preprocessing = true
+
+  map = [
+    jsonencode({
+      # First priority
+      # All input values ​​in the list are mapped to 'ValueAA'.
+      "mapped_param_value": "ValueAA",
+      "map_param_list": ["ValueA"]
+    }),
+    jsonencode({
+      # Second priority
+      "mapped_param_value": "ValueBB",
+      "map_param_list": ["ValueB"]
+    })
+  ]
+}
+```
+
+### Manages an orchestration rule with range type and no preprocessing
+
+```hcl
+variable "instance_id" {}
+variable "orchestration_rule_name" {}
+
+resource "huaweicloud_apig_orchestration_rule" "test" {
+  instance_id = var.instance_id
+  name        = var.orchestration_rule_name
+  strategy    = "range"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "rangeParam",
+    "mapped_param_type": "number",
+    "mapped_param_location": "query"
+  })
+
+  map = [
+    jsonencode({
+      # First priority
+      # All input values ​​in the range 1000 to 1999 are mapped to 10001.
+      "mapped_param_value": "10001",
+      "map_param_range": {
+        "range_start": "1000",
+        "range_end": "1999"
+      }
+    }),
+    jsonencode({
+      # Second priority
+      "mapped_param_value": "10002",
+      "map_param_range": {
+        "range_start": "2000",
+        "range_end": "2999"
+      }
+    }),
+    jsonencode({
+      # Third priority
+      "mapped_param_value": "10003",
+      "map_param_range": {
+        "range_start": "3000",
+        "range_end": "3999"
+      }
+    })
+  ]
+}
+```
+
+### Manages an orchestration rule with hash type and no preprocessing
+
+```hcl
+variable "instance_id" {}
+variable "orchestration_rule_name" {}
+
+resource "huaweicloud_apig_orchestration_rule" "test" {
+  instance_id = var.instance_id
+  name        = var.orchestration_rule_name
+  strategy    = "hash"
+
+  mapped_param = jsonencode({
+    # The value of the request header is directly mapped to the new request header after hash calculation.
+    "mapped_param_name": "hashParam",
+    "mapped_param_type": "string",
+    "mapped_param_location": "header"
+  })
+}
+```
+
+### Manages an orchestration rule with hash range type and no preprocessing
+
+```hcl
+variable "instance_id" {}
+variable "orchestration_rule_name" {}
+
+resource "huaweicloud_apig_orchestration_rule" "test" {
+  instance_id = var.instance_id
+  name        = var.orchestration_rule_name
+  strategy    = "hash_range"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "hashParam",
+    "mapped_param_type": "number",
+    "mapped_param_location": "header"
+  })
+
+  # Use the request parameter to generate a hash value, and then use the hash value to perform range arrangement.
+  map = [
+    jsonencode({
+      # First priority
+      # If the hash value is ​​in the range 1000 to 1999, then mapped to 10001.
+      "mapped_param_value": "10001",
+      "map_param_range": {
+        "range_start": "1000",
+        "range_end": "1999"
+      }
+    }),
+    jsonencode({
+      # Second priority
+      "mapped_param_value": "10002",
+      "map_param_range": {
+        "range_start": "2000",
+        "range_end": "2999"
+      }
+    }),
+    jsonencode({
+      # Third priority
+      "mapped_param_value": "10003",
+      "map_param_range": {
+        "range_start": "3000",
+        "range_end": "3999"
+      }
+    })
+  ]
+}
+```
+
+### Manages an orchestration rule with none value type
+
+```hcl
+variable "instance_id" {}
+variable "orchestration_rule_name" {}
+
+resource "huaweicloud_apig_orchestration_rule" "test" {
+  instance_id = var.instance_id
+  name        = var.orchestration_rule_name
+  strategy    = "none_value"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "noneValueParam",
+    "mapped_param_type": "string",
+    "mapped_param_location": "header"
+  })
+
+  map = [
+    jsonencode({
+      # This orchestration value will be returned when the request parameter is empty.
+      "mapped_param_value": "NoneValueReturnedForExample"
+    })
+  ]
+}
+```
+
+### Manages an orchestration rule with default type
+
+```hcl
+variable "instance_id" {}
+variable "orchestration_rule_name" {}
+
+resource "huaweicloud_apig_orchestration_rule" "test" {
+  instance_id = var.instance_id
+  name        = var.orchestration_rule_name
+  strategy    = "default"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "defaultParam",
+    "mapped_param_type": "string",
+    "mapped_param_location": "header"
+  })
+
+  map = [
+    jsonencode({
+      # When the request parameters exist but no orchestration rule can match them, the orchestration mapping value of
+      # the default rule is returned.
+      "mapped_param_value": "DefaultValueReturnedForExample"
+    })
+  ]
+}
+```
+
+### Manages an orchestration rule with head N type
+
+```hcl
+variable "instance_id" {}
+variable "orchestration_rule_name" {}
+
+resource "huaweicloud_apig_orchestration_rule" "test" {
+  instance_id = var.instance_id
+  name        = var.orchestration_rule_name
+  strategy    = "head_n"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "headNParam",
+    "mapped_param_type": "string",
+    "mapped_param_location": "header"
+  })
+
+  map = [
+    jsonencode({
+      # Try to intercept the first N characters of the string as the new value.
+      "intercept_length": 5,
+      "mapped_param_value": "" # Note that the absence of this empty value configuration will cause script changes.
+    })
+  ]
+}
+```
+
+### Manages an orchestration rule with tail N type
+
+```hcl
+variable "instance_id" {}
+variable "orchestration_rule_name" {}
+
+resource "huaweicloud_apig_orchestration_rule" "test" {
+  instance_id = var.instance_id
+  name        = var.orchestration_rule_name
+  strategy    = "tail_n"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "tailNParam",
+    "mapped_param_type": "string",
+    "mapped_param_location": "header"
+  })
+
+  map = [
+    jsonencode({
+      # Try to intercept the last N characters of the string as the new value.
+      "intercept_length": 5,
+      "mapped_param_value": "" # Note that the absence of this empty value configuration will cause script changes.
+    })
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the orchestration rule is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the dedicated instance to which the orchestration
+  rule belongs.  
+  Changing this will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the orchestration rule.  
+  The valid length is limited from `3` to `64`, only letters, digits and underscores (_) are allowed.  
+  The name must start with a letter and must be unique.
+
+* `strategy` - (Required, String) Specifies the type of the orchestration rule.  
+  The valid values are as follows:
+  + **list**: Maps the values ​​in the list to new values.
+  + **range**: Maps the values ​​in the range to new values.
+  + **hash**: The value of the request header is directly mapped to the new request header after hash calculation.
+  + **hash_range**: Use the request parameter to generate a hash value, and then use the hash value to perform range
+    arrangement.
+  + **none_value**: Value returned when the request parameter is empty.
+  + **default**: When the request parameters exist but no orchestration rule can match them, the orchestration
+    mapping value of the default rule is returned.
+  + **head_n**: Try to intercept the first N characters of the string as the new value.
+  + **tail_n**: Try to intercept the last N characters of the string as the new value.
+
+* `is_preprocessing` - (Optional, Bool, ForceNew) Specifies whether rule is a preprocessing rule.  
+  Defaults to **false**. Changing this will create a new resource.
+
+  -> Type **none_value** and type **default** do not have this configuration.
+
+* `mapped_param` - (Optional, String, ForceNew) Specifies the parameter configuration after orchestration, in JSON
+  format.  
+  Changing this will create a new resource.  
+  For the parameter configuration, please refer to the [document](https://support.huaweicloud.com/intl/en-us/api-apig/CreateOrchestration.html#CreateOrchestration__request_OrchestrationMappedParam).
+
+* `map` - (Optional, List) Specifies the list of orchestration mapping rules, each item should be in JSON format.
+  For the parameter configuration of list items, please refer to the [document](https://support.huaweicloud.com/intl/en-us/api-apig/CreateOrchestration.html#CreateOrchestration__request_OrchestrationMap).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the orchestration rule.
+
+* `created_at` - The creation time of the orchestration rule, in RFC3339 format.
+
+* `updated_at` - The latest update time of the orchestration rule, in RFC3339 format.
+
+## Import
+
+Orchestration rules be imported using related `instance_id` and their `id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_apig_orchestration_rule.test <instance_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1324,6 +1324,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_instance_feature":               apig.ResourceInstanceFeature(),
 			"huaweicloud_apig_instance_routes":                apig.ResourceInstanceRoutes(),
 			"huaweicloud_apig_instance":                       apig.ResourceApigInstanceV2(),
+			"huaweicloud_apig_orchestration_rule":             apig.ResourceOrchestrationRule(),
 			"huaweicloud_apig_plugin_associate":               apig.ResourcePluginAssociate(),
 			"huaweicloud_apig_plugin":                         apig.ResourcePlugin(),
 			"huaweicloud_apig_response":                       apig.ResourceApigResponseV2(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_orchestration_rule_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_orchestration_rule_test.go
@@ -1,0 +1,967 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
+)
+
+func getOrchestrationRuleFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("apig", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating APIG client: %s", err)
+	}
+
+	return apig.GetOrchestrationRuleById(client, state.Primary.Attributes["instance_id"], state.Primary.ID)
+}
+
+func TestAccOrchestrationRule_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		typeList   = "huaweicloud_apig_orchestration_rule.type_list"
+		rcTypeList = acceptance.InitResourceCheck(typeList, &obj, getOrchestrationRuleFunc)
+
+		typeRange   = "huaweicloud_apig_orchestration_rule.type_range"
+		rcTypeRange = acceptance.InitResourceCheck(typeRange, &obj, getOrchestrationRuleFunc)
+
+		typeHash   = "huaweicloud_apig_orchestration_rule.type_hash"
+		rcTypeHash = acceptance.InitResourceCheck(typeHash, &obj, getOrchestrationRuleFunc)
+
+		typeHashRange   = "huaweicloud_apig_orchestration_rule.type_hash_range"
+		rcTypeHashRange = acceptance.InitResourceCheck(typeHashRange, &obj, getOrchestrationRuleFunc)
+
+		typeNoneValue   = "huaweicloud_apig_orchestration_rule.type_none_value"
+		rcTypeNoneValue = acceptance.InitResourceCheck(typeNoneValue, &obj, getOrchestrationRuleFunc)
+
+		typeDefault   = "huaweicloud_apig_orchestration_rule.type_default"
+		rcTypeDefault = acceptance.InitResourceCheck(typeDefault, &obj, getOrchestrationRuleFunc)
+
+		typeHeadN   = "huaweicloud_apig_orchestration_rule.type_head_n"
+		rcTypeHeadN = acceptance.InitResourceCheck(typeHeadN, &obj, getOrchestrationRuleFunc)
+
+		typeTailN   = "huaweicloud_apig_orchestration_rule.type_tail_n"
+		rcTypeTailN = acceptance.InitResourceCheck(typeTailN, &obj, getOrchestrationRuleFunc)
+
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcTypeList.CheckResourceDestroy(),
+			rcTypeRange.CheckResourceDestroy(),
+			rcTypeHash.CheckResourceDestroy(),
+			rcTypeHashRange.CheckResourceDestroy(),
+			rcTypeNoneValue.CheckResourceDestroy(),
+			rcTypeDefault.CheckResourceDestroy(),
+			rcTypeHeadN.CheckResourceDestroy(),
+			rcTypeTailN.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				// Check whether illegal type ​​can be intercepted normally (create phase).
+				Config:      testAccPlugin_basic_invalidType(),
+				ExpectError: regexp.MustCompile(`Invalid parameter value.*orchestration_strategy`),
+			},
+			{
+				Config: testAccOrchestrationRule_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Orchestration rule: type list.
+					rcTypeList.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeList, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeList, "name", name+"_type_list"),
+					resource.TestCheckResourceAttr(typeList, "strategy", "list"),
+					resource.TestCheckResourceAttr(typeList, "is_preprocessing", "false"),
+					resource.TestCheckResourceAttr(typeList, "mapped_param",
+						"{\"mapped_param_location\":\"header\",\"mapped_param_name\":\"listParam\",\"mapped_param_type\":\"string\"}"),
+					resource.TestCheckResourceAttr(typeList, "map.#", "3"),
+					resource.TestCheckResourceAttr(typeList, "map.0",
+						"{\"map_param_list\":[\"ValueA\"],\"mapped_param_value\":\"ValueAA\"}"),
+					resource.TestCheckResourceAttr(typeList, "map.1",
+						"{\"map_param_list\":[\"ValueC\"],\"mapped_param_value\":\"ValueCC\"}"),
+					resource.TestCheckResourceAttr(typeList, "map.2",
+						"{\"map_param_list\":[\"ValueB\"],\"mapped_param_value\":\"ValueBB\"}"),
+					resource.TestMatchResourceAttr(typeList, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type range.
+					rcTypeRange.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeRange, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeRange, "name", name+"_type_range"),
+					resource.TestCheckResourceAttr(typeRange, "strategy", "range"),
+					resource.TestCheckResourceAttr(typeRange, "is_preprocessing", "false"),
+					resource.TestCheckResourceAttr(typeRange, "mapped_param",
+						"{\"mapped_param_location\":\"query\",\"mapped_param_name\":\"rangeParam\",\"mapped_param_type\":\"number\"}"),
+					resource.TestCheckResourceAttr(typeRange, "map.#", "3"),
+					resource.TestCheckResourceAttr(typeRange, "map.0",
+						"{\"map_param_range\":{\"range_end\":\"1999\",\"range_start\":\"1000\"},\"mapped_param_value\":\"10001\"}"),
+					resource.TestCheckResourceAttr(typeRange, "map.1",
+						"{\"map_param_range\":{\"range_end\":\"3999\",\"range_start\":\"3000\"},\"mapped_param_value\":\"10003\"}"),
+					resource.TestCheckResourceAttr(typeRange, "map.2",
+						"{\"map_param_range\":{\"range_end\":\"2999\",\"range_start\":\"2000\"},\"mapped_param_value\":\"10002\"}"),
+					resource.TestMatchResourceAttr(typeRange, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type hash.
+					rcTypeHash.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeHash, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeHash, "name", name+"_type_hash"),
+					resource.TestCheckResourceAttr(typeHash, "strategy", "hash"),
+					resource.TestCheckResourceAttr(typeHash, "is_preprocessing", "false"),
+					resource.TestCheckResourceAttr(typeHash, "mapped_param",
+						"{\"mapped_param_location\":\"header\",\"mapped_param_name\":\"hashParam\",\"mapped_param_type\":\"string\"}"),
+					resource.TestMatchResourceAttr(typeHash, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type hash range.
+					rcTypeHashRange.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeHashRange, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeHashRange, "name", name+"_type_hash_range"),
+					resource.TestCheckResourceAttr(typeHashRange, "strategy", "hash_range"),
+					resource.TestCheckResourceAttr(typeHashRange, "is_preprocessing", "false"),
+					resource.TestCheckResourceAttr(typeHashRange, "mapped_param",
+						"{\"mapped_param_location\":\"header\",\"mapped_param_name\":\"hashRangeParam\",\"mapped_param_type\":\"number\"}"),
+					resource.TestCheckResourceAttr(typeHashRange, "map.#", "3"),
+					resource.TestCheckResourceAttr(typeHashRange, "map.0",
+						"{\"map_param_range\":{\"range_end\":\"1999\",\"range_start\":\"1000\"},\"mapped_param_value\":\"10001\"}"),
+					resource.TestCheckResourceAttr(typeRange, "map.1",
+						"{\"map_param_range\":{\"range_end\":\"3999\",\"range_start\":\"3000\"},\"mapped_param_value\":\"10003\"}"),
+					resource.TestCheckResourceAttr(typeRange, "map.2",
+						"{\"map_param_range\":{\"range_end\":\"2999\",\"range_start\":\"2000\"},\"mapped_param_value\":\"10002\"}"),
+					resource.TestMatchResourceAttr(typeRange, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type none value.
+					rcTypeNoneValue.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeNoneValue, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeNoneValue, "name", name+"_type_none_value"),
+					resource.TestCheckResourceAttr(typeNoneValue, "strategy", "none_value"),
+					resource.TestCheckResourceAttr(typeNoneValue, "is_preprocessing", "false"),
+					resource.TestCheckResourceAttr(typeNoneValue, "mapped_param",
+						"{\"mapped_param_location\":\"query\",\"mapped_param_name\":\"noneValueParam\",\"mapped_param_type\":\"string\"}"),
+					resource.TestCheckResourceAttr(typeNoneValue, "map.#", "1"),
+					resource.TestCheckResourceAttr(typeNoneValue, "map.0", "{\"mapped_param_value\":\"NoneValueReturned\"}"),
+					resource.TestMatchResourceAttr(typeNoneValue, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type default.
+					rcTypeDefault.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeDefault, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeDefault, "name", name+"_type_default"),
+					resource.TestCheckResourceAttr(typeDefault, "strategy", "default"),
+					resource.TestCheckResourceAttr(typeDefault, "is_preprocessing", "false"),
+					resource.TestCheckResourceAttr(typeDefault, "mapped_param",
+						"{\"mapped_param_location\":\"query\",\"mapped_param_name\":\"defaultParam\",\"mapped_param_type\":\"string\"}"),
+					resource.TestCheckResourceAttr(typeDefault, "map.#", "1"),
+					resource.TestCheckResourceAttr(typeDefault, "map.0", "{\"mapped_param_value\":\"DefaultValueReturned\"}"),
+					resource.TestMatchResourceAttr(typeDefault, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type head N.
+					rcTypeHeadN.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeHeadN, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeHeadN, "name", name+"_type_head_n"),
+					resource.TestCheckResourceAttr(typeHeadN, "strategy", "head_n"),
+					resource.TestCheckResourceAttr(typeHeadN, "is_preprocessing", "false"),
+					resource.TestCheckResourceAttr(typeHeadN, "mapped_param",
+						"{\"mapped_param_location\":\"query\",\"mapped_param_name\":\"headNParam\",\"mapped_param_type\":\"string\"}"),
+					resource.TestCheckResourceAttr(typeHeadN, "map.#", "1"),
+					resource.TestCheckResourceAttr(typeHeadN, "map.0", "{\"intercept_length\":5,\"mapped_param_value\":\"\"}"),
+					resource.TestMatchResourceAttr(typeHeadN, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type tail N.
+					rcTypeTailN.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeTailN, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeTailN, "name", name+"_type_tail_n"),
+					resource.TestCheckResourceAttr(typeTailN, "strategy", "tail_n"),
+					resource.TestCheckResourceAttr(typeTailN, "is_preprocessing", "false"),
+					resource.TestCheckResourceAttr(typeTailN, "mapped_param",
+						"{\"mapped_param_location\":\"query\",\"mapped_param_name\":\"tailNParam\",\"mapped_param_type\":\"string\"}"),
+					resource.TestCheckResourceAttr(typeTailN, "map.#", "1"),
+					resource.TestCheckResourceAttr(typeTailN, "map.0", "{\"intercept_length\":5,\"mapped_param_value\":\"\"}"),
+					resource.TestMatchResourceAttr(typeTailN, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccOrchestrationRule_basic(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					// Orchestration rule: type list.
+					rcTypeList.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeList, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeList, "name", updateName+"_type_list"),
+					resource.TestMatchResourceAttr(typeList, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type range.
+					rcTypeRange.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeRange, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeRange, "name", updateName+"_type_range"),
+					resource.TestMatchResourceAttr(typeRange, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type hash.
+					rcTypeHash.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeHash, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeHash, "name", updateName+"_type_hash"),
+					resource.TestMatchResourceAttr(typeHash, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type hash range.
+					rcTypeHashRange.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeHashRange, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeHashRange, "name", updateName+"_type_hash_range"),
+					resource.TestMatchResourceAttr(typeHashRange, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type none value.
+					rcTypeNoneValue.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeNoneValue, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeNoneValue, "name", updateName+"_type_none_value"),
+					resource.TestMatchResourceAttr(typeNoneValue, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type default.
+					rcTypeDefault.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeDefault, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeDefault, "name", updateName+"_type_default"),
+					resource.TestMatchResourceAttr(typeDefault, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type head N.
+					rcTypeHeadN.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeHeadN, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeHeadN, "name", updateName+"_type_head_n"),
+					resource.TestMatchResourceAttr(typeHeadN, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type tail N.
+					rcTypeTailN.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeTailN, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeTailN, "name", updateName+"_type_tail_n"),
+					resource.TestMatchResourceAttr(typeTailN, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      typeList,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccOrchestrationRuleImportStateFunc(typeList),
+			},
+			{
+				ResourceName:      typeRange,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccOrchestrationRuleImportStateFunc(typeRange),
+			},
+			{
+				ResourceName:      typeHash,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccOrchestrationRuleImportStateFunc(typeHash),
+			},
+			{
+				ResourceName:      typeHashRange,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccOrchestrationRuleImportStateFunc(typeHashRange),
+			},
+			{
+				ResourceName:      typeNoneValue,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccOrchestrationRuleImportStateFunc(typeNoneValue),
+			},
+			{
+				ResourceName:      typeDefault,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccOrchestrationRuleImportStateFunc(typeDefault),
+			},
+			{
+				ResourceName:      typeHeadN,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccOrchestrationRuleImportStateFunc(typeHeadN),
+			},
+			{
+				ResourceName:      typeTailN,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccOrchestrationRuleImportStateFunc(typeTailN),
+			},
+		},
+	})
+}
+
+func testAccOrchestrationRuleImportStateFunc(rsName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rsName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", rsName)
+		}
+		if rs.Primary.Attributes["instance_id"] == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<id>', but got '%s/%s'",
+				rs.Primary.Attributes["instance_id"], rs.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.ID), nil
+	}
+}
+
+func testAccPlugin_basic_invalidType() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_apig_orchestration_rule" "type_invalid" {
+  instance_id = "%[1]s"
+  name        = "%[2]s_type_invalid"
+  strategy    = "invalid"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "invalidParam",
+    "mapped_param_type": "string",
+    "mapped_param_location": "header"
+  })
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+}
+
+func testAccOrchestrationRule_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_apig_orchestration_rule" "type_list" {
+  instance_id = "%[1]s"
+  name        = "%[2]s_type_list"
+  strategy    = "list"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "listParam",
+    "mapped_param_type": "string",
+    "mapped_param_location": "header"
+  })
+
+  map = [
+    jsonencode({
+      "mapped_param_value": "ValueAA",
+      "map_param_list": ["ValueA"]
+    }),
+    jsonencode({
+      "mapped_param_value": "ValueCC",
+      "map_param_list": ["ValueC"]
+    }),
+    jsonencode({
+      "mapped_param_value": "ValueBB",
+      "map_param_list": ["ValueB"]
+    })
+  ]
+}
+
+resource "huaweicloud_apig_orchestration_rule" "type_range" {
+  instance_id = "%[1]s"
+  name        = "%[2]s_type_range"
+  strategy    = "range"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "rangeParam",
+    "mapped_param_type": "number",
+    "mapped_param_location": "query"
+  })
+
+  map = [
+    jsonencode({
+      "mapped_param_value": "10001",
+      "map_param_range": {
+        "range_start": "1000",
+        "range_end": "1999"
+      }
+    }),
+    jsonencode({
+      "mapped_param_value": "10003",
+      "map_param_range": {
+        "range_start": "3000",
+        "range_end": "3999"
+      }
+    }),
+    jsonencode({
+      "mapped_param_value": "10002",
+      "map_param_range": {
+        "range_start": "2000",
+        "range_end": "2999"
+      }
+    })
+  ]
+}
+
+resource "huaweicloud_apig_orchestration_rule" "type_hash" {
+  instance_id = "%[1]s"
+  name        = "%[2]s_type_hash"
+  strategy    = "hash"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "hashParam",
+    "mapped_param_type": "string",
+    "mapped_param_location": "header"
+  })
+}
+
+resource "huaweicloud_apig_orchestration_rule" "type_hash_range" {
+  instance_id = "%[1]s"
+  name        = "%[2]s_type_hash_range"
+  strategy    = "hash_range"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "hashRangeParam",
+    "mapped_param_type": "number",
+    "mapped_param_location": "header"
+  })
+
+  map = [
+    jsonencode({
+      "mapped_param_value": "10001",
+      "map_param_range": {
+        "range_start": "1000",
+        "range_end": "1999"
+      }
+    }),
+    jsonencode({
+      "mapped_param_value": "10003",
+      "map_param_range": {
+        "range_start": "3000",
+        "range_end": "3999"
+      }
+    }),
+    jsonencode({
+      "mapped_param_value": "10002",
+      "map_param_range": {
+        "range_start": "2000",
+        "range_end": "2999"
+      }
+    })
+  ]
+}
+
+resource "huaweicloud_apig_orchestration_rule" "type_none_value" {
+  instance_id = "%[1]s"
+  name        = "%[2]s_type_none_value"
+  strategy    = "none_value"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "noneValueParam",
+    "mapped_param_type": "string",
+    "mapped_param_location": "query"
+  })
+
+  map = [
+    jsonencode({
+      "mapped_param_value": "NoneValueReturned"
+    })
+  ]
+}
+
+resource "huaweicloud_apig_orchestration_rule" "type_default" {
+  instance_id = "%[1]s"
+  name        = "%[2]s_type_default"
+  strategy    = "default"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "defaultParam",
+    "mapped_param_type": "string",
+    "mapped_param_location": "query"
+  })
+
+  map = [
+    jsonencode({
+      "mapped_param_value": "DefaultValueReturned"
+    })
+  ]
+}
+
+resource "huaweicloud_apig_orchestration_rule" "type_head_n" {
+  instance_id = "%[1]s"
+  name        = "%[2]s_type_head_n"
+  strategy    = "head_n"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "headNParam",
+    "mapped_param_type": "string",
+    "mapped_param_location": "query"
+  })
+
+  map = [
+    jsonencode({
+      "intercept_length": 5,
+      "mapped_param_value": ""
+    })
+  ]
+}
+
+resource "huaweicloud_apig_orchestration_rule" "type_tail_n" {
+  instance_id = "%[1]s"
+  name        = "%[2]s_type_tail_n"
+  strategy    = "tail_n"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "tailNParam",
+    "mapped_param_type": "string",
+    "mapped_param_location": "query"
+  })
+
+  map = [
+    jsonencode({
+      "intercept_length": 5,
+      "mapped_param_value": ""
+    })
+  ]
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+}
+
+func TestAccOrchestrationRule_preprocessing(t *testing.T) {
+	var (
+		obj interface{}
+
+		typeList   = "huaweicloud_apig_orchestration_rule.type_list"
+		rcTypeList = acceptance.InitResourceCheck(typeList, &obj, getOrchestrationRuleFunc)
+
+		typeRange   = "huaweicloud_apig_orchestration_rule.type_range"
+		rcTypeRange = acceptance.InitResourceCheck(typeRange, &obj, getOrchestrationRuleFunc)
+
+		typeHash   = "huaweicloud_apig_orchestration_rule.type_hash"
+		rcTypeHash = acceptance.InitResourceCheck(typeHash, &obj, getOrchestrationRuleFunc)
+
+		typeHashRange   = "huaweicloud_apig_orchestration_rule.type_hash_range"
+		rcTypeHashRange = acceptance.InitResourceCheck(typeHashRange, &obj, getOrchestrationRuleFunc)
+
+		typeHeadN   = "huaweicloud_apig_orchestration_rule.type_head_n"
+		rcTypeHeadN = acceptance.InitResourceCheck(typeHeadN, &obj, getOrchestrationRuleFunc)
+
+		typeTailN   = "huaweicloud_apig_orchestration_rule.type_tail_n"
+		rcTypeTailN = acceptance.InitResourceCheck(typeTailN, &obj, getOrchestrationRuleFunc)
+
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcTypeList.CheckResourceDestroy(),
+			rcTypeRange.CheckResourceDestroy(),
+			rcTypeHash.CheckResourceDestroy(),
+			rcTypeHashRange.CheckResourceDestroy(),
+			rcTypeHeadN.CheckResourceDestroy(),
+			rcTypeTailN.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrchestrationRule_preprocessing(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Orchestration rule: type list.
+					rcTypeList.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeList, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeList, "name", name+"_type_list"),
+					resource.TestCheckResourceAttr(typeList, "strategy", "list"),
+					resource.TestCheckResourceAttr(typeList, "is_preprocessing", "true"),
+					resource.TestCheckResourceAttr(typeList, "mapped_param", ""),
+					resource.TestCheckResourceAttr(typeList, "map.#", "3"),
+					resource.TestCheckResourceAttr(typeList, "map.0",
+						"{\"map_param_list\":[\"ValueA\"],\"mapped_param_value\":\"ValueAA\"}"),
+					resource.TestCheckResourceAttr(typeList, "map.1",
+						"{\"map_param_list\":[\"ValueC\"],\"mapped_param_value\":\"ValueCC\"}"),
+					resource.TestCheckResourceAttr(typeList, "map.2",
+						"{\"map_param_list\":[\"ValueB\"],\"mapped_param_value\":\"ValueBB\"}"),
+					resource.TestMatchResourceAttr(typeList, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type range.
+					rcTypeRange.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeRange, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeRange, "name", name+"_type_range"),
+					resource.TestCheckResourceAttr(typeRange, "strategy", "range"),
+					resource.TestCheckResourceAttr(typeRange, "is_preprocessing", "true"),
+					resource.TestCheckResourceAttr(typeRange, "mapped_param", ""),
+					resource.TestCheckResourceAttr(typeRange, "map.#", "3"),
+					resource.TestCheckResourceAttr(typeRange, "map.0",
+						"{\"map_param_range\":{\"range_end\":\"1999\",\"range_start\":\"1000\"},\"mapped_param_value\":\"10001\"}"),
+					resource.TestCheckResourceAttr(typeRange, "map.1",
+						"{\"map_param_range\":{\"range_end\":\"3999\",\"range_start\":\"3000\"},\"mapped_param_value\":\"10003\"}"),
+					resource.TestCheckResourceAttr(typeRange, "map.2",
+						"{\"map_param_range\":{\"range_end\":\"2999\",\"range_start\":\"2000\"},\"mapped_param_value\":\"10002\"}"),
+					resource.TestMatchResourceAttr(typeRange, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type hash.
+					rcTypeHash.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeHash, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeHash, "name", name+"_type_hash"),
+					resource.TestCheckResourceAttr(typeHash, "strategy", "hash"),
+					resource.TestCheckResourceAttr(typeHash, "is_preprocessing", "true"),
+					resource.TestCheckResourceAttr(typeHash, "mapped_param", ""),
+					resource.TestMatchResourceAttr(typeHash, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type hash range.
+					rcTypeHashRange.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeHashRange, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeHashRange, "name", name+"_type_hash_range"),
+					resource.TestCheckResourceAttr(typeHashRange, "strategy", "hash_range"),
+					resource.TestCheckResourceAttr(typeHashRange, "is_preprocessing", "true"),
+					resource.TestCheckResourceAttr(typeHashRange, "mapped_param", ""),
+					resource.TestCheckResourceAttr(typeHashRange, "map.#", "3"),
+					resource.TestCheckResourceAttr(typeHashRange, "map.0",
+						"{\"map_param_range\":{\"range_end\":\"1999\",\"range_start\":\"1000\"},\"mapped_param_value\":\"10001\"}"),
+					resource.TestCheckResourceAttr(typeHashRange, "map.1",
+						"{\"map_param_range\":{\"range_end\":\"3999\",\"range_start\":\"3000\"},\"mapped_param_value\":\"10003\"}"),
+					resource.TestCheckResourceAttr(typeHashRange, "map.2",
+						"{\"map_param_range\":{\"range_end\":\"2999\",\"range_start\":\"2000\"},\"mapped_param_value\":\"10002\"}"),
+					resource.TestMatchResourceAttr(typeHashRange, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type head N.
+					rcTypeHeadN.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeHeadN, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeHeadN, "name", name+"_type_head_n"),
+					resource.TestCheckResourceAttr(typeHeadN, "strategy", "head_n"),
+					resource.TestCheckResourceAttr(typeHeadN, "is_preprocessing", "true"),
+					resource.TestCheckResourceAttr(typeHeadN, "mapped_param", ""),
+					resource.TestCheckResourceAttr(typeHeadN, "map.#", "1"),
+					resource.TestCheckResourceAttr(typeHeadN, "map.0", "{\"intercept_length\":5,\"mapped_param_value\":\"\"}"),
+					resource.TestMatchResourceAttr(typeHeadN, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type tail N.
+					rcTypeTailN.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeTailN, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeTailN, "name", name+"_type_tail_n"),
+					resource.TestCheckResourceAttr(typeTailN, "strategy", "tail_n"),
+					resource.TestCheckResourceAttr(typeTailN, "is_preprocessing", "true"),
+					resource.TestCheckResourceAttr(typeTailN, "mapped_param", ""),
+					resource.TestCheckResourceAttr(typeTailN, "map.#", "1"),
+					resource.TestCheckResourceAttr(typeTailN, "map.0", "{\"intercept_length\":5,\"mapped_param_value\":\"\"}"),
+					resource.TestMatchResourceAttr(typeTailN, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccOrchestrationRule_basic(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					// Orchestration rule: type list.
+					rcTypeList.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeList, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeList, "name", updateName+"_type_list"),
+					resource.TestMatchResourceAttr(typeList, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type range.
+					rcTypeRange.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeRange, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeRange, "name", updateName+"_type_range"),
+					resource.TestMatchResourceAttr(typeRange, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type hash.
+					rcTypeHash.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeHash, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeHash, "name", updateName+"_type_hash"),
+					resource.TestMatchResourceAttr(typeHash, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type hash range.
+					rcTypeHashRange.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeHashRange, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeHashRange, "name", updateName+"_type_hash_range"),
+					resource.TestMatchResourceAttr(typeHashRange, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type head N.
+					rcTypeHeadN.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeHeadN, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeHeadN, "name", updateName+"_type_head_n"),
+					resource.TestMatchResourceAttr(typeHeadN, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Orchestration rule: type tail N.
+					rcTypeTailN.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeTailN, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeTailN, "name", updateName+"_type_tail_n"),
+					resource.TestMatchResourceAttr(typeTailN, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      typeList,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccOrchestrationRuleImportStateFunc(typeList),
+			},
+			{
+				ResourceName:      typeRange,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccOrchestrationRuleImportStateFunc(typeRange),
+			},
+			{
+				ResourceName:      typeHash,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccOrchestrationRuleImportStateFunc(typeHash),
+			},
+			{
+				ResourceName:      typeHashRange,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccOrchestrationRuleImportStateFunc(typeHashRange),
+			},
+			{
+				ResourceName:      typeHeadN,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccOrchestrationRuleImportStateFunc(typeHeadN),
+			},
+			{
+				ResourceName:      typeTailN,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccOrchestrationRuleImportStateFunc(typeTailN),
+			},
+		},
+	})
+}
+
+func testAccOrchestrationRule_preprocessing(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_apig_orchestration_rule" "type_list" {
+  instance_id      = "%[1]s"
+  name             = "%[2]s_type_list"
+  strategy         = "list"
+  is_preprocessing = true
+
+  map = [
+    jsonencode({
+      "mapped_param_value": "ValueAA",
+      "map_param_list": ["ValueA"]
+    }),
+    jsonencode({
+      "mapped_param_value": "ValueCC",
+      "map_param_list": ["ValueC"]
+    }),
+    jsonencode({
+      "mapped_param_value": "ValueBB",
+      "map_param_list": ["ValueB"]
+    })
+  ]
+}
+
+resource "huaweicloud_apig_orchestration_rule" "type_range" {
+  instance_id      = "%[1]s"
+  name             = "%[2]s_type_range"
+  strategy         = "range"
+  is_preprocessing = true
+
+  map = [
+    jsonencode({
+      "mapped_param_value": "10001",
+      "map_param_range": {
+        "range_start": "1000",
+        "range_end": "1999"
+      }
+    }),
+    jsonencode({
+      "mapped_param_value": "10003",
+      "map_param_range": {
+        "range_start": "3000",
+        "range_end": "3999"
+      }
+    }),
+    jsonencode({
+      "mapped_param_value": "10002",
+      "map_param_range": {
+        "range_start": "2000",
+        "range_end": "2999"
+      }
+    })
+  ]
+}
+
+resource "huaweicloud_apig_orchestration_rule" "type_hash" {
+  instance_id      = "%[1]s"
+  name             = "%[2]s_type_hash"
+  strategy         = "hash"
+  is_preprocessing = true
+}
+
+resource "huaweicloud_apig_orchestration_rule" "type_hash_range" {
+  instance_id      = "%[1]s"
+  name             = "%[2]s_type_hash_range"
+  strategy         = "hash_range"
+  is_preprocessing = true
+
+  map = [
+    jsonencode({
+      "mapped_param_value": "10001",
+      "map_param_range": {
+        "range_start": "1000",
+        "range_end": "1999"
+      }
+    }),
+    jsonencode({
+      "mapped_param_value": "10003",
+      "map_param_range": {
+        "range_start": "3000",
+        "range_end": "3999"
+      }
+    }),
+    jsonencode({
+      "mapped_param_value": "10002",
+      "map_param_range": {
+        "range_start": "2000",
+        "range_end": "2999"
+      }
+    })
+  ]
+}
+
+resource "huaweicloud_apig_orchestration_rule" "type_head_n" {
+  instance_id      = "%[1]s"
+  name             = "%[2]s_type_head_n"
+  strategy         = "head_n"
+  is_preprocessing = true
+
+  map = [
+    jsonencode({
+      "intercept_length": 5,
+      "mapped_param_value": ""
+    })
+  ]
+}
+
+resource "huaweicloud_apig_orchestration_rule" "type_tail_n" {
+  instance_id      = "%[1]s"
+  name             = "%[2]s_type_tail_n"
+  strategy         = "tail_n"
+  is_preprocessing = true
+
+  map = [
+    jsonencode({
+      "intercept_length": 5,
+      "mapped_param_value": ""
+    })
+  ]
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+}
+
+func TestAccOrchestrationRule_strategyConvert(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceName = "huaweicloud_apig_orchestration_rule.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getOrchestrationRuleFunc)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrchestrationRule_strategyConvert_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Orchestration rule: type hash.
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(resourceName, "name", name+"_type_hash"),
+					resource.TestCheckResourceAttr(resourceName, "strategy", "hash"),
+					resource.TestCheckResourceAttr(resourceName, "is_preprocessing", "false"),
+					resource.TestCheckResourceAttr(resourceName, "mapped_param",
+						"{\"mapped_param_location\":\"header\",\"mapped_param_name\":\"strategyConvertParam\",\"mapped_param_type\":\"string\"}"),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccOrchestrationRule_strategyConvert_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Orchestration rule: type hash range.
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(resourceName, "name", name+"_type_hash_range"),
+					resource.TestCheckResourceAttr(resourceName, "strategy", "hash_range"),
+					resource.TestCheckResourceAttr(resourceName, "is_preprocessing", "false"),
+					resource.TestCheckResourceAttr(resourceName, "mapped_param",
+						"{\"mapped_param_location\":\"header\",\"mapped_param_name\":\"strategyConvertParam\",\"mapped_param_type\":\"string\"}"),
+					resource.TestCheckResourceAttr(resourceName, "map.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "map.0",
+						"{\"map_param_range\":{\"range_end\":\"1999\",\"range_start\":\"1000\"},\"mapped_param_value\":\"10001\"}"),
+					resource.TestCheckResourceAttr(resourceName, "map.1",
+						"{\"map_param_range\":{\"range_end\":\"3999\",\"range_start\":\"3000\"},\"mapped_param_value\":\"10003\"}"),
+					resource.TestCheckResourceAttr(resourceName, "map.2",
+						"{\"map_param_range\":{\"range_end\":\"2999\",\"range_start\":\"2000\"},\"mapped_param_value\":\"10002\"}"),
+					resource.TestMatchResourceAttr(resourceName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccOrchestrationRuleImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccOrchestrationRule_strategyConvert_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_apig_orchestration_rule" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s_type_hash"
+  strategy    = "hash"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "strategyConvertParam",
+    "mapped_param_type": "string",
+    "mapped_param_location": "header"
+  })
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+}
+
+func testAccOrchestrationRule_strategyConvert_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_apig_orchestration_rule" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s_type_hash_range"
+  strategy    = "hash_range"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "strategyConvertParam",
+    "mapped_param_type": "string",
+    "mapped_param_location": "header"
+  })
+
+  map = [
+    jsonencode({
+      "mapped_param_value": "10001",
+      "map_param_range": {
+        "range_start": "1000",
+        "range_end": "1999"
+      }
+    }),
+    jsonencode({
+      "mapped_param_value": "10003",
+      "map_param_range": {
+        "range_start": "3000",
+        "range_end": "3999"
+      }
+    }),
+    jsonencode({
+      "mapped_param_value": "10002",
+      "map_param_range": {
+        "range_start": "2000",
+        "range_end": "2999"
+      }
+    })
+  ]
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_orchestration_rule.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_orchestration_rule.go
@@ -1,0 +1,293 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/orchestrations
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/orchestrations/{orchestration_id}
+// @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}/orchestrations/{orchestration_id}
+// @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/orchestrations/{orchestration_id}
+func ResourceOrchestrationRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceOrchestrationRuleCreate,
+		ReadContext:   resourceOrchestrationRuleRead,
+		UpdateContext: resourceOrchestrationRuleUpdate,
+		DeleteContext: resourceOrchestrationRuleDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceOrchestrationRuleImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the orchestration rule is located.",
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of the dedicated instance to which the orchestration rule belongs.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the orchestration rule.",
+			},
+			"strategy": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The type of the orchestration rule.",
+			},
+			"is_preprocessing": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Whether rule is a preprocessing rule.",
+			},
+			"mapped_param": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  "The parameter configuration after orchestration, in JSON format.",
+				ValidateFunc: validation.StringIsJSON,
+			},
+			"map": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsJSON,
+				},
+				Description: "The list of orchestration mapping rules, each item should be in JSON format.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the orchestration rule, in RFC3339 format.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The latest update time of the orchestration rule, in RFC3339 format.",
+			},
+		},
+	}
+}
+
+func buildOrchestrationRuleMapList(mapList []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(mapList))
+
+	for _, val := range mapList {
+		if strVal, ok := val.(string); ok && strVal != "" {
+			result = append(result, utils.StringToJson(strVal))
+		}
+	}
+
+	return result
+}
+
+func buildOrchestrationRuleModifyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"orchestration_name":         d.Get("name"),
+		"orchestration_strategy":     d.Get("strategy"),
+		"orchestration_mapped_param": utils.StringToJson(d.Get("mapped_param").(string)),
+		"is_preprocessing":           d.Get("is_preprocessing"),
+		"orchestration_map":          buildOrchestrationRuleMapList(d.Get("map").([]interface{})),
+	}
+}
+
+func resourceOrchestrationRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/orchestrations"
+		instanceId = d.Get("instance_id").(string)
+	)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildOrchestrationRuleModifyBodyParams(d)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating orchestration rule under dedicated instance (%s): %s", instanceId, err)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	orchestrationId := utils.PathSearch("orchestration_id", respBody, "").(string)
+	if orchestrationId == "" {
+		return diag.Errorf("unable to find the orchestration rule ID from the API response")
+	}
+	d.SetId(orchestrationId)
+
+	return resourceOrchestrationRuleRead(ctx, d, meta)
+}
+
+func flattenOrchestrationRuleMap(mapList []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(mapList))
+
+	for _, val := range mapList {
+		result = append(result, utils.JsonToString(val))
+	}
+
+	return result
+}
+
+func GetOrchestrationRuleById(client *golangsdk.ServiceClient, instanceId, ruleId string) (interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/apigw/instances/{instance_id}/orchestrations/{orchestration_id}"
+	)
+
+	queryPath := client.Endpoint + httpUrl
+	queryPath = strings.ReplaceAll(queryPath, "{project_id}", client.ProjectID)
+	queryPath = strings.ReplaceAll(queryPath, "{instance_id}", instanceId)
+	queryPath = strings.ReplaceAll(queryPath, "{orchestration_id}", ruleId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", queryPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceOrchestrationRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+		ruleId     = d.Id()
+	)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	rule, err := GetOrchestrationRuleById(client, instanceId, ruleId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error querying orchestration rule (%s)", ruleId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("orchestration_name", rule, nil)),
+		d.Set("strategy", utils.PathSearch("orchestration_strategy", rule, nil)),
+		d.Set("mapped_param", utils.JsonToString(utils.PathSearch("orchestration_mapped_param", rule, nil))),
+		d.Set("is_preprocessing", utils.PathSearch("is_preprocessing", rule, nil)),
+		d.Set("map", flattenOrchestrationRuleMap(utils.PathSearch("orchestration_map", rule, make([]interface{}, 0)).([]interface{}))),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("orchestration_create_time",
+			rule, "").(string))/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("orchestration_update_time",
+			rule, "").(string))/1000, false)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving orchestration rule fields: %s", err)
+	}
+	return nil
+}
+
+func resourceOrchestrationRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg             = meta.(*config.Config)
+		region          = cfg.GetRegion(d)
+		httpUrl         = "v2/{project_id}/apigw/instances/{instance_id}/orchestrations/{orchestration_id}"
+		instanceId      = d.Get("instance_id").(string)
+		orchestrationId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", instanceId)
+	updatePath = strings.ReplaceAll(updatePath, "{orchestration_id}", orchestrationId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildOrchestrationRuleModifyBodyParams(d)),
+	}
+
+	_, err = client.Request("PUT", updatePath, &opt)
+	if err != nil {
+		return diag.Errorf("error updating orchestration rule under dedicated instance (%s): %s", instanceId, err)
+	}
+
+	return resourceOrchestrationRuleRead(ctx, d, meta)
+}
+
+func resourceOrchestrationRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg             = meta.(*config.Config)
+		region          = cfg.GetRegion(d)
+		httpUrl         = "v2/{project_id}/apigw/instances/{instance_id}/orchestrations/{orchestration_id}"
+		instanceId      = d.Get("instance_id").(string)
+		orchestrationId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceId)
+	deletePath = strings.ReplaceAll(deletePath, "{orchestration_id}", orchestrationId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &opt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting orchestration rule (%s)", orchestrationId))
+	}
+	return nil
+}
+
+func resourceOrchestrationRuleImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<id>', but got '%s'",
+			importedId)
+	}
+
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, d.Set("instance_id", parts[0])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new resource that used to manage orchestration rules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Supports a new resource that used to manage orchestration rules.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccOrchestrationRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccOrchestrationRule_basic -timeout 360m -parallel 10
=== RUN   TestAccOrchestrationRule_basic
=== PAUSE TestAccOrchestrationRule_basic
=== CONT  TestAccOrchestrationRule_basic
--- PASS: TestAccOrchestrationRule_basic (75.81s)
PASS
coverage: 3.0% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      75.869s coverage: 3.0% of statements in ./huaweicloud/services/apig
```
```
./scripts/coverage.sh -o apig -f TestAccOrchestrationRule_preprocessing
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccOrchestrationRule_preprocessing -timeout 360m -parallel 10
=== RUN   TestAccOrchestrationRule_preprocessing
=== PAUSE TestAccOrchestrationRule_preprocessing
=== CONT  TestAccOrchestrationRule_preprocessing
--- PASS: TestAccOrchestrationRule_preprocessing (58.87s)
PASS
coverage: 2.7% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      58.952s coverage: 2.7% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/1b9908e0-f54e-47f9-8321-a77d8d0f7110)

    ab. Related resources (parent resources) not found
    ![image](https://github.com/user-attachments/assets/1a2c988f-af1a-4445-a9d5-439d866bdd19)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![image](https://github.com/user-attachments/assets/328e889b-5ae6-4f90-83fa-0a09ff1999fa)

    bb. Related resources (parent resources) not found
    ![image](https://github.com/user-attachments/assets/dbc7ab57-fce3-4694-bbb3-287d37a14398)
