### PR TITLE
feat(apig/api): API resource supports orchestration rules' configuration

### DIFF
--- a/docs/resources/apig_api.md
+++ b/docs/resources/apig_api.md
@@ -245,6 +245,14 @@ The `request_params` block supports:
   + **1**: enable
   + **2**: disable (by default)
 
+* `orchestrations` - (Optional, List) Specifies the list of orchestration rule IDs which parameter used.  
+  The order of the IDs determines the priority of the rules, and the priority decreases according to the order of the
+  list elements.
+
+  -> 1. The **none_value** rule has the highest priority, a maximum of one **none_value** rule can be bound.<br>2. The
+     **default** rule has the lowest priority, a maximum of one **default** rule can be bound.<br>3. Only one parameter
+     of each API can be bound with unique orchestration rules.
+
 <a name="apig_api_backend_params"></a>
 The `backend_params` block supports:
 
@@ -525,6 +533,14 @@ The `conditions` block supports:
 * `type` - (Optional, String) Specifies the condition type of the backend policy.  
   The valid values are **Equal**, **Enumerated** and **Matching**, defaults to **Equal**.  
   When the `sys_name` is **req_method**, the valid values are **Equal** and **Enumerated**.
+
+* `mapped_param_name` - (Optional, String) Specifies the name of a parameter generated after orchestration.
+  This parameter is required if the policy type is **orchestration**.  
+  The generated parameter name must exist in the orchestration rule bound to the API.
+
+* `mapped_param_location` - (Optional, String) Specifies the location of a parameter generated after orchestration.
+  This parameter is required if the policy type is **orchestration**.  
+  The generated parameter location must exist in the orchestration rule bound to the API.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20241219073404-a317c4d1ad44
+	github.com/chnsz/golangsdk v0.0.0-20241223075604-9d56447e0fa3
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20241219073404-a317c4d1ad44 h1:eg7jhR7/FtyNPtGetsEggPLX8TL9vzlbEuTbcxiu/qM=
-github.com/chnsz/golangsdk v0.0.0-20241219073404-a317c4d1ad44/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20241223075604-9d56447e0fa3 h1:JbrUK2HgqDQrzX3tytXeuLrwEdZ6P1HLoli61XmhIgk=
+github.com/chnsz/golangsdk v0.0.0-20241223075604-9d56447e0fa3/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_api.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_api.go
@@ -75,12 +75,6 @@ const (
 	EffectiveModeAll EffectiveMode = "ALL"
 	EffectiveModeAny EffectiveMode = "ANY"
 
-	ConditionSourceParam              ConditionSource = "param"
-	ConditionSourceSource             ConditionSource = "source"
-	ConditionSourceSystem             ConditionSource = "system"
-	ConditionSourceCookie             ConditionSource = "cookie"
-	ConditionSourceFrontendAuthorizer ConditionSource = "frontend_authorizer"
-
 	ConditionTypeEqual      ConditionType = "Equal"
 	ConditionTypeEnumerated ConditionType = "Enumerated"
 	ConditionTypeMatching   ConditionType = "Matching"
@@ -317,6 +311,12 @@ func ResourceApigAPIV2() *schema.Resource {
 							Optional:    true,
 							Computed:    true,
 							Description: "Whether to enable the parameter validation.",
+						},
+						"orchestrations": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "The list of orchestration rules that parameter used.",
 						},
 					},
 				},
@@ -863,28 +863,26 @@ func policyConditionSchemaResource() *schema.Resource {
 				Description: "The frontend authentication parameter name.",
 			},
 			"source": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  string(ConditionSourceParam),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(ConditionSourceParam),
-					string(ConditionSourceSource),
-					string(ConditionSourceSystem),
-					string(ConditionSourceCookie),
-					string(ConditionSourceFrontendAuthorizer),
-				}, false),
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "param",
 				Description: "The type of the backend policy.",
 			},
 			"type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  string(ConditionTypeEqual),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(ConditionTypeEqual),
-					string(ConditionTypeEnumerated),
-					string(ConditionTypeMatching),
-				}, false),
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     string(ConditionTypeEqual),
 				Description: "The condition type.",
+			},
+			"mapped_param_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of a parameter generated after orchestration.",
+			},
+			"mapped_param_location": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The location of a parameter generated after orchestration.",
 			},
 		},
 	}
