### PR TITLE
feat(cce): support updating tags in autopilot cluster

### DIFF
--- a/docs/resources/cce_autopilot_cluster.md
+++ b/docs/resources/cce_autopilot_cluster.md
@@ -46,6 +46,11 @@ resource "huaweicloud_cce_autopilot_cluster" "mycluster" {
       subnet_id = huaweicloud_vpc_subnet.mysubnet.ipv4_subnet_id
     }
   }
+
+  tags = {
+    "foo" = "bar"
+    "key" = "value"
+  }
 }
 ```
 
@@ -111,7 +116,7 @@ The following arguments are supported:
 * `authentication` - (Optional, List, NonUpdatable) Specifies the configurations of the cluster authentication mode.
   The [authentication](#autopilot_cluster_authentication) structure is documented below.
 
-* `tags` - (Optional, Map, NonUpdatable) Specifies the cluster tags in the format of key-value pairs.
+* `tags` - (Optional, Map) Specifies the cluster tags in the format of key-value pairs.
 
 * `kube_proxy_mode` - (Optional, String, NonUpdatable) Specifies the kube proxy mode of the cluster.
   The value can be: **iptables**.

--- a/huaweicloud/services/acceptance/cceautopilot/resource_huaweicloud_cce_autopilot_cluster_test.go
+++ b/huaweicloud/services/acceptance/cceautopilot/resource_huaweicloud_cce_autopilot_cluster_test.go
@@ -70,6 +70,8 @@ func TestAccAutopilotCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "flavor", "cce.autopilot.cluster"),
 					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform"),
 					resource.TestCheckResourceAttr(resourceName, "container_network.0.mode", "eni"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttrPair(resourceName, "host_network.0.vpc", "huaweicloud_vpc.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "host_network.0.subnet", "huaweicloud_vpc_subnet.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "eni_network.0.subnets.0.subnet_id",
@@ -85,6 +87,8 @@ func TestAccAutopilotCluster_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "alias", rName+"-update"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key_update", "value_update"),
 				),
 			},
 			{
@@ -119,6 +123,11 @@ resource "huaweicloud_cce_autopilot_cluster" "test" {
       subnet_id = huaweicloud_vpc_subnet.test.ipv4_subnet_id
     }
   }
+
+  tags = {
+    "foo" = "bar"
+    "key" = "value"
+  }
 }
 `, common.TestVpc(rName), rName)
 }
@@ -146,6 +155,11 @@ resource "huaweicloud_cce_autopilot_cluster" "test" {
     subnets {
       subnet_id = huaweicloud_vpc_subnet.test.ipv4_subnet_id
     }
+  }
+
+  tags = {
+    "foo"        = "bar_update"
+    "key_update" = "value_update"
   }
 }
 `, common.TestVpc(rName), rName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cceautopilot' TESTARGS='-run TestAccAutopilotCluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cceautopilot -v -run TestAccAutopilotCluster -timeout 360m -parallel 4
=== RUN   TestAccAutopilotCluster_basic
=== PAUSE TestAccAutopilotCluster_basic
=== RUN   TestAccAutopilotCluster_withEip
=== PAUSE TestAccAutopilotCluster_withEip
=== CONT  TestAccAutopilotCluster_basic
=== CONT  TestAccAutopilotCluster_withEip
--- PASS: TestAccAutopilotCluster_basic (691.91s)
--- PASS: TestAccAutopilotCluster_withEip (1337.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cceautopilot      1338.038s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
