### PR TITLE
fix(geip): fix error when gcb is empty

### DIFF
--- a/huaweicloud/services/eip/resource_huaweicloud_global_eip_associate.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_global_eip_associate.go
@@ -199,7 +199,9 @@ func resourceGlobalEIPAssociateCreate(ctx context.Context, d *schema.ResourceDat
 	}
 	gcbID := utils.PathSearch("global_eip.global_connection_bandwidth_info.gcb_id", geip, "").(string)
 	if gcbID == "" {
-		return diag.Errorf("unable to find global connection bandwidth ID from the API response")
+		if v, ok := d.GetOk("gc_bandwidth"); ok && len(v.([]interface{})) > 0 {
+			return diag.Errorf("unable to find global connection bandwidth ID from the API response")
+		}
 	}
 
 	// if bandwidth charge_mode is not "bwd", call Update GCB


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix error when gcb is empty

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccGEIPAssociate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccGEIPAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccGEIPAssociate_basic
=== PAUSE TestAccGEIPAssociate_basic
=== CONT  TestAccGEIPAssociate_basic
--- PASS: TestAccGEIPAssociate_basic (275.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       275.792s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