@@ -1030,16 +1028,17 @@ func buildRequestParameters(requests *schema.Set) []apis.ReqParamBase {
 		paramMap := v.(map[string]interface{})
 		paramType := paramMap["type"].(string)
 		param := apis.ReqParamBase{
-			Type:         paramType,
-			Name:         paramMap["name"].(string),
-			Required:     isObjectEnabled(paramMap["required"].(bool)),
-			Location:     paramMap["location"].(string),
-			Description:  utils.String(paramMap["description"].(string)),
-			Enumerations: utils.String(paramMap["enumeration"].(string)),
-			PassThrough:  isObjectEnabled(paramMap["passthrough"].(bool)),
-			DefaultValue: utils.String(paramMap["default"].(string)),
-			SampleValue:  paramMap["example"].(string),
-			ValidEnable:  paramMap["valid_enable"].(int),
+			Type:           paramType,
+			Name:           paramMap["name"].(string),
+			Required:       isObjectEnabled(paramMap["required"].(bool)),
+			Location:       paramMap["location"].(string),
+			Description:    utils.String(paramMap["description"].(string)),
+			Enumerations:   utils.String(paramMap["enumeration"].(string)),
+			PassThrough:    isObjectEnabled(paramMap["passthrough"].(bool)),
+			DefaultValue:   utils.String(paramMap["default"].(string)),
+			SampleValue:    paramMap["example"].(string),
+			ValidEnable:    paramMap["valid_enable"].(int),
+			Orchestrations: utils.ExpandToStringList(paramMap["orchestrations"].([]interface{})),
 		}
 		switch paramType {
 		case string(ParamTypeNumber):
@@ -1105,21 +1104,26 @@ func buildPolicyConditions(conditions *schema.Set) []apis.APIConditionBase {
 
 	result := make([]apis.APIConditionBase, conditions.Len())
 	for i, v := range conditions.List() {
-		cm := v.(map[string]interface{})
+		source := utils.PathSearch("source", v, "param").(string)
+
 		condition := apis.APIConditionBase{
-			ReqParamName:                cm["param_name"].(string),
-			SysParamName:                cm["sys_name"].(string),
-			CookieParamName:             cm["cookie_name"].(string),
-			FrontendAuthorizerParamName: cm["frontend_authorizer_name"].(string),
-			ConditionOrigin:             cm["source"].(string),
-			ConditionValue:              cm["value"].(string),
+			ConditionValue:              utils.PathSearch("value", v, "").(string),
+			ReqParamName:                utils.PathSearch("param_name", v, "").(string),
+			SysParamName:                utils.PathSearch("sys_name", v, "").(string),
+			CookieParamName:             utils.PathSearch("cookie_name", v, "").(string),
+			FrontendAuthorizerParamName: utils.PathSearch("frontend_authorizer_name", v, "").(string),
+			ConditionOrigin:             source,
+			MappedParamName:             utils.PathSearch("mapped_param_name", v, "").(string),
+			MappedParamLocation:         utils.PathSearch("mapped_param_location", v, "").(string),
 		}
-		conType := cm["type"].(string)
+
+		conType := utils.PathSearch("type", v, string(ConditionTypeEqual)).(string)
 		// If the input of the condition type is invalid, keep the condition parameter omitted and the API will throw an
 		// error.
-		if v, ok := conditionType[conType]; ok {
-			condition.ConditionType = v
+		if vt, ok := conditionType[conType]; ok {
+			condition.ConditionType = vt
 		}
+
 		result[i] = condition
 	}
 	return result
@@ -1447,16 +1451,17 @@ func flattenApiRequestParams(reqParams []apis.ReqParamResp) []map[string]interfa
 	result := make([]map[string]interface{}, len(reqParams))
 	for i, v := range reqParams {
 		param := map[string]interface{}{
-			"name":         v.Name,
-			"location":     v.Location,
-			"type":         v.Type,
-			"required":     parseObjectEnabled(v.Required),
-			"passthrough":  parseObjectEnabled(v.PassThrough),
-			"enumeration":  v.Enumerations,
-			"example":      v.SampleValue,
-			"default":      v.DefaultValue,
-			"description":  v.Description,
-			"valid_enable": v.ValidEnable,
+			"name":           v.Name,
+			"location":       v.Location,
+			"type":           v.Type,
+			"required":       parseObjectEnabled(v.Required),
+			"passthrough":    parseObjectEnabled(v.PassThrough),
+			"enumeration":    v.Enumerations,
+			"example":        v.SampleValue,
+			"default":        v.DefaultValue,
+			"description":    v.Description,
+			"valid_enable":   v.ValidEnable,
+			"orchestrations": v.Orchestrations,
 		}
 		switch v.Type {
 		case string(ParamTypeNumber):
@@ -1545,6 +1550,8 @@ func flattenPolicyConditions(conditions []apis.APIConditionBase) []map[string]in
 			"frontend_authorizer_name": v.FrontendAuthorizerParamName,
 			"type":                     analyseConditionType(v.ConditionType),
 			"value":                    v.ConditionValue,
+			"mapped_param_name":        v.MappedParamName,
+			"mapped_param_location":    v.MappedParamLocation,
 		}
 	}
 	return result

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis/requests.go
@@ -245,6 +245,12 @@ type ReqParamBase struct {
 	MaxSize *int `json:"max_size,omitempty"`
 	// Indicates whether to transparently transfer the parameter. The valid values are 1 (yes) and 2 (no).
 	PassThrough int `json:"pass_through,omitempty"`
+	// Request parameter orchestration rules are prioritized in the same sequence as the list.
+	// The none_value rule in a rule list has the highest priority. A maximum of one none_value rule can be bound.
+	// The default rule in a rule list has the lowest priority. A maximum of one default rule can be bound.
+	// The preprocessing orchestration rule cannot be used as the last orchestration rule except the default rule.
+	// Only one parameter of each API can be bound with unique orchestration rules. The number of orchestration rules that can be bound is limited by quota. For details, see "Notes and Constraints" in APIG Service Overview.
+	Orchestrations []string `json:"orchestrations,omitempty"`
 }
 
 // PolicyMock is an object which will be build up a backend policy of the mock.
@@ -416,6 +422,14 @@ type APIConditionBase struct {
 	ReqParamId string `json:"req_param_id,omitempty"`
 	// The location of the corresponding request parameter.
 	ReqParamLocation string `json:"req_param_location,omitempty"`
+	// Name of a parameter generated after orchestration.
+	// This parameter is mandatory when condition_origin is set to orchestration.
+	// The generated parameter name must exist in the orchestration rule bound to the API.
+	MappedParamName string `json:"mapped_param_name,omitempty"`
+	// Location of a parameter generated after orchestration.
+	// This parameter is mandatory when condition_origin is set to orchestration.
+	// This location must exist in the orchestration rule bound to the API.
+	MappedParamLocation string `json:"mapped_param_location,omitempty"`
 }
 
 // APIOptsBuilder is an interface which to support request body build of the API creation and updation.

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis/results.go
@@ -192,6 +192,12 @@ type ReqParamResp struct {
 	// Parameter ID.
 	// Notes: This parameter is used for response.
 	ID string `json:"id"`
+	// Request parameter orchestration rules are prioritized in the same sequence as the list.
+	// The none_value rule in a rule list has the highest priority. A maximum of one none_value rule can be bound.
+	// The default rule in a rule list has the lowest priority. A maximum of one default rule can be bound.
+	// The preprocessing orchestration rule cannot be used as the last orchestration rule except the default rule.
+	// Only one parameter of each API can be bound with unique orchestration rules. The number of orchestration rules that can be bound is limited by quota. For details, see "Notes and Constraints" in APIG Service Overview.
+	Orchestrations []string `json:"orchestrations"`
 }
 
 // BackendParamResp is an object struct that represents the elements of the back-end parameter.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20241219073404-a317c4d1ad44
+# github.com/chnsz/golangsdk v0.0.0-20241223075604-9d56447e0fa3
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New parameters support for orchestration rules configuration:
- request_params.orchestrations
- *.conditions.mapped_param_name
- *.conditions.mapped_param_location

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. API resource supports orchestration rules' configuration.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccApi_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccApi_ -timeout 360m -parallel 10
=== RUN   TestAccApi_basic
=== PAUSE TestAccApi_basic
=== RUN   TestAccApi_orchestration
=== PAUSE TestAccApi_orchestration
=== CONT  TestAccApi_basic
=== CONT  TestAccApi_orchestration
--- PASS: TestAccApi_orchestration (184.37s)
--- PASS: TestAccApi_basic (205.65s)
PASS
coverage: 13.0% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      205.713s        coverage: 13.0% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
