### PR TITLE
feat(apig): add new data source to query orchestration rules

### DIFF
--- a/docs/data-sources/apig_orchestration_rules.md
+++ b/docs/data-sources/apig_orchestration_rules.md
@@ -1,0 +1,85 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_orchestration_rules"
+description: |-
+  Use this data source to get the list of orchestration rules under specified instance within HuaweiCloud.
+---
+
+# huaweicloud_apig_orchestration_rules
+
+Use this data source to get the list of orchestration rules under specified instance within HuaweiCloud.
+
+## Example Usage
+
+### Query all orchestration rules under specified APIG instance
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_apig_orchestration_rules" "test" {
+  instance_id = var.instance_id
+}
+```
+
+### Query specified orchestration rule using its ID
+
+```hcl
+variable "instance_id" {}
+variable "orchestration_rule_id" {}
+
+data "huaweicloud_apig_orchestration_rules" "test" {
+  instance_id = var.instance_id
+  rule_id     = var.orchestration_rule_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the associated signatures.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the orchestration rules belong.
+
+* `rule_id` - (Optional, String) Specifies the ID of the orchestration rule to be queried.
+
+* `name` - (Optional, String) Specifies the name of the orchestration rule to be queried, fuzzy matching is supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `rules` - All orchestration rules that match the filter parameters.
+  The [rules](#orchestration_rules) structure is documented below.
+
+<a name="orchestration_rules"></a>
+The `rules` block supports:
+
+* `id` - The ID of the orchestration rule.
+
+* `name` - The name of the orchestration rule.
+
+* `strategy` - The type of the orchestration rule.  
+  The values are as follows:
+  + **list**: Maps the values ​​in the list to new values.
+  + **range**: Maps the values ​​in the range to new values.
+  + **hash**: The value of the request header is directly mapped to the new request header after hash calculation.
+  + **hash_range**: Use the request parameter to generate a hash value, and then use the hash value to perform range
+    arrangement.
+  + **none_value**: Value returned when the request parameter is empty.
+  + **default**: When the request parameters exist but no orchestration rule can match them, the orchestration
+    mapping value of the default rule is returned.
+  + **head_n**: Try to intercept the first N characters of the string as the new value.
+  + **tail_n**: Try to intercept the last N characters of the string as the new value.
+
+* `is_preprocessing` - Whether rule is a preprocessing rule.
+
+* `mapped_param` - The parameter configuration after orchestration, in JSON format.
+
+* `created_at` - The creation time of the orchestration rule, in RFC3339 format.
+
+* `updated_at` - The latest update time of the orchestration rule, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -455,6 +455,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_instance_features":                  apig.DataSourceInstanceFeatures(),
 			"huaweicloud_apig_instance_supported_features":        apig.DataSourceInstanceSupportedFeatures(),
 			"huaweicloud_apig_instances":                          apig.DataSourceInstances(),
+			"huaweicloud_apig_orchestration_rules":                apig.DataSourceOrchestrationRules(),
 			"huaweicloud_apig_signatures":                         apig.DataSourceSignatures(),
 			"huaweicloud_apig_throttling_policies":                apig.DataSourceThrottlingPolicies(),
 

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_orchestration_rules_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_orchestration_rules_test.go
@@ -1,0 +1,186 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceOrchestrationRules_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_apig_orchestration_rules.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byId   = "data.huaweicloud_apig_orchestration_rules.filter_by_id"
+		dcById = acceptance.InitDataSourceCheck(byId)
+
+		byName   = "data.huaweicloud_apig_orchestration_rules.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byNotFoundName   = "data.huaweicloud_apig_orchestration_rules.filter_by_not_found_name"
+		dcByNotFoundName = acceptance.InitDataSourceCheck(byNotFoundName)
+
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceOrchestrationRules_base(name),
+			},
+			{
+				// Update the orchestration rule's name to make sure the update time generated successfully.
+				Config: testAccDataSourceOrchestrationRules_base(updateName),
+			},
+			{
+				Config: testAccDataSourceOrchestrationRules_basic(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "rules.#", regexp.MustCompile(`[1-9]\d*`)),
+					dcById.CheckResourceExists(),
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+					resource.TestCheckResourceAttr(byId, "rules.#", "1"),
+					resource.TestCheckResourceAttrPair(byId, "rules.0.id", "huaweicloud_apig_orchestration_rule.test", "id"),
+					resource.TestCheckResourceAttr(byId, "rules.0.name", updateName),
+					resource.TestCheckResourceAttr(byId, "rules.0.strategy", "hash"),
+					resource.TestCheckResourceAttr(byId, "rules.0.is_preprocessing", "false"),
+					resource.TestCheckResourceAttr(byId, "rules.0.mapped_param",
+						"{\"mapped_param_location\":\"header\",\"mapped_param_name\":\"standard-param\",\"mapped_param_type\":\"string\"}"),
+					resource.TestMatchResourceAttr(byId, "rules.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(byId, "rules.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcByNotFoundName.CheckResourceExists(),
+					resource.TestCheckOutput("is_not_found_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceOrchestrationRules_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_apig_orchestration_rule" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+  strategy    = "hash"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "standard-param",
+    "mapped_param_type": "string",
+    "mapped_param_location": "header"
+  })
+}
+
+resource "huaweicloud_apig_orchestration_rule" "with_suffix_index" {
+  count = 2
+
+  instance_id = "%[1]s"
+  name        = format("reverse_%%s_%%d", strrev("%[2]s"), count.index)
+  strategy    = "hash"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "reversed-param-with-suffix-index-${count.index}",
+    "mapped_param_type": "string",
+    "mapped_param_location": "header"
+  })
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+}
+
+func testAccDataSourceOrchestrationRules_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_orchestration_rules" "test" {
+  depends_on = [
+    huaweicloud_apig_orchestration_rule.test,
+    huaweicloud_apig_orchestration_rule.with_suffix_index,
+  ]
+
+  instance_id = "%[2]s"
+}
+
+# Filter by ID
+locals {
+  rule_id = huaweicloud_apig_orchestration_rule.test.id
+}
+
+data "huaweicloud_apig_orchestration_rules" "filter_by_id" {
+  # Need to be executed after all resources are created (excluding implicit dependencies).
+  depends_on = [
+    huaweicloud_apig_orchestration_rule.with_suffix_index,
+  ]
+
+  instance_id = "%[2]s"
+  rule_id     = local.rule_id
+}
+
+locals {
+  id_filter_result = [
+    for v in data.huaweicloud_apig_orchestration_rules.filter_by_id.rules[*].id : v == local.rule_id
+  ]
+}
+
+output "is_id_filter_useful" {
+  value = length(local.id_filter_result) > 0 && alltrue(local.id_filter_result)
+}
+
+# Filter by name
+locals {
+  rule_name = huaweicloud_apig_orchestration_rule.test.name
+}
+
+data "huaweicloud_apig_orchestration_rules" "filter_by_name" {
+  # Since a specified name is used, there is no dependency relationship with resource attachment, and the dependency
+  # needs to be manually set.
+  depends_on = [
+    huaweicloud_apig_orchestration_rule.test,
+    huaweicloud_apig_orchestration_rule.with_suffix_index,
+  ]
+
+  instance_id = "%[2]s"
+  name        = local.rule_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_apig_orchestration_rules.filter_by_name.rules[*].name : strcontains(v, local.rule_name)
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+
+# Filter by name and the name is not exist
+data "huaweicloud_apig_orchestration_rules" "filter_by_not_found_name" {
+  # Since there is not any parameter used and no dependency relationship with resource attachment, and the dependency
+  # needs to be manually set.
+  depends_on = [
+    huaweicloud_apig_orchestration_rule.test,
+    huaweicloud_apig_orchestration_rule.with_suffix_index,
+  ]
+
+  instance_id = "%[2]s"
+  name        = "not_found_name"
+}
+
+output "is_not_found_name_filter_useful" {
+  value = length(data.huaweicloud_apig_orchestration_rules.filter_by_not_found_name.rules) == 0
+}
+`, testAccDataSourceOrchestrationRules_base(name), acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_orchestration_rules.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_orchestration_rules.go
@@ -1,0 +1,193 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/orchestrations
+func DataSourceOrchestrationRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceOrchestrationRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the orchestration rules are located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the orchestration rules belong.`,
+			},
+			"rule_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the orchestration rule to be queried.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the orchestration rule to be queried, fuzzy matching is supported.`,
+			},
+			"rules": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `All orchestration rules that match the filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the orchestration rule.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the orchestration rule.`,
+						},
+						"strategy": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the orchestration rule.`,
+						},
+						"is_preprocessing": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether rule is a preprocessing rule.`,
+						},
+						"mapped_param": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The parameter configuration after orchestration, in JSON format.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the orchestration rule, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the orchestration rule, in RFC3339 format.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildOrchestrationRulesQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if signId, ok := d.GetOk("rule_id"); ok {
+		res = fmt.Sprintf("%s&orchestration_id=%v", res, signId)
+	}
+	if name, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&orchestration_name=%v", res, name)
+	}
+	return res
+}
+
+func listOrchestrationRules(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/orchestrations?limit=100"
+		instanceId = d.Get("instance_id").(string)
+		offset     = 0
+		result     = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath += buildOrchestrationRulesQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error query orchestration rules under specified dedicated instance (%s): %s",
+				instanceId, err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		rules := utils.PathSearch("orchestrations", respBody, make([]interface{}, 0)).([]interface{})
+		if len(rules) < 1 {
+			break
+		}
+		result = append(result, rules...)
+		offset += len(rules)
+	}
+	return result, nil
+}
+
+func dataSourceOrchestrationRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	rules, err := listOrchestrationRules(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("rules", flattenOrchestrationRules(rules)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenOrchestrationRules(rules []interface{}) []interface{} {
+	if len(rules) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(rules))
+	for _, rule := range rules {
+		result = append(result, map[string]interface{}{
+			"id":               utils.PathSearch("orchestration_id", rule, nil),
+			"name":             utils.PathSearch("orchestration_name", rule, nil),
+			"strategy":         utils.PathSearch("orchestration_strategy", rule, nil),
+			"is_preprocessing": utils.PathSearch("is_preprocessing", rule, nil),
+			"mapped_param": utils.JsonToString(utils.PathSearch("orchestration_mapped_param",
+				rule, make(map[string]interface{}))),
+			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(
+				utils.PathSearch("orchestration_create_time", rule, "").(string))/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(
+				utils.PathSearch("orchestration_update_time", rule, "").(string))/1000, false),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new data source that used to query APIG orchestration rules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source that used to query APIG orchestration rules.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccDataSourceOrchestrationRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataSourceOrchestrationRules_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceOrchestrationRules_basic
=== PAUSE TestAccDataSourceOrchestrationRules_basic
=== CONT  TestAccDataSourceOrchestrationRules_basic
--- PASS: TestAccDataSourceOrchestrationRules_basic (45.66s)
PASS
coverage: 3.6% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      45.719s coverage: 3.6% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.
