### PR TITLE
feat(live): support a new resource to manage IP address acl

### DIFF
--- a/docs/resources/live_ip_acl.md
+++ b/docs/resources/live_ip_acl.md
@@ -1,0 +1,57 @@
+---
+subcategory: "Live"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_live_ip_acl"
+description: |-
+  Manages a Live IP address acl resource within HuaweiCloud.
+---
+
+# huaweicloud_live_ip_acl
+
+Manages a Live IP address acl resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "domain_name" {}
+variable "auth_type" {}
+variable "ip_auth_list" {}
+
+resource "huaweicloud_live_ip_acl" "test" {
+  domain_name  = var.domain_name
+  auth_type    = var.auth_type
+  ip_auth_list = var.ip_auth_list
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create new resource.
+
+* `domain_name` - (Required, String) Specifies the ingest or streaming domain name.
+
+* `auth_type` - (Required, String) Specifies the authentication mode.
+  The options are as follows:
+  + **WHITE**: IP address whitelist authentication.
+  + **BLACK**: IP address blacklist authentication.
+
+* `ip_auth_list` - (Required, String) Specifies the blacklist or whitelist IP addresses. Use semicolons (;) to separate
+  IP addresses, for example, **192.168.0.0;192.168.0.8**. A maximum of `100` IP addresses are allowed.
+  IP network segments can be added, for example, **127.0.0.1/24**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The Live IP address acl resource can be imported using `domain_name`, e.g.
+
+```bash
+$ terraform import huaweicloud_live_ip_acl.test <domain_name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1851,6 +1851,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_live_channel":              live.ResourceChannel(),
 			"huaweicloud_live_https_certificate":    live.ResourceHTTPSCertificate(),
 			"huaweicloud_live_geo_blocking":         live.ResourceGeoBlocking(),
+			"huaweicloud_live_ip_acl":               live.ResourceIpAcl(),
 
 			"huaweicloud_lts_aom_access":                       lts.ResourceAOMAccess(),
 			"huaweicloud_lts_group":                            lts.ResourceLTSGroup(),

--- a/huaweicloud/services/acceptance/live/resource_huaweicloud_live_ip_acl_test.go
+++ b/huaweicloud/services/acceptance/live/resource_huaweicloud_live_ip_acl_test.go
@@ -1,0 +1,141 @@
+package live
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	acl "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/live"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getResourceIpAclFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region     = acceptance.HW_REGION_NAME
+		product    = "live"
+		domainName = state.Primary.Attributes["domain_name"]
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Live client: %s", err)
+	}
+
+	respBody, err := acl.ReadIPAddressAcl(client, domainName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Live IP address acl: %s", err)
+	}
+
+	authType := utils.PathSearch("auth_type", respBody, "").(string)
+	if authType == "NONE" {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return respBody, nil
+}
+
+func TestAccResourceIpAcl_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_live_ip_acl.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getResourceIpAclFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLiveStreamingDomainName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceIpAcl_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "domain_name", acceptance.HW_LIVE_STREAMING_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(rName, "auth_type", "WHITE"),
+					resource.TestCheckResourceAttr(rName, "ip_auth_list", "192.168.0.0;192.168.0.8;127.0.0.1/24"),
+				),
+			},
+			{
+				Config: testResourceIpAcl_basic_update1(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "domain_name", acceptance.HW_LIVE_STREAMING_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(rName, "auth_type", "WHITE"),
+					resource.TestCheckResourceAttr(rName, "ip_auth_list", "192.168.0.0;192.168.0.8"),
+				),
+			},
+			{
+				Config: testResourceIpAcl_basic_update2(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "domain_name", acceptance.HW_LIVE_STREAMING_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(rName, "auth_type", "BLACK"),
+					resource.TestCheckResourceAttr(rName, "ip_auth_list", "192.168.0.0"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccIPAclImportState(rName),
+			},
+		},
+	})
+}
+
+func testResourceIpAcl_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_ip_acl" "test" {
+  domain_name  = "%s"
+  auth_type    = "WHITE"
+  ip_auth_list = "192.168.0.0;192.168.0.8;127.0.0.1/24"
+}
+`, acceptance.HW_LIVE_STREAMING_DOMAIN_NAME)
+}
+
+func testResourceIpAcl_basic_update1() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_ip_acl" "test" {
+  domain_name  = "%s"
+  auth_type    = "WHITE"
+  ip_auth_list = "192.168.0.0;192.168.0.8"
+}
+`, acceptance.HW_LIVE_STREAMING_DOMAIN_NAME)
+}
+
+func testResourceIpAcl_basic_update2() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_ip_acl" "test" {
+  domain_name  = "%s"
+  auth_type    = "BLACK"
+  ip_auth_list = "192.168.0.0"
+}
+`, acceptance.HW_LIVE_STREAMING_DOMAIN_NAME)
+}
+
+func testAccIPAclImportState(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", rName)
+		}
+
+		domainName := rs.Primary.Attributes["domain_name"]
+		if domainName == "" {
+			return "", fmt.Errorf("the imported ID format is invalid, 'domain_name' is empty")
+		}
+		return domainName, nil
+	}
+}

