### PR TITLE
test(servicestage): adjust the script of update phase and do not update name

### DIFF
--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_component_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_component_test.go
@@ -42,7 +42,7 @@ func TestAccComponent_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComponent_basic(randName),
+				Config: testAccComponent_basic_step1(randName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", randName),
@@ -51,14 +51,15 @@ func TestAccComponent_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "framework", "Mesher"),
 				),
 			},
+			// Unable to update the component name because the update method do not work.
 			{
-				Config: testAccComponent_update(randName),
+				Config: testAccComponent_basic_step2(randName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
-					resource.TestCheckResourceAttr(resourceName, "type", "MicroService"),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "type", "Common"),
 					resource.TestCheckResourceAttr(resourceName, "runtime", "Docker"),
-					resource.TestCheckResourceAttr(resourceName, "framework", "Mesher"),
+					resource.TestCheckResourceAttr(resourceName, "framework", ""),
 				),
 			},
 			{
@@ -115,7 +116,7 @@ func TestAccComponent_web(t *testing.T) {
 				Config: testAccComponent_webUpdate(randName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
 					resource.TestCheckResourceAttr(resourceName, "type", "Webapp"),
 					resource.TestCheckResourceAttr(resourceName, "runtime", "Nodejs14"),
 					resource.TestCheckResourceAttr(resourceName, "framework", "Web"),
@@ -154,7 +155,7 @@ func testAccComponentImportStateIdFunc() resource.ImportStateIdFunc {
 	}
 }
 
-func testAccComponent_basic(rName string) string {
+func testAccComponent_basic_step1(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_servicestage_application" "test" {
   name = "%[1]s"
@@ -171,7 +172,7 @@ resource "huaweicloud_servicestage_component" "test" {
 }`, rName)
 }
 
-func testAccComponent_update(rName string) string {
+func testAccComponent_basic_step2(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_servicestage_application" "test" {
   name = "%[1]s"
@@ -180,11 +181,10 @@ resource "huaweicloud_servicestage_application" "test" {
 resource "huaweicloud_servicestage_component" "test" {
   application_id = huaweicloud_servicestage_application.test.id
 
-  name = "%[1]s-update"
+  name = "%[1]s"
 
-  type      = "MicroService"
-  runtime   = "Docker"
-  framework = "Mesher"
+  type    = "Common"
+  runtime = "Docker"
 }`, rName)
 }
 
@@ -326,7 +326,7 @@ resource "huaweicloud_servicestage_component" "test" {
   runtime        = "Nodejs14"
   framework      = "Web"
 
-  name = "%[2]s-update"
+  name = "%[2]s"
 
   source {
     type         = "package"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The name cannot be updated and we don't know why update method doesn't worked.
So skip the name test and check the other parameters update logic to instead.
![3dbcaf1f383b7daf050447149ccadf9](https://github.com/user-attachments/assets/7bf6c75f-832b-4f60-bf50-1e3444484e9e)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. adjust the script of update phase and do not update name.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o servicestage -f TestAccComponent_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccComponent_basic -timeout 360m -parallel 10
=== RUN   TestAccComponent_basic
=== PAUSE TestAccComponent_basic
=== CONT  TestAccComponent_basic
--- PASS: TestAccComponent_basic (17.05s)
PASS
coverage: 7.9% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      17.103s coverage: 7.9% of statements in ./huaweicloud/services/servicestage
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
