### PR TITLE
fix(workspace): some attribute or status are missing corresponding checks

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -209,10 +209,14 @@ var (
 	HW_AAD_IP_ADDRESS  = os.Getenv("HW_AAD_IP_ADDRESS")
 
 	HW_WORKSPACE_AD_DOMAIN_NAMES = os.Getenv("HW_WORKSPACE_AD_DOMAIN_NAMES") // Domain name, e.g. "example.com".
-	HW_WORKSPACE_AD_SERVER_PWD   = os.Getenv("HW_WORKSPACE_AD_SERVER_PWD")   // The password of AD server.
-	HW_WORKSPACE_AD_DOMAIN_IPS   = os.Getenv("HW_WORKSPACE_AD_DOMAIN_IPS")   // Active domain IP, e.g. "192.168.196.3".
-	HW_WORKSPACE_AD_VPC_ID       = os.Getenv("HW_WORKSPACE_AD_VPC_ID")       // The VPC ID to which the AD server and desktops belongs.
-	HW_WORKSPACE_AD_NETWORK_ID   = os.Getenv("HW_WORKSPACE_AD_NETWORK_ID")   // The network ID to which the AD server belongs.
+	// Please make sure all AD servers (master and standby) have the same account configuration (with same name and password).
+	HW_WORKSPACE_AD_SERVER_ACCOUNT = os.Getenv("HW_WORKSPACE_AD_SERVER_ACCOUNT") // The admin user name of the AD servers.
+	HW_WORKSPACE_AD_SERVER_PWD     = os.Getenv("HW_WORKSPACE_AD_SERVER_PWD")     // The password of the admin user for the AD servers.
+	// The IP addresses of the AD servers.
+	// The format is '{master IP address},{standby IP address}' (with the standby AD server) or '{master IP address}'.
+	HW_WORKSPACE_AD_DOMAIN_IPS = os.Getenv("HW_WORKSPACE_AD_DOMAIN_IPS")
+	HW_WORKSPACE_AD_VPC_ID     = os.Getenv("HW_WORKSPACE_AD_VPC_ID")     // The VPC ID to which the AD servers and desktops belong.
+	HW_WORKSPACE_AD_NETWORK_ID = os.Getenv("HW_WORKSPACE_AD_NETWORK_ID") // The network ID to which the AD servers belong.
 	// The internet access port to which the Workspace service.
 	HW_WORKSPACE_INTERNET_ACCESS_PORT              = os.Getenv("HW_WORKSPACE_INTERNET_ACCESS_PORT")
 	HW_WORKSPACE_APP_SERVER_GROUP_ID               = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_ID")
@@ -1526,9 +1530,9 @@ func TestAccPreCheckWorkspaceAD(t *testing.T) {
 		t.Skip(`The Workspace AD service need IP address configurations for both master and standby servers, plesse config them in the
 HW_WORKSPACE_AD_DOMAIN_IPS environment variable, separated by a comma (,).`)
 	}
-	if HW_WORKSPACE_AD_SERVER_PWD == "" || HW_WORKSPACE_AD_VPC_ID == "" || HW_WORKSPACE_AD_NETWORK_ID == "" {
+	if HW_WORKSPACE_AD_SERVER_ACCOUNT == "" || HW_WORKSPACE_AD_SERVER_PWD == "" || HW_WORKSPACE_AD_VPC_ID == "" || HW_WORKSPACE_AD_NETWORK_ID == "" {
 		t.Skip(`The configuration of AD server is not completed for Workspace service acceptance test, please check your inputs for
-HW_WORKSPACE_AD_SERVER_PWD, HW_WORKSPACE_AD_VPC_ID and HW_WORKSPACE_AD_NETWORK_ID.`)
+HW_WORKSPACE_AD_SERVER_ACCOUNT, HW_WORKSPACE_AD_SERVER_PWD, HW_WORKSPACE_AD_VPC_ID and HW_WORKSPACE_AD_NETWORK_ID.`)
 	}
 }
 

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_service_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_service_test.go
@@ -227,7 +227,7 @@ func TestAccService_localAD(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "auth_type", "LOCAL_AD"),
 					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.name",
 						retrieveAdDomain(strings.Split(acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES, ","))),
-					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.admin_account", "Administrator"),
+					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.admin_account", acceptance.HW_WORKSPACE_AD_SERVER_ACCOUNT),
 					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.password", acceptance.HW_WORKSPACE_AD_SERVER_PWD),
 					resource.TestCheckResourceAttr(resourceName, "ad_domain.0.active_domain_name",
 						retrieveActiveDomainName(strings.Split(acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES, ","))),
@@ -411,21 +411,22 @@ func testAccService_localAD_step1() string {
 resource "huaweicloud_workspace_service" "test" {
   ad_domain {
     name               = try(element(regexall("\\w+\\.(.*)", element(split(",", "%[1]s"), 0))[0], 0), "")
-    admin_account      = "Administrator"
-    password           = "%[2]s"
     active_domain_name = element(split(",", "%[1]s"), 0)
-    active_domain_ip   = element(split(",", "%[3]s"), 0)
-    active_dns_ip      = element(split(",", "%[3]s"), 0)
+    active_domain_ip   = element(split(",", "%[2]s"), 0)
+    active_dns_ip      = element(split(",", "%[2]s"), 0)
+    admin_account      = "%[3]s"
+    password           = "%[4]s"
   }
 
   auth_type   = "LOCAL_AD"
   access_mode = "INTERNET"
-  vpc_id      = "%[4]s"
-  network_ids = ["%[5]s"]
+  vpc_id      = "%[5]s"
+  network_ids = ["%[6]s"]
 }
 `, acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES,
-		acceptance.HW_WORKSPACE_AD_SERVER_PWD,
 		acceptance.HW_WORKSPACE_AD_DOMAIN_IPS,
+		acceptance.HW_WORKSPACE_AD_SERVER_ACCOUNT,
+		acceptance.HW_WORKSPACE_AD_SERVER_PWD,
 		acceptance.HW_WORKSPACE_AD_VPC_ID,
 		acceptance.HW_WORKSPACE_AD_NETWORK_ID)
 }
@@ -435,20 +436,20 @@ func testAccService_localAD_step2() string {
 resource "huaweicloud_workspace_service" "test" {
   ad_domain {
     name                = try(element(regexall("\\w+\\.(.*)", element(split(",", "%[1]s"), 0))[0], 0), "")
-    admin_account       = "Administrator"
-    password            = "%[2]s"
     active_domain_name  = element(split(",", "%[1]s"), 0)
-    active_domain_ip    = element(split(",", "%[3]s"), 0)
-    active_dns_ip       = element(split(",", "%[3]s"), 0)
+    active_domain_ip    = element(split(",", "%[2]s"), 0)
+    active_dns_ip       = element(split(",", "%[2]s"), 0)
     standby_domain_name = element(split(",", "%[1]s"), 1)
-    standby_domain_ip   = element(split(",", "%[3]s"), 1)
-    standby_dns_ip      = element(split(",", "%[3]s"), 1)
+    standby_domain_ip   = element(split(",", "%[2]s"), 1)
+    standby_dns_ip      = element(split(",", "%[2]s"), 1)
+    admin_account       = "%[3]s"
+    password            = "%[4]s"
   }
 
   auth_type   = "LOCAL_AD"
   access_mode = "INTERNET"
-  vpc_id      = "%[4]s"
-  network_ids = ["%[5]s"]
+  vpc_id      = "%[5]s"
+  network_ids = ["%[6]s"]
 
   enterprise_id = "custom-workspace-service"
 
@@ -458,8 +459,9 @@ resource "huaweicloud_workspace_service" "test" {
   }
 }
 `, acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES,
-		acceptance.HW_WORKSPACE_AD_SERVER_PWD,
 		acceptance.HW_WORKSPACE_AD_DOMAIN_IPS,
+		acceptance.HW_WORKSPACE_AD_SERVER_ACCOUNT,
+		acceptance.HW_WORKSPACE_AD_SERVER_PWD,
 		acceptance.HW_WORKSPACE_AD_VPC_ID,
 		acceptance.HW_WORKSPACE_AD_NETWORK_ID)
 }
@@ -469,20 +471,20 @@ func testAccService_localAD_step3() string {
 resource "huaweicloud_workspace_service" "test" {
   ad_domain {
     name                = try(element(regexall("\\w+\\.(.*)", element(split(",", "%[1]s"), 0))[0], 0), "")
-    admin_account       = "Administrator"
-    password            = "%[2]s"
     active_domain_name  = element(split(",", "%[1]s"), 0)
-    active_domain_ip    = element(split(",", "%[3]s"), 0)
-    active_dns_ip       = element(split(",", "%[3]s"), 0)
+    active_domain_ip    = element(split(",", "%[2]s"), 0)
+    active_dns_ip       = element(split(",", "%[2]s"), 0)
     standby_domain_name = element(split(",", "%[1]s"), 1)
-    standby_domain_ip   = element(split(",", "%[3]s"), 1)
-    standby_dns_ip      = element(split(",", "%[3]s"), 1)
+    standby_domain_ip   = element(split(",", "%[2]s"), 1)
+    standby_dns_ip      = element(split(",", "%[2]s"), 1)
+    admin_account       = "%[3]s"
+    password            = "%[4]s"
   }
 
   auth_type   = "LOCAL_AD"
   access_mode = "INTERNET"
-  vpc_id      = "%[4]s"
-  network_ids = ["%[5]s"]
+  vpc_id      = "%[5]s"
+  network_ids = ["%[6]s"]
 
   enterprise_id = "custom-workspace-service"
 
@@ -494,8 +496,9 @@ resource "huaweicloud_workspace_service" "test" {
   }
 }
 `, acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES,
-		acceptance.HW_WORKSPACE_AD_SERVER_PWD,
 		acceptance.HW_WORKSPACE_AD_DOMAIN_IPS,
+		acceptance.HW_WORKSPACE_AD_SERVER_ACCOUNT,
+		acceptance.HW_WORKSPACE_AD_SERVER_PWD,
 		acceptance.HW_WORKSPACE_AD_VPC_ID,
 		acceptance.HW_WORKSPACE_AD_NETWORK_ID)
 }
