### PR TITLE
feat(lts): the log stream supports modifying ttl_in_days field

### DIFF
--- a/docs/data-sources/lts_streams.md
+++ b/docs/data-sources/lts_streams.md
@@ -44,6 +44,8 @@ The `streams` block supports:
 
 * `name` - The name of the log stream.
 
+* `ttl_in_days` - The log expiration time (days).
+
 * `tags` - The key/value pairs to associate with the log stream.
 
 * `created_at` - The creation time of the log stream, in RFC3339 format.

--- a/docs/resources/lts_stream.md
+++ b/docs/resources/lts_stream.md
@@ -34,8 +34,8 @@ The following arguments are supported:
 * `stream_name` - (Required, String, ForceNew) Specifies the log stream name. Changing this parameter will create a new
   resource.
 
-* `ttl_in_days` - (Optional, Int, ForceNew) Specifies the log expiration time(days), value range: 1-365.
-  If not specified, it will inherit the log group setting. Changing this parameter will create a new resource.
+* `ttl_in_days` - (Optional, Int) Specifies the log expiration time (days).
+  The valid value is a non-zero integer from `-1` to `365`, defaults to `-1` which means inherit the log group settings.
 
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID.
   Changing this parameter will create a new resource.
@@ -59,19 +59,3 @@ The log stream can be imported using the group ID and stream ID separated by a s
 ```bash
 $ terraform import huaweicloud_lts_stream.test <group_id>/<id>
 ```
-
-Note that the imported state may not be identical to your resource definition, due to `ttl_in_days` attribute missing
-from the API response. It is generally recommended running `terraform plan` after importing a resource.
-You can then decide if changes should be applied to the resource, or the resource definition should be updated to
-align with the resource. Also you can ignore changes as below.
-
-```hcl
-resource "huaweicloud_lts_stream" "test" {
-  ...
-
-  lifecycle {
-    ignore_changes = [
-      ttl_in_days,
-    ]
-  }
-}

--- a/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_streams_test.go
+++ b/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_streams_test.go
@@ -39,6 +39,7 @@ func TestAccDataSourceStreams_basic(t *testing.T) {
 					dcByName.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(byName, "streams.0.id", "huaweicloud_lts_stream.test", "id"),
 					resource.TestCheckResourceAttr(byName, "streams.0.name", rName),
+					resource.TestCheckResourceAttr(byName, "streams.0.ttl_in_days", "60"),
 					resource.TestCheckResourceAttr(byName, "streams.0.tags._sys_enterprise_project_id", "0"),
 					resource.TestCheckResourceAttr(byName, "streams.0.tags.terraform", "test"),
 					resource.TestCheckOutput("is_name_filter_useful", "true"),
@@ -70,6 +71,7 @@ resource "huaweicloud_lts_group" "test" {
 resource "huaweicloud_lts_stream" "test" {
   group_id              = huaweicloud_lts_group.test.id
   stream_name           = huaweicloud_lts_group.test.group_name
+  ttl_in_days           = 60
   enterprise_project_id = "0"
 
   tags = {
@@ -88,6 +90,7 @@ locals {
   stream_name = huaweicloud_lts_stream.test.stream_name
 }
 
+# The name is an exact match.
 data "huaweicloud_lts_streams" "filter_by_name" {
   depends_on = [
     huaweicloud_lts_stream.test

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_stream_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_stream_test.go
@@ -68,6 +68,7 @@ func TestAccLtsStream_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "stream_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "ttl_in_days", "-1"),
 					resource.TestCheckResourceAttr(resourceName, "filter_count", "0"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
@@ -81,16 +82,16 @@ func TestAccLtsStream_basic(t *testing.T) {
 				Config: testAccLtsStream_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "ttl_in_days", "60"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ttl_in_days"},
-				ImportStateIdFunc:       testLtsStreamImportState(resourceName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testLtsStreamImportState(resourceName),
 			},
 		},
 	})
@@ -124,7 +125,6 @@ resource "huaweicloud_lts_group" "test" {
 resource "huaweicloud_lts_stream" "test" {
   group_id    = huaweicloud_lts_group.test.id
   stream_name = "%[1]s"
-  ttl_in_days = 60
 
   tags = {
     foo       = "bar"

--- a/huaweicloud/services/lts/data_source_huaweicloud_lts_streams.go
+++ b/huaweicloud/services/lts/data_source_huaweicloud_lts_streams.go
@@ -53,6 +53,11 @@ func DataSourceLtsStreams() *schema.Resource {
 							Computed:    true,
 							Description: `The name of the log stream.`,
 						},
+						"ttl_in_days": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `the log expiration time (days).`,
+						},
 						"tags": {
 							Type:        schema.TypeMap,
 							Computed:    true,
@@ -132,10 +137,11 @@ func (w *StreamsDSWrapper) listLogStreamsToSchema(body *gjson.Result) error {
 		d.Set("streams", schemas.SliceToList(body.Get("log_streams"),
 			func(streams gjson.Result) any {
 				return map[string]any{
-					"id":         streams.Get("log_stream_id").Value(),
-					"name":       streams.Get("log_stream_name").Value(),
-					"tags":       schemas.MapToStrMap(streams.Get("tag")),
-					"created_at": w.setLogStrCreTime(streams),
+					"id":          streams.Get("log_stream_id").Value(),
+					"name":        streams.Get("log_stream_name").Value(),
+					"ttl_in_days": streams.Get("ttl_in_days").Value(),
+					"tags":        schemas.MapToStrMap(streams.Get("tag")),
+					"created_at":  w.setLogStrCreTime(streams),
 				}
 			},
 		)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The log stream resource  and data source supports modifying `ttl_in_days` field.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
the log stream supports modifying ttl_in_days field.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o lts -f TestAccLtsStream
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccLtsStream -timeout 360m -parallel 10
=== RUN   TestAccLtsStream_basic
=== PAUSE TestAccLtsStream_basic
=== RUN   TestAccLtsStream_epsId
=== PAUSE TestAccLtsStream_epsId
=== CONT  TestAccLtsStream_basic
=== CONT  TestAccLtsStream_epsId
--- PASS: TestAccLtsStream_epsId (48.31s)
--- PASS: TestAccLtsStream_basic (77.86s)
PASS
coverage: 9.9% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       77.937s coverage: 9.9% of statements in ./huaweicloud/services/lts

./scripts/coverage.sh -o lts -f TestAccDataSourceStreams_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccDataSourceStreams_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceStreams_basic
=== PAUSE TestAccDataSourceStreams_basic
=== CONT  TestAccDataSourceStreams_basic
--- PASS: TestAccDataSourceStreams_basic (156.98s)
PASS
coverage: 9.6% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       157.036s        coverage: 9.6% of statements in ./huaweicloud/services/lts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