--- a/huaweicloud/services/live/resource_huaweicloud_live_ip_acl.go
+++ b/huaweicloud/services/live/resource_huaweicloud_live_ip_acl.go
@@ -1,0 +1,203 @@
+package live
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API LIVE PUT /v1/{project_id}/guard/ip
+// @API LIVE GET /v1/{project_id}/guard/ip
+func ResourceIpAcl() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIpAclCreate,
+		ReadContext:   resourceIpAclRead,
+		UpdateContext: resourceIpAclUpdate,
+		DeleteContext: resourceIpAclDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceIpAclImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"domain_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ingest or streaming domain name.`,
+			},
+			"auth_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the authentication mode.`,
+			},
+			"ip_auth_list": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the blacklist or whitelist IP addresses.`,
+			},
+		},
+	}
+}
+
+func buildUpdateIPAddressAclBodyParams(d *schema.ResourceData, authType string) map[string]interface{} {
+	return map[string]interface{}{
+		"domain":       d.Get("domain_name"),
+		"auth_type":    authType,
+		"ip_auth_list": d.Get("ip_auth_list"),
+	}
+}
+
+func updateIPAddressAcl(client *golangsdk.ServiceClient, d *schema.ResourceData, authType string) error {
+	requestPath := client.Endpoint + "v1/{project_id}/guard/ip"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildUpdateIPAddressAclBodyParams(d, authType),
+	}
+	_, err := client.Request("PUT", requestPath, &requestOpt)
+	return err
+}
+
+func resourceIpAclCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		product  = "live"
+		authType = d.Get("auth_type").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	resourceID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating Live IP address acl resource ID: %s", err)
+	}
+
+	if err := updateIPAddressAcl(client, d, authType); err != nil {
+		return diag.Errorf("error creating Live IP address acl: %s", err)
+	}
+
+	d.SetId(resourceID)
+
+	return resourceIpAclRead(ctx, d, meta)
+}
+
+func ReadIPAddressAcl(client *golangsdk.ServiceClient, domainName string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/guard/ip"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?domain=%s", domainName)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceIpAclRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		product = "live"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	respBody, err := ReadIPAddressAcl(client, d.Get("domain_name").(string))
+	if err != nil {
+		// When the domain does not exist, it will respond with a `400` status code.
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "LIVE.100011001"),
+			"error retrieving Live IP address acl")
+	}
+
+	authType := utils.PathSearch("auth_type", respBody, "").(string)
+	if authType == "NONE" {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("domain_name", utils.PathSearch("domain", respBody, nil)),
+		d.Set("auth_type", authType),
+		d.Set("ip_auth_list", utils.PathSearch("ip_auth_list", respBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceIpAclUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		product  = "live"
+		authType = d.Get("auth_type").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	if err := updateIPAddressAcl(client, d, authType); err != nil {
+		return diag.Errorf("error updating Live IP address acl: %s", err)
+	}
+
+	return resourceIpAclRead(ctx, d, meta)
+}
+
+func resourceIpAclDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "live"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	if err := updateIPAddressAcl(client, d, "NONE"); err != nil {
+		return diag.Errorf("error deleting Live IP address acl: %s", err)
+	}
+	return nil
+}
+
+func resourceIpAclImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+	return []*schema.ResourceData{d}, d.Set("domain_name", importedId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support a new resource to manage IP address acl.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/live' TESTARGS='-run TestAccResourceIpAcl_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/live -v -run TestAccResourceIpAcl_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceIpAcl_basic
=== PAUSE TestAccResourceIpAcl_basic
=== CONT  TestAccResourceIpAcl_basic
--- PASS: TestAccResourceIpAcl_basic (23.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      23.420s
```

* [X] Documentation updated.
* [X] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    
![image](https://github.com/user-attachments/assets/d7f37e73-bbb8-43c2-98d9-1534be231b56)

