### PR TITLE
feat(CodeArts/Deploy): support group permission management

### DIFF
--- a/docs/resources/codearts_deploy_group.md
+++ b/docs/resources/codearts_deploy_group.md
@@ -93,6 +93,9 @@ In addition to all arguments above, the following attributes are exported:
 * `permission` - The group permission detail.
   The [permission](#DeployGroup_permission) structure is documented below.
 
+* `permission_matrix` - The group permission matrix detail.
+  The [permission_matrix](#DeployGroup_permission_matrix) structure is documented below.
+
 <a name="DeployGroup_user"></a>
 The `object` block supports:
 
@@ -114,6 +117,31 @@ The `permission` block supports:
 * `can_manage` - Indicates whether the user has the management permission.
 
 * `can_copy` - Indicates whether the user has the permission to copy.
+
+<a name="DeployGroup_permission_matrix"></a>
+The `permission_matrix` block supports:
+
+* `role_id` - Indicates the role ID.
+
+* `role_name` - Indicates the role name.
+
+* `role_type` - Indicates the role type.
+
+* `can_view` - Indicates whether the role has the view permission.
+
+* `can_edit` - Indicates whether the role has the edit permission.
+
+* `can_delete` - Indicates whether the role has the deletion permission.
+
+* `can_add_host` - Indicates whether the role has the permission to add hosts.
+
+* `can_manage` - Indicates whether the role has the management permission.
+
+* `can_copy` - Indicates whether the role has the permission to copy.
+
+* `created_at` - The permission create time.
+
+* `updated_at` - The permission update time.
 
 ## Import
 

--- a/docs/resources/codearts_deploy_group_permission.md
+++ b/docs/resources/codearts_deploy_group_permission.md
@@ -1,0 +1,66 @@
+---
+subcategory: "CodeArts Deploy"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_codearts_deploy_group_permission"
+description: |-
+  Manages a CodeArts deploy group permission resource within HuaweiCloud.
+---
+
+# huaweicloud_codearts_deploy_group_permission
+
+Manages a CodeArts deploy group permission resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "project_id" {}
+variable "group_id" {}
+variable "role_id" {}
+
+resource "huaweicloud_codearts_deploy_group_permission" "test" {
+  project_id       = var.project_id
+  group_id         = var.group_id
+  role_id          = var.role_id
+  permission_name  = "can_add_host"
+  permission_value = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `project_id` - (Required, String, ForceNew) Specifies the project ID.
+  Changing this creates a new resource.
+
+* `group_id` - (Required, String, ForceNew) Specifies the group ID.
+  Changing this creates a new resource.
+
+* `role_id` - (Required, String, ForceNew) Specifies the role ID.
+  Changing this creates a new resource.
+
+* `permission_name` - (Required, String, ForceNew) Specifies the permission name.
+  Valid values are **can_view**, **can_edit**, **can_delete**, **can_add_host**, **can_manage**, and **can_copy**.
+
+  Changing this creates a new resource.
+
+* `permission_value` - (Optional, Bool) Specifies whether to enable the permission.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The CodeArts deploy group permission resource can be imported using the `project_id`, `group_id`, `role_id` and
+`permission_name`, separated by slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_codearts_deploy_group_permission.test <project_id>/<group_id>/<role_id>/<permission_name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2211,6 +2211,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_codearts_deploy_application":       codeartsdeploy.ResourceDeployApplication(),
 			"huaweicloud_codearts_deploy_application_group": codeartsdeploy.ResourceDeployApplicationGroup(),
 			"huaweicloud_codearts_deploy_group":             codeartsdeploy.ResourceDeployGroup(),
+			"huaweicloud_codearts_deploy_group_permission":  codeartsdeploy.ResourceDeployGroupPermission(),
 			"huaweicloud_codearts_deploy_host":              codeartsdeploy.ResourceDeployHost(),
 
 			"huaweicloud_codearts_inspector_website":      codeartsinspector.ResourceInspectorWebsite(),

--- a/huaweicloud/services/acceptance/codeartsdeploy/resource_huaweicloud_codearts_deploy_group_permission_test.go
+++ b/huaweicloud/services/acceptance/codeartsdeploy/resource_huaweicloud_codearts_deploy_group_permission_test.go
@@ -1,0 +1,64 @@
+package codeartsdeploy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDeployGroupPermissionModify_basic(t *testing.T) {
+	resourceName := "huaweicloud_codearts_deploy_group_permission.test"
+	rName := acceptance.RandomAccResourceName()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeployGroupPermissionModify_basic(rName, false),
+			},
+			{
+				Config: testAccDeployGroupPermissionModify_basic(rName, true),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testDeployGroupPermissionImportState(resourceName),
+			},
+		},
+	})
+}
+
+func testAccDeployGroupPermissionModify_basic(rName string, value bool) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_codearts_deploy_group_permission" "test" {
+  project_id       = huaweicloud_codearts_deploy_group.test.project_id
+  group_id         = huaweicloud_codearts_deploy_group.test.id
+  role_id          = try(huaweicloud_codearts_deploy_group.test.permission_matrix[2].role_id, "")
+  permission_name  = "can_add_host"
+  permission_value = %t
+}`, testDeployGroup_basic(rName), value)
+}
+
+// testDeployGroupPermissionImportState use to return an ID with format <project_id>/<id>
+func testDeployGroupPermissionImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		projectId := rs.Primary.Attributes["project_id"]
+		if projectId == "" {
+			return "", fmt.Errorf("attribute (project_id) of resource (%s) not found: %s", name, rs)
+		}
+		return projectId + "/" + rs.Primary.ID, nil
+	}
+}

--- a/huaweicloud/services/codeartsdeploy/resource_huaweicloud_codearts_deploy_group_permission.go
+++ b/huaweicloud/services/codeartsdeploy/resource_huaweicloud_codearts_deploy_group_permission.go
@@ -1,0 +1,174 @@
+package codeartsdeploy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CodeArtsDeploy PUT /v2/host-groups/{group_id}/permissions
+// @API CodeArtsDeploy GET /v2/host-groups/{group_id}/permissions
+func ResourceDeployGroupPermission() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDeployGroupPermissionCreateOrUpdate,
+		ReadContext:   resourceDeployGroupPermissionRead,
+		UpdateContext: resourceDeployGroupPermissionCreateOrUpdate,
+		DeleteContext: resourceDeployGroupPermissionDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDeployGroupPermissionImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"role_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"permission_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"permission_value": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceDeployGroupPermissionCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("codearts_deploy", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	err = modifyDeployGroupPermission(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if d.IsNewResource() {
+		d.SetId(d.Get("group_id").(string) + "/" + d.Get("role_id").(string) + "/" + d.Get("permission_name").(string))
+	}
+
+	return resourceDeployGroupPermissionRead(ctx, d, meta)
+}
+
+func modifyDeployGroupPermission(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v2/host-groups/{group_id}/permissions"
+	modifyPath := client.Endpoint + httpUrl
+	modifyPath = strings.ReplaceAll(modifyPath, "{group_id}", d.Get("group_id").(string))
+
+	modifyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+		JSONBody: buildDeployGroupPermissionBodyParams(d),
+	}
+
+	_, err := client.Request("PUT", modifyPath, &modifyOpt)
+	if err != nil {
+		return fmt.Errorf("error modifying CodeArts deploy group permission")
+	}
+
+	return nil
+}
+
+func buildDeployGroupPermissionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"project_id":       d.Get("project_id"),
+		"role_id":          d.Get("role_id"),
+		"permission_name":  d.Get("permission_name"),
+		"permission_value": d.Get("permission_value"),
+	}
+}
+
+func resourceDeployGroupPermissionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("codearts_deploy", region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	permissionMatrix, err := getDeployGroupPermissionMatrix(client, d.Get("group_id").(string))
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CodeArts deploy group permission")
+	}
+
+	roleId := d.Get("role_id").(string)
+	permissionName := d.Get("permission_name").(string)
+	expression := fmt.Sprintf("[?role_id=='%s']|[0]", roleId)
+	role := utils.PathSearch(expression, permissionMatrix, nil)
+	if role == nil {
+		return diag.Errorf("unable to find role (%s) from API response", roleId)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("permission_value", utils.PathSearch(permissionName, role, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDeployGroupPermissionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting permission resource is not supported. The resource is only removed from the state," +
+		" the group permission matrix remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}
+
+func resourceDeployGroupPermissionImportState(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<project_id>/<group_id>/<role_id>/<permission_name>',"+
+			" but got '%s'", d.Id())
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("project_id", parts[0]),
+		d.Set("group_id", parts[1]),
+		d.Set("role_id", parts[2]),
+		d.Set("permission_name", parts[3]),
+	)
+
+	d.SetId(parts[1] + "/" + parts[2] + "/" + parts[3])
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 support group permission management

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/codeartsdeploy" TESTARGS="-run TestAccDeployGroup_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codeartsdeploy -v -run TestAccDeployGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccDeployGroup_basic
=== PAUSE TestAccDeployGroup_basic
=== CONT  TestAccDeployGroup_basic
--- PASS: TestAccDeployGroup_basic (60.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codeartsdeploy    60.349s

make testacc TEST="./huaweicloud/services/acceptance/codeartsdeploy" TESTARGS="-run TestAccDeployGroupPermissionModify_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codeartsdeploy -v -run TestAccDeployGroupPermissionModify_basic -timeout 360m -parallel 4
=== RUN   TestAccDeployGroupPermissionModify_basic
=== PAUSE TestAccDeployGroupPermissionModify_basic
=== CONT  TestAccDeployGroupPermissionModify_basic
--- PASS: TestAccDeployGroupPermissionModify_basic (50.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codeartsdeploy    50.411s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/4e5d156a-8ab7-4332-9beb-5bc7f0bb617b)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
