### PR TITLE
feat(servicestage): add new data source to query components

### DIFF
--- a/docs/data-sources/servicestagev3_components.md
+++ b/docs/data-sources/servicestagev3_components.md
@@ -1,0 +1,130 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestagev3_components"
+description: |-
+  Use this data source to query the list of components under specified application within HuaweiCloud.
+---
+
+# huaweicloud_servicestagev3_components
+
+Use this data source to query the list of components under specified application within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "application_id" {}
+
+data "huaweicloud_servicestagev3_components" "test" {
+  application_id = var.application_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the components are located.  
+  If omitted, the provider-level region will be used.
+
+* `application_id` - (Required, String) Specifies the ID of the application to which the components belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID, in UUID format.
+
+* `components` - All components details.  
+  The [components](#servicestage_v3_components) structure is documented below.
+
+<a name="servicestage_v3_components"></a>
+The `components` block supports:
+
+* `id` - The component ID.
+
+* `environment_id` - The environment ID where the component is deployed.
+
+* `name` - The name of the component.
+
+* `runtime_stack` - The configuration of the runtime stack.  
+  The [runtime_stack](#servicestage_v3_components_runtime_stack) structure is documented below.
+
+* `source` - The source configuration of the component, in JSON format.  
+  For the keys, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/api-servicestage/servicestage_06_0077.html#servicestage_06_0077__en-us_topic_0220056058_ref28944532).
+
+* `version` - The version of the component.
+
+* `refer_resources` - The configuration of the reference resources.  
+  The [refer_resources](#servicestage_v3_components_refer_resources) structure is documented below.
+
+* `build` - The build configuration of the component, in JSON format.  
+  For the keys, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/api-servicestage/servicestage_06_0076.html#servicestage_06_0076__en-us_topic_0220056060_table7559740).
+
+* `external_accesses` - The configuration of the external accesses.  
+  The [external_accesses](#servicestage_v3_components_external_accesses) structure is documented below.
+
+* `tags` - The key/value pairs to associate with the component.
+
+* `status` - The status of the component.
+  + **FAILED**
+  + **RUNNING**
+  + **DOWN**
+  + **RESERVED**
+  + **STOPPED**
+  + **PENDING**
+  + **UNKNOWN**
+  + **PARTIALLY_FAILED**
+
+* `created_at` - The creation time of the component, in RFC3339 format.
+
+* `updated_at` - The latest update time of the component, in RFC3339 format.
+
+<a name="servicestage_v3_components_runtime_stack"></a>
+The `runtime_stack` block supports:
+
+* `name` - The stack name.
+
+* `type` - The stack type.
+  + **Java**
+  + **Tomcat**
+  + **Nodejs**
+  + **Php**
+  + **Docker**
+  + **Python**
+
+* `deploy_mode` - The deploy mode of the stack.
+  + **container**
+  + **virtualmachine**
+
+* `version` - The stack version.
+
+<a name="servicestage_v3_components_refer_resources"></a>
+The `refer_resources` block supports:
+
+* `id` - The resource ID.
+
+* `type` - The resource type.
+  + **vpc**
+  + **eip**
+  + **elb**
+  + **cce**
+  + **ecs**
+  + **as**
+  + **cse**
+  + **dcs**
+  + **rds**
+
+* `parameters` - The resource parameters, in JSON format.  
+  For the keys, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/api-servicestage/servicestage_06_0076.html#servicestage_06_0076__table838321632514).
+
+<a name="servicestage_v3_components_external_accesses"></a>
+The `external_accesses` block supports:
+
+* `protocol` - The protocol of the external access.
+  + **http**
+  + **https**
+
+* `address` - The address of the external access.
+
+* `forward_port` - The forward port of the external access.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1069,6 +1069,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),
 			// Querying by Ver.3 APIs
 			"huaweicloud_servicestagev3_applications":   servicestage.DataSourceV3Applications(),
+			"huaweicloud_servicestagev3_components":     servicestage.DataSourceV3Components(),
 			"huaweicloud_servicestagev3_environments":   servicestage.DataSourceV3Environments(),
 			"huaweicloud_servicestagev3_runtime_stacks": servicestage.DataSourceV3RuntimeStacks(),
 

--- a/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestagev3_components_test.go
+++ b/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestagev3_components_test.go
@@ -1,0 +1,131 @@
+package servicestage
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataV3Components_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		all = "data.huaweicloud_servicestagev3_components.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Make sure at least one of node exist.
+			acceptance.TestAccPreCheckCceClusterId(t)
+			// Make sure the networks of the CCE cluster and the CSE engine are same.
+			acceptance.TestAccPreCheckCSEMicroserviceEngineID(t)
+			acceptance.TestAccPreCheckImsImageUrl(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataV3Components_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "components.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckOutput("is_component_id_set_and_valid", "true"),
+					resource.TestCheckOutput("is_environment_id_set_and_valid", "true"),
+					resource.TestCheckOutput("is_component_name_set_and_valid", "true"),
+					resource.TestCheckOutput("is_component_runtime_stack_set_and_valid", "true"),
+					resource.TestCheckOutput("is_component_source_set_and_valid", "true"),
+					resource.TestCheckOutput("is_component_version_set_and_valid", "true"),
+					resource.TestCheckOutput("is_component_refer_resources_set_and_valid", "true"),
+					resource.TestCheckOutput("is_component_build_set_and_valid", "true"),
+					resource.TestCheckOutput("is_component_tags_set_and_valid", "true"),
+					resource.TestCheckOutput("is_component_status_set", "true"),
+					resource.TestCheckOutput("is_component_created_at_set_and_valid", "true"),
+					resource.TestCheckOutput("is_component_updated_at_set_and_valid", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataV3Components_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_servicestagev3_components" "test" {
+  depends_on = [
+    huaweicloud_servicestagev3_component.test
+  ]
+
+  application_id = huaweicloud_servicestagev3_application.test.id
+}
+
+locals {
+  component_id            = huaweicloud_servicestagev3_component.test.id
+  component_filter_result = try([
+    for v in data.huaweicloud_servicestagev3_components.test.components : v if v.id == local.component_id
+  ][0], null)
+}
+
+output "is_component_id_set_and_valid" {
+  value = local.component_filter_result != null
+}
+
+output "is_environment_id_set_and_valid" {
+  value = try(local.component_filter_result.environment_id == huaweicloud_servicestagev3_environment.test.id, false)
+}
+
+output "is_component_name_set_and_valid" {
+  value = try(local.component_filter_result.name == huaweicloud_servicestagev3_component.test.name, false)
+}
+
+output "is_component_runtime_stack_set_and_valid" {
+  value = try(length(local.component_filter_result.runtime_stack) > 0 && alltrue([
+	  local.component_filter_result.runtime_stack[0].name == huaweicloud_servicestagev3_component.test.runtime_stack[0].name,
+	  local.component_filter_result.runtime_stack[0].type == huaweicloud_servicestagev3_component.test.runtime_stack[0].type,
+	  local.component_filter_result.runtime_stack[0].deploy_mode == huaweicloud_servicestagev3_component.test.runtime_stack[0].deploy_mode,
+	  local.component_filter_result.runtime_stack[0].version == huaweicloud_servicestagev3_component.test.runtime_stack[0].version,
+  ]))
+}
+
+output "is_component_source_set_and_valid" {
+  value = try(local.component_filter_result.source == huaweicloud_servicestagev3_component.test.source, false)
+}
+
+output "is_component_version_set_and_valid" {
+  value = try(local.component_filter_result.version == huaweicloud_servicestagev3_component.test.version, false)
+}
+
+output "is_component_refer_resources_set_and_valid" {
+  value = try(length(local.component_filter_result.refer_resources) == length(huaweicloud_servicestagev3_component.test.refer_resources), false)
+}
+
+output "is_component_build_set_and_valid" {
+  value = try(local.component_filter_result.build == huaweicloud_servicestagev3_component.test.build, false)
+}
+
+output "is_component_tags_set_and_valid" {
+  value = try(length(setintersection(matchkeys(values(huaweicloud_servicestagev3_component.test.tags),
+    keys(huaweicloud_servicestagev3_component.test.tags), keys(local.component_filter_result.tags)),
+    values(local.component_filter_result.tags))) == length(local.component_filter_result.tags), false)
+}
+
+output "is_component_status_set" {
+  value = local.component_filter_result.status != ""
+}
+
+output "is_component_created_at_set_and_valid" {
+  value = try(length(regexall("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
+    local.component_filter_result.created_at)) > 0, false)
+}
+
+output "is_component_updated_at_set_and_valid" {
+  value = try(length(regexall("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
+    local.component_filter_result.updated_at)) > 0, false)
+}
+`, testAccV3Component_basic_step1(name))
+}

--- a/huaweicloud/services/servicestage/data_source_huaweicloud_servicestagev3_components.go
+++ b/huaweicloud/services/servicestage/data_source_huaweicloud_servicestagev3_components.go
@@ -1,0 +1,273 @@
+package servicestage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ServiceStage GET /v3/{project_id}/cas/applications/{application_id}/components
+func DataSourceV3Components() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV3ComponentsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the components are located.`,
+			},
+			"application_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the application to which the components belong.`,
+			},
+			"components": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The component ID.`,
+						},
+						"environment_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The environment ID where the component is deployed.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the component.`,
+						},
+						"runtime_stack": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The stack name.`,
+									},
+									"type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The stack type.`,
+									},
+									"deploy_mode": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The deploy mode of the stack.`,
+									},
+									"version": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The stack version.`,
+									},
+								},
+							},
+							Description: "The configuration of the runtime stack.",
+						},
+						"source": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The source configuration of the component, in JSON format.`,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The version of the component.`,
+						},
+						"refer_resources": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The resource ID.`,
+									},
+									"type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The resource type.`,
+									},
+									"parameters": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The resource parameters, in JSON format.`,
+									},
+								},
+							},
+							Description: `The configuration of the reference resources.`,
+						},
+						"build": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The build configuration of the component, in JSON format.`,
+						},
+						"external_accesses": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"protocol": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The protocol of the external access.`,
+									},
+									"address": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The address of the external access.`,
+									},
+									"forward_port": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The forward port of the external access.`,
+									},
+								},
+							},
+							Description: "The configuration of the external accesses.",
+						},
+						"tags": common.TagsComputedSchema(
+							`The key/value pairs to associate with the component.`,
+						),
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the component.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the component, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the component, in RFC3339 format.`,
+						},
+					},
+				},
+				Description: "All application details.",
+			},
+		},
+	}
+}
+
+func queryV3Components(client *golangsdk.ServiceClient, appId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v3/{project_id}/cas/applications/{application_id}/components?limit=100"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{application_id}", appId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		components := utils.PathSearch("components", respBody, make([]interface{}, 0)).([]interface{})
+		if len(components) < 1 {
+			break
+		}
+		result = append(result, components...)
+		offset += len(components)
+	}
+
+	return result, nil
+}
+
+func flattenV3Components(components []interface{}) []map[string]interface{} {
+	if len(components) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(components))
+	for _, component := range components {
+		result = append(result, map[string]interface{}{
+			"id":             utils.PathSearch("id", component, nil),
+			"environment_id": utils.PathSearch("environment_id", component, nil),
+			"name":           utils.PathSearch("name", component, nil),
+			"runtime_stack": flattenV3ComponentRuntimeStackConfig(utils.PathSearch("runtime_stack", component,
+				make(map[string]interface{})).(map[string]interface{})),
+			"source":  utils.JsonToString(utils.PathSearch("source", component, nil)),
+			"version": utils.PathSearch("version", component, nil),
+			"refer_resources": flattenV3ComponentReferResources(utils.PathSearch("refer_resources", component,
+				make([]interface{}, 0)).([]interface{})),
+			"build": utils.JsonToString(utils.PathSearch("build", component, nil)),
+			"external_accesses": flattenV3ExternalAccesses(utils.PathSearch("external_accesses", component,
+				make(map[string]interface{})).(map[string]interface{})),
+			"tags":   utils.FlattenTagsToMap(utils.PathSearch("labels", component, make([]interface{}, 0))),
+			"status": utils.PathSearch("status.component_status", component, nil),
+			"created_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("status.create_time", component,
+				float64(0)).(float64))/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("status.update_time", component,
+				float64(0)).(float64))/1000, false),
+		})
+	}
+
+	return result
+}
+
+func dataSourceV3ComponentsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		appId  = d.Get("application_id").(string)
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	components, err := queryV3Components(client, appId)
+	if err != nil {
+		return diag.Errorf("error getting components: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("components", flattenV3Components(components)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new data source that used to query ServiceStage components via ver.3 OpenAPIs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query components.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o servicestage -f TestAccDataV3Components_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccDataV3Components_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV3Components_basic
=== PAUSE TestAccDataV3Components_basic
=== CONT  TestAccDataV3Components_basic
--- PASS: TestAccDataV3Components_basic (349.62s)
PASS
coverage: 29.3% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      349.688s        coverage: 29.3% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
