### PR TITLE
feat(live): support a new resource to manage geo-blocking

### DIFF
--- a/docs/resources/live_geo_blocking.md
+++ b/docs/resources/live_geo_blocking.md
@@ -1,0 +1,62 @@
+---
+subcategory: "Live"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_live_geo_blocking"
+description: |-
+  Manages a Live geo-blocking resource within HuaweiCloud.
+---
+
+# huaweicloud_live_geo_blocking
+
+Manages a Live geo-blocking resource within HuaweiCloud.
+
+-> Destroying this resource means that there is no geo-blocking on the streaming domain name.
+
+## Example Usage
+
+```hcl
+variable "domain_name" {}
+
+resource "huaweicloud_live_geo_blocking" "test" {
+  domain_name    = var.domain_name
+  app_name       = "live"
+  area_whitelist = ["CN-IN", "CN-HK"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `domain_name` - (Required, String, ForceNew) Specifies the streaming domain name.
+
+  Changing this will create a new resource.
+
+* `app_name` - (Required, String) Specifies the application name.
+
+* `area_whitelist` - (Required, List) Specifies the list of supported areas.
+  The values of all region codes, except that of China, contain two uppercase letters.
+  For the code format, see [ISO 3166-1alpha-2](https://www.iso.org/obp/ui/#search/code/).
+  Some options are as follows:
+  + **CN-IN**: Chinese mainland.
+  + **CN-HK**: Hong Kong (China).
+  + **CN-MO**: Macao (China).
+  + **CN-TW**: Taiwan (China).
+  + **BR**: Brazil.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The Live geo-blocking resource can be imported using `domain_name` and `app_name`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_live_geo_blocking.test <domain_name>/<app_name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1848,6 +1848,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_live_url_validation":       live.ResourceUrlValidation(),
 			"huaweicloud_live_channel":              live.ResourceChannel(),
 			"huaweicloud_live_https_certificate":    live.ResourceHTTPSCertificate(),
+			"huaweicloud_live_geo_blocking":         live.ResourceGeoBlocking(),
 
 			"huaweicloud_lts_aom_access":                       lts.ResourceAOMAccess(),
 			"huaweicloud_lts_group":                            lts.ResourceLTSGroup(),

--- a/huaweicloud/services/acceptance/live/resource_huaweicloud_live_geo_blocking_test.go
+++ b/huaweicloud/services/acceptance/live/resource_huaweicloud_live_geo_blocking_test.go
@@ -1,0 +1,126 @@
+package live
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	blocking "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/live"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getResourceGeoBlockingFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region     = acceptance.HW_REGION_NAME
+		product    = "live"
+		domainName = state.Primary.Attributes["domain_name"]
+		app        = state.Primary.Attributes["app_name"]
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Live client: %s", err)
+	}
+
+	respBody, err := blocking.ReadGeoBlocking(client, domainName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Live geo blocking: %s", err)
+	}
+
+	expression := fmt.Sprintf("apps[?app == '%s']|[0].area_whitelist", app)
+	areaWhitelist := utils.PathSearch(expression, respBody, nil)
+	if areaWhitelist == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return respBody, nil
+}
+
+func TestAccResourceGeoBlocking_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_live_geo_blocking.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getResourceGeoBlockingFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLiveStreamingDomainName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceGeoBlocking_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "domain_name", acceptance.HW_LIVE_STREAMING_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(rName, "app_name", "live"),
+					resource.TestCheckResourceAttr(rName, "area_whitelist.#", "5"),
+				),
+			},
+			{
+				Config: testResourceGeoBlocking_basic_update(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "domain_name", acceptance.HW_LIVE_STREAMING_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(rName, "app_name", "live"),
+					resource.TestCheckResourceAttr(rName, "area_whitelist.#", "3"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccGeoBlockingImportState(rName),
+			},
+		},
+	})
+}
+
+func testResourceGeoBlocking_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_geo_blocking" "test" {
+  domain_name    = "%s"
+  app_name       = "live"
+  area_whitelist = ["AE", "AF", "CN-IN", "CN-HK", "CN-MO"]
+}
+`, acceptance.HW_LIVE_STREAMING_DOMAIN_NAME)
+}
+
+func testResourceGeoBlocking_basic_update() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_geo_blocking" "test" {
+  domain_name    = "%s"
+  app_name       = "live"
+  area_whitelist = ["AE", "AF", "CN-IN"]
+}
+`, acceptance.HW_LIVE_STREAMING_DOMAIN_NAME)
+}
+
+func testAccGeoBlockingImportState(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", rName)
+		}
+
+		domainName := rs.Primary.Attributes["domain_name"]
+		appName := rs.Primary.Attributes["app_name"]
+		if domainName == "" || appName == "" {
+			return "", fmt.Errorf("the imported ID format is invalid, want '<domain_name>/<app_name>',"+
+				" but got '%s/%s'", domainName, appName)
+		}
+		return fmt.Sprintf("%s/%s", domainName, appName), nil
+	}
+}

--- a/huaweicloud/services/live/resource_huaweicloud_live_geo_blocking.go
+++ b/huaweicloud/services/live/resource_huaweicloud_live_geo_blocking.go
@@ -1,0 +1,224 @@
+package live
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API LIVE PUT /v1/{project_id}/domain/geo-blocking
+// @API LIVE GET /v1/{project_id}/domain/geo-blocking
+func ResourceGeoBlocking() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGeoBlockingCreate,
+		ReadContext:   resourceGeoBlockingRead,
+		UpdateContext: resourceGeoBlockingUpdate,
+		DeleteContext: resourceGeoBlockingDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceGeoBlockingImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"domain_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the streaming domain name.`,
+			},
+			"app_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the application name.`,
+			},
+			// This field is specially designed to be mandatory compared to the parameters of openapi.
+			// This design is intended to prevent the terraform lifecycle from being disrupted.
+			"area_whitelist": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				MinItems:    1,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Specifies the list of supported areas. An empty list indicates no restriction.`,
+			},
+		},
+	}
+}
+
+func buildUpdateGeoBlockingBodyParams(d *schema.ResourceData, areaWhitelist []interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"app":            d.Get("app_name"),
+		"area_whitelist": areaWhitelist,
+	}
+}
+
+func updateGeoBlocking(client *golangsdk.ServiceClient, d *schema.ResourceData, areaWhitelist []interface{}) error {
+	requestPath := client.Endpoint + "v1/{project_id}/domain/geo-blocking"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?play_domain=%s", d.Get("domain_name").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildUpdateGeoBlockingBodyParams(d, areaWhitelist),
+	}
+	_, err := client.Request("PUT", requestPath, &requestOpt)
+	return err
+}
+
+func resourceGeoBlockingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		product       = "live"
+		areaWhitelist = d.Get("area_whitelist").(*schema.Set).List()
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	resourceID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating Live geo blocking resource ID: %s", err)
+	}
+
+	if err := updateGeoBlocking(client, d, areaWhitelist); err != nil {
+		return diag.Errorf("error creating Live geo blocking: %s", err)
+	}
+
+	d.SetId(resourceID)
+
+	return resourceGeoBlockingRead(ctx, d, meta)
+}
+
+func ReadGeoBlocking(client *golangsdk.ServiceClient, domainDomain string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/domain/geo-blocking"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?play_domain=%s", domainDomain)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceGeoBlockingRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		product = "live"
+		appName = d.Get("app_name").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	respBody, err := ReadGeoBlocking(client, d.Get("domain_name").(string))
+	if err != nil {
+		// When the domain does not exist, it will respond with a `400` status code.
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "LIVE.100011001"),
+			"error retrieving Live geo blocking")
+	}
+
+	expression := fmt.Sprintf("apps[?app == '%s']|[0].area_whitelist", appName)
+	areaWhitelist := utils.PathSearch(expression, respBody, nil)
+	if areaWhitelist == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("domain_name", utils.PathSearch("play_domain", respBody, nil)),
+		d.Set("app_name", appName),
+		d.Set("area_whitelist", areaWhitelist),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceGeoBlockingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		product       = "live"
+		areaWhitelist = d.Get("area_whitelist").(*schema.Set).List()
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	if err := updateGeoBlocking(client, d, areaWhitelist); err != nil {
+		return diag.Errorf("error updating Live geo blocking: %s", err)
+	}
+	return resourceGeoBlockingRead(ctx, d, meta)
+}
+
+func resourceGeoBlockingDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "live"
+		// Passing an empty list to this field means no restriction.
+		areaWhitelist = make([]interface{}, 0)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	if err := updateGeoBlocking(client, d, areaWhitelist); err != nil {
+		// When the domain does not exist, it will respond with a `400` status code.
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "LIVE.100011001"),
+			"error deleting Live geo blocking")
+	}
+	return nil
+}
+
+func resourceGeoBlockingImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate ID: %s", err)
+	}
+
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<domain_name>/<app_name>', but got '%s'",
+			importedId)
+	}
+
+	d.SetId(resourceId)
+	mErr := multierror.Append(nil,
+		d.Set("domain_name", parts[0]),
+		d.Set("app_name", parts[1]),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support a new resource to manage geo-blocking.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
go test -v -coverprofile=coverage_1734072249506_TestAccResourceGeoBlocking_basic.cov -coverpkg=./huaweicloud/services/live ./huaweicloud/services/acceptance/live -run TestAccResourceGeoBlocking_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceGeoBlocking_basic
=== PAUSE TestAccResourceGeoBlocking_basic
=== CONT  TestAccResourceGeoBlocking_basic
--- PASS: TestAccResourceGeoBlocking_basic (16.03s)
PASS
coverage: 8.5% of statements in ./huaweicloud/services/live
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      16.090s coverage: 8.5% of statements in ./huaweicloud/services/live
```

![image](https://github.com/user-attachments/assets/bfd5b1ab-686f-4d53-a1fd-5b3806cf0750)


* [X] Documentation updated.
* [X] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/eb43f932-d3ec-45b5-b0d9-5a70eddaa5dd)

    
    ab. Related resources (parent resources) not found
    
![image](https://github.com/user-attachments/assets/78be2854-a863-457d-90c3-0e36b0e62e9a)


  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![image](https://github.com/user-attachments/assets/21dcac18-984c-4dc1-af10-fd67ebad2a71)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
