### PR TITLE
chore(fgs): upgrade the parameters description and import validation

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -264,6 +264,10 @@ The following arguments are supported:
 * `app_agency` - (Optional, String) Specifies the execution agency enables you to obtain a token or an AK/SK for
   accessing other cloud services.
 
+  -> After using this parameter, the function execution agency (`app_agency`) and the function configuration
+     agency (`agency`) can be independently set, which can reduce unnecessary performance loss. Otherwise, the same
+     agency is used for both function execution and function configuration.
+
 * `description` - (Optional, String) Specifies the description of the function.
 
 * `initializer_handler` - (Optional, String) Specifies the initializer of the function.
@@ -327,7 +331,8 @@ The following arguments are supported:
 * `concurrency_num` - (Optional, Int) Specifies the number of concurrent requests of the function.
   The valid value ranges from `1` to `1,000`, the default value is `1`.
   
-  -> This parameter is only supported by the `v2` version of the function.
+  -> 1. This parameter is only supported by the `v2` version of the function.
+     <br>2. This parameter is available only when the `runtime` parameter is set to **http** or **Custom Image**.
 
 * `gpu_memory` - (Optional, Int) Specifies the GPU memory size allocated to the function, in MByte (MB).
   The valid value ranges form `1,024` to `16,384`, the value must be a multiple of `1,024`.

--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -492,8 +492,7 @@ $ terraform import huaweicloud_fgs_function.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to the attribute missing from the
-API response. The missing attributes are:
-`app`, `func_code`, `agency`, `tags"`, `package`.
+API response. The missing attributes are: `app`, `func_code`, `tags`.
 It is generally recommended running `terraform plan` after importing a function.
 You can then decide if changes should be applied to the function, or the resource definition should be updated to align
 with the function. Also you can ignore changes as below.
@@ -503,7 +502,7 @@ resource "huaweicloud_fgs_function" "test" {
   ...
   lifecycle {
     ignore_changes = [
-      app, func_code, agency, tags, package,
+      app, func_code, tags,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -83,11 +83,7 @@ func TestAccFgsV2Function_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"app",
-					"package",
 					"func_code",
-					"xrole",
-					"agency",
 					"tags",
 				},
 			},
@@ -127,8 +123,6 @@ func TestAccFgsV2Function_withEpsId(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"app",
-					"package",
 					"func_code",
 				},
 			},
@@ -163,8 +157,6 @@ func TestAccFgsV2Function_text(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"app",
-					"package",
 					"func_code",
 				},
 			},
@@ -245,23 +237,11 @@ func TestAccFgsV2Function_createByImage(t *testing.T) {
 				ResourceName:      rName1,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"app",
-					"package",
-					"xrole",
-					"agency",
-				},
 			},
 			{
 				ResourceName:      rName2,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"app",
-					"package",
-					"xrole",
-					"agency",
-				},
 			},
 		},
 	})
@@ -615,8 +595,6 @@ func TestAccFgsV2Function_strategy(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"app",
-					"package",
 					"func_code",
 				},
 			},
@@ -702,8 +680,6 @@ func TestAccFgsV2Function_versions(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"app",
-					"package",
 					"func_code",
 				},
 			},
@@ -819,10 +795,6 @@ func TestAccFgsV2Function_domain(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"xrole",
-					"agency",
-					"app",
-					"package",
 					"func_code",
 				},
 			},
@@ -1018,8 +990,6 @@ func TestAccFgsV2Function_reservedInstance_version(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"app",
-					"package",
 					"func_code",
 					"tags",
 				},
@@ -1070,8 +1040,6 @@ func TestAccFgsV2Function_reservedInstance_alias(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"app",
-					"package",
 					"func_code",
 					"tags",
 				},
@@ -1199,8 +1167,6 @@ func TestAccFgsV2Function_concurrencyNum(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"app",
-					"package",
 					"func_code",
 				},
 			},
