### PR TITLE
chore(cfw): deprecate cfw protection rule resource

### DIFF
--- a/docs/resources/cfw_protection_rule.md
+++ b/docs/resources/cfw_protection_rule.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Firewall (CFW)"
+subcategory: "Deprecated"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_cfw_protection_rule"
 description: |-
@@ -7,6 +7,8 @@ description: |-
 ---
 
 # huaweicloud_cfw_protection_rule
+
+!> **WARNING:** It has been deprecated, use `huaweicloud_cfw_acl_rule` instead.
 
 Manages a CFW protection rule resource within HuaweiCloud.
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1433,7 +1433,6 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_address_group_member": cfw.ResourceAddressGroupMember(),
 			"huaweicloud_cfw_black_white_list":     cfw.ResourceBlackWhiteList(),
 			"huaweicloud_cfw_eip_protection":       cfw.ResourceEipProtection(),
-			"huaweicloud_cfw_protection_rule":      cfw.ResourceProtectionRule(),
 			"huaweicloud_cfw_service_group":        cfw.ResourceServiceGroup(),
 			"huaweicloud_cfw_service_group_member": cfw.ResourceServiceGroupMember(),
 			"huaweicloud_cfw_firewall":             cfw.ResourceFirewall(),
@@ -2286,6 +2285,7 @@ func Provider() *schema.Provider {
 			// Deprecated
 			"huaweicloud_apig_vpc_channel":               deprecated.ResourceApigVpcChannelV2(),
 			"huaweicloud_blockstorage_volume_v2":         deprecated.ResourceBlockStorageVolumeV2(),
+			"huaweicloud_cfw_protection_rule":            deprecated.ResourceProtectionRule(),
 			"huaweicloud_csbs_backup":                    deprecated.ResourceCSBSBackupV1(),
 			"huaweicloud_csbs_backup_policy":             deprecated.ResourceCSBSBackupPolicyV1(),
 			"huaweicloud_csbs_backup_policy_v1":          deprecated.ResourceCSBSBackupPolicyV1(),

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_cfw_protection_rule_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_cfw_protection_rule_test.go
@@ -1,4 +1,4 @@
-package cfw
+package deprecated
 
 import (
 	"fmt"
@@ -9,7 +9,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cfw"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/deprecated"
 )
 
 func getProtectionRuleResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -19,7 +19,7 @@ func getProtectionRuleResourceFunc(conf *config.Config, state *terraform.Resourc
 		return nil, fmt.Errorf("error creating CFW client: %s", err)
 	}
 
-	return cfw.GetProtectionRule(client, state.Primary.ID, state.Primary.Attributes["object_id"])
+	return deprecated.GetProtectionRule(client, state.Primary.ID, state.Primary.Attributes["object_id"])
 }
 
 func TestAccProtectionRule_basic(t *testing.T) {
@@ -894,4 +894,12 @@ resource "huaweicloud_cfw_domain_name_group" "dg2" {
   }
 }
 `, name)
+}
+
+func testAccDatasourceFirewalls_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_firewalls" "test" {
+  fw_instance_id = "%s"
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
 }

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_acl_rule.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_acl_rule.go
@@ -94,7 +94,7 @@ func ResourceAclRule() *schema.Resource {
 			"custom_services": {
 				Type:          schema.TypeList,
 				Optional:      true,
-				Elem:          ProtectionRuleRuleServiceItemSchema(),
+				Elem:          ACLRuleServiceItemSchema(),
 				Description:   `The custom service configuration.`,
 				ConflictsWith: []string{"custom_service_groups", "predefined_service_groups"},
 			},
@@ -102,7 +102,7 @@ func ResourceAclRule() *schema.Resource {
 				Type:          schema.TypeList,
 				MaxItems:      1,
 				Optional:      true,
-				Elem:          AclRuleServiceGroupSchema(),
+				Elem:          ACLRuleServiceGroupSchema(),
 				Description:   `The custom service group list.`,
 				ConflictsWith: []string{"custom_services"},
 			},
@@ -110,7 +110,7 @@ func ResourceAclRule() *schema.Resource {
 				Type:          schema.TypeList,
 				MaxItems:      1,
 				Optional:      true,
-				Elem:          AclRuleServiceGroupSchema(),
+				Elem:          ACLRuleServiceGroupSchema(),
 				Description:   `The predefined service group list.`,
 				ConflictsWith: []string{"custom_services"},
 			},
@@ -126,7 +126,7 @@ func ResourceAclRule() *schema.Resource {
 				Type:          schema.TypeList,
 				MinItems:      1,
 				Optional:      true,
-				Elem:          ProtectionRuleIpRegionDtoSchema(),
+				Elem:          ACLRuleIpRegionDtoSchema(),
 				Description:   `The source region list.`,
 				ConflictsWith: []string{"source_addresses", "source_address_groups", "source_predefined_groups"},
 			},
@@ -167,7 +167,7 @@ func ResourceAclRule() *schema.Resource {
 				Type:        schema.TypeList,
 				MinItems:    1,
 				Optional:    true,
-				Elem:        ProtectionRuleIpRegionDtoSchema(),
+				Elem:        ACLRuleIpRegionDtoSchema(),
 				Description: `The destination region list.`,
 				ConflictsWith: []string{
 					"destination_addresses", "destination_domain_address_name", "destination_domain_group_id",
@@ -308,7 +308,30 @@ func ACLRuleOrderRuleAclDtoSchema() *schema.Resource {
 	return &sc
 }
 
-func AclRuleServiceGroupSchema() *schema.Resource {
+func ACLRuleServiceItemSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"protocol": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The protocol type.`,
+			},
+			"source_port": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The source port.`,
+			},
+			"dest_port": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The destination port.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func ACLRuleServiceGroupSchema() *schema.Resource {
 	sc := schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"protocols": {
@@ -324,6 +347,34 @@ func AclRuleServiceGroupSchema() *schema.Resource {
 				MinItems:    1,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `The IDs of the service groups.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func ACLRuleIpRegionDtoSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"region_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The region ID.`,
