### PR TITLE
feat(live): add a new resource to manage referer validation

### DIFF
--- a/docs/resources/live_referer_validation.md
+++ b/docs/resources/live_referer_validation.md
@@ -1,0 +1,67 @@
+---
+subcategory: "Live"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_live_referer_validation"
+description: |-
+  Manages a referer validation resource within HuaweiCloud.
+---
+
+# huaweicloud_live_referer_validation
+
+Manages a referer validation resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "domain_name" {}
+variable "referer_config_empty" {}
+variable "referer_white_list" {}
+variable "referer_auth_list" {
+  type = list(string)
+}
+
+resource "huaweicloud_live_referer_validation" "test" {
+  domain_name          = var.domain_name
+  referer_config_empty = var.referer_config_empty
+  referer_white_list   = var.referer_white_list
+  referer_auth_list    = var.referer_auth_list
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `domain_name` - (Required, String, ForceNew) Specifies the streaming domain name to which the referer validation
+  belongs.
+  Changing this parameter will create a new resource.
+
+* `referer_config_empty` - (Required, String) Specifies whether the referer header is included.
+  The value can be **true** or **false**.
+
+* `referer_white_list` - (Required, String) Specifies whether the referer is in the trustlist.
+  The valid values are as follows:
+  + **true**: Indicates referer whitelist.
+  + **false**: Indicates referer blacklist.
+
+* `referer_auth_list` - (Required, List) Specifies the domain name list.
+  The maximum length is `100`.
+  The domain name can be a specific domain name or a regular expression. e.g. `www.example.com`, `www.*com`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, UUID format.
+
+## Import
+
+The resource can be imported using `domain_name`, e.g.
+
+```bash
+$ terraform import huaweicloud_live_referer_validation.test <domain_name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1832,6 +1832,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_live_domain":               live.ResourceDomain(),
 			"huaweicloud_live_record_callback":      live.ResourceRecordCallback(),
 			"huaweicloud_live_recording":            live.ResourceRecording(),
+			"huaweicloud_live_referer_validation":   live.ResourceRefererValidation(),
 			"huaweicloud_live_snapshot":             live.ResourceLiveSnapshot(),
 			"huaweicloud_live_transcoding":          live.ResourceTranscoding(),
 			"huaweicloud_live_url_validation":       live.ResourceUrlValidation(),

--- a/huaweicloud/services/acceptance/live/resource_huaweicloud_live_referer_validation_test.go
+++ b/huaweicloud/services/acceptance/live/resource_huaweicloud_live_referer_validation_test.go
@@ -1,0 +1,146 @@
+package live
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getRefererValidationFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Live client: %s", err)
+	}
+
+	getHttpUrl := "v1/{project_id}/guard/referer-chain"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = fmt.Sprintf("%s?domain=%v", getPath, state.Primary.Attributes["domain_name"])
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving referer validation: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	refererAuthList := utils.PathSearch("referer_auth_list", getRespBody, make([]interface{}, 0)).([]interface{})
+	if len(refererAuthList) == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return getRespBody, nil
+}
+
+func TestAccRefererValidation_basic(t *testing.T) {
+	var (
+		refererValidationObj interface{}
+		rName                = "huaweicloud_live_referer_validation.test"
+		domainName           = fmt.Sprintf("%s.huaweicloud.com", acceptance.RandomAccResourceNameWithDash())
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&refererValidationObj,
+		getRefererValidationFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRefererValidation_basic(domainName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "domain_name", "huaweicloud_live_domain.test", "name"),
+					resource.TestCheckResourceAttr(rName, "referer_config_empty", "true"),
+					resource.TestCheckResourceAttr(rName, "referer_white_list", "true"),
+					resource.TestCheckResourceAttr(rName, "referer_auth_list.#", "1"),
+				),
+			},
+			{
+				Config: testAccRefererValidation_update(domainName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "referer_config_empty", "false"),
+					resource.TestCheckResourceAttr(rName, "referer_white_list", "false"),
+					resource.TestCheckResourceAttr(rName, "referer_auth_list.#", "2"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateIdFunc: testAccRefererValidationImportState(rName),
+			},
+		},
+	})
+}
+
+func testAccRefererValidation_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_domain" "test" {
+  name = "%s"
+  type = "pull"
+}
+
+resource "huaweicloud_live_referer_validation" "test" {
+  domain_name          = huaweicloud_live_domain.test.name
+  referer_config_empty = "true"
+  referer_white_list   = "true"
+  referer_auth_list    = ["www.test.com"]
+}
+`, name)
+}
+
+func testAccRefererValidation_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_domain" "test" {
+  name = "%s"
+  type = "pull"
+}
+
+resource "huaweicloud_live_referer_validation" "test" {
+  domain_name          = huaweicloud_live_domain.test.name
+  referer_config_empty = "false"
+  referer_white_list   = "false"
+  referer_auth_list    = ["www.test.com","www.*com"]
+}
+`, name)
+}
+
+func testAccRefererValidationImportState(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var domainName string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", rName)
+		}
+
+		domainName = rs.Primary.Attributes["domain_name"]
+		if domainName == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, 'domain_name' is empty")
+		}
+		return domainName, nil
+	}
+}

--- a/huaweicloud/services/live/resource_huaweicloud_live_referer_validation.go
+++ b/huaweicloud/services/live/resource_huaweicloud_live_referer_validation.go
@@ -1,0 +1,232 @@
+package live
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Live PUT /v1/{project_id}/guard/referer-chain
+// @API Live GET /v1/{project_id}/guard/referer-chain
+// @API Live DELETE /v1/{project_id}/guard/referer-chain
+func ResourceRefererValidation() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRefererValidationCreate,
+		ReadContext:   resourceRefererValidationRead,
+		UpdateContext: resourceRefererValidationUpdate,
+		DeleteContext: resourceRefererValidationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceRefererValidationImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"domain_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the streaming domain name to which the referer validation belongs.`,
+			},
+			"referer_config_empty": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies whether the referer header is included.`,
+			},
+			"referer_white_list": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies whether the referer is in the trustlist.`,
+			},
+			"referer_auth_list": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Specifies the domain name list.`,
+			},
+		},
+	}
+}
+
+func resourceRefererValidationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	err = createOrUpdateRefererValidation(client, d)
+	if err != nil {
+		return diag.Errorf("error creating Live referer validation: %s", err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	return resourceRefererValidationRead(ctx, d, meta)
+}
+
+func createOrUpdateRefererValidation(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	validationHttpUrl := "v1/{project_id}/guard/referer-chain"
+	validationPath := client.Endpoint + validationHttpUrl
+	validationPath = strings.ReplaceAll(validationPath, "{project_id}", client.ProjectID)
+
+	validationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildRefererValidationBodyParams(d)),
+	}
+
+	_, err := client.Request("PUT", validationPath, &validationOpt)
+	return err
+}
+
+func buildRefererValidationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"guard_switch":         "true",
+		"domain":               d.Get("domain_name"),
+		"referer_config_empty": d.Get("referer_config_empty"),
+		"referer_white_list":   d.Get("referer_white_list"),
+		"referer_auth_list":    utils.ExpandToStringList(d.Get("referer_auth_list").([]interface{})),
+	}
+
+	return params
+}
+
+func resourceRefererValidationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		domainName = d.Get("domain_name").(string)
+		getHttpUrl = "v1/{project_id}/guard/referer-chain"
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = fmt.Sprintf("%s?domain=%v", getPath, domainName)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", domainNameNotExistsCode),
+			"error retrieving referer validation")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	refererAuthList := utils.PathSearch("referer_auth_list", getRespBody, make([]interface{}, 0)).([]interface{})
+	if len(refererAuthList) == 0 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "referer validation")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("domain_name", domainName),
+		d.Set("referer_config_empty", utils.PathSearch("referer_config_empty", getRespBody, nil)),
+		d.Set("referer_white_list", utils.PathSearch("referer_white_list", getRespBody, nil)),
+		d.Set("referer_auth_list", utils.PathSearch("referer_auth_list", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceRefererValidationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	err = createOrUpdateRefererValidation(client, d)
+	if err != nil {
+		return diag.Errorf("error updating referer validation: %s", err)
+	}
+
+	return resourceRefererValidationRead(ctx, d, meta)
+}
+
+func resourceRefererValidationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		deleteHttpUrl = "v1/{project_id}/guard/referer-chain"
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	deletePath := client.Endpoint + deleteHttpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = fmt.Sprintf("%s?domain=%v", deletePath, d.Get("domain_name"))
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", domainNameNotExistsCode),
+			"error deleting referer validation")
+	}
+
+	return nil
+}
+
+func resourceRefererValidationImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	if importedId == "" {
+		return nil, fmt.Errorf("invalid format specified for import ID, 'domain_name' is empty")
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("domain_name", importedId),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new resource to manage referer validation.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new resource to manage the referer validation resource.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/live" TESTARGS="-run TestAccRefererValidation_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/live -v -run TestAccRefererValidation_basic -timeout 360m -parallel 4
=== RUN   TestAccRefererValidation_basic
=== PAUSE TestAccRefererValidation_basic
=== CONT  TestAccRefererValidation_basic
--- PASS: TestAccRefererValidation_basic (325.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      326.000s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/71ceb9e3-b76d-4851-b3f8-58653c17d64c)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/72500523-2951-4fbb-9f94-b5b094de9180)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