@@ -1277,8 +1243,6 @@ func TestAccFgsV2Function_gpuMemory(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"app",
-					"package",
 					"func_code",
 				},
 			},

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -205,6 +205,7 @@ func TestAccFgsV2Function_createByImage(t *testing.T) {
 					resource.TestCheckResourceAttr(rName1, "custom_image.0.command", "/bin/sh"),
 					resource.TestCheckResourceAttr(rName1, "custom_image.0.args", "-args,value"),
 					resource.TestCheckResourceAttr(rName1, "custom_image.0.working_dir", "/"),
+					resource.TestCheckResourceAttr(rName1, "concurrency_num", "1"),
 					rc2.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName2, "name", randName+"_2"),
 					resource.TestCheckResourceAttr(rName2, "agency", "functiongraph_swr_trust"),
@@ -226,6 +227,7 @@ func TestAccFgsV2Function_createByImage(t *testing.T) {
 					resource.TestCheckResourceAttr(rName1, "custom_image.0.command", ""),
 					resource.TestCheckResourceAttr(rName1, "custom_image.0.args", ""),
 					resource.TestCheckResourceAttr(rName1, "custom_image.0.working_dir", "/"),
+					resource.TestCheckResourceAttr(rName1, "concurrency_num", "1000"),
 					rc2.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName2, "handler", "-"),
 					resource.TestCheckResourceAttrPair(rName2, "vpc_id", "huaweicloud_vpc.test", "id"),
@@ -372,7 +374,7 @@ resource "huaweicloud_fgs_function" "test" {
     newkey = "value"
   }
 }
-`, common.TestBaseNetwork(rName), rName)
+`, common.TestVpc(rName), rName)
 }
 
 func testAccFgsV2Function_basic_step3(rName, obsConfig string) string {
@@ -407,7 +409,7 @@ resource "huaweicloud_fgs_function" "test" {
     newkey = "value"
   }
 }
-`, common.TestBaseNetwork(rName), obsConfig, rName)
+`, common.TestVpc(rName), obsConfig, rName)
 }
 
 func testAccFgsV2Function_text(rName string) string {
@@ -462,13 +464,14 @@ func testAccFgsV2Function_createByImage_step_1(rName string) string {
 %[1]s
 
 resource "huaweicloud_fgs_function" "create_with_vpc_access" {
-  name        = "%[2]s_1"
-  app         = "default"
-  handler     = "-"
-  memory_size = 128
-  runtime     = "Custom Image"
-  timeout     = 3
-  agency      = "functiongraph_swr_trust"
+  name                  = "%[2]s_1"
+  app                   = "default"
+  handler               = "-"
+  functiongraph_version = "v2"
+  memory_size           = 128
+  runtime               = "Custom Image"
+  timeout               = 3
+  agency                = "functiongraph_swr_trust"
 
   custom_image {
     url         = "%[3]s"
@@ -494,7 +497,7 @@ resource "huaweicloud_fgs_function" "create_without_vpc_access" {
     url = "%[3]s"
   }
 }
-`, common.TestBaseNetwork(rName), rName, acceptance.HW_BUILD_IMAGE_URL)
+`, common.TestVpc(rName), rName, acceptance.HW_BUILD_IMAGE_URL)
 }
 
 func testAccFgsV2Function_createByImage_step_2(rName string) string {
@@ -503,17 +506,20 @@ func testAccFgsV2Function_createByImage_step_2(rName string) string {
 
 # Closs the VPC access
 resource "huaweicloud_fgs_function" "create_with_vpc_access" {
-  name        = "%[2]s_1"
-  app         = "default"
-  handler     = "-"
-  memory_size = 128
-  runtime     = "Custom Image"
-  timeout     = 3
-  agency      = "functiongraph_swr_trust"
+  name                  = "%[2]s_1"
+  app                   = "default"
+  handler               = "-"
+  functiongraph_version = "v2"
+  memory_size           = 128
+  runtime               = "Custom Image"
+  timeout               = 3
+  agency                = "functiongraph_swr_trust"
 
   custom_image {
     url = "%[3]s"
   }
+
+  concurrency_num = 1000
 }
 
 # Open the VPC access
@@ -533,7 +539,7 @@ resource "huaweicloud_fgs_function" "create_without_vpc_access" {
   vpc_id     = huaweicloud_vpc.test.id
   network_id = huaweicloud_vpc_subnet.test.id
 }
-`, common.TestBaseNetwork(rName), rName, acceptance.HW_BUILD_IMAGE_URL_UPDATED)
+`, common.TestVpc(rName), rName, acceptance.HW_BUILD_IMAGE_URL_UPDATED)
 }
 
 func TestAccFgsV2Function_strategy(t *testing.T) {
@@ -816,7 +822,7 @@ resource "huaweicloud_dns_zone" "test" {
     router_id = huaweicloud_vpc.test.id
   }
 }
-`, common.TestBaseNetwork(name))
+`, common.TestVpc(name))
 }
 
 func testAccFunction_domain_step1(name string) string {
@@ -882,15 +888,16 @@ resource "huaweicloud_lts_stream" "test" {
 }
 
 resource "huaweicloud_fgs_function" "test" {
-  name        = "%[1]s"
-  app         = "default"
-  description = "fuction test"
-  handler     = "index.handler"
-  memory_size = 128
-  timeout     = 3
-  runtime     = "Python2.7"
-  code_type   = "inline"
-  func_code   = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+  name                  = "%[1]s"
+  app                   = "default"
+  description           = "fuction test"
+  handler               = "index.handler"
+  functiongraph_version = "v1"
+  memory_size           = 128
+  timeout               = 3
+  runtime               = "Python2.7"
+  code_type             = "inline"
+  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
 
   log_group_id    = huaweicloud_lts_group.test.id
   log_stream_id   = huaweicloud_lts_stream.test.id
@@ -923,15 +930,16 @@ resource "huaweicloud_lts_stream" "test1" {
 }
 
 resource "huaweicloud_fgs_function" "test" {
-  name        = "%[1]s"
-  app         = "default"
-  description = "fuction test"
-  handler     = "index.handler"
-  memory_size = 128
-  timeout     = 3
-  runtime     = "Python2.7"
-  code_type   = "inline"
-  func_code   = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+  name                  = "%[1]s"
+  app                   = "default"
+  description           = "fuction test"
+  handler               = "index.handler"
+  functiongraph_version = "v1"
+  memory_size           = 128
+  timeout               = 3
+  runtime               = "Python2.7"
+  code_type             = "inline"
+  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
 
   log_group_id    = huaweicloud_lts_group.test1.id
   log_stream_id   = huaweicloud_lts_stream.test1.id
@@ -1127,68 +1135,6 @@ resource "huaweicloud_fgs_function" "test" {
   }
 }
 `, rName, aliasName)
-}
-
-func TestAccFgsV2Function_concurrencyNum(t *testing.T) {
-	var (
-		f function.Function
-
-		name         = acceptance.RandomAccResourceName()
-		resourceName = "huaweicloud_fgs_function.test"
-	)
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&f,
-		getResourceObj,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFunction_strategy_default(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "concurrency_num", "1"),
-				),
-			},
-			{
-				Config: testAccFunction_concurrencyNum(name, 1000),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "concurrency_num", "1000"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"func_code",
-				},
-			},
-		},
-	})
-}
-
-func testAccFunction_concurrencyNum(name string, concurrencyNum int) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_fgs_function" "test" {
-  functiongraph_version = "v2"
-  name                  = "%[1]s"
-  app                   = "default"
-  handler               = "index.handler"
-  memory_size           = 128
-  timeout               = 3
-  runtime               = "Python2.7"
-  code_type             = "inline"
-  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
-  concurrency_num       = %[2]d
-}
-`, name, concurrencyNum)
 }
 
 func TestAccFgsV2Function_gpuMemory(t *testing.T) {

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -665,17 +665,17 @@ func createFunctionVersions(client *golangsdk.ServiceClient, functionUrn string,
 }
 
 func setFgsFunctionApp(d *schema.ResourceData, app string) error {
-	if _, ok := d.GetOk("app"); ok {
-		return d.Set("app", app)
+	if _, ok := d.GetOk("package"); ok {
+		return d.Set("package", app)
 	}
-	return d.Set("package", app)
+	return d.Set("app", app)
 }
 
 func setFgsFunctionAgency(d *schema.ResourceData, agency string) error {
-	if _, ok := d.GetOk("agency"); ok {
-		return d.Set("agency", agency)
+	if _, ok := d.GetOk("xrole"); ok {
+		return d.Set("xrole", agency)
 	}
-	return d.Set("xrole", agency)
+	return d.Set("agency", agency)
 }
 
 func setFgsFunctionVpcAccess(d *schema.ResourceData, funcVpc function.FuncVpc) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Add note for `app_agency` and `concurrency_num` parameters of the `huaweicloud_fgs_function` resource.
2. Remove `package` and `xrole` parameters from **ignore_changes**.
3. Adjust scceptance test.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add note for app_agency and concurrency_num parameters of the huaweicloud_fgs_function resource.
2. remove package and xrole parameters from ignore_changes.
3. adjust scceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o fgs -f TestAccFgsV2Function_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFgsV2Function_ -timeout 360m -parallel 10
=== RUN   TestAccFgsV2Function_basic
=== PAUSE TestAccFgsV2Function_basic
=== RUN   TestAccFgsV2Function_withEpsId
=== PAUSE TestAccFgsV2Function_withEpsId
=== RUN   TestAccFgsV2Function_text
=== PAUSE TestAccFgsV2Function_text
=== RUN   TestAccFgsV2Function_createByImage
=== PAUSE TestAccFgsV2Function_createByImage
=== RUN   TestAccFgsV2Function_logConfig
=== PAUSE TestAccFgsV2Function_logConfig
=== RUN   TestAccFgsV2Function_strategy
=== PAUSE TestAccFgsV2Function_strategy
=== RUN   TestAccFgsV2Function_versions
=== PAUSE TestAccFgsV2Function_versions
=== RUN   TestAccFgsV2Function_domain
=== PAUSE TestAccFgsV2Function_domain
=== RUN   TestAccFgsV2Function_reservedInstance_version
=== PAUSE TestAccFgsV2Function_reservedInstance_version
=== RUN   TestAccFgsV2Function_reservedInstance_alias
=== PAUSE TestAccFgsV2Function_reservedInstance_alias
=== RUN   TestAccFgsV2Function_gpuMemory
=== PAUSE TestAccFgsV2Function_gpuMemory
=== CONT  TestAccFgsV2Function_basic
=== CONT  TestAccFgsV2Function_versions
=== CONT  TestAccFgsV2Function_createByImage
=== CONT  TestAccFgsV2Function_text
=== CONT  TestAccFgsV2Function_withEpsId
=== CONT  TestAccFgsV2Function_strategy
=== CONT  TestAccFgsV2Function_gpuMemory
=== CONT  TestAccFgsV2Function_reservedInstance_version
=== CONT  TestAccFgsV2Function_domain
=== CONT  TestAccFgsV2Function_logConfig
=== CONT  TestAccFgsV2Function_gpuMemory
    acceptance.go:804: HW_FGS_GPU_TYPE must be set for FGS acceptance tests
--- SKIP: TestAccFgsV2Function_gpuMemory (0.09s)
=== CONT  TestAccFgsV2Function_reservedInstance_alias
--- PASS: TestAccFgsV2Function_text (175.06s)
--- PASS: TestAccFgsV2Function_withEpsId (185.15s)
--- PASS: TestAccFgsV2Function_reservedInstance_alias (434.71s)
--- PASS: TestAccFgsV2Function_reservedInstance_version (444.76s)
--- PASS: TestAccFgsV2Function_versions (641.51s)
--- PASS: TestAccFgsV2Function_strategy (1103.71s)
--- PASS: TestAccFgsV2Function_createByImage (1265.35s)
--- PASS: TestAccFgsV2Function_logConfig (1306.55s)
--- PASS: TestAccFgsV2Function_domain (1342.61s)
--- PASS: TestAccFgsV2Function_basic (1451.25s)
PASS
coverage: 29.5% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       1451.341s       coverage: 29.5% of statements in ./huaweicloud/services/fgs```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
