### PR TITLE
test(dns): fix incorrect acceptance test

### DIFF
--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_floating_ptrrecords_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_floating_ptrrecords_test.go
@@ -57,7 +57,7 @@ locals {
 resource "huaweicloud_dns_ptrrecord" "test" {
   name          = "%s"
   description   = "Created by terraform"
-  floatingip_id = huaweicloud_vpc_eip.eip_1.id
+  floatingip_id = huaweicloud_vpc_eip.test.id
   ttl           = 300
   tags          = local.tags
 }
@@ -77,7 +77,7 @@ output "is_record_id_filter_useful" {
 }
 
 locals {
-  public_ip = huaweicloud_vpc_eip.eip_1.address
+  public_ip = huaweicloud_vpc_eip.test.address
 }
 
 data "huaweicloud_dns_floating_ptrrecords" "filter_by_public_id" {

--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_zones_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_zones_test.go
@@ -159,32 +159,32 @@ func testAccDatasourceDNSZones_public(name string) string {
 %s
 
 data "huaweicloud_dns_zones" "test" {
-  zone_type = huaweicloud_dns_zone.zone_1.zone_type
+  zone_type = huaweicloud_dns_zone.test.zone_type
 }
 
 data "huaweicloud_dns_zones" "tags_filter" {
-  zone_type = huaweicloud_dns_zone.zone_1.zone_type
+  zone_type = huaweicloud_dns_zone.test.zone_type
   tags      = "zone_type,public"
 }
 data "huaweicloud_dns_zones" "name_filter" {
-  zone_type = huaweicloud_dns_zone.zone_1.zone_type
-  name      = huaweicloud_dns_zone.zone_1.name
+  zone_type = huaweicloud_dns_zone.test.zone_type
+  name      = huaweicloud_dns_zone.test.name
 }
 data "huaweicloud_dns_zones" "status_filter" {
-  zone_type = huaweicloud_dns_zone.zone_1.zone_type
+  zone_type = huaweicloud_dns_zone.test.zone_type
   status    = data.huaweicloud_dns_zones.test.zones.0.status
 }
 data "huaweicloud_dns_zones" "enterprise_project_id_filter" {
-  zone_type             = huaweicloud_dns_zone.zone_1.zone_type
-  enterprise_project_id = huaweicloud_dns_zone.zone_1.enterprise_project_id
+  zone_type             = huaweicloud_dns_zone.test.zone_type
+  enterprise_project_id = huaweicloud_dns_zone.test.enterprise_project_id
 }
 
 locals {
   tags_filter_result = [for v in data.huaweicloud_dns_zones.tags_filter.zones[*].tags : v.zone_type == "public"]
-  name_filter_result = [for v in data.huaweicloud_dns_zones.name_filter.zones[*].name : v == huaweicloud_dns_zone.zone_1.name]
+  name_filter_result = [for v in data.huaweicloud_dns_zones.name_filter.zones[*].name : v == huaweicloud_dns_zone.test.name]
   status_filter_result = [for v in data.huaweicloud_dns_zones.status_filter.zones[*].status : v == data.huaweicloud_dns_zones.test.zones.0.status]
   enterprise_project_id_filter_result = [for v in data.huaweicloud_dns_zones.enterprise_project_id_filter.zones[*].enterprise_project_id :
-v == huaweicloud_dns_zone.zone_1.enterprise_project_id]
+v == huaweicloud_dns_zone.test.enterprise_project_id]
 }
 
 output "tags_filter_is_useful" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 Fix incorrect acceptance test.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fix incorrect acceptance test.

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAcc
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAcc -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCustomLines_basic
=== PAUSE TestAccDataSourceCustomLines_basic
=== RUN   TestAccDataSourceFloatingPtrrecords_basic
=== PAUSE TestAccDataSourceFloatingPtrrecords_basic
=== RUN   TestAccDataSourceLineGroups_basic
=== PAUSE TestAccDataSourceLineGroups_basic
=== RUN   TestAccDataSourceNameservers_basic
=== PAUSE TestAccDataSourceNameservers_basic
=== RUN   TestAccDataSourceQuotas_basic
=== PAUSE TestAccDataSourceQuotas_basic
=== RUN   TestAccDataSourceQuotas_expectError
=== PAUSE TestAccDataSourceQuotas_expectError
=== RUN   TestAccDatasourceDNSRecordsets_basic
=== PAUSE TestAccDatasourceDNSRecordsets_basic
=== RUN   TestAccDatasourceDNSRecordsets_private
=== PAUSE TestAccDatasourceDNSRecordsets_private
=== RUN   TestAccDatasourceDNSZones_basic
=== PAUSE TestAccDatasourceDNSZones_basic
=== RUN   TestAccDatasourceDNSZones_public
=== PAUSE TestAccDatasourceDNSZones_public
=== RUN   TestAccDNSCustomLine_basic
=== PAUSE TestAccDNSCustomLine_basic
=== RUN   TestAccEndpointAssignment_basic
=== PAUSE TestAccEndpointAssignment_basic
=== RUN   TestAccDNSEndpoint_basic
=== PAUSE TestAccDNSEndpoint_basic
=== RUN   TestAccDNSLineGroup_basic
=== PAUSE TestAccDNSLineGroup_basic
=== RUN   TestAccDNSPtrRecord_basic
=== PAUSE TestAccDNSPtrRecord_basic
=== RUN   TestAccDNSPtrRecord_withEpsId
=== PAUSE TestAccDNSPtrRecord_withEpsId
=== RUN   TestAccDNSRecordset_basic
=== PAUSE TestAccDNSRecordset_basic
=== RUN   TestAccDNSRecordset_publicZone
=== PAUSE TestAccDNSRecordset_publicZone
=== RUN   TestAccDNSRecordset_privateZone
=== PAUSE TestAccDNSRecordset_privateZone
=== RUN   TestAccDNSV2RecordSet_basic
=== PAUSE TestAccDNSV2RecordSet_basic
=== RUN   TestAccDNSV2RecordSet_private
=== PAUSE TestAccDNSV2RecordSet_private
=== RUN   TestAccDNSResolverRuleAssociate_basic
=== PAUSE TestAccDNSResolverRuleAssociate_basic
=== RUN   TestAccDNSResolverRule_basic
=== PAUSE TestAccDNSResolverRule_basic
=== RUN   TestAccDNSZone_basic
=== PAUSE TestAccDNSZone_basic
=== RUN   TestAccDNSZone_private
=== PAUSE TestAccDNSZone_private
=== RUN   TestAccDNSZone_readTTL
=== PAUSE TestAccDNSZone_readTTL
=== RUN   TestAccDNSZone_withEpsId
=== PAUSE TestAccDNSZone_withEpsId
=== CONT  TestAccDataSourceCustomLines_basic
=== CONT  TestAccDNSPtrRecord_basic
=== CONT  TestAccDNSResolverRuleAssociate_basic
=== CONT  TestAccDNSV2RecordSet_private
=== CONT  TestAccDatasourceDNSRecordsets_private
=== CONT  TestAccDNSV2RecordSet_basic
=== CONT  TestAccDatasourceDNSRecordsets_basic
=== CONT  TestAccDNSLineGroup_basic
=== CONT  TestAccDNSZone_withEpsId
=== CONT  TestAccDNSRecordset_privateZone
--- PASS: TestAccDNSZone_withEpsId (196.06s)
=== CONT  TestAccDataSourceQuotas_expectError
--- PASS: TestAccDataSourceQuotas_expectError (14.99s)
=== CONT  TestAccDataSourceQuotas_basic
--- PASS: TestAccDNSLineGroup_basic (240.04s)
=== CONT  TestAccDataSourceNameservers_basic
--- PASS: TestAccDNSV2RecordSet_private (271.64s)
=== CONT  TestAccDataSourceLineGroups_basic
--- PASS: TestAccDataSourceCustomLines_basic (391.67s)
=== CONT  TestAccDataSourceFloatingPtrrecords_basic
--- PASS: TestAccDNSPtrRecord_basic (395.05s)
=== CONT  TestAccDNSRecordset_basic
--- PASS: TestAccDataSourceQuotas_basic (231.94s)
=== CONT  TestAccDNSRecordset_publicZone
--- PASS: TestAccDataSourceNameservers_basic (259.32s)
=== CONT  TestAccDNSCustomLine_basic
--- PASS: TestAccDNSV2RecordSet_basic (591.98s)
=== CONT  TestAccDNSEndpoint_basic
--- PASS: TestAccDatasourceDNSRecordsets_basic (645.56s)
=== CONT  TestAccEndpointAssignment_basic
--- PASS: TestAccDatasourceDNSRecordsets_private (666.97s)
=== CONT  TestAccDNSPtrRecord_withEpsId
--- PASS: TestAccDataSourceLineGroups_basic (417.11s)
=== CONT  TestAccDNSZone_private
--- PASS: TestAccDNSRecordset_privateZone (735.05s)
=== CONT  TestAccDNSZone_readTTL
--- PASS: TestAccDNSCustomLine_basic (283.01s)
=== CONT  TestAccDNSZone_basic
--- PASS: TestAccDNSRecordset_basic (469.35s)
=== CONT  TestAccDatasourceDNSZones_public
--- PASS: TestAccDNSRecordset_publicZone (442.51s)
=== CONT  TestAccDNSResolverRule_basic
--- PASS: TestAccDNSZone_readTTL (165.32s)
=== CONT  TestAccDatasourceDNSZones_basic
--- PASS: TestAccDNSPtrRecord_withEpsId (267.13s)
--- PASS: TestAccDNSResolverRuleAssociate_basic (947.72s)
--- PASS: TestAccDataSourceFloatingPtrrecords_basic (652.09s)
--- PASS: TestAccDNSZone_basic (286.20s)
=== CONT  TestAccDNSEndpoint_basic
    resource_huaweicloud_dns_endpoint_test.go:37: Step 2/3 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # huaweicloud_dns_endpoint.test will be updated in-place
          ~ resource "huaweicloud_dns_endpoint" "test" {
                id                  = "ff8080829295ced20193be18ec9c47f0"
                name                = "tf_test_30qkf_update"
                # (6 unchanged attributes hidden)
        
              ~ ip_addresses {
                  ~ subnet_id     = "9c80f4af-838e-4368-abc8-c3e280dfcf50" -> "13d5b9e6-b004-4a5a-96cb-045387c6726f"
                    # (5 unchanged attributes hidden)
                }
              ~ ip_addresses {
                  ~ subnet_id     = "13d5b9e6-b004-4a5a-96cb-045387c6726f" -> "9c80f4af-838e-4368-abc8-c3e280dfcf50"
                    # (5 unchanged attributes hidden)
                }
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- PASS: TestAccDNSZone_private (508.54s)
--- FAIL: TestAccDNSEndpoint_basic (646.82s)
--- PASS: TestAccDatasourceDNSZones_public (411.97s)
--- PASS: TestAccDatasourceDNSZones_basic (405.70s)
--- PASS: TestAccDNSResolverRule_basic (501.41s)
--- PASS: TestAccEndpointAssignment_basic (798.57s)
FAIL
coverage: 82.2% of statements in ./huaweicloud/services/dns
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       1444.261s
FAIL
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