@@ -523,24 +526,25 @@ func testAccService_localAD_internetAccessPort_update() string {
 resource "huaweicloud_workspace_service" "test" {
   ad_domain {
     name               = try(element(regexall("\\w+\\.(.*)", element(split(",", "%[1]s"), 0))[0], 0), "")
-    admin_account      = "Administrator"
-    password           = "%[2]s"
     active_domain_name = element(split(",", "%[1]s"), 0)
-    active_domain_ip   = element(split(",", "%[3]s"), 0)
-    active_dns_ip      = element(split(",", "%[3]s"), 0)
+    active_domain_ip   = element(split(",", "%[2]s"), 0)
+    active_dns_ip      = element(split(",", "%[2]s"), 0)
+    admin_account      = "%[3]s"
+    password           = "%[4]s"
   }
 
   auth_type   = "LOCAL_AD"
   access_mode = "INTERNET"
-  vpc_id      = "%[4]s"
-  network_ids = ["%[5]s"]
+  vpc_id      = "%[5]s"
+  network_ids = ["%[6]s"]
 
-  internet_access_port = "%[6]s"
+  internet_access_port = "%[7]s"
   enterprise_id        = "custom-workspace-service"
 }
 `, acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES,
-		acceptance.HW_WORKSPACE_AD_SERVER_PWD,
 		acceptance.HW_WORKSPACE_AD_DOMAIN_IPS,
+		acceptance.HW_WORKSPACE_AD_SERVER_ACCOUNT,
+		acceptance.HW_WORKSPACE_AD_SERVER_PWD,
 		acceptance.HW_WORKSPACE_AD_VPC_ID,
 		acceptance.HW_WORKSPACE_AD_NETWORK_ID,
 		acceptance.HW_WORKSPACE_INTERNET_ACCESS_PORT)

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_service.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_service.go
@@ -350,7 +350,7 @@ func refreshServiceStatusFunc(client *golangsdk.ServiceClient) resource.StateRef
 func waitForServiceCreateCompleted(ctx context.Context, client *golangsdk.ServiceClient, timeout time.Duration) (string,
 	error) {
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"SUBSCRIBING"},
+		Pending:      []string{"PREPARING", "SUBSCRIBING"},
 		Target:       []string{"SUBSCRIBED"},
 		Refresh:      refreshServiceStatusFunc(client),
 		Timeout:      timeout,

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_service.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_service.go
@@ -695,6 +695,34 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	return resourceServiceRead(ctx, d, meta)
 }
 
+func refreshServiceClosableStatusFunc(client *golangsdk.ServiceClient) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := services.Get(client)
+		if err != nil {
+			return resp, "ERROR", err
+		}
+
+		if !resp.Closable {
+			return resp, "PENDING", nil
+		}
+		return resp, "COMPLETE", nil
+	}
+}
+
+func waitForServiceClosableReady(ctx context.Context, client *golangsdk.ServiceClient, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETE"},
+		Refresh:      refreshServiceClosableStatusFunc(client),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
 func waitForServiceDeleteCompleted(ctx context.Context, client *golangsdk.ServiceClient, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"DEREGISTERING"},
@@ -714,6 +742,11 @@ func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, meta int
 	client, err := conf.WorkspaceV2Client(conf.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating Workspace v2 client: %s", err)
+	}
+
+	err = waitForServiceClosableReady(ctx, client, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return diag.Errorf("The current service is not allowed to be deleted (the value of the closable attribute is false): %s", err)
 	}
 
 	_, err = services.Delete(client)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The service resource have these issues:
- preparing status is missing while create service
- closable value should be checked before delete service
- according to the current AD servers configuration, there is no longer to use default admin user (Administrator) and use custom users instead.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supplement the preparing status to the create fresh check.
2. make sure the closable value being true before delete service.
3. supplement a new env to support the custom users definition.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.
