### PR TITLE
feat(live): support a new resource to manage HTTPS certificate

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1836,6 +1836,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_live_transcoding":          live.ResourceTranscoding(),
 			"huaweicloud_live_url_validation":       live.ResourceUrlValidation(),
 			"huaweicloud_live_channel":              live.ResourceChannel(),
+			"huaweicloud_live_https_certificate":    live.ResourceHTTPSCertificate(),
 
 			"huaweicloud_lts_aom_access":                       lts.ResourceAOMAccess(),
 			"huaweicloud_lts_group":                            lts.ResourceLTSGroup(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -192,6 +192,8 @@ var (
 	HW_LIVE_INGEST_SRT_DOMAIN_NAME         = os.Getenv("HW_LIVE_INGEST_SRT_DOMAIN_NAME")
 	HW_LIVE_TRANSCODING_TEPLATE_ID         = os.Getenv("HW_LIVE_TRANSCODING_TEPLATE_ID")
 	HW_LIVE_TRANSCODING_TEPLATE_ANOTHER_ID = os.Getenv("HW_LIVE_TRANSCODING_TEPLATE_ANOTHER_ID")
+	HW_LIVE_HTTPS_TLS_CERT_BODY_PATH       = os.Getenv("HW_LIVE_HTTPS_TLS_CERT_BODY_PATH")
+	HW_LIVE_HTTPS_TLS_CERT_KEY_PATH        = os.Getenv("HW_LIVE_HTTPS_TLS_CERT_KEY_PATH")
 
 	HW_CHAIR_EMAIL              = os.Getenv("HW_CHAIR_EMAIL")
 	HW_GUEST_EMAIL              = os.Getenv("HW_GUEST_EMAIL")
@@ -1961,6 +1963,13 @@ func TestAccPreCheckLiveTranscodingTemplateID(t *testing.T) {
 func TestAccPreCheckLiveTranscodingTemplateAnotherID(t *testing.T) {
 	if HW_LIVE_TRANSCODING_TEPLATE_ANOTHER_ID == "" {
 		t.Skip("HW_LIVE_TRANSCODING_TEPLATE_ANOTHER_ID must be set for Live acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckLiveTLSCert(t *testing.T) {
+	if HW_LIVE_HTTPS_TLS_CERT_BODY_PATH == "" || HW_LIVE_HTTPS_TLS_CERT_KEY_PATH == "" {
+		t.Skip("HW_LIVE_HTTPS_TLS_CERT_BODY_PATH and HW_LIVE_HTTPS_TLS_CERT_KEY_PATH must be set for Live acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/live/resource_huaweicloud_live_https_certificate_test.go
+++ b/huaweicloud/services/acceptance/live/resource_huaweicloud_live_https_certificate_test.go
@@ -1,0 +1,45 @@
+package live
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceHttpsCertificate_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLiveStreamingDomainName(t)
+			acceptance.TestAccPreCheckLiveTLSCert(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testResourceHttpsCertificate_basic(),
+				ExpectError: regexp.MustCompile("The certificate verify failed"),
+			},
+		},
+	})
+}
+
+func testResourceHttpsCertificate_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_https_certificate" "test" {
+  domain_name        = "%[1]s"
+  certificate_format = "PEM"
+  force_redirect     = true
+
+  tls_certificate {
+    source = "user"
+    certificate = file("%[2]s")
+    certificate_key = file("%[3]s")
+  }
+}
+`, acceptance.HW_LIVE_STREAMING_DOMAIN_NAME, acceptance.HW_LIVE_HTTPS_TLS_CERT_BODY_PATH, acceptance.HW_LIVE_HTTPS_TLS_CERT_KEY_PATH)
+}

--- a/huaweicloud/services/live/resource_huaweicloud_live_https_certificate.go
+++ b/huaweicloud/services/live/resource_huaweicloud_live_https_certificate.go
@@ -1,0 +1,400 @@
+package live
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API LIVE PUT /v1/{project_id}/guard/https-cert
+// @API LIVE GET /v1/{project_id}/guard/https-cert
+// @API LIVE DELETE /v1/{project_id}/guard/https-cert
+
+// ResourceHTTPSCertificate Due to lack of testing conditions, this resource has only been tested in limited scenarios.
+// It is not yet certain whether this resource supports editing, so all fields are currently `forceNew`.
+// There is currently no open documentation for this resource.
+// Due to lack of test conditions, there is no support for `404` validation after successful certificate deletion.
+func ResourceHTTPSCertificate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHTTPSCertificateCreate,
+		ReadContext:   resourceHTTPSCertificateRead,
+		DeleteContext: resourceHTTPSCertificateDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceHTTPSCertificateImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"domain_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the streaming domain name`,
+			},
+			"certificate": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the certificate body.`,
+			},
+			"certificate_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Sensitive:   true,
+				Description: `Specifies the private key`,
+			},
+			"certificate_format": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the certificate format.`,
+			},
+			"force_redirect": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies whether to enable redirection.`,
+			},
+			"gm_certificate": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Elem:        gmCertificateSchema(),
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the GM certificate configuration.`,
+			},
+			"tls_certificate": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Elem:        tlsCertificateSchema(),
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the TLS certificate configuration.`,
+			},
+		},
+	}
+}
+
+func gmCertificateSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cert_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the SCM certificate name.`,
+			},
+			"cert_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the SCM certificate ID.`,
+			},
+			"sign_certificate": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the Chinese (SM) signature certificate body`,
+			},
+			"sign_certificate_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Sensitive:   true,
+				Description: `Specifies the Chinese (SM) signature private key`,
+			},
+			"enc_certificate": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the Chinese (SM) encryption certificate body`,
+			},
+			"enc_certificate_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Sensitive:   true,
+				Description: `Specifies the Chinese (SM) encryption private key`,
+			},
+			"source": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the certificate source.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func tlsCertificateSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cert_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the SCM certificate name.`,
+			},
+			"cert_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the SCM certificate ID.`,
+			},
+			"certificate": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the certificate body.`,
+			},
+			"certificate_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Sensitive:   true,
+				Description: `Specifies the private key.`,
+			},
+			"source": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the certificate source.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func buildGMCertificateBodyParams(rawParams interface{}) map[string]interface{} {
+	rawArray, ok := rawParams.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	raw := rawArray[0].(map[string]interface{})
+	return map[string]interface{}{
+		"source":               utils.ValueIgnoreEmpty(raw["source"]),
+		"cert_name":            utils.ValueIgnoreEmpty(raw["cert_name"]),
+		"cert_id":              utils.ValueIgnoreEmpty(raw["cert_id"]),
+		"sign_certificate":     utils.ValueIgnoreEmpty(raw["sign_certificate"]),
+		"sign_certificate_key": utils.ValueIgnoreEmpty(raw["sign_certificate_key"]),
+		"enc_certificate":      utils.ValueIgnoreEmpty(raw["enc_certificate"]),
+		"enc_certificate_key":  utils.ValueIgnoreEmpty(raw["enc_certificate_key"]),
+	}
+}
+
+func buildTLSCertificateBodyParams(rawParams interface{}) map[string]interface{} {
+	rawArray, ok := rawParams.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	raw := rawArray[0].(map[string]interface{})
+	return map[string]interface{}{
+		"source":          utils.ValueIgnoreEmpty(raw["source"]),
+		"cert_name":       utils.ValueIgnoreEmpty(raw["cert_name"]),
+		"cert_id":         utils.ValueIgnoreEmpty(raw["cert_id"]),
+		"certificate":     utils.ValueIgnoreEmpty(raw["certificate"]),
+		"certificate_key": utils.ValueIgnoreEmpty(raw["certificate_key"]),
+	}
+}
+
+func buildUpdateHTTPSCertificateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"certificate_format": utils.ValueIgnoreEmpty(d.Get("certificate_format")),
+		"certificate":        utils.ValueIgnoreEmpty(d.Get("certificate")),
+		"certificate_key":    utils.ValueIgnoreEmpty(d.Get("certificate_key")),
+		"force_redirect":     utils.ValueIgnoreEmpty(d.Get("force_redirect")),
+		"gm_certificate":     buildGMCertificateBodyParams(d.Get("gm_certificate")),
+		"tls_certificate":    buildTLSCertificateBodyParams(d.Get("tls_certificate")),
+	}
+}
+
+func resourceHTTPSCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/guard/https-cert"
+		product = "live"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	resourceID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating Live HTTPS certificate resource ID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildHTTPSCertificateQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildUpdateHTTPSCertificateBodyParams(d)),
+	}
+
+	_, err = client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating Live HTTPS certificate: %s", err)
+	}
+
+	d.SetId(resourceID)
+
+	return resourceHTTPSCertificateRead(ctx, d, meta)
+}
+
+func buildHTTPSCertificateQueryParams(d *schema.ResourceData) string {
+	return fmt.Sprintf("?domain=%s", d.Get("domain_name").(string))
+}
+
+func resourceHTTPSCertificateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v1/{project_id}/guard/https-cert"
+		product = "live"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildHTTPSCertificateQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "LIVE.100011001"),
+			"error retrieving Live HTTPS certificate")
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("certificate_format", utils.PathSearch("certificate_format", respBody, nil)),
+		d.Set("certificate", utils.PathSearch("certificate", respBody, nil)),
+		d.Set("certificate_key", utils.PathSearch("certificate_key", respBody, nil)),
+		d.Set("force_redirect", utils.PathSearch("force_redirect", respBody, nil)),
+		d.Set("gm_certificate", flattenGMCertificateResponseBody(utils.PathSearch("gm_certificate", respBody, nil))),
+		d.Set("tls_certificate", flattenTLSCertificateResponseBody(utils.PathSearch("tls_certificate", respBody, nil))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGMCertificateResponseBody(respBody interface{}) []interface{} {
+	if respBody == nil {
+		return nil
+	}
+
+	return []interface{}{map[string]interface{}{
+		"source":               utils.PathSearch("source", respBody, nil),
+		"cert_name":            utils.PathSearch("cert_name", respBody, nil),
+		"cert_id":              utils.PathSearch("cert_id", respBody, nil),
+		"sign_certificate":     utils.PathSearch("sign_certificate", respBody, nil),
+		"sign_certificate_key": utils.PathSearch("sign_certificate_key", respBody, nil),
+		"enc_certificate":      utils.PathSearch("enc_certificate", respBody, nil),
+		"enc_certificate_key":  utils.PathSearch("enc_certificate_key", respBody, nil),
+	}}
+}
+
+func flattenTLSCertificateResponseBody(respBody interface{}) []interface{} {
+	if respBody == nil {
+		return nil
+	}
+
+	return []interface{}{map[string]interface{}{
+		"source":          utils.PathSearch("source", respBody, nil),
+		"cert_name":       utils.PathSearch("cert_name", respBody, nil),
+		"cert_id":         utils.PathSearch("cert_id", respBody, nil),
+		"certificate":     utils.PathSearch("certificate", respBody, nil),
+		"certificate_key": utils.PathSearch("certificate_key", respBody, nil),
+	}}
+}
+
+func resourceHTTPSCertificateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/guard/https-cert"
+		product = "live"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildHTTPSCertificateQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "LIVE.100011001"),
+			"error deleting Live HTTPS certificate")
+	}
+
+	return nil
+}
+
+func resourceHTTPSCertificateImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+	return []*schema.ResourceData{d}, d.Set("domain_name", importedId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support a new resource to manage HTTPS certificate

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Due to lack of testing conditions, this resource has only been tested in limited scenarios.
- There is currently no open documentation for this resource.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/live' TESTARGS='-run TestAccResourceHttpsCertificate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/live -v -run TestAccResourceHttpsCertificate_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceHttpsCertificate_basic
=== PAUSE TestAccResourceHttpsCertificate_basic
=== CONT  TestAccResourceHttpsCertificate_basic
--- PASS: TestAccResourceHttpsCertificate_basic (3.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      3.560s
```

![image](https://github.com/user-attachments/assets/9106ec07-daa3-4e35-b85d-fba6f3092998)


* [ ] Documentation updated.
* [X] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
   
![image](https://github.com/user-attachments/assets/17dee9e6-3c02-469d-830f-4578b73dd51b)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    
