### PR TITLE
fix(servicestage): the flatten method of logs param is missing

### DIFF
--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_component.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_component.go
@@ -1108,6 +1108,23 @@ func flattenV3ComponentMesher(mesher map[string]interface{}) []map[string]interf
 	}
 }
 
+func flattenV3ComponentLogs(logList []interface{}) []interface{} {
+	if len(logList) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(logList))
+	for _, val := range logList {
+		result = append(result, map[string]interface{}{
+			"log_path":         utils.PathSearch("log_path", val, nil),
+			"rotate":           utils.PathSearch("rotate", val, nil),
+			"host_path":        utils.PathSearch("host_path", val, nil),
+			"host_extend_path": utils.PathSearch("host_extend_path", val, nil),
+		})
+	}
+	return result
+}
+
 func flattenV3ComponentCustomMetric(customMetric map[string]interface{}) []map[string]interface{} {
 	if len(customMetric) < 1 {
 		return nil
@@ -1255,7 +1272,7 @@ func resourceV3ComponentRead(_ context.Context, d *schema.ResourceData, meta int
 		d.Set("timezone", utils.PathSearch("timezone", respBody, nil)),
 		d.Set("jvm_opts", utils.PathSearch("jvm_opts", respBody, nil)),
 		d.Set("tomcat_opts", utils.JsonToString(utils.PathSearch("tomcat_opts", respBody, nil))),
-		d.Set("logs", utils.PathSearch("logs", respBody, nil)),
+		d.Set("logs", flattenV3ComponentLogs(utils.PathSearch("logs", respBody, make([]interface{}, 0)).([]interface{}))),
 		d.Set("custom_metric", flattenV3ComponentCustomMetric(utils.PathSearch("custom_metric", respBody,
 			make(map[string]interface{})).(map[string]interface{}))),
 		d.Set("affinity", flattenV3ComponentAffinity(utils.PathSearch("affinity", respBody,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Missing corresponding flatten method for the parameter 'logs' and the panic will be triggered because the new parameter is supported for log structure: path_pattern.
There is the panic message for the method's missing.

```
panic: Invalid address to set: []string{"logs", "0", "path_pattern"}

goroutine 399 [running]:
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*ResourceData).Set(0xc001ec6b00, {0x2fc7748, 0x4}, {0x2a222c0, 0xc001951fc8})
        /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_data.go:230 +0x291
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/servicestage.resourceV3ComponentRead({0x35c6068?, 0xc0014cc9c0?}, 0xc001ec6b00, {0x2fbc360?, 0xc00172c480})
        /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_component.go:1258 +0xd72
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/servicestage.resourceV3ComponentCreate({0x35c6068, 0xc0014cc9c0}, 0x0?, {0x2fbc360?, 0xc00172c480})
        /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_component.go:972 +0x7e9
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xc000fb0380, {0x35c60a0, 0xc001554840}, 0xd?, {0x2fbc360, 0xc00172c480})
        /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go:707 +0x12e
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc000fb0380, {0x35c60a0, 0xc001554840}, 0xc000e5cd00, 0xc001ec6980, {0x2fbc360, 0xc00172c480})
        /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go:837 +0xa85
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc0021ab3c8, {0x35c60a0?, 0xc001554780?}, 0xc0012180f0)
        /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/grpc_provider.go:1021 +0xe8d
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc00180c640, {0x35c60a0?, 0xc001554120?}, 0xc001df4070)
        /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server/server.go:818 +0x574
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x2efc540?, 0xc00180c640}, {0x35c60a0, 0xc001554120}, 0xc001df4000, 0x0)
        /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:385 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00281ab40, {0x35caae0, 0xc000e50680}, 0xc000d64000, 0xc001864210, 0x4dea020, 0x0)
        /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/vendor/google.golang.org/grpc/server.go:1335 +0xdf0
google.golang.org/grpc.(*Server).handleStream(0xc00281ab40, {0x35caae0, 0xc000e50680}, 0xc000d64000, 0x0)
        /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/vendor/google.golang.org/grpc/server.go:1712 +0xa2f
google.golang.org/grpc.(*Server).serveStreams.func1.1()
        /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/vendor/google.golang.org/grpc/server.go:947 +0xca
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/vendor/google.golang.org/grpc/server.go:958 +0x15c
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
supplement the missing flatten method for the parameter logs param is missing.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o servicestage -f TestAccV3Component_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccV3Component_basic -timeout 360m -parallel 10
=== RUN   TestAccV3Component_basic
=== PAUSE TestAccV3Component_basic
=== CONT  TestAccV3Component_basic
--- PASS: TestAccV3Component_basic (614.30s)
PASS
coverage: 29.3% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      614.348s        coverage: 29.3% of statements in ./huaweicloud/services/servicestage
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.