### PR TITLE
chore(EVS): improve the robustness of resource code

### DIFF
--- a/docs/resources/evs_volume.md
+++ b/docs/resources/evs_volume.md
@@ -2,7 +2,8 @@
 subcategory: "Elastic Volume Service (EVS)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_evs_volume"
-description: ""
+description: |-
+  Manages a volume resource within HuaweiCloud.
 ---
 
 # huaweicloud_evs_volume
@@ -12,12 +13,14 @@ Manages a volume resource within HuaweiCloud.
 ## Example Usage
 
 ```hcl
+variable "availability_zone" {}
+
 resource "huaweicloud_evs_volume" "volume" {
   name              = "volume"
   description       = "my volume"
   volume_type       = "SAS"
   size              = 20
-  availability_zone = "cn-north-4a"
+  availability_zone = var.availability_zone
 
   tags = {
     foo = "bar"
@@ -29,13 +32,15 @@ resource "huaweicloud_evs_volume" "volume" {
 ## Example Usage with KMS encryption
 
 ```hcl
+variable "availability_zone" {}
+
 resource "huaweicloud_evs_volume" "volume" {
   name              = "volume"
   description       = "my volume"
   volume_type       = "SAS"
   size              = 20
   kms_id            = var.kms_id
-  availability_zone = "cn-north-4a"
+  availability_zone = var.availability_zone
 
   tags = {
     foo = "bar"
@@ -47,19 +52,23 @@ resource "huaweicloud_evs_volume" "volume" {
 ## Example Usage with server_id
 
 ```hcl
+variable "image_id" {}
+variable "flavor_id" {}
+variable "key_pair" {}
 variable "security_group_id" {}
 variable "availability_zone" {}
+variable "subnet_id" {}
 
 resource "huaweicloud_compute_instance" "myinstance" {
   name               = "instance"
-  image_id           = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id          = "s6.small.1"
-  key_pair           = "my_key_pair_name"
+  image_id           = var.image_id
+  flavor_id          = var.flavor_id
+  key_pair           = var.key_pair
   security_group_ids = [var.security_group_id]
   availability_zone  = var.availability_zone
 
   network {
-    uuid = "55534eaa-533a-419d-9b40-ec427ea7195a"
+    uuid = var.subnet_id
   }
 }
 
@@ -83,12 +92,13 @@ resource "huaweicloud_evs_volume" "volume" {
 The following arguments are supported:
 
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the disk. If omitted, the
-  provider-level region will be used. Changing this creates a new disk.
+  provider-level region will be used. Changing this parameter will create a new resource.
 
-* `availability_zone` - (Required, String, ForceNew) Specifies the availability zone for the disk. Changing this creates
-  a new disk.
+* `availability_zone` - (Required, String, ForceNew) Specifies the availability zone for the disk.
 
-* `volume_type` - (Required, String, ForceNew) Specifies the disk type. Changing this creates a new disk.
+  Changing this parameter will create a new resource.
+
+* `volume_type` - (Required, String, ForceNew) Specifies the disk type. Changing this parameter will create a new resource.
   Valid values are as follows:
   + **SAS**: High I/O type.
   + **SSD**: Ultra-high I/O type.
@@ -97,106 +107,129 @@ The following arguments are supported:
   + **GPSSD2**: General purpose SSD V2 type.
   + **ESSD2**: Extreme SSD V2 type.
 
-  -> If the specified disk type is not available in the AZ, the disk will fail to create.
-  The volume type **ESSD2** only support in postpaid charging mode.
+  If the specified disk type is not available in the AZ, the disk will fail to create. The volume type **ESSD2** only
+  support in postpaid charging mode. When creating a cloud disk from a snapshot, the `volume_type` field must be
+  consistent with the snapshot source cloud disk.
 
 * `iops` - (Optional, Int) Specifies the IOPS(Input/Output Operations Per Second) for the volume.
   The field is valid and required when `volume_type` is set to **GPSSD2** or **ESSD2**.
-
-  + If `volume_type` is set to **GPSSD2**. The field `iops` ranging from 3,000 to 128,000.
-    This IOPS must also be less than or equal to 500 multiplying the capacity.
-
-  + If `volume_type` is set to **ESSD2**. The field `iops` ranging from 100 to 256,000.
-    This IOPS must also be less than or equal to 1000 multiplying the capacity.
+  This field can be changed only when the disk status is Available or In-use.
 
 * `throughput` - (Optional, Int) Specifies the throughput for the volume. The Unit is MiB/s.
   The field is valid and required when `volume_type` is set to **GPSSD2**.
+  This field can be changed only when the disk status is Available or In-use.
 
-  + If `volume_type` is set to **GPSSD2**. The field `throughput` ranging from 125 to 1,000.
-    This throughput must also be less than or equal to the IOPS divided by 4.
+-> Before configuring the parameters `volume_type`, `iops`, and `throughput`, please refer to
+[Disk Types and Performance](https://support.huaweicloud.com/intl/en-us/productdesc-evs/en-us_topic_0014580744.html).
 
-* `name` - (Optional, String) Specifies the disk name. The value can contain a maximum of 255 bytes.
+* `name` - (Optional, String) Specifies the disk name. You can enter up to `64` characters.
 
-* `size` - (Optional, Int) Specifies the disk size, in GB. The valid value is range from:
-  + System disk: 1 GB to 1024 GB
-  + Data disk: 10 GB to 32768 GB
+* `size` - (Optional, Int) Specifies the disk size, in GB.
+  For system disk, the valid value ranges from `1` GB to `1,024` GB.
+  For data disk, the valid value ranges from `10` GB to `32,768` GB.
 
-  This parameter is required when:
-  + Create an empty disk.
-  + Create the disk from a snapshot. The disk size must be greater than or equal to the snapshot size.
-  + Create the disk from an image. The disk size must be greater than or equal to the minimum disk capacity required by
-  min_disk in the image attributes.
-
-  This parameter is optional when you create the disk from a backup. If this parameter is not specified, the
+  -> There are the following restrictions for configuring this field:
+  <br/>1. This parameter is required when creating an empty disk.
+  <br/>2. This parameter is required when creating a disk from a snapshot. The disk size must be greater than or equal
+  to the snapshot size.
+  <br/>3. This parameter is required when creating a disk from an image. The disk size must be greater than or equal to
+  the minimum disk capacity required by min_disk in the image attributes.
+  <br/>4. This parameter is optional when you create the disk from a backup. If this parameter is not specified, the
   disk size is equal to the backup size.
 
-  -> **NOTE:** Shrinking the disk is not supported.
+  -> Editing this field has the following restrictions:
+  <br/>1. Shrinking the disk is not supported.
+  <br/>2. If the status of the to-be-expanded disk is **available**, there are no restrictions.
+  <br/>3. If the status of the to-be-expanded disk is **in-use**, a shared disk cannot be expanded, which means that
+  the value of `multiattach` must be **false**.
+  <br/>4. If the status of the to-be-expanded disk is **in-use**, the status of the server to which the disk attached
+  must be **ACTIVE**, **PAUSED**, **SUSPENDED**, or **SHUTOFF**.
+  <br/>5. Please refer to [Notes and Constraints](https://support.huaweicloud.com/intl/en-us/productdesc-evs/evs_01_0085.html)
+  to view the limitations of disk capacity expansion.
 
-* `description` - (Optional, String) Specifies the disk description. The value can contain a maximum of 255 bytes.
+* `description` - (Optional, String) Specifies the disk description. You can enter up to `85` characters.
 
-* `image_id` - (Optional, String, ForceNew) Specifies the image ID from which to create the disk. Changing this creates
-  a new disk.
+* `image_id` - (Optional, String, ForceNew) Specifies the image ID from which to create the disk.
 
-* `backup_id` - (Optional, String, ForceNew) Specifies the backup ID from which to create the disk. Changing this
-  creates a new disk.
+  Changing this parameter will create a new resource.
 
-* `snapshot_id` - (Optional, String, ForceNew) Specifies the snapshot ID from which to create the disk. Changing this
-  creates a new disk.
+* `backup_id` - (Optional, String, ForceNew) Specifies the backup ID from which to create the disk.
+
+  Changing this parameter will create a new resource.
+
+* `snapshot_id` - (Optional, String, ForceNew) Specifies the snapshot ID from which to create the disk.
+
+  Changing this parameter will create a new resource.
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the disk.
 
-* `multiattach` - (Optional, Bool, ForceNew) Specifies whether the disk is shareable. The default value is false.
-  Changing this creates a new disk.
+* `multiattach` - (Optional, Bool, ForceNew) Specifies whether the disk is shareable. Defaults to **false**.
 
-* `kms_id` - (Optional, String, ForceNew) Specifies the Encryption KMS ID to create the disk. Changing this creates a
-  new disk.
+  Changing this parameter will create a new resource.
 
-* `device_type` - (Optional, String, ForceNew) Specifies the device type of disk to create. Valid options are VBD and
-  SCSI. Defaults to VBD. Changing this creates a new disk.
+* `kms_id` - (Optional, String, ForceNew) Specifies the Encryption KMS ID to create the disk.
+
+  Changing this parameter will create a new resource.
+
+* `device_type` - (Optional, String, ForceNew) Specifies the device type of disk to create. Valid options are **VBD** and
+  **SCSI**. Defaults to **VBD**.
+
+  Changing this parameter will create a new resource.
 
 * `dedicated_storage_id` - (Optional, String, ForceNew) Specifies the ID of the DSS storage pool accommodating the disk.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the disk. Changing this
-  creates a new disk.
+  Changing this parameter will create a new resource.
 
-* `cascade` - (Optional, Bool) Specifies the delete mode of snapshot. The default value is false. All snapshot
-  associated with the disk will also be deleted when the parameter is set to true.
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of the disk.
+  For enterprise users, if omitted, default enterprise project will be used.
+
+  Changing this parameter will create a new resource.
+
+* `cascade` - (Optional, Bool) Specifies the delete mode of snapshot. The default value is **false**. All snapshot
+  associated with the disk will also be deleted when the parameter is set to **true**.
 
   -> This parameter is only valid for pay-as-you-go resources, and the snapshots bound to the package period resources
-     will be removed while resources unsubscribed.
+  will be removed while resources unsubscribed.
 
 * `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the disk.
   The valid values are as follows:
   + **prePaid**: the yearly/monthly billing mode.
   + **postPaid**: the pay-per-use billing mode.
-    Changing this creates a new disk.
+
+  Defaults to **postPaid**. Changing this parameter will create a new resource.
 
 * `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the disk.
   Valid values are **month** and **year**. This parameter is mandatory if `charging_mode` is set to **prePaid**.
-  Changing this creates a new disk.
+
+  Changing this parameter will create a new resource.
 
 * `period` - (Optional, Int, ForceNew) Specifies the charging period of the disk.
-  If `period_unit` is set to **month**, the value ranges from 1 to 9.
-  If `period_unit` is set to **year**, the valid value is 1.
+  + If `period_unit` is set to **month**, the value ranges from `1` to `9`.
+  + If `period_unit` is set to **year**, the valid value is `1`.
+
   This parameter is mandatory if `charging_mode` is set to **prePaid**.
-  Changing this creates a new disk.
 
-* `auto_renew` - (Optional, String) Specifies whether auto renew is enabled.
-  Valid values are **true** and **false**.
+  Changing this parameter will create a new resource.
 
-* `server_id` - (Optional, String, ForceNew) Specify the server ID to which the cloudvolume is to be mounted.
-  After specifying the value of this field, the cloudvolume will be automatically attached on the cloudserver.
-  The charging_mode of the created cloudvolume will be consistent with that of the cloudserver.
-  Currently, only ECS cloudservers are supported, and BMS bare metal cloudservers are not supported yet.
-  Changing this creates a new disk.
+* `auto_renew` - (Optional, String) Specifies whether auto-renew is enabled.
+  Valid values are **true** and **false**. Defaults to **false**.
+
+* `server_id` - (Optional, String, ForceNew) Specifies the server ID to which the cloud volume is to be mounted.
+  After specifying the value of this field, the cloud volume will be automatically attached on the cloud server.
+  The charging_mode of the created cloud volume will be consistent with that of the cloud server.
+  Currently, only ECS cloud-servers are supported, and BMS bare metal cloud-servers are not supported yet.
+
+  Changing this parameter will create a new resource.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - A resource ID in UUID format.
-* `attachment` - If a disk is attached to an instance, this attribute will display the Attachment ID, Instance ID, and
-  the Device as the Instance sees it. The [object](#attachment_struct) structure is documented below.
+* `id` - The resource ID in UUID format.
+
+* `attachment` - If a disk is attached to an instance, this attribute will display the attachment ID, instance ID, and
+  the device as the instance sees it. The [attachment](#attachment_struct) structure is documented below.
+
 * `wwn` - The unique identifier used for mounting the EVS disk.
 
 <a name="attachment_struct"></a>
@@ -210,32 +243,6 @@ The `attachment` block supports:
 
 * `dedicated_storage_name` - The name of the DSS storage pool accommodating the disk.
 
-## Import
-
-Volumes can be imported using the `id`, e.g.
-
-```bash
-$ terraform import huaweicloud_evs_volume.volume_1 14a80bc7-c12c-4fe0-a38a-cb77eeac9bd6
-```
-
-Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: **cascade**, **period_unit**, **period**,
-**server_id** and **auto_renew**. It is generally recommended running terraform plan after importing an disk.
-You can then decide if changes should be applied to the disk, or the resource definition should be updated to align
-with the disk. Also you can ignore changes as below.
-
-```hcl
-resource "huaweicloud_evs_volume" "volume_1" {
-    ...
-
-  lifecycle {
-    ignore_changes = [
-      cascade, server_id, charging_mode, period, period_unit,
-    ]
-  }
-}
-```
-
 ## Timeouts
 
 This resource provides the following timeouts configuration options:
@@ -243,3 +250,29 @@ This resource provides the following timeouts configuration options:
 * `create` - Default is 10 minutes.
 * `update` - Default is 3 minutes.
 * `delete` - Default is 3 minutes.
+
+## Import
+
+Volumes can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_evs_volume.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `cascade`, `period_unit`, `period`,
+`server_id`, `auto_renew`, and `charging_mode`. It is generally recommended running terraform plan after importing a disk.
+You can then decide if changes should be applied to the disk, or the resource definition should be updated to align
+with the disk. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_evs_volume" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      cascade, period_unit, period, server_id, auto_renew, charging_mode, 
+    ]
+  }
+}
+```

--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_test.go
@@ -21,101 +21,10 @@ func getVolumeResourceFunc(conf *config.Config, state *terraform.ResourceState) 
 	return cloudvolumes.Get(c, state.Primary.ID).Extract()
 }
 
-func TestAccEvsVolume_basic(t *testing.T) {
+// This test case is used to test the `GPSSD2` type cloud hard disk, which can be used in cn-north-4.
+func TestAccEvsVolume_postPaidWithoutServer(t *testing.T) {
 	var volume cloudvolumes.Volume
-	rName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_evs_volume.test"
-	resourceName1 := "huaweicloud_evs_volume.test.0"
-	resourceName2 := "huaweicloud_evs_volume.test.1"
-	resourceName3 := "huaweicloud_evs_volume.test.2"
-	resourceName4 := "huaweicloud_evs_volume.test.3"
-	resourceName5 := "huaweicloud_evs_volume.test.4"
-	resourceName6 := "huaweicloud_evs_volume.test.5"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&volume,
-		getVolumeResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccEvsVolume_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckMultiResourcesExists(6),
-					// Common configuration
-					resource.TestCheckResourceAttrPair(resourceName1, "availability_zone",
-						"data.huaweicloud_availability_zones.test", "names.0"),
-					resource.TestCheckResourceAttr(resourceName1, "description",
-						"Created by acc test script."),
-					resource.TestCheckResourceAttr(resourceName1, "volume_type", "SSD"),
-					resource.TestCheckResourceAttr(resourceName1, "size", "100"),
-					resource.TestCheckResourceAttr(resourceName1, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(resourceName1, "tags.key", "value"),
-					// Personalized configuration
-					resource.TestCheckResourceAttr(resourceName1, "name", rName+"_vbd_normal_volume"),
-					resource.TestCheckResourceAttr(resourceName1, "device_type", "VBD"),
-					resource.TestCheckResourceAttr(resourceName1, "multiattach", "false"),
-
-					resource.TestCheckResourceAttr(resourceName2, "name", rName+"_vbd_share_volume"),
-					resource.TestCheckResourceAttr(resourceName2, "device_type", "VBD"),
-					resource.TestCheckResourceAttr(resourceName2, "multiattach", "true"),
-
-					resource.TestCheckResourceAttr(resourceName3, "name", rName+"_scsi_normal_volume"),
-					resource.TestCheckResourceAttr(resourceName3, "device_type", "SCSI"),
-					resource.TestCheckResourceAttr(resourceName3, "multiattach", "false"),
-
-					resource.TestCheckResourceAttr(resourceName4, "name", rName+"_scsi_share_volume"),
-					resource.TestCheckResourceAttr(resourceName4, "device_type", "SCSI"),
-					resource.TestCheckResourceAttr(resourceName4, "multiattach", "true"),
-
-					resource.TestCheckResourceAttr(resourceName5, "name", rName+"_gpssd2_normal_volume"),
-					resource.TestCheckResourceAttr(resourceName5, "volume_type", "GPSSD2"),
-					resource.TestCheckResourceAttr(resourceName5, "device_type", "SCSI"),
-					resource.TestCheckResourceAttr(resourceName5, "multiattach", "false"),
-					resource.TestCheckResourceAttr(resourceName5, "iops", "3000"),
-					resource.TestCheckResourceAttr(resourceName5, "throughput", "500"),
-
-					resource.TestCheckResourceAttr(resourceName6, "name", rName+"_essd2_normal_volume"),
-					resource.TestCheckResourceAttr(resourceName6, "volume_type", "ESSD2"),
-					resource.TestCheckResourceAttr(resourceName6, "device_type", "SCSI"),
-					resource.TestCheckResourceAttr(resourceName6, "multiattach", "false"),
-					resource.TestCheckResourceAttr(resourceName6, "iops", "3000"),
-				),
-			},
-			{
-				Config: testAccEvsVolume_update(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckMultiResourcesExists(6),
-					// Common configuration
-					resource.TestCheckResourceAttrPair(resourceName1, "availability_zone",
-						"data.huaweicloud_availability_zones.test", "names.0"),
-					resource.TestCheckResourceAttr(resourceName1, "description",
-						"Updated by acc test script."),
-					resource.TestCheckResourceAttr(resourceName1, "volume_type", "SSD"),
-					resource.TestCheckResourceAttr(resourceName1, "size", "200"),
-					resource.TestCheckResourceAttr(resourceName1, "tags.foo1", "bar"),
-					resource.TestCheckResourceAttr(resourceName1, "tags.key", "value1"),
-					// Personalized configuration
-					resource.TestCheckResourceAttr(resourceName1, "name", rName+"_vbd_normal_volume_update"),
-					resource.TestCheckResourceAttr(resourceName2, "name", rName+"_vbd_share_volume_update"),
-					resource.TestCheckResourceAttr(resourceName3, "name", rName+"_scsi_normal_volume_update"),
-					resource.TestCheckResourceAttr(resourceName4, "name", rName+"_scsi_share_volume_update"),
-					resource.TestCheckResourceAttr(resourceName5, "name", rName+"_gpssd2_normal_volume_update"),
-					resource.TestCheckResourceAttr(resourceName6, "name", rName+"_essd2_normal_volume_update"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccEvsVolume_withEpsId(t *testing.T) {
-	var volume cloudvolumes.Volume
-	rName := acceptance.RandomAccResourceName()
+	name := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_evs_volume.test"
 
 	rc := acceptance.InitResourceCheck(
@@ -133,12 +42,66 @@ func TestAccEvsVolume_withEpsId(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEvsVolume_epsId(rName),
+				Config: testAccEvsVolume_postPaidWithoutServer(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id",
-						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD2"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "3000"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "125"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+				),
+			},
+			{
+				Config: testAccEvsVolume_postPaidWithoutServer_update1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description update"),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD2"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "150"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+				),
+			},
+			{
+				Config: testAccEvsVolume_postPaidWithoutServer_update2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD2"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "150"),
+
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
 				),
 			},
 			{
@@ -153,9 +116,76 @@ func TestAccEvsVolume_withEpsId(t *testing.T) {
 	})
 }
 
-func TestAccEvsVolume_withServerId(t *testing.T) {
+func testAccEvsVolume_postPaidWithoutServer(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%s"
+  size                  = 100
+  description           = "test description"
+  volume_type           = "GPSSD2"
+  iops                  = 3000
+  throughput            = 125
+  device_type           = "VBD"
+  multiattach           = false
+  enterprise_project_id = "%s"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccEvsVolume_postPaidWithoutServer_update1(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%s_update"
+  size                  = 200
+  description           = "test description update"
+  volume_type           = "GPSSD2"
+  iops                  = 4000
+  throughput            = 150
+  device_type           = "VBD"
+  multiattach           = false
+  enterprise_project_id = "%s"
+
+  tags = {
+    foo = "bar_update"
+    key = "value_update"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccEvsVolume_postPaidWithoutServer_update2(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%s_update"
+  size                  = 200
+  volume_type           = "GPSSD2"
+  iops                  = 4000
+  throughput            = 150
+  device_type           = "VBD"
+  multiattach           = false
+  enterprise_project_id = "%s"
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+// This test case is used to test the `GPSSD` type cloud hard disk, which can be used in cn-north-4.
+func TestAccEvsVolume_postPaidWithServer(t *testing.T) {
 	var volume cloudvolumes.Volume
-	rName := acceptance.RandomAccResourceName()
+	name := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_evs_volume.test"
 
 	rc := acceptance.InitResourceCheck(
@@ -167,439 +197,98 @@ func TestAccEvsVolume_withServerId(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEvsVolume_serverId(rName),
+				Config: testAccEvsVolume_postPaidWithServer(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
 						"data.huaweicloud_availability_zones.test", "names.0"),
-					resource.TestCheckResourceAttrPair(resourceName, "attachment.0.instance_id", "huaweicloud_compute_instance.test", "id")),
+					resource.TestCheckResourceAttrPair(resourceName, "server_id",
+						"huaweicloud_compute_instance.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "0"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "postPaid"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+				),
+			},
+			{
+				Config: testAccEvsVolume_postPaidWithServer_update1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttrPair(resourceName, "server_id",
+						"huaweicloud_compute_instance.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description update"),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "0"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "postPaid"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+				),
+			},
+			{
+				Config: testAccEvsVolume_postPaidWithServer_update2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttrPair(resourceName, "server_id",
+						"huaweicloud_compute_instance.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "0"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "postPaid"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"cascade", "server_id", "charging_mode", "period", "period_unit",
+					"cascade",
+					"charging_mode",
+					"server_id",
 				},
 			},
 		},
 	})
 }
 
-func TestAccEvsVolume_GPSSD2(t *testing.T) {
-	var volume cloudvolumes.Volume
-	rName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_evs_volume.test"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&volume,
-		getVolumeResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			// Type GPSSD2 is only supported in part availability_zones under the certain region.
-			acceptance.TestAccPreCheckAvailabilityZoneGPSSD2(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccEvsVolume_GPSSD2(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "availability_zone", acceptance.HW_EVS_AVAILABILITY_ZONE_GPSSD2),
-					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD2"),
-					resource.TestCheckResourceAttr(resourceName, "iops", "3000"),
-					resource.TestCheckResourceAttr(resourceName, "throughput", "125"),
-				),
-			},
-			{
-				Config: testAccEvsVolume_GPSSD2_update(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD2"),
-					resource.TestCheckResourceAttr(resourceName, "iops", "4000"),
-					resource.TestCheckResourceAttr(resourceName, "throughput", "150"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccEvsVolume_ESSD2(t *testing.T) {
-	var volume cloudvolumes.Volume
-	rName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_evs_volume.test"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&volume,
-		getVolumeResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			// Type ESSD2 is only supported in part availability_zones under the certain region.
-			acceptance.TestAccPreCheckAvailabilityZoneESSD2(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccEvsVolume_ESSD2(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "availability_zone", acceptance.HW_EVS_AVAILABILITY_ZONE_ESSD2),
-					resource.TestCheckResourceAttr(resourceName, "volume_type", "ESSD2"),
-					resource.TestCheckResourceAttr(resourceName, "iops", "3000"),
-				),
-			},
-			{
-				Config: testAccEvsVolume_ESSD2_update(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "volume_type", "ESSD2"),
-					resource.TestCheckResourceAttr(resourceName, "iops", "4000"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccEvsVolume_prePaid_withoutServerId(t *testing.T) {
-	var volume cloudvolumes.Volume
-	rName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_evs_volume.test"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&volume,
-		getVolumeResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckChargingMode(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccEvsVolume_prePaid_withoutServerId(rName, true),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "description",
-						"test volume when charging_mode is prePaid and the volume is not attached"),
-					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
-						"data.huaweicloud_availability_zones.test", "names.0"),
-					resource.TestCheckResourceAttr(resourceName, "size", "100"),
-					resource.TestCheckResourceAttr(resourceName, "volume_type", "SSD"),
-					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
-					resource.TestCheckResourceAttr(resourceName, "auto_renew", "true"),
-				),
-			},
-			{
-				Config: testAccEvsVolume_prePaid_withoutServerId(rName, false),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "auto_renew", "false"),
-				),
-			},
-		},
-	})
-}
-
-func testAccEvsVolume_prePaid_withoutServerId(rName string, isAutoRenew bool) string {
+func testAccEvsVolume_postPaidWithServer_base(name string) string {
 	return fmt.Sprintf(`
-data "huaweicloud_availability_zones" "test" {}
-
-resource "huaweicloud_evs_volume" "test" {
-  name              = "%[1]s"
-  description       = "test volume when charging_mode is prePaid and the volume is not attached"
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  size              = 100
-  volume_type       = "SSD"
-
-  charging_mode     = "prePaid"
-  period_unit       = "month"
-  period            = 1
-  auto_renew        = "%[2]v"
-}`, rName, isAutoRenew)
-}
-
-func TestAccEvsVolume_prePaid_withServerId(t *testing.T) {
-	var volume cloudvolumes.Volume
-	rName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_evs_volume.test"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&volume,
-		getVolumeResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckChargingMode(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccEvsVolume_prePaid_withServerId(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "description",
-						"test volume when charging_mode is prePaid and the volume is attached"),
-					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
-						"data.huaweicloud_availability_zones.test", "names.0"),
-					resource.TestCheckResourceAttr(resourceName, "size", "100"),
-					resource.TestCheckResourceAttr(resourceName, "volume_type", "SSD"),
-					resource.TestCheckResourceAttrPair(resourceName, "server_id",
-						"huaweicloud_compute_instance.test", "id"),
-					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
-				),
-			},
-			{
-				Config: testAccEvsVolume_prePaid_withServerId_updateSize(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "size", "200"),
-				),
-			},
-		},
-	})
-}
-
-func testAccEvsVolume_prePaid_withServerId(rName string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_evs_volume" "test" {
-  name              = "%[2]s"
-  description       = "test volume when charging_mode is prePaid and the volume is attached"
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  size              = 100
-  volume_type       = "SSD"
-  server_id         = huaweicloud_compute_instance.test.id
-
-  charging_mode     = "prePaid"
-  period_unit       = "month"
-  period            = 1
-}`, testAccComputeInstance_prePaid(rName), rName)
-}
-
-func testAccEvsVolume_prePaid_withServerId_updateSize(rName string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_evs_volume" "test" {
-  name              = "%[2]s"
-  description       = "test volume when charging_mode is prePaid and the volume is attached"
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  size              = 200
-  volume_type       = "SSD"
-  server_id         = huaweicloud_compute_instance.test.id
-
-  charging_mode     = "prePaid"
-  period_unit       = "month"
-  period            = 1
-}`, testAccComputeInstance_prePaid(rName), rName)
-}
-
-func testAccComputeInstance_prePaid(rName string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_compute_instance" "test" {
-  name                = "%[2]s"
-  description         = "terraform test"
-  hostname            = "hostname-test"
-  image_id            = data.huaweicloud_images_image.test.id
-  flavor_id           = data.huaweicloud_compute_flavors.test.ids[0]
-  security_group_ids  = [data.huaweicloud_networking_secgroup.test.id]
-  availability_zone   = data.huaweicloud_availability_zones.test.names[0]
-  stop_before_destroy = true
-  agency_name         = "test111"
-  agent_list          = "hss"
-
-  network {
-    uuid              = data.huaweicloud_vpc_subnet.test.id
-    source_dest_check = false
-  }
-
-  system_disk_type = "SAS"
-  system_disk_size = 50
-
-  data_disks {
-    type = "SAS"
-    size = "10"
-  }
-
-  metadata = {
-    foo = "bar"
-    key = "value"
-  }
-
-  tags = {
-    foo = "bar"
-    key = "value"
-  }
-
-  charging_mode     = "prePaid"
-  period_unit       = "month"
-  period            = 1
-}
-`, testAccCompute_data, rName)
-}
-
-func testAccEvsVolume_base() string {
-	return `
-variable "volume_configuration" {
-  type = list(object({
-    suffix      = string
-    device_type = string
-    volume_type = string
-    multiattach = bool
-    iops        = number
-    throughput  = number
-  }))
-  default = [
-    {
-      suffix = "vbd_normal_volume",
-      device_type = "VBD",
-      volume_type = "SSD",
-      multiattach = false,
-      iops = 0,
-      throughput = 0
-    },
-    {
-      suffix = "vbd_share_volume",
-      device_type = "VBD",
-      volume_type = "SSD",
-      multiattach = true,
-      iops = 0,
-      throughput = 0
-    },
-    {
-      suffix = "scsi_normal_volume",
-      device_type = "SCSI",
-      volume_type = "SSD",
-      multiattach = false,
-      iops = 0,
-      throughput = 0
-    },
-    {
-      suffix = "scsi_share_volume",
-      device_type = "SCSI",
-      volume_type = "SSD",
-      multiattach = true,
-      iops = 0,
-      throughput = 0
-    },
-    {
-      suffix = "gpssd2_normal_volume",
-      device_type = "SCSI",
-      volume_type = "GPSSD2",
-      multiattach = false,
-      iops = 3000,
-      throughput = 500
-    },
-    {
-      suffix = "essd2_normal_volume",
-      device_type = "SCSI",
-      volume_type = "ESSD2",
-      multiattach = false,
-      iops = 3000,
-      throughput = 0
-    },
-  ]
-}
-
-data "huaweicloud_availability_zones" "test" {}
-`
-}
-
-func testAccEvsVolume_basic(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_evs_volume" "test" {
-  count = length(var.volume_configuration)
-
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  name              = "%s_${var.volume_configuration[count.index].suffix}"
-  size              = 100
-  description       = "Created by acc test script."
-  volume_type       = var.volume_configuration[count.index].volume_type
-  device_type       = var.volume_configuration[count.index].device_type
-  multiattach       = var.volume_configuration[count.index].multiattach
-  iops              = var.volume_configuration[count.index].iops
-  throughput        = var.volume_configuration[count.index].throughput
-
-  tags = {
-    foo = "bar"
-    key = "value"
-  }
-}
-`, testAccEvsVolume_base(), rName)
-}
-
-func testAccEvsVolume_update(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_evs_volume" "test" {
-  count = length(var.volume_configuration)
-
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  name              = "%s_${var.volume_configuration[count.index].suffix}_update"
-  size              = 200
-  description       = "Updated by acc test script."
-  volume_type       = var.volume_configuration[count.index].volume_type
-  device_type       = var.volume_configuration[count.index].device_type
-  multiattach       = var.volume_configuration[count.index].multiattach
-  iops              = var.volume_configuration[count.index].iops
-  throughput        = var.volume_configuration[count.index].throughput
-
-  tags = {
-    foo1 = "bar"
-    key  = "value1"
-  }
-}
-`, testAccEvsVolume_base(), rName)
-}
-
-func testAccEvsVolume_epsId(rName string) string {
-	return fmt.Sprintf(`
-data "huaweicloud_availability_zones" "test" {}
-
-resource "huaweicloud_evs_volume" "test" {
-  name                  = "%s"
-  description           = "test volume for epsID"
-  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
-  volume_type           = "SSD"
-  size                  = 100
-  enterprise_project_id = "%s"
-}
-`, rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
-}
-
-const testAccCompute_data = `
 data "huaweicloud_availability_zones" "test" {}
 
 data "huaweicloud_compute_flavors" "test" {
@@ -621,14 +310,425 @@ data "huaweicloud_images_image" "test" {
 data "huaweicloud_networking_secgroup" "test" {
   name = "default"
 }
-`
 
-func testAccComputeInstance_basic(rName string) string {
+resource "huaweicloud_compute_instance" "test" {
+  name                = "%s"
+  description         = "terraform test"
+  hostname            = "hostname-test"
+  image_id            = data.huaweicloud_images_image.test.id
+  flavor_id           = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids  = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone   = data.huaweicloud_availability_zones.test.names[0]
+  stop_before_destroy = true
+  agency_name         = "test111"
+  agent_list          = "hss"
+
+  network {
+    uuid              = data.huaweicloud_vpc_subnet.test.id
+    source_dest_check = false
+  }
+
+  system_disk_type = "SAS"
+  system_disk_size = 50
+
+  data_disks {
+    type = "SAS"
+    size = "10"
+  }
+}
+`, name)
+}
+
+func testAccEvsVolume_postPaidWithServer(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%[2]s"
+  size                  = 100
+  description           = "test description"
+  volume_type           = "GPSSD"
+  multiattach           = false
+  enterprise_project_id = "%[3]s"
+  server_id             = huaweicloud_compute_instance.test.id
+  charging_mode         = "postPaid"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccEvsVolume_postPaidWithServer_base(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccEvsVolume_postPaidWithServer_update1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%[2]s_update"
+  size                  = 200
+  description           = "test description update"
+  volume_type           = "GPSSD"
+  multiattach           = false
+  enterprise_project_id = "%[3]s"
+  server_id             = huaweicloud_compute_instance.test.id
+  charging_mode         = "postPaid"
+
+  tags = {
+    foo = "bar_update"
+    key = "value_update"
+  }
+}
+`, testAccEvsVolume_postPaidWithServer_base(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccEvsVolume_postPaidWithServer_update2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%[2]s_update"
+  size                  = 200
+  volume_type           = "GPSSD"
+  multiattach           = false
+  enterprise_project_id = "%[3]s"
+  server_id             = huaweicloud_compute_instance.test.id
+  charging_mode         = "postPaid"
+}
+`, testAccEvsVolume_postPaidWithServer_base(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+// This test case is used to test the `GPSSD2` type cloud hard disk, which can be used in cn-north-4.
+func TestAccEvsVolume_prePaidWithoutServer(t *testing.T) {
+	var volume cloudvolumes.Volume
+	name := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_evs_volume.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&volume,
+		getVolumeResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+			acceptance.TestAccPreCheckChargingMode(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEvsVolume_prePaidWithoutServer(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD2"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "3000"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "125"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "period", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+				),
+			},
+			{
+				Config: testAccEvsVolume_prePaidWithoutServer_update1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description update"),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD2"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "150"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "period", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+				),
+			},
+			{
+				Config: testAccEvsVolume_prePaidWithoutServer_update2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD2"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "150"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "period", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"cascade",
+					"period_unit",
+					"period",
+					"server_id",
+					"auto_renew",
+					"charging_mode",
+				},
+			},
+		},
+	})
+}
+
+func testAccEvsVolume_prePaidWithoutServer(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%s"
+  size                  = 100
+  description           = "test description"
+  volume_type           = "GPSSD2"
+  iops                  = 3000
+  throughput            = 125
+  device_type           = "VBD"
+  multiattach           = false
+  enterprise_project_id = "%s"
+  charging_mode         = "prePaid"
+  period_unit           = "month"
+  period                = 1
+  auto_renew            = "true"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccEvsVolume_prePaidWithoutServer_update1(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%s_update"
+  size                  = 200
+  description           = "test description update"
+  volume_type           = "GPSSD2"
+  iops                  = 4000
+  throughput            = 150
+  device_type           = "VBD"
+  multiattach           = false
+  enterprise_project_id = "%s"
+  charging_mode         = "prePaid"
+  period_unit           = "month"
+  period                = 1
+  auto_renew            = "false"
+
+  tags = {
+    foo = "bar_update"
+    key = "value_update"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccEvsVolume_prePaidWithoutServer_update2(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%s_update"
+  size                  = 200
+  volume_type           = "GPSSD2"
+  iops                  = 4000
+  throughput            = 150
+  device_type           = "VBD"
+  multiattach           = false
+  enterprise_project_id = "%s"
+  charging_mode         = "prePaid"
+  period_unit           = "month"
+  period                = 1
+  auto_renew            = "true"
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+// This test case is used to test the `GPSSD` type cloud hard disk, which can be used in cn-north-4.
+func TestAccEvsVolume_prePaidWithServer(t *testing.T) {
+	var volume cloudvolumes.Volume
+	name := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_evs_volume.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&volume,
+		getVolumeResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+			acceptance.TestAccPreCheckChargingMode(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEvsVolume_prePaidWithServer(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttrPair(resourceName, "server_id",
+						"huaweicloud_compute_instance.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "0"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "period", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+				),
+			},
+			{
+				Config: testAccEvsVolume_prePaidWithServer_update1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttrPair(resourceName, "server_id",
+						"huaweicloud_compute_instance.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description update"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "0"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "period", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+				),
+			},
+			{
+				Config: testAccEvsVolume_prePaidWithServer_update2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttrPair(resourceName, "server_id",
+						"huaweicloud_compute_instance.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "0"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "period", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"cascade",
+					"charging_mode",
+					"server_id",
+					"period_unit",
+					"period",
+				},
+			},
+		},
+	})
+}
+
+func testAccEvsVolume_prePaidWithServer_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
+
+data "huaweicloud_images_image" "test" {
+  name        = "Ubuntu 18.04 server 64bit"
+  most_recent = true
+}
+
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
+
 resource "huaweicloud_compute_instance" "test" {
-  name                = "%[2]s"
+  name                = "%s"
   description         = "terraform test"
   hostname            = "hostname-test"
   image_id            = data.huaweicloud_images_image.test.id
@@ -652,85 +752,78 @@ resource "huaweicloud_compute_instance" "test" {
     size = "10"
   }
 
-  metadata = {
-    foo = "bar"
-    key = "value"
-  }
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+}
+`, name)
+}
+
+func testAccEvsVolume_prePaidWithServer(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%[2]s"
+  size                  = 100
+  description           = "test description"
+  volume_type           = "GPSSD"
+  multiattach           = false
+  enterprise_project_id = "%[3]s"
+  server_id             = huaweicloud_compute_instance.test.id
+  charging_mode         = "prePaid"
+  period_unit           = "month"
+  period                = 1
 
   tags = {
     foo = "bar"
     key = "value"
   }
 }
-`, testAccCompute_data, rName)
+`, testAccEvsVolume_prePaidWithServer_base(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
-func testAccEvsVolume_serverId(rName string) string {
+func testAccEvsVolume_prePaidWithServer_update1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
-	
+
 resource "huaweicloud_evs_volume" "test" {
-  name              = "%[2]s"
-  volume_type       = "GPSSD"
-  description       = "test volume for charging mode"
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  server_id         = huaweicloud_compute_instance.test.id
-  size              = 100
-  charging_mode     = "postPaid"
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%[2]s_update"
+  size                  = 200
+  description           = "test description update"
+  volume_type           = "GPSSD"
+  multiattach           = false
+  enterprise_project_id = "%[3]s"
+  server_id             = huaweicloud_compute_instance.test.id
+  charging_mode         = "prePaid"
+  period_unit           = "month"
+  period                = 1
+
+  tags = {
+    foo = "bar_update"
+    key = "value_update"
+  }
 }
-`, testAccComputeInstance_basic(rName), rName)
+`, testAccEvsVolume_prePaidWithServer_base(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
-func testAccEvsVolume_GPSSD2(rName string) string {
+func testAccEvsVolume_prePaidWithServer_update2(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_evs_volume" "test" {
-  name              = "%[1]s"
-  description       = "test volume for updating QoS when volume_type is GPSSD2"
-  availability_zone = "%[2]s"
-  size              = 100
-  volume_type       = "GPSSD2"
-  iops              = 3000
-  throughput        = 125
-}
-`, rName, acceptance.HW_EVS_AVAILABILITY_ZONE_GPSSD2)
-}
+%[1]s
 
