### PR TITLE
feat(GaussDB): gaussdb opengauss instance support tags

### DIFF
--- a/docs/resources/gaussdb_opengauss_instance.md
+++ b/docs/resources/gaussdb_opengauss_instance.md
@@ -169,6 +169,8 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the GaussDB OpenGauss instance.
+
 * `force_import` - (Optional, Bool) Specifies whether to import the instance with the given configuration instead of
   creation. If specified, try to import the instance instead of creation if the instance already existed.
 

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance_test.go
@@ -100,6 +100,8 @@ func TestAccOpenGaussInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "40"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.start_time", "20:00-21:00"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "6"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
 			},
 			{
@@ -114,6 +116,8 @@ func TestAccOpenGaussInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "80"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.start_time", "08:00-09:00"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "8"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo_update", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
 				),
 			},
 		},
@@ -295,6 +299,11 @@ resource "huaweicloud_gaussdb_opengauss_instance" "test" {
     start_time = "20:00-21:00"
     keep_days  = 6
   }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
 }
 `, testAccOpenGaussInstance_base(rName), rName, password, replicaNum, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
@@ -345,6 +354,11 @@ resource "huaweicloud_gaussdb_opengauss_instance" "test" {
   backup_strategy {
     start_time = "08:00-09:00"
     keep_days  = 8
+  }
+
+  tags = {
+    foo_update = "bar"
+    key        = "value_update"
   }
 }
 `, testAccOpenGaussInstance_base(rName), rName, password, replicaNum, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  gaussdb opengauss instance support tags
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  gaussdb opengauss instance support tags
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccOpenGaussInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccOpenGaussInstance_ -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussInstance_basic
=== PAUSE TestAccOpenGaussInstance_basic
=== RUN   TestAccOpenGaussInstance_flavor
=== PAUSE TestAccOpenGaussInstance_flavor
=== RUN   TestAccOpenGaussInstance_haModeCentralized
=== PAUSE TestAccOpenGaussInstance_haModeCentralized
=== CONT  TestAccOpenGaussInstance_basic
=== CONT  TestAccOpenGaussInstance_haModeCentralized
=== CONT  TestAccOpenGaussInstance_flavor
--- PASS: TestAccOpenGaussInstance_flavor (3481.05s)
--- PASS: TestAccOpenGaussInstance_haModeCentralized (4073.40s)
--- PASS: TestAccOpenGaussInstance_basic (5544.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   5544.684s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
