### PR TITLE
refactor: feat(apig/channel): adjust the parameter behavior and supports new value

### DIFF
--- a/docs/resources/apig_channel.md
+++ b/docs/resources/apig_channel.md
@@ -151,6 +151,43 @@ resource "huaweicloud_apig_channel" "test" {
 }
 ```
 
+### Create a channel of type reference
+
+```hcl
+variable "instance_id" {}
+variable "channel_name" {}
+variable "member_group_name" {}
+variable "reference_channel_id" {}
+
+resource "huaweicloud_apig_channel" "test" {
+  instance_id      = var.instance_id
+  name             = var.channel_name
+  port             = 82
+  balance_strategy = 2
+  member_type      = "ecs"
+  type             = "reference"
+
+  member_group {
+    name                     = var.member_group_name
+    description              = "Created by terraform script"
+    weight                   = 2
+    reference_vpc_channel_id = var.reference_channel_id
+  }
+
+  health_check {
+    protocol           = "HTTPS"
+    threshold_normal   = 2
+    threshold_abnormal = 5
+    interval           = 10
+    timeout            = 5
+    path               = "/terraform/"
+    method             = "GET"
+    port               = "50"
+    http_codes         = "500"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -186,6 +223,7 @@ The following arguments are supported:
   The valid values are as follows:
   + **builtin**: Server type.
   + **microservice**: Microservice type.
+  + **reference**: Reference load balance channel type.
 
   Defaults to `builtin` (server type).
 
@@ -221,6 +259,9 @@ The `member_group` block supports:
   The valid value ranges from `0` to `65,535`.
 
 * `microservice_labels` - (Optional, Map) Specifies the microservice tags of the backend server group.
+
+* `reference_vpc_channel_id` - (Optional, String) Specifies the ID of the reference load balance channel.
+  This parameter is only available if the `type` is **reference**.
 
 <a name="channel_members"></a>
 The `member` block supports:

--- a/docs/resources/apig_channel.md
+++ b/docs/resources/apig_channel.md
@@ -112,7 +112,7 @@ resource "huaweicloud_apig_channel" "test" {
   port             = 80
   balance_strategy = 1
   member_type      = "ip"
-  type             = 3
+  type             = "microservice"
 
   dynamic "member_group" {
     for_each = var.member_groups_config
@@ -182,18 +182,18 @@ The following arguments are supported:
   + **ip**.
   + **ecs**.
 
-* `type` - (Optional, Int) Specifies the type of the channel.  
+* `type` - (Optional, String) Specifies the type of the channel.  
   The valid values are as follows:
-  + **2**: Server type.
-  + **3**: Microservice type.
+  + **builtin**: Server type.
+  + **microservice**: Microservice type.
 
-  Defaults to `2` (server type).
+  Defaults to `builtin` (server type).
 
 * `member_group` - (Optional, List) Specifies the backend (server) groups of the channel.  
   The [object](#channel_member_group) structure is documented below.
 
 * `member` - (Optional, List) Specifies the backend servers of the channel.  
-  This parameter is required and only available if the `type` is `2`.  
+  This parameter is required and only available if the `type` is `builtin`.  
   The [object](#channel_members) structure is documented below.
 
 * `health_check` - (Optional, List) Specifies the health configuration of cloud servers associated with the load balance

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20241223075604-9d56447e0fa3
+	github.com/chnsz/golangsdk v0.0.0-20241224015804-3881691a8961
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20241223075604-9d56447e0fa3 h1:JbrUK2HgqDQrzX3tytXeuLrwEdZ6P1HLoli61XmhIgk=
-github.com/chnsz/golangsdk v0.0.0-20241223075604-9d56447e0fa3/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20241224015804-3881691a8961 h1:fz4oQHt1QyL3r5sP1sHNiwysBqyk7Z+Paq5mGothiRw=
+github.com/chnsz/golangsdk v0.0.0-20241224015804-3881691a8961/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_channel_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_channel_test.go
@@ -24,19 +24,19 @@ func getChannelFunc(cfg *config.Config, state *terraform.ResourceState) (interfa
 
 func TestAccChannel_basic(t *testing.T) {
 	var (
-		channel channels.Channel
+		channel interface{}
 
 		// Only letters, digits and underscores (_) are allowed in the environment name and dedicated instance name.
-		rName      = "huaweicloud_apig_channel.test"
 		name       = acceptance.RandomAccResourceName()
 		updateName = acceptance.RandomAccResourceName()
-		baseConfig = testAccChannel_base(name)
-	)
 
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&channel,
-		getChannelFunc,
+		typeServer       = "huaweicloud_apig_channel.type_server"
+		typeServerLegacy = "huaweicloud_apig_channel.type_server_legacy"
+
+		rcTypeServer       = acceptance.InitResourceCheck(typeServer, &channel, getChannelFunc)
+		rcTypeServerLegacy = acceptance.InitResourceCheck(typeServerLegacy, &channel, getChannelFunc)
+
+		baseConfig = testAccChannel_base(name)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -46,66 +46,112 @@ func TestAccChannel_basic(t *testing.T) {
 			acceptance.TestAccPreCheckApigChannelRelatedInfo(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcTypeServer.CheckResourceDestroy(),
+			rcTypeServerLegacy.CheckResourceDestroy(),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccChannel_basic_step1(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "port", "80"),
-					resource.TestCheckResourceAttr(rName, "balance_strategy", "1"),
-					resource.TestCheckResourceAttr(rName, "member_type", "ecs"),
-					resource.TestCheckResourceAttr(rName, "type", "2"),
-					resource.TestCheckResourceAttr(rName, "health_check.0.protocol", "TCP"),
-					resource.TestCheckResourceAttr(rName, "health_check.0.threshold_normal", "1"),
-					resource.TestCheckResourceAttr(rName, "health_check.0.threshold_abnormal", "1"),
-					resource.TestCheckResourceAttr(rName, "health_check.0.interval", "1"),
-					resource.TestCheckResourceAttr(rName, "health_check.0.timeout", "1"),
-					resource.TestCheckResourceAttr(rName, "health_check.0.path", ""),
-					resource.TestCheckResourceAttr(rName, "health_check.0.method", ""),
-					resource.TestCheckResourceAttr(rName, "health_check.0.port", "0"),
-					resource.TestCheckResourceAttr(rName, "health_check.0.http_codes", ""),
-					resource.TestCheckResourceAttr(rName, "member.#", "1"),
+					rcTypeServer.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeServer, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeServer, "name", name+"_type_server"),
+					resource.TestCheckResourceAttr(typeServer, "port", "80"),
+					resource.TestCheckResourceAttr(typeServer, "balance_strategy", "1"),
+					resource.TestCheckResourceAttr(typeServer, "member_type", "ecs"),
+					resource.TestCheckResourceAttr(typeServer, "type", "builtin"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.#", "1"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.protocol", "TCP"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.threshold_normal", "1"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.threshold_abnormal", "1"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.interval", "1"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.timeout", "1"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.path", ""),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.method", ""),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.port", "0"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.http_codes", ""),
+					resource.TestCheckResourceAttr(typeServer, "member.#", "1"),
+					rcTypeServerLegacy.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeServerLegacy, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeServerLegacy, "name", name+"_type_server_legacy"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "port", "81"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "balance_strategy", "1"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "member_type", "ecs"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "type", "builtin"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.#", "1"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.protocol", "TCP"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.threshold_normal", "1"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.threshold_abnormal", "1"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.interval", "1"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.timeout", "1"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.path", ""),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.method", ""),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.port", "0"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.http_codes", ""),
+					resource.TestCheckResourceAttr(typeServerLegacy, "member.#", "1"),
 				),
 			},
 			{
 				Config: testAccChannel_basic_step2(baseConfig, updateName),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", updateName),
-					resource.TestCheckResourceAttr(rName, "port", "8000"),
-					resource.TestCheckResourceAttr(rName, "balance_strategy", "2"),
-					resource.TestCheckResourceAttr(rName, "member_type", "ecs"),
-					resource.TestCheckResourceAttr(rName, "type", "2"),
-					resource.TestCheckResourceAttr(rName, "health_check.0.protocol", "HTTPS"),
-					resource.TestCheckResourceAttr(rName, "health_check.0.threshold_normal", "10"),
-					resource.TestCheckResourceAttr(rName, "health_check.0.threshold_abnormal", "10"),
-					resource.TestCheckResourceAttr(rName, "health_check.0.interval", "300"),
-					resource.TestCheckResourceAttr(rName, "health_check.0.timeout", "30"),
-					resource.TestCheckResourceAttr(rName, "health_check.0.path", "/terraform/"),
-					resource.TestCheckResourceAttr(rName, "health_check.0.method", "HEAD"),
-					resource.TestCheckResourceAttr(rName, "health_check.0.port", "8080"),
-					resource.TestCheckResourceAttr(rName, "health_check.0.http_codes", "201,202,303-404"),
-					resource.TestCheckResourceAttr(rName, "member.#", "2"),
+					rcTypeServer.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeServer, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeServer, "name", updateName+"_type_server"),
+					resource.TestCheckResourceAttr(typeServer, "port", "8000"),
+					resource.TestCheckResourceAttr(typeServer, "balance_strategy", "2"),
+					resource.TestCheckResourceAttr(typeServer, "member_type", "ecs"),
+					resource.TestCheckResourceAttr(typeServer, "type", "builtin"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.threshold_normal", "10"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.threshold_abnormal", "10"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.interval", "300"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.timeout", "30"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.path", "/terraform/"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.method", "HEAD"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.port", "8080"),
+					resource.TestCheckResourceAttr(typeServer, "health_check.0.http_codes", "201,202,303-404"),
+					resource.TestCheckResourceAttr(typeServer, "member.#", "2"),
+					rcTypeServerLegacy.CheckResourceExists(),
+					resource.TestCheckResourceAttr(typeServerLegacy, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(typeServerLegacy, "name", updateName+"_type_server_legacy"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "port", "8001"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "balance_strategy", "2"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "member_type", "ecs"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "type", "builtin"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.threshold_normal", "10"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.threshold_abnormal", "10"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.interval", "300"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.timeout", "30"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.path", "/terraform/"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.method", "HEAD"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.port", "8080"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "health_check.0.http_codes", "201,202,303-404"),
+					resource.TestCheckResourceAttr(typeServerLegacy, "member.#", "2"),
 				),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:      typeServer,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccChannelImportStateFunc(),
+				ImportStateIdFunc: testAccChannelImportStateFunc(typeServer),
+			},
+			{
+				ResourceName:      typeServerLegacy,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccChannelImportStateFunc(typeServerLegacy),
 			},
 		},
 	})
 }
 
-func testAccChannelImportStateFunc() resource.ImportStateIdFunc {
+func testAccChannelImportStateFunc(rsName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
-		rName := "huaweicloud_apig_channel.test"
-		rs, ok := s.RootModule().Resources[rName]
+		rs, ok := s.RootModule().Resources[rsName]
 		if !ok {
-			return "", fmt.Errorf("Resource (%s) not found: %s", rName, rs)
+			return "", fmt.Errorf("Resource (%s) not found: %s", rsName, rs)
 		}
 		if rs.Primary.Attributes["instance_id"] == "" || rs.Primary.ID == "" {
 			return "", fmt.Errorf("resource not found: %s/%s", rs.Primary.Attributes["instance_id"],
@@ -148,10 +194,37 @@ resource "huaweicloud_compute_instance" "test" {
   }
 }
 
-resource "huaweicloud_apig_channel" "test" {
+resource "huaweicloud_apig_channel" "type_server" {
   instance_id        = local.instance_id
-  name               = "%[2]s"
+  name               = "%[2]s_type_server"
   port               = 80
+  balance_strategy   = 1
+  member_type        = "ecs"
+  type               = "builtin"
+
+  health_check {
+    protocol           = "TCP"
+    threshold_normal   = 1 # minimum value
+    threshold_abnormal = 1 # minimum value
+    interval           = 1 # minimum value
+    timeout            = 1 # minimum value
+  }
+
+  dynamic "member" {
+    for_each = huaweicloud_compute_instance.test[*]
+
+    content {
+      id   = member.value.id
+      name = member.value.name
+    }
+  }
+}
+
+
+resource "huaweicloud_apig_channel" "type_server_legacy" {
+  instance_id        = local.instance_id
+  name               = "%[2]s_type_server_legacy"
+  port               = 81
   balance_strategy   = 1
   member_type        = "ecs"
   type               = 2
@@ -195,13 +268,43 @@ resource "huaweicloud_compute_instance" "test" {
   }
 }
 
-resource "huaweicloud_apig_channel" "test" {
+resource "huaweicloud_apig_channel" "type_server" {
   instance_id      = local.instance_id
-  name             = "%[2]s"
+  name             = "%[2]s_type_server"
   port             = 8000
   balance_strategy = 2
-  member_type        = "ecs"
-  type               = 2
+  member_type      = "ecs"
+  type             = "builtin"
+
+  health_check {
+    protocol           = "HTTPS"
+    threshold_normal   = 10  # maximum value
+    threshold_abnormal = 10  # maximum value
+    interval           = 300 # maximum value
+    timeout            = 30  # maximum value
+    path               = "/terraform/"
+    method             = "HEAD"
+    port               = 8080
+    http_codes         = "201,202,303-404"
+  }
+
+  dynamic "member" {
+    for_each = huaweicloud_compute_instance.test[*]
+
+    content {
+      id   = member.value.id
+      name = member.value.name
+    }
+  }
+}
+
+resource "huaweicloud_apig_channel" "type_server_legacy" {
+  instance_id      = local.instance_id
+  name             = "%[2]s_type_server_legacy"
+  port             = 8001
+  balance_strategy = 2
+  member_type      = "ecs"
+  type             = 2
 
   health_check {
     protocol           = "HTTPS"
@@ -284,7 +387,7 @@ func TestAccChannel_eipMembers(t *testing.T) {
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccChannelImportStateFunc(),
+				ImportStateIdFunc: testAccChannelImportStateFunc(rName),
 			},
 		},
 	})

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_channel.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_channel.go
@@ -121,6 +121,12 @@ func ResourceChannel() *schema.Resource {
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Description: "The microservice tags of the backend server group.",
 						},
+						"reference_vpc_channel_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The ID of the reference load balance channel.",
+						},
 					},
 				},
 				Description: "The backend server groups of the channel.",
@@ -397,12 +403,13 @@ func buildChannelMemberGroups(groups []interface{}) []channels.MemberGroup {
 	for i, val := range groups {
 		group := val.(map[string]interface{})
 		result[i] = channels.MemberGroup{
-			Name:                group["name"].(string),
-			Description:         group["description"].(string),
-			Weight:              group["weight"].(int),
-			MicroserviceVersion: group["microservice_version"].(string),
-			MicroservicePort:    group["microservice_port"].(int),
-			MicroserviceLabels:  buildMicroserviceLabels(group["microservice_labels"].(map[string]interface{})),
+			Name:                  group["name"].(string),
+			Description:           group["description"].(string),
+			Weight:                group["weight"].(int),
+			MicroserviceVersion:   group["microservice_version"].(string),
+			MicroservicePort:      group["microservice_port"].(int),
+			MicroserviceLabels:    buildMicroserviceLabels(group["microservice_labels"].(map[string]interface{})),
+			ReferenceVpcChannelId: group["reference_vpc_channel_id"].(string),
 		}
 	}
 
@@ -549,12 +556,13 @@ func flattenChannelMemberGroups(groups []channels.MemberGroup) []map[string]inte
 	result := make([]map[string]interface{}, len(groups))
 	for i, v := range groups {
 		result[i] = map[string]interface{}{
-			"name":                 v.Name,
-			"description":          v.Description,
-			"weight":               v.Weight,
-			"microservice_version": v.MicroserviceVersion,
-			"microservice_port":    v.MicroservicePort,
-			"microservice_labels":  flattenMicroserviceLabels(v.MicroserviceLabels),
+			"name":                     v.Name,
+			"description":              v.Description,
+			"weight":                   v.Weight,
+			"microservice_version":     v.MicroserviceVersion,
+			"microservice_port":        v.MicroservicePort,
+			"microservice_labels":      flattenMicroserviceLabels(v.MicroserviceLabels),
+			"reference_vpc_channel_id": v.ReferenceVpcChannelId,
 		}
 	}
 	return result

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/channels/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/channels/requests.go
@@ -33,6 +33,13 @@ type ChannelOpts struct {
 	// + 2: Server type.
 	// + 3: Microservice type.
 	Type int `json:"type,omitempty"`
+	// builtin: server type
+	// + microservice: microservice type
+	// + reference: reference load balance channel
+	// If vpc_channel_type is empty, the load balance channel type depends on the value of the type field.
+	// If vpc_channel_type is non-empty and type is non-empty or non-zero, an error occurs when they are specified.
+	// If vpc_channel_type is non-empty and type is empty or 0, the value of vpc_channel_type is used to specify the load balance channel type.
+	VpcChannelType string `json:"vpc_channel_type,omitempty"`
 	// Dictionary code of the channel.
 	// The value can contain letters, digits, hyphens (-), underscores (_), and periods (.).
 	DictCode string `json:"dict_code,omitempty"`
@@ -74,6 +81,9 @@ type MemberGroup struct {
 	// Tags of the backend server group.
 	// This parameter is supported only when the channel type is microservice.
 	MicroserviceLabels []MicroserviceLabel `json:"microservice_labels,omitempty"`
+	// ID of the reference load balance channel.
+	// This parameter is supported only when the VPC channel type is reference (vpc_channel_type=reference).
+	ReferenceVpcChannelId string `json:"reference_vpc_channel_id,omitempty"`
 }
 
 // MicroserviceLabel is an object that represents a specified microservice label.

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/channels/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/channels/results.go
@@ -28,6 +28,10 @@ type Channel struct {
 	// + 2: Server type.
 	// + 3: Microservice type.
 	Type int `json:"type"`
+	// builtin: server type
+	// + microservice: microservice type
+	// + reference: reference load balance
+	VpcChannelType string `json:"vpc_channel_type"`
 	// Dictionary code of the channel.
 	// The value can contain letters, digits, hyphens (-), underscores (_), and periods (.).
 	DictCode string `json:"dict_code"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20241223075604-9d56447e0fa3
+# github.com/chnsz/golangsdk v0.0.0-20241224015804-3881691a8961
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

During the parameters of the channel APIs updated, there are some changes for resource and corresponding test:
1. Recommand the new enums for channel type.
     The old enums (type integer) are as follows:
        - 2 (Server)
        - 3 (Microservice)
     The new enums (type string, due to convert logic of the terrafrom provider, integer values can be easily convert to string values) are as follows:
        - builtin (Server)
        - microservice (Microservice)

     Althrough the type are changed, but the old enums' setting are also allowed.

2. New type value reference (Reference of load balance channel) is supported.
3. Supports new parameter for reference type usage.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. adjust the parameter type of the channel type from int to string and recommand the new enums.
2. new type value reference is supported.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccChannel_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccChannel_basic -timeout 360m -parallel 10
=== RUN   TestAccChannel_basic
=== PAUSE TestAccChannel_basic
=== CONT  TestAccChannel_basic
--- PASS: TestAccChannel_basic (244.37s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      244.434s        coverage: 4.6% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