+			},
+			"region_type": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "The region type.",
+			},
+			"description_cn": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The Chinese description of the region.",
+			},
+			"description_en": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The English description of the region.",
 			},
 		},
 	}
@@ -392,7 +443,7 @@ func buildACLRulesOpts(d *schema.ResourceData, isUpdate bool) map[string]interfa
 		"long_connect_time_second": utils.ValueIgnoreEmpty(d.Get("long_connect_time_second")),
 		"name":                     utils.ValueIgnoreEmpty(d.Get("name")),
 		"status":                   d.Get("status"),
-		"tag":                      buildProtectionRuleRequestBodyTagsVO(d.Get("tags").(map[string]interface{})),
+		"tag":                      buildACLRuleRequestBodyTagsVO(d.Get("tags").(map[string]interface{})),
 	}
 
 	if !isUpdate {
@@ -454,6 +505,15 @@ func buildACLRulesOpts(d *schema.ResourceData, isUpdate bool) map[string]interfa
 		params["destination"] = buildACLRuleRequestBodyRuleAddressGroups(destinationAddressGroups, make([]interface{}, 0), destinationAddressType)
 	}
 	return params
+}
+
+func buildACLRuleRequestBodyTagsVO(tagmap map[string]interface{}) map[string]interface{} {
+	tags := make(map[string]interface{})
+	for k, v := range tagmap {
+		tags["tag_key"] = k
+		tags["tag_value"] = v
+	}
+	return tags
 }
 
 func buildACLRuleRequestBodyOrderRuleAclDto(rawParams interface{}) map[string]interface{} {
@@ -636,7 +696,7 @@ func resourceACLRuleRead(_ context.Context, d *schema.ResourceData, meta interfa
 		return common.CheckDeletedDiag(d, parseError(err), "error retrieving ACL rule")
 	}
 
-	count, err := getRuleHitCount(getACLRuleClient, d.Id())
+	count, err := getACLRuleHitCount(getACLRuleClient, d.Id())
 	if err != nil {
 		return diag.Errorf("error retrieving ACL rule hit count: %s", err)
 	}
@@ -671,7 +731,7 @@ func resourceACLRuleRead(_ context.Context, d *schema.ResourceData, meta interfa
 		d.Set("destination_address_groups", utils.PathSearch("destination.address_group_names[?address_set_type==`0`].set_id", rule, nil)),
 		d.Set("destination_address_type", utils.PathSearch("destination.address_type", rule, nil)),
 		d.Set("status", utils.PathSearch("status", rule, nil)),
-		d.Set("tags", flattenGetProtectionRuleResponseBodyRuleTagsVO(rule)),
+		d.Set("tags", flattenGetACLRuleResponseBodyRuleTagsVO(rule)),
 		d.Set("rule_hit_count", ruleHitCount),
 	)
 
@@ -731,6 +791,61 @@ func GetACLRule(client *golangsdk.ServiceClient, id, objectID string) (interface
 			return nil, golangsdk.ErrDefault404{}
 		}
 	}
