### PR TITLE
feat(cbr): vault supports new param cloud_type

### DIFF
--- a/docs/resources/cbr_vault.md
+++ b/docs/resources/cbr_vault.md
@@ -189,6 +189,9 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the CBR vault. If omitted, the
   provider-level region will be used. Changing this will create a new vault.
 
+* `cloud_type` - (Required, String, ForceNew) Specifies the cloud type of the vault.  
+  Changing this will create a new vault.
+
 * `name` - (Required, String) Specifies a unique name of the CBR vault. This parameter can contain a maximum of 64
   characters, which may consist of letters, digits, underscores(_) and hyphens (-).
 

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_test.go
@@ -42,6 +42,7 @@ func TestAccVault_backupServer(t *testing.T) {
 				Config: testAccVault_backupServer_step1(basicConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "cloud_type", "public"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeServer),
 					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
@@ -1039,10 +1040,8 @@ func TestAccVault_backupVMware(t *testing.T) {
 	var (
 		vault interface{}
 
-		resourceName  = "huaweicloud_cbr_vault.test"
-		resourceName1 = "huaweicloud_cbr_vault.test.0"
-		resourceName2 = "huaweicloud_cbr_vault.test.1"
-		name          = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_cbr_vault.test"
+		name         = acceptance.RandomAccResourceName()
 
 		rc = acceptance.InitResourceCheck(resourceName, &vault, getVaultResourceFunc)
 	)
@@ -1057,20 +1056,14 @@ func TestAccVault_backupVMware(t *testing.T) {
 			{
 				Config: testAccVault_backupVMware_step1(name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckMultiResourcesExists(2),
-					resource.TestCheckResourceAttr(resourceName1, "name", name+"_0"),
-					resource.TestCheckResourceAttr(resourceName1, "consistent_level", "app_consistent"),
-					resource.TestCheckResourceAttr(resourceName1, "type", cbr.VaultTypeVMware),
-					resource.TestCheckResourceAttr(resourceName1, "protection_type", "backup"),
-					resource.TestCheckResourceAttr(resourceName1, "size", "100"),
-					resource.TestCheckResourceAttr(resourceName1, "enterprise_project_id", "0"),
-
-					resource.TestCheckResourceAttr(resourceName2, "name", name+"_1"),
-					resource.TestCheckResourceAttr(resourceName2, "consistent_level", "crash_consistent"),
-					resource.TestCheckResourceAttr(resourceName2, "type", cbr.VaultTypeVMware),
-					resource.TestCheckResourceAttr(resourceName2, "protection_type", "backup"),
-					resource.TestCheckResourceAttr(resourceName2, "size", "200"),
-					resource.TestCheckResourceAttr(resourceName2, "enterprise_project_id", "0"),
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "cloud_type", "hybrid"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeVMware),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
 				),
 			},
 		},
@@ -1079,32 +1072,13 @@ func TestAccVault_backupVMware(t *testing.T) {
 
 func testAccVault_backupVMware_step1(name string) string {
 	return fmt.Sprintf(`
-variable "file_backup_configuration" {
-  type = list(object({
-    consistent_level = string
-    size             = number
-  }))
-
-  default = [
-    {
-      consistent_level = "app_consistent"
-      size             = 100
-    },
-    {
-      consistent_level = "crash_consistent"
-      size             = 200
-    }
-  ]
-}
-
 resource "huaweicloud_cbr_vault" "test" {
-  count = 2
-
-  name              = format("%[1]s_%%d", count.index)
-  type              = "vmware"
-  consistent_level  = var.file_backup_configuration[count.index]["consistent_level"]
-  protection_type   = "backup"
-  size              = var.file_backup_configuration[count.index]["size"]
+  cloud_type       = "hybrid"
+  name             = "%[1]s"
+  type             = "vmware"
+  consistent_level = "crash_consistent"
+  protection_type  = "backup"
+  size             = 100
 }
 `, name)
 }
@@ -1113,10 +1087,8 @@ func TestAccVault_backupFile(t *testing.T) {
 	var (
 		vault interface{}
 
-		resourceName  = "huaweicloud_cbr_vault.test"
-		resourceName1 = "huaweicloud_cbr_vault.test.0"
-		resourceName2 = "huaweicloud_cbr_vault.test.1"
-		name          = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_cbr_vault.test"
+		name         = acceptance.RandomAccResourceName()
 
 		rc = acceptance.InitResourceCheck(resourceName, &vault, getVaultResourceFunc)
 	)
@@ -1130,20 +1102,14 @@ func TestAccVault_backupFile(t *testing.T) {
 			{
 				Config: testAccVault_backupFile_step1(name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckMultiResourcesExists(2),
-					resource.TestCheckResourceAttr(resourceName1, "name", name+"_0"),
-					resource.TestCheckResourceAttr(resourceName1, "consistent_level", "app_consistent"),
-					resource.TestCheckResourceAttr(resourceName1, "type", cbr.VaultTypeFile),
-					resource.TestCheckResourceAttr(resourceName1, "protection_type", "backup"),
-					resource.TestCheckResourceAttr(resourceName1, "size", "100"),
-					resource.TestCheckResourceAttr(resourceName1, "enterprise_project_id", "0"),
-
-					resource.TestCheckResourceAttr(resourceName2, "name", name+"_1"),
-					resource.TestCheckResourceAttr(resourceName2, "consistent_level", "crash_consistent"),
-					resource.TestCheckResourceAttr(resourceName2, "type", cbr.VaultTypeFile),
-					resource.TestCheckResourceAttr(resourceName2, "protection_type", "backup"),
-					resource.TestCheckResourceAttr(resourceName2, "size", "200"),
-					resource.TestCheckResourceAttr(resourceName2, "enterprise_project_id", "0"),
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "cloud_type", "hybrid"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeFile),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
 				),
 			},
 		},
@@ -1152,32 +1118,13 @@ func TestAccVault_backupFile(t *testing.T) {
 
 func testAccVault_backupFile_step1(name string) string {
 	return fmt.Sprintf(`
-variable "file_backup_configuration" {
-  type = list(object({
-    consistent_level = string
-    size             = number
-  }))
-
-  default = [
-    {
-      consistent_level = "app_consistent"
-      size             = 100
-    },
-    {
-      consistent_level = "crash_consistent"
-      size             = 200
-    }
-  ]
-}
-
 resource "huaweicloud_cbr_vault" "test" {
-  count = 2
-
-  name              = format("%[1]s_%%d", count.index)
-  type              = "file"
-  consistent_level  = var.file_backup_configuration[count.index]["consistent_level"]
-  protection_type   = "backup"
-  size              = var.file_backup_configuration[count.index]["size"]
+  cloud_type       = "hybrid"
+  name             = "%[1]s"
+  type             = "file"
+  consistent_level = "crash_consistent"
+  protection_type  = "backup"
+  size             = 100
 }
 `, name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new parameter cloud_type for the CBR vault resource.
The VMware and file object types are only hybrid cloud type of the vault supported.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new parameter support: cloud_type.
2. adjust the acceptance scripts for the VMware and file object type.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cbr -f TestAccVault
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccVault -timeout 360m -parallel 10
=== RUN   TestAccVault_backupServer
=== PAUSE TestAccVault_backupServer
=== RUN   TestAccVault_replicationServer
=== PAUSE TestAccVault_replicationServer
=== RUN   TestAccVault_prePaidServer
=== PAUSE TestAccVault_prePaidServer
=== RUN   TestAccVault_volume
=== PAUSE TestAccVault_volume
=== RUN   TestAccVault_backupTurbo
=== PAUSE TestAccVault_backupTurbo
=== RUN   TestAccVault_replicationTurbo
=== PAUSE TestAccVault_replicationTurbo
=== RUN   TestAccVault_AutoBind
=== PAUSE TestAccVault_AutoBind
=== RUN   TestAccVault_bindPolicies
=== PAUSE TestAccVault_bindPolicies
=== RUN   TestAccVault_backupWorkspace
=== PAUSE TestAccVault_backupWorkspace
=== RUN   TestAccVault_backupVMware
=== PAUSE TestAccVault_backupVMware
=== RUN   TestAccVault_backupFile
=== PAUSE TestAccVault_backupFile
=== RUN   TestAccVault_withEpsId
=== PAUSE TestAccVault_withEpsId
=== CONT  TestAccVault_backupServer
=== CONT  TestAccVault_withEpsId
=== CONT  TestAccVault_AutoBind
=== CONT  TestAccVault_backupFile
=== CONT  TestAccVault_backupWorkspace
=== CONT  TestAccVault_backupVMware
=== CONT  TestAccVault_volume
=== CONT  TestAccVault_replicationTurbo
=== CONT  TestAccVault_backupTurbo
=== CONT  TestAccVault_prePaidServer
--- PASS: TestAccVault_backupVMware (68.84s)
=== CONT  TestAccVault_bindPolicies
--- PASS: TestAccVault_backupFile (72.89s)
=== CONT  TestAccVault_replicationServer
--- PASS: TestAccVault_replicationTurbo (77.08s)
--- PASS: TestAccVault_AutoBind (104.88s)
--- PASS: TestAccVault_replicationServer (38.74s)
--- PASS: TestAccVault_bindPolicies (66.98s)
--- PASS: TestAccVault_withEpsId (399.25s)
--- PASS: TestAccVault_backupServer (402.97s)
--- PASS: TestAccVault_prePaidServer (506.98s)
--- PASS: TestAccVault_backupWorkspace (1164.84s)
--- PASS: TestAccVault_volume (1571.09s)
--- PASS: TestAccVault_backupTurbo (1609.64s)
PASS
coverage: 43.6% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       1609.690s       coverage: 43.6% of statements in ./huaweicloud/services/cbr
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.
