### PR TITLE
feat(live/hls_configuration): support Live HLS configuration resource

### DIFF
--- a/docs/resources/live_hls_configuration.md
+++ b/docs/resources/live_hls_configuration.md
@@ -1,0 +1,79 @@
+---
+subcategory: "Live"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_live_hls_configuration"
+description: |-
+  Manages a Live HLS configuration resource within HuaweiCloud.
+---
+
+# huaweicloud_live_hls_configuration
+
+Manages a Live HLS configuration resource within HuaweiCloud.
+
+-> This resource is an operational resource, and destroying it will not change the current HLS configuration.
+
+## Example Usage
+
+```hcl
+variable "domain_name" {}
+variable "app_name" {}
+
+resource "huaweicloud_live_hls_configuration" "test" {
+  domain_name = var.domain_name
+
+  application {
+    name          = var.app_name
+    hls_fragment  = 5
+    hls_ts_count  = 5
+    hls_min_frags = 5
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `domain_name` - (Required, String, ForceNew) Specifies the ingest domain name.
+  Changing this parameter will create a new resource.
+
+* `application` - (Required, List) Specifies app configuration of the ingest domain.
+
+  The [application](#hls_application) structure is documented below.
+
+<a name="hls_application"></a>
+The `application` block supports:
+
+* `name` - (Required, String, ForceNew) Specifies the application name.
+  Changing this parameter will create a new resource.
+
+* `hls_fragment` - (Required, Int) Specifies the HLS slice duration in seconds.
+
+* `hls_ts_count` - (Required, Int) Specifies the number of ts slices in each M3U8 file.
+
+* `hls_min_frags` - (Required, Int) Specifies the minimum number of ts shards in each M3U8 file.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 3 minutes.
+* `update` - Default is 3 minutes.
+
+## Import
+
+The resource can be imported using `domain_name`, e.g.
+
+```bash
+$ terraform import huaweicloud_live_hls_configuration.test <domain_name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1866,6 +1866,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_live_https_certificate":    live.ResourceHTTPSCertificate(),
 			"huaweicloud_live_geo_blocking":         live.ResourceGeoBlocking(),
 			"huaweicloud_live_ip_acl":               live.ResourceIpAcl(),
+			"huaweicloud_live_hls_configuration":    live.ResourceHlsConfiguration(),
 
 			"huaweicloud_lts_aom_access":                       lts.ResourceAOMAccess(),
 			"huaweicloud_lts_group":                            lts.ResourceLTSGroup(),

--- a/huaweicloud/services/acceptance/live/resource_huaweicloud_live_hls_configuration_test.go
+++ b/huaweicloud/services/acceptance/live/resource_huaweicloud_live_hls_configuration_test.go
@@ -1,0 +1,130 @@
+package live
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/live"
+)
+
+func getHlsConfigurationFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region     = acceptance.HW_REGION_NAME
+		domainName = state.Primary.Attributes["domain_name"]
+	)
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Live client: %s", err)
+	}
+
+	getRespBody, err := live.ReadHlsConfiguration(client, domainName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Live HLS configuration: %s", err)
+	}
+
+	return getRespBody, nil
+}
+
+func TestAccHlsConfiguration_basic(t *testing.T) {
+	var (
+		hlsConfigurationObj interface{}
+		rName               = "huaweicloud_live_hls_configuration.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&hlsConfigurationObj,
+		getHlsConfigurationFunc,
+	)
+
+	// Avoid CheckDestroy, because there is nothing in the resource destroy method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLiveIngestDomainName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHlsConfiguration_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "domain_name", acceptance.HW_LIVE_INGEST_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(rName, "application.#", "1"),
+					resource.TestCheckResourceAttr(rName, "application.0.name", "live"),
+					resource.TestCheckResourceAttr(rName, "application.0.hls_fragment", "5"),
+					resource.TestCheckResourceAttr(rName, "application.0.hls_ts_count", "5"),
+					resource.TestCheckResourceAttr(rName, "application.0.hls_min_frags", "5"),
+				),
+			},
+			{
+				Config: testAccHlsConfiguration_update(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "application.0.name", "live"),
+					resource.TestCheckResourceAttr(rName, "application.0.hls_fragment", "4"),
+					resource.TestCheckResourceAttr(rName, "application.0.hls_ts_count", "4"),
+					resource.TestCheckResourceAttr(rName, "application.0.hls_min_frags", "4"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateIdFunc: testAccHlsConfigurationImportState(rName),
+			},
+		},
+	})
+}
+
+func testAccHlsConfiguration_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_hls_configuration" "test" {
+  domain_name = "%s"
+
+  application {
+    name          = "live"
+    hls_fragment  = 5
+    hls_ts_count  = 5
+    hls_min_frags = 5
+  }
+}
+`, acceptance.HW_LIVE_INGEST_DOMAIN_NAME)
+}
+
+func testAccHlsConfiguration_update() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_hls_configuration" "test" {
+  domain_name = "%s"
+
+  application {
+    name          = "live"
+    hls_fragment  = 4
+    hls_ts_count  = 4
+    hls_min_frags = 4
+  }
+}
+`, acceptance.HW_LIVE_INGEST_DOMAIN_NAME)
+}
+
+func testAccHlsConfigurationImportState(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var domainName string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", rName)
+		}
+
+		domainName = rs.Primary.Attributes["domain_name"]
+		if domainName == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, `domain_name` is empty")
+		}
+		return domainName, nil
+	}
+}