-func testAccEvsVolume_GPSSD2_update(rName string) string {
-	return fmt.Sprintf(`
 resource "huaweicloud_evs_volume" "test" {
-  name              = "%[1]s"
-  description       = "test volume for updating QoS when volume_type is GPSSD2"
-  availability_zone = "%[2]s"
-  size              = 100
-  volume_type       = "GPSSD2"
-  iops              = 4000
-  throughput        = 150
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%[2]s_update"
+  size                  = 200
+  volume_type           = "GPSSD"
+  multiattach           = false
+  enterprise_project_id = "%[3]s"
+  server_id             = huaweicloud_compute_instance.test.id
+  charging_mode         = "prePaid"
+  period_unit           = "month"
+  period                = 1
 }
-`, rName, acceptance.HW_EVS_AVAILABILITY_ZONE_GPSSD2)
-}
-
-func testAccEvsVolume_ESSD2(rName string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_evs_volume" "test" {
-  name              = "%[1]s"
-  description       = "test volume for updating QoS when volume_type is ESSD2"
-  availability_zone = "%[2]s"
-  size              = 100
-  volume_type       = "ESSD2"
-  iops              = 3000
-}
-`, rName, acceptance.HW_EVS_AVAILABILITY_ZONE_ESSD2)
-}
-
-func testAccEvsVolume_ESSD2_update(rName string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_evs_volume" "test" {
-  name              = "%[1]s"
-  description       = "test volume for updating QoS when volume_type is ESSD2"
-  availability_zone = "%[2]s"
-  size              = 100
-  volume_type       = "ESSD2"
-  iops              = 4000
-}
-`, rName, acceptance.HW_EVS_AVAILABILITY_ZONE_ESSD2)
+`, testAccEvsVolume_prePaidWithServer_base(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Improve the robustness of resource code.
  - Optimize the document format and supplement the instructions for use.
  - Enhance the robustness of resource code refresh logic.
  - Optimize test cases to increase their readability and maintainability.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
go test -v -coverprofile=coverage_1734922941802_TestAccEvsVolume_.cov -coverpkg=./huaweicloud/services/evs ./huaweicloud/services/acceptance/evs -run TestAccEvsVolume_ -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_postPaidWithoutServer
=== PAUSE TestAccEvsVolume_postPaidWithoutServer
=== RUN   TestAccEvsVolume_postPaidWithServer
=== PAUSE TestAccEvsVolume_postPaidWithServer
=== RUN   TestAccEvsVolume_prePaidWithoutServer
=== PAUSE TestAccEvsVolume_prePaidWithoutServer
=== RUN   TestAccEvsVolume_prePaidWithServer
=== PAUSE TestAccEvsVolume_prePaidWithServer
=== CONT  TestAccEvsVolume_postPaidWithoutServer
=== CONT  TestAccEvsVolume_prePaidWithoutServer
=== CONT  TestAccEvsVolume_postPaidWithServer
=== CONT  TestAccEvsVolume_prePaidWithServer
--- PASS: TestAccEvsVolume_postPaidWithoutServer (93.93s)
--- PASS: TestAccEvsVolume_prePaidWithoutServer (288.28s)
--- PASS: TestAccEvsVolume_postPaidWithServer (356.00s)
--- PASS: TestAccEvsVolume_prePaidWithServer (508.24s)
PASS
coverage: 34.2% of statements in ./huaweicloud/services/evs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       508.302s        coverage: 34.2% of statements in ./huaweicloud/services/evs
```


![image](https://github.com/user-attachments/assets/5f9f3e3b-7b85-48a9-93ff-aec24cf33621)



* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
