### PR TITLE
feat(workspace): add new data source to query service detail

### DIFF
--- a/docs/data-sources/workspace_service.md
+++ b/docs/data-sources/workspace_service.md
@@ -1,0 +1,137 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_service"
+description: |-
+  Use this data source to get the configuration of the Workspace service within HuaweiCloud.
+---
+
+# huaweicloud_workspace_service
+
+Use this data source to get the configuration of the Workspace service within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_workspace_service" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The service ID.
+  If the service is closed, the value will be a random UUID.
+
+* `vpc_id` - The VPC ID to which the service belongs.
+
+* `network_ids` - The network ID list of subnets that the service have.
+
+* `access_mode` - The access mode of Workspace service.
+  + **INTERNET**: Access through Internet.
+  + **DEDICATED**: Access through Direct Connect.
+  + **DEDICATED**: Access through Internet or Direct Connect.
+
+* `auth_type` - The authentication type of Workspace service.
+  + **LITE_AS**: Local authentication.
+  + **LOCAL_AD**: Local AD.
+
+* `ad_domain` - The configuration of AD domain.  
+  The [ad_domain](#workspace_data_service_ad_domain) structure is documented below.
+
+* `enterprise_id` - The enterprise ID.
+
+* `internet_access_port` - The internet access port.
+
+* `internet_access_address` - The internet access address.
+
+* `dedicated_subnets` - The subnet segments of the dedicated access.
+
+* `management_subnet_cidr` - The subnet segment of the management component.
+
+* `infrastructure_security_group` - The management component security group automatically created under the specified
+  VPC after service is registered.  
+  The [infrastructure_security_group](#workspace_data_service_security_group) structure is documented below.
+
+* `desktop_security_group` - The desktop security group automatically created under the specified VPC after the service
+  is registered.  
+  The [desktop_security_group](#workspace_data_service_security_group) structure is documented below.
+
+* `status` - The current status of the Workspace service.
+  + **SUBSCRIBED**: The service has been subscribed.
+  + **SUBSCRIPTION_FAILED**: The service cannot be subscribed.
+  + **DEREGISTERING**: The service is being unsubscribed.
+  + **DEREGISTRATION_FAILED**: The service cannot be unsubscribed.
+  + **CLOSED**: The service has been unsubscribed and is not subscribed.
+
+* `otp_config_info` - The configuration of auxiliary authentication.  
+  The [otp_config_info](#workspace_data_service_otp_config_info) structure is documented below.
+
+* `is_locked` - Whether the service is locked.
+  + **0**: unlocked.
+  + **1**: locked.
+
+* `lock_time` - The time when the service is locked.
+
+* `lock_reason` - The lock reason of the service.
+
+<a name="workspace_data_service_ad_domain"></a>
+The `ad_domain` block supports:
+
+* `name` - The domain name.
+
+* `admin_account` - The domain administrator account.
+
+* `active_domain_ip` - The IP address of primary domain controller.
+
+* `active_domain_name` - The name of the primary domain controller.
+
+* `active_dns_ip` - The primary DNS IP address.
+
+* `standby_domain_ip` - The IP address of standby domain controller.
+
+* `standby_domain_name` - The name of the standby domain controller.
+
+* `standby_dns_ip` - The standby DNS IP address.
+
+* `delete_computer_object` - Whether to delete the corresponding computer object on AD while deleting the desktop.
+
+<a name="workspace_data_service_security_group"></a>
+The `infrastructure_security_group` and `desktop_security_group` block support:
+
+* `id` - The security group ID.
+
+* `name` - The security group name.
+
+<a name="workspace_data_service_otp_config_info"></a>
+The `otp_config_info` block supports:
+
+* `enable` - Whether to enable auxiliary authentication.
+
+* `receive_mode` - The verification code receiving mode.
+  + **VMFA**: Virtual MFA device
+  + **HMFA**: Hardware MFA device
+
+* `auth_url` - The auxiliary authentication server address.
+
+* `app_id` - The auxiliary authentication server access account.
+
+* `app_secret` - The authentication service access password.
+
+* `auth_server_access_mode` - The authentication service access mode.
+
+* `cert_content` - The certificate content, in PEM format.
+
+* `rule_type` - The type of the object to which authentication applies.
+  + **ACCESS_MODE**: Access type.
+
+* `rule` - The object to which authentication applies.
+  + **INTERNET**: Internet access.
+  + **PRIVATE**: private line access.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1195,6 +1195,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_storage_policies":     workspace.DataSourceAppStoragePolicies(),
 			"huaweicloud_workspace_desktops":                 workspace.DataSourceDesktops(),
 			"huaweicloud_workspace_flavors":                  workspace.DataSourceWorkspaceFlavors(),
+			"huaweicloud_workspace_service":                  workspace.DataSourceService(),
 
 			// Legacy
 			"huaweicloud_images_image_v2":        ims.DataSourceImagesImageV2(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_service_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_service_test.go
@@ -1,0 +1,113 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceService_basic(t *testing.T) {
+	var (
+		dcName = "data.huaweicloud_workspace_service.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAD(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceService_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_service_id_set_and_valid", "true"),
+					resource.TestCheckOutput("is_ad_domain_set_and_valid", "true"),
+					resource.TestCheckOutput("is_auth_type_set_and_valid", "true"),
+					resource.TestCheckOutput("is_access_mode_set_and_valid", "true"),
+					resource.TestCheckOutput("is_vpc_id_set_and_valid", "true"),
+					resource.TestCheckOutput("is_network_ids_set_and_valid", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceService_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_service" "test" {
+  ad_domain {
+    name               = try(element(regexall("\\w+\\.(.*)", element(split(",", "%[1]s"), 0))[0], 0), "")
+    active_domain_name = element(split(",", "%[1]s"), 0)
+    active_domain_ip   = element(split(",", "%[2]s"), 0)
+    active_dns_ip      = element(split(",", "%[2]s"), 0)
+    // Standby configuration
+    standby_domain_name = element(split(",", "%[1]s"), 1)
+    standby_domain_ip   = element(split(",", "%[2]s"), 1)
+    standby_dns_ip      = element(split(",", "%[2]s"), 1)
+    admin_account      = "Administrator"
+    password           = "%[3]s"
+  }
+
+  auth_type   = "LOCAL_AD"
+  access_mode = "INTERNET"
+  vpc_id      = "%[4]s"
+  network_ids = ["%[5]s"]
+}
+
+data "huaweicloud_workspace_service" "test" {
+  depends_on = [
+    huaweicloud_workspace_service.test
+  ]
+}
+
+locals {
+  service_result = data.huaweicloud_workspace_service.test
+}
+
+output "is_service_id_set_and_valid" {
+  value = local.service_result.id == huaweicloud_workspace_service.test.id
+}
+
+output "is_ad_domain_set_and_valid" {
+  value = alltrue([
+    local.service_result.ad_domain[0].name == huaweicloud_workspace_service.test.ad_domain[0].name,
+    local.service_result.ad_domain[0].active_domain_name == huaweicloud_workspace_service.test.ad_domain[0].active_domain_name,
+    local.service_result.ad_domain[0].active_domain_ip == huaweicloud_workspace_service.test.ad_domain[0].active_domain_ip,
+    local.service_result.ad_domain[0].active_dns_ip == huaweicloud_workspace_service.test.ad_domain[0].active_dns_ip,
+    local.service_result.ad_domain[0].standby_domain_name == huaweicloud_workspace_service.test.ad_domain[0].standby_domain_name,
+    local.service_result.ad_domain[0].standby_domain_ip == huaweicloud_workspace_service.test.ad_domain[0].standby_domain_ip,
+    local.service_result.ad_domain[0].standby_dns_ip == huaweicloud_workspace_service.test.ad_domain[0].standby_dns_ip,
+    local.service_result.ad_domain[0].admin_account == huaweicloud_workspace_service.test.ad_domain[0].admin_account,
+  ])
+}
+
+output "is_auth_type_set_and_valid" {
+  value = local.service_result.auth_type == huaweicloud_workspace_service.test.auth_type
+}
+
+output "is_access_mode_set_and_valid" {
+  value = local.service_result.access_mode == huaweicloud_workspace_service.test.access_mode
+}
+
+output "is_vpc_id_set_and_valid" {
+  value = local.service_result.vpc_id == huaweicloud_workspace_service.test.vpc_id
+}
+
+output "is_network_ids_set_and_valid" {
+  value = alltrue([
+    length(local.service_result.network_ids) == 1,
+    local.service_result.network_ids[0] == huaweicloud_workspace_service.test.network_ids[0],
+  ])
+}
+`, acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES,
+		acceptance.HW_WORKSPACE_AD_DOMAIN_IPS,
+		acceptance.HW_WORKSPACE_AD_SERVER_PWD,
+		acceptance.HW_WORKSPACE_AD_VPC_ID,
+		acceptance.HW_WORKSPACE_AD_NETWORK_ID)
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_service.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_service.go
@@ -1,0 +1,442 @@
+package workspace
+
+import (
+	"context"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v2/{project_id}/workspaces
+// @API Workspace GET /v2/{project_id}/assist-auth-config/method-config
+// @API Workspace GET /v2/{project_id}/workspaces/lock-status
+func DataSourceService() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceServiceRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the environments are located.`,
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The VPC ID to which the service belongs.`,
+			},
+			"network_ids": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The network ID list of subnets that the service have.`,
+			},
+			"access_mode": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The access mode of Workspace service.`,
+			},
+			"auth_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The authentication type of Workspace service.`,
+			},
+			"ad_domain": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataServiceAdDomainSchema(),
+				Description: `The configuration of AD domain.`,
+			},
+			"enterprise_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The enterprise ID.`,
+			},
+			"internet_access_port": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The internet access port.`,
+			},
+			"internet_access_address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The internet access address.`,
+			},
+			"dedicated_subnets": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The subnet segments of the dedicated access.`,
+			},
+			"management_subnet_cidr": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The subnet segment of the management component.`,
+			},
+			"infrastructure_security_group": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataServiceSecurityGroupSchema(),
+				Description: `The management component security group automatically created under the specified VPC
+after service is registered.`,
+			},
+			"desktop_security_group": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataServiceSecurityGroupSchema(),
+				Description: `The desktop security group automatically created under the specified VPC after the service
+is registered.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current status of the Workspace service.`,
+			},
+			"otp_config_info": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataServiceAssistAuthSchema(),
+				Description: `The configuration of auxiliary authentication.`,
+			},
+			"is_locked": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Whether the service is locked.`,
+			},
+			"lock_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the service is locked.`,
+			},
+			"lock_reason": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the service is locked.`,
+			},
+		},
+	}
+}
+
+func dataServiceAdDomainSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The domain name.`,
+			},
+			"admin_account": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The domain administrator account.`,
+			},
+			"active_domain_ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The IP address of primary domain controller.`,
+			},
+			"active_domain_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the primary domain controller.`,
+			},
+			"active_dns_ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The primary DNS IP address.`,
+			},
+			"standby_domain_ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The IP address of standby domain controller.`,
+			},
+			"standby_domain_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the standby domain controller.`,
+			},
+			"standby_dns_ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The standby DNS IP address.`,
+			},
+			"delete_computer_object": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to delete the corresponding computer object on AD while deleting the desktop.`,
+			},
+		},
+	}
+}
+
+func dataServiceSecurityGroupSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The security group ID.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The security group name.`,
+			},
+		},
+	}
+}
+
+func dataServiceAssistAuthSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to enable auxiliary authentication.`,
+			},
+			"receive_mode": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The verification code receiving mode.`,
+			},
+			"auth_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The auxiliary authentication server address.`,
+			},
+			"app_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The auxiliary authentication server access account.`,
+			},
+			"app_secret": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The authentication service access password.`,
+			},
+			"auth_server_access_mode": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The authentication service access mode.`,
+			},
+			"cert_content": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The certificate content, in PEM format.`,
+			},
+			"rule_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The authentication application object type.`,
+			},
+			"rule": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The authentication application object.`,
+			},
+		},
+	}
+}
+
+func showService(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v2/{project_id}/workspaces"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func flattenDataServiceAdDomain(adDomain interface{}) []map[string]interface{} {
+	if adDomain == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"name":                   utils.PathSearch("domain_name", adDomain, nil),
+			"admin_account":          utils.PathSearch("domain_admin_account", adDomain, nil),
+			"active_domain_ip":       utils.PathSearch("active_domain_ip", adDomain, nil),
+			"active_domain_name":     utils.PathSearch("active_domain_name", adDomain, nil),
+			"active_dns_ip":          utils.PathSearch("active_dns_ip", adDomain, nil),
+			"standby_domain_ip":      utils.PathSearch("standby_domain_ip", adDomain, nil),
+			"standby_domain_name":    utils.PathSearch("standby_domain_name", adDomain, nil),
+			"standby_dns_ip":         utils.PathSearch("standby_dns_ip", adDomain, nil),
+			"delete_computer_object": parseIsDeleteObject(utils.PathSearch("delete_computer_object", adDomain, "").(string)),
+		},
+	}
+}
+
+func parseDataServiceInternetAccessPort(portStr string) int {
+	var (
+		portNum int
+		err     error
+	)
+	if portStr == "" {
+		return portNum
+	}
+
+	portNum, err = strconv.Atoi(portStr)
+	if err != nil {
+		log.Printf("[ERROR] error converting internet access port (value: %s) from string to integer: %s", portStr, err)
+	}
+	return portNum
+}
+
+func flattenDataServiceSecurityGroup(securityGroup interface{}) []map[string]interface{} {
+	if securityGroup == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"id":   utils.PathSearch("id", securityGroup, nil),
+			"name": utils.PathSearch("name", securityGroup, nil),
+		},
+	}
+}
+
+func showAssistAuthConfig(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v2/{project_id}/assist-auth-config/method-config"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func flattenDataServiceAssistAuthConfig(assistAuthConfig interface{}) []map[string]interface{} {
+	if assistAuthConfig == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"enable":                  utils.PathSearch("enable", assistAuthConfig, nil),
+			"receive_mode":            utils.PathSearch("receive_mode", assistAuthConfig, nil),
+			"auth_url":                utils.PathSearch("auth_url", assistAuthConfig, nil),
+			"app_id":                  utils.PathSearch("app_id", assistAuthConfig, nil),
+			"app_secret":              utils.PathSearch("app_secret", assistAuthConfig, nil),
+			"auth_server_access_mode": utils.PathSearch("auth_server_access_mode", assistAuthConfig, nil),
+			"cert_content":            utils.PathSearch("cert_content", assistAuthConfig, nil),
+			"rule":                    utils.PathSearch("apply_rule.rule", assistAuthConfig, nil),
+			"rule_type":               utils.PathSearch("apply_rule.rule_type", assistAuthConfig, nil),
+		},
+	}
+}
+
+func showServiceLockStatus(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v2/{project_id}/workspaces/lock-status"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func dataSourceServiceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	service, err := showService(client)
+	if err != nil {
+		return diag.Errorf("error querying service: %s", err)
+	}
+
+	if serviceId := utils.PathSearch("id", service, "").(string); serviceId != "" {
+		d.SetId(serviceId)
+	} else {
+		uuid, err := uuid.GenerateUUID()
+		if err != nil {
+			return diag.Errorf("unable to generate ID: %s", err)
+		}
+		d.SetId(uuid)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("vpc_id", utils.PathSearch("vpc_id", service, nil)),
+		d.Set("network_ids", utils.PathSearch("subnet_ids[*].subnet_id", service, make([]interface{}, 0))),
+		d.Set("access_mode", utils.PathSearch("access_mode", service, nil)),
+		d.Set("auth_type", utils.PathSearch("ad_domains.domain_type", service, nil)),
+		d.Set("ad_domain", flattenDataServiceAdDomain(utils.PathSearch("ad_domains", service, nil))),
+		d.Set("enterprise_id", utils.PathSearch("enterprise_id", service, nil)),
+		d.Set("internet_access_address", utils.PathSearch("internet_access_address", service, nil)),
+		d.Set("internet_access_port", parseDataServiceInternetAccessPort(utils.PathSearch("internet_access_port", service, "").(string))),
+		d.Set("dedicated_subnets", strings.Split(utils.PathSearch("dedicated_subnets", service, "").(string), ";")),
+		d.Set("management_subnet_cidr", utils.PathSearch("management_subnet_cidr", service, nil)),
+		d.Set("infrastructure_security_group", flattenDataServiceSecurityGroup(utils.PathSearch("infrastructure_security_group", service, nil))),
+		d.Set("desktop_security_group", flattenDataServiceSecurityGroup(utils.PathSearch("desktop_security_group", service, nil))),
+		d.Set("status", utils.PathSearch("status", service, nil)),
+	)
+
+	assistAuthConfig, err := showAssistAuthConfig(client)
+	if err != nil {
+		log.Printf("[ERROR] error querying assist auth configuration of the Workspace service: %s", err)
+	} else {
+		mErr = multierror.Append(mErr, d.Set("otp_config_info", flattenDataServiceAssistAuthConfig(assistAuthConfig)))
+	}
+
+	lockStatus, err := showServiceLockStatus(client)
+	if err != nil {
+		log.Printf("[ERROR] error querying assist auth configuration of the Workspace service: %s", err)
+	} else {
+		mErr = multierror.Append(mErr,
+			d.Set("is_locked", utils.PathSearch("is_locked", lockStatus, nil)),
+			d.Set("lock_time", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(
+				utils.PathSearch("lock_time", lockStatus, "").(string),
+				"2006-01-02 15:04:05",
+			)/1000, false)),
+			d.Set("lock_reason", utils.PathSearch("lock_reason", lockStatus, nil)),
+		)
+	}
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new data source that used to query the service configuration.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query service detail.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataSourceService_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataSourceService_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceService_basic
--- PASS: TestAccDataSourceService_basic (638.82s)
PASS
coverage: 6.5% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 638.875s        coverage: 6.5% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.