--- a/huaweicloud/services/live/resource_huaweicloud_live_hls_configuration.go
+++ b/huaweicloud/services/live/resource_huaweicloud_live_hls_configuration.go
@@ -1,0 +1,308 @@
+package live
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Live PUT /v1/{project_id}/domain/hls
+// @API Live GET /v1/{project_id}/domain/hls
+func ResourceHlsConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHlsConfigurationCreate,
+		ReadContext:   resourceHlsConfigurationRead,
+		UpdateContext: resourceHlsConfigurationUpdate,
+		DeleteContext: resourceHlsConfigurationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceHlsConfigImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(3 * time.Minute),
+			Update: schema.DefaultTimeout(3 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"application": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"hls_fragment": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"hls_ts_count": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"hls_min_frags": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceHlsConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	err = updateHlsConfiguration(client, d)
+	if err != nil {
+		return diag.Errorf("error creating Live HLS configuration: %s", err)
+	}
+
+	// After successfully calling the update HLS configuration API,
+	// When calling the query API immediately, there may be a situation where the configuration has not been updated,
+	// So we need to add a waiting logic.
+	err = waitingForHlsConfigurationComplete(ctx, client, d, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for Live HLS configuration creation to complete: %s", err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	return resourceHlsConfigurationRead(ctx, d, meta)
+}
+
+func waitingForHlsConfigurationComplete(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			getRespBody, err := ReadHlsConfiguration(client, d.Get("domain_name").(string))
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			curJson := utils.PathSearch("application", getRespBody, make([]interface{}, 0))
+			curArray := curJson.([]interface{})
+			if len(curArray) == 0 {
+				return nil, "ERROR", fmt.Errorf("the application is not found in query API response")
+			}
+
+			// Check if the response of the query API matches the target value.
+			hlsFragmentResp := utils.PathSearch("hls_fragment", curArray[0], float64(0)).(float64)
+			hlsTsCountResp := utils.PathSearch("hls_ts_count", curArray[0], float64(0)).(float64)
+			hlsMinFragsResp := utils.PathSearch("hls_min_frags", curArray[0], float64(0)).(float64)
+			applicationRepMap := d.Get("application").([]interface{})[0].(map[string]interface{})
+			if int(hlsFragmentResp) == applicationRepMap["hls_fragment"].(int) &&
+				int(hlsTsCountResp) == applicationRepMap["hls_ts_count"].(int) &&
+				int(hlsMinFragsResp) == applicationRepMap["hls_min_frags"].(int) {
+				return getRespBody, "COMPLETED", nil
+			}
+
+			return getRespBody, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func updateHlsConfiguration(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	hlsConfigurationHttpUrl := "v1/{project_id}/domain/hls"
+	hlsConfigurationPath := client.Endpoint + hlsConfigurationHttpUrl
+	hlsConfigurationPath = strings.ReplaceAll(hlsConfigurationPath, "{project_id}", client.ProjectID)
+
+	hlsConfigurationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildHlsConfigurationBodyParams(d),
+	}
+
+	_, err := client.Request("PUT", hlsConfigurationPath, &hlsConfigurationOpt)
+	return err
+}
+
+func buildHlsConfigurationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	hlsConfigurationBodyParams := map[string]interface{}{
+		"push_domain": d.Get("domain_name"),
+		"application": buildHlsConfigurationApplicationBodyParams(d),
+	}
+
+	return hlsConfigurationBodyParams
+}
+
+func buildHlsConfigurationApplicationBodyParams(d *schema.ResourceData) []map[string]interface{} {
+	application := d.Get("application").([]interface{})
+	applicationBodyParams := make([]map[string]interface{}, 0)
+	for _, v := range application {
+		applicationMap := v.(map[string]interface{})
+		applicationBodyParam := map[string]interface{}{
+			"name":          applicationMap["name"],
+			"hls_fragment":  applicationMap["hls_fragment"],
+			"hls_ts_count":  applicationMap["hls_ts_count"],
+			"hls_min_frags": applicationMap["hls_min_frags"],
+		}
+		applicationBodyParams = append(applicationBodyParams, applicationBodyParam)
+	}
+
+	return applicationBodyParams
+}
+
+func ReadHlsConfiguration(client *golangsdk.ServiceClient, domainName string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/domain/hls"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?push_domain=%s", domainName)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceHlsConfigurationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		product = "live"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	getRespBody, err := ReadHlsConfiguration(client, d.Get("domain_name").(string))
+	// When the `domain_name` does not exist, calling the query API will return a `404` status code.
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving Live HLS configuration")
+	}
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("domain_name", utils.PathSearch("push_domain", getRespBody, nil)),
+		d.Set("application", flattenApplication(getRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenApplication(getRespBody interface{}) []interface{} {
+	if getRespBody == nil {
+		return nil
+	}
+
+	curJson := utils.PathSearch("application", getRespBody, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	if len(curArray) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0)
+	for _, v := range curArray {
+		result = append(result, map[string]interface{}{
+			"name":          utils.PathSearch("name", v, nil),
+			"hls_fragment":  utils.PathSearch("hls_fragment", v, nil),
+			"hls_ts_count":  utils.PathSearch("hls_ts_count", v, nil),
+			"hls_min_frags": utils.PathSearch("hls_min_frags", v, nil),
+		})
+	}
+
+	return result
+}
+
+func resourceHlsConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	err = updateHlsConfiguration(client, d)
+	if err != nil {
+		return diag.Errorf("error updating Live HLS configuration: %s", err)
+	}
+
+	err = waitingForHlsConfigurationComplete(ctx, client, d, d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return diag.Errorf("error waiting for Live HLS configuration update to complete: %s", err)
+	}
+
+	return resourceHlsConfigurationRead(ctx, d, meta)
+}
+
+func resourceHlsConfigurationDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceHlsConfigImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	if importedId == "" {
+		return nil, fmt.Errorf("invalid format specified for import ID, `domain_name` is empty")
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("domain_name", importedId),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support Live HLS configuration resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Support Live HLS configuration resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ export HW_LIVE_INGEST_DOMAIN_NAME=xxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/live" TESTARGS="-run TestAccHlsConfiguration_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/live -v -run TestAccHlsConfiguration_basic -timeout 360m -parallel 4
=== RUN   TestAccHlsConfiguration_basic
=== PAUSE TestAccHlsConfiguration_basic
=== CONT  TestAccHlsConfiguration_basic
--- PASS: TestAccHlsConfiguration_basic (27.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      27.771s

```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/2d4a21c2-7cb9-44cf-847a-e29d9f0a525f)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