+}
+
+func getACLRuleHitCount(client *golangsdk.ServiceClient, id string) (interface{}, error) {
+	getACLRuleHitCountHttpUrl := "v1/{project_id}/acl-rule/count"
+	getACLRuleHitCountPath := client.Endpoint + getACLRuleHitCountHttpUrl
+	getACLRuleHitCountPath = strings.ReplaceAll(getACLRuleHitCountPath, "{project_id}", client.ProjectID)
+
+	getACLRuleHitCountOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildRuleHitCountBodyParams(id),
+	}
+
+	getACLRuleHitCountResp, err := client.Request("POST", getACLRuleHitCountPath, &getACLRuleHitCountOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	getACLRuleHitCountRespBody, err := utils.FlattenResponse(getACLRuleHitCountResp)
+	if err != nil {
+		return nil, err
+	}
+
+	count := utils.PathSearch("data.records[0].rule_hit_count", getACLRuleHitCountRespBody, nil)
+	if count == nil {
+		return nil, fmt.Errorf("error parsing rule_hit_count from response= %#v", getACLRuleHitCountRespBody)
+	}
+	return count, nil
+}
+
+func buildRuleHitCountBodyParams(id string) map[string]interface{} {
+	return map[string]interface{}{
+		"rule_ids": []string{id},
+	}
+}
+
+func flattenGetACLRuleResponseBodyRuleTagsVO(resp interface{}) map[string]interface{} {
+	curJson := utils.PathSearch("tag", resp, nil)
+
+	if curJson == nil {
+		return nil
+	}
+
+	if tagMap, ok := curJson.(map[string]interface{}); ok {
+		key, value := "", ""
+		for k, v := range tagMap {
+			switch k {
+			case "tag_key":
+				key = v.(string)
+			case "tag_value":
+				value = v.(string)
+			}
+		}
+		return map[string]interface{}{key: value}
+	}
+	return nil
 }
 
 func flattenGetACLRuleResponseBodyRuleCustomServices(resp interface{}) []interface{} {

--- a/huaweicloud/services/deprecated/resource_huaweicloud_cfw_protection_rule.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_cfw_protection_rule.go
@@ -3,7 +3,7 @@
 // @Product CFW
 // ---------------------------------------------------------------
 
-package cfw
+package deprecated
 
 import (
 	"context"
@@ -558,7 +558,10 @@ func resourceProtectionRuleRead(_ context.Context, d *schema.ResourceData, meta 
 	objectID := d.Get("object_id").(string)
 	rule, err := GetProtectionRule(client, d.Id(), objectID)
 	if err != nil {
-		return common.CheckDeletedDiag(d, parseError(err), "error retrieving protection rule")
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "CFW.00200005"),
+			"error retrieving protection rule",
+		)
 	}
 
 	count, err := getRuleHitCount(client, d.Id())
@@ -1004,11 +1007,17 @@ func resourceProtectionRuleDelete(ctx context.Context, d *schema.ResourceData, m
 	}
 	_, err = client.Request("DELETE", deleteProtectionRulePath, &deleteProtectionRuleOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, parseError(err), "error deleting protection rule")
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "CFW.00200005"),
+			"error deleting protection rule",
+		)
 	}
 
 	err = deleteProtectionRuleWaitingForCompleted(ctx, client, d.Id(), d.Get("object_id").(string), d.Timeout(schema.TimeoutDelete))
-	return common.CheckDeletedDiag(d, parseError(err), "error deleting protection rule")
+	return common.CheckDeletedDiag(d,
+		common.ConvertExpected400ErrInto404Err(err, "error_code", "CFW.00200005"),
+		"error deleting protection rule",
+	)
 }
 
 func deleteProtectionRuleWaitingForCompleted(ctx context.Context, client *golangsdk.ServiceClient, id, objectID string, timeout time.Duration) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
deprecate cfw protection rule resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.deprecate cfw protection rule resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/deprecated" TESTARGS="-run TestAccProtectionRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/deprecated -v -run TestAccProtectionRule_basic -timeout 360m -parallel 4
=== RUN   TestAccProtectionRule_basic
=== PAUSE TestAccProtectionRule_basic
=== CONT  TestAccProtectionRule_basic
--- PASS: TestAccProtectionRule_basic (124.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/deprecated        125.148s

make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccACLRule_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccACLRule_ -timeout 360m -parallel 4
=== RUN   TestAccACLRule_basic
=== PAUSE TestAccACLRule_basic
=== RUN   TestAccACLRule_serviceGroups_regionList
=== PAUSE TestAccACLRule_serviceGroups_regionList
=== RUN   TestAccACLRule_domainAddressName_domainGroup
=== PAUSE TestAccACLRule_domainAddressName_domainGroup
=== RUN   TestAccACLRule_addressGroups
=== PAUSE TestAccACLRule_addressGroups
=== CONT  TestAccACLRule_basic
=== CONT  TestAccACLRule_domainAddressName_domainGroup
=== CONT  TestAccACLRule_serviceGroups_regionList
=== CONT  TestAccACLRule_addressGroups
--- PASS: TestAccACLRule_basic (261.99s)
--- PASS: TestAccACLRule_serviceGroups_regionList (478.32s)
--- PASS: TestAccACLRule_domainAddressName_domainGroup (679.32s)
--- PASS: TestAccACLRule_addressGroups (732.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       732.843s

```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
