### PR TITLE
feat(evs): enhance evs resource capabilities

### DIFF
--- a/docs/resources/evs_volume.md
+++ b/docs/resources/evs_volume.md
@@ -98,8 +98,7 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `volume_type` - (Required, String, ForceNew) Specifies the disk type. Changing this parameter will create a new resource.
-  Valid values are as follows:
+* `volume_type` - (Required, String) Specifies the disk type. Valid values are as follows:
   + **SAS**: High I/O type.
   + **SSD**: Ultra-high I/O type.
   + **GPSSD**: General purpose SSD type.
@@ -110,6 +109,15 @@ The following arguments are supported:
   If the specified disk type is not available in the AZ, the disk will fail to create. The volume type **ESSD2** only
   support in postpaid charging mode. When creating a cloud disk from a snapshot, the `volume_type` field must be
   consistent with the snapshot source cloud disk.
+
+  -> There are some restrictions on changing the cloud disk type:
+  <br/>1. Changing the cloud disk type is currently in the public beta stage. Please submit a work order in advance
+  to apply for the public beta.
+  <br/>2. The cloud disk type can be changed only when the disk status is Available or In-use.
+  <br/>3. Changing the disk type may take several hours or even longer, and cannot be stopped.
+  **It is strongly recommended that users proactively configure a reasonable change timeout before changing the disk type.**
+  <br/>4. Refer to [Changing the EVS Disk Type](https://support.huaweicloud.com/intl/en-us/usermanual-evs/evs_01_0062.html)
+  for more details.
 
 * `iops` - (Optional, Int) Specifies the IOPS(Input/Output Operations Per Second) for the volume.
   The field is valid and required when `volume_type` is set to **GPSSD2** or **ESSD2**.
@@ -243,12 +251,15 @@ The `attachment` block supports:
 
 * `dedicated_storage_name` - The name of the DSS storage pool accommodating the disk.
 
+* `status` - The disk status.
+  Please refer to [EVS Disk Status](https://support.huaweicloud.com/intl/en-us/api-evs/evs_04_0040.html).
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:
 
 * `create` - Default is 10 minutes.
-* `update` - Default is 3 minutes.
+* `update` - Default is 180 minutes.
 * `delete` - Default is 3 minutes.
 
 ## Import

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -443,6 +443,7 @@ var (
 	HW_EVS_AVAILABILITY_ZONE_ESSD2  = os.Getenv("HW_EVS_AVAILABILITY_ZONE_ESSD2")
 	HW_EVS_TRANSFER_ID              = os.Getenv("HW_EVS_TRANSFER_ID")
 	HW_EVS_TRANSFER_AUTH_KEY        = os.Getenv("HW_EVS_TRANSFER_AUTH_KEY")
+	HW_EVS_ENABLE_FLAG              = os.Getenv("HW_EVS_ENABLE_FLAG")
 
 	HW_ECS_LAUNCH_TEMPLATE_ID = os.Getenv("HW_ECS_LAUNCH_TEMPLATE_ID")
 
@@ -2783,6 +2784,13 @@ func TestAccPrecheckSfsFileSystemNames(t *testing.T, min int) {
 func TestAccPrecheckEVSTransferAccepter(t *testing.T) {
 	if HW_EVS_TRANSFER_ID == "" || HW_EVS_TRANSFER_AUTH_KEY == "" {
 		t.Skip("HW_EVS_TRANSFER_ID and HW_EVS_TRANSFER_AUTH_KEY must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckEVSFlag(t *testing.T) {
+	if HW_EVS_ENABLE_FLAG == "" {
+		t.Skip("Skip the EVS acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_test.go
@@ -827,3 +827,341 @@ resource "huaweicloud_evs_volume" "test" {
 }
 `, testAccEvsVolume_prePaidWithServer_base(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
+
+// Changing the disk type takes a long time. This test case may take several hours, so a separate test case is provided.
+// Before executing this test case, please submit a work order to apply for public beta qualification to change the disk type.
+func TestAccEvsVolume_postPaidEditDiskType(t *testing.T) {
+	var volume cloudvolumes.Volume
+	name := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_evs_volume.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&volume,
+		getVolumeResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+			acceptance.TestAccPreCheckEVSFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEvsVolume_postPaidEditDiskType(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "SAS"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "0"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+				),
+			},
+			{
+				Config: testAccEvsVolume_postPaidEditDiskType_update1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description update"),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD2"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "3000"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "125"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+				),
+			},
+			{
+				Config: testAccEvsVolume_postPaidEditDiskType_update2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "0"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"cascade",
+				},
+			},
+		},
+	})
+}
+
+func testAccEvsVolume_postPaidEditDiskType(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%s"
+  size                  = 100
+  description           = "test description"
+  volume_type           = "SAS"
+  device_type           = "VBD"
+  multiattach           = false
+  enterprise_project_id = "%s"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccEvsVolume_postPaidEditDiskType_update1(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%s_update"
+  size                  = 200
+  description           = "test description update"
+  volume_type           = "GPSSD2"
+  iops                  = 3000
+  throughput            = 125
+  device_type           = "VBD"
+  multiattach           = false
+  enterprise_project_id = "%s"
+
+  tags = {
+    foo = "bar_update"
+    key = "value_update"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccEvsVolume_postPaidEditDiskType_update2(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%s_update"
+  size                  = 200
+  volume_type           = "GPSSD"
+  device_type           = "VBD"
+  multiattach           = false
+  enterprise_project_id = "%s"
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+// Changing the disk type takes a long time. This test case may take several hours, so a separate test case is provided.
+// Before executing this test case, please submit a work order to apply for public beta qualification to change the disk type.
+func TestAccEvsVolume_prePaidEditDiskType(t *testing.T) {
+	var volume cloudvolumes.Volume
+	name := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_evs_volume.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&volume,
+		getVolumeResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+			acceptance.TestAccPreCheckEVSFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEvsVolume_prePaidEditDiskType(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "0"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+				),
+			},
+			{
+				Config: testAccEvsVolume_prePaidEditDiskType_update1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description update"),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD2"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "3000"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "125"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+				),
+			},
+			{
+				Config: testAccEvsVolume_prePaidEditDiskType_update2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "SSD"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "0"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "0"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttrSet(resourceName, "wwn"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"cascade",
+					"period_unit",
+					"period",
+					"auto_renew",
+					"charging_mode",
+				},
+			},
+		},
+	})
+}
+
+func testAccEvsVolume_prePaidEditDiskType(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%s"
+  size                  = 100
+  description           = "test description"
+  volume_type           = "GPSSD"
+  device_type           = "VBD"
+  multiattach           = false
+  enterprise_project_id = "%s"
+  charging_mode         = "prePaid"
+  period_unit           = "month"
+  period                = 1
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccEvsVolume_prePaidEditDiskType_update1(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%s_update"
+  size                  = 200
+  description           = "test description update"
+  volume_type           = "GPSSD2"
+  iops                  = 3000
+  throughput            = 125
+  device_type           = "VBD"
+  multiattach           = false
+  enterprise_project_id = "%s"
+  charging_mode         = "prePaid"
+  period_unit           = "month"
+  period                = 1
+
+  tags = {
+    foo = "bar_update"
+    key = "value_update"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccEvsVolume_prePaidEditDiskType_update2(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%s_update"
+  size                  = 200
+  volume_type           = "SSD"
+  device_type           = "VBD"
+  multiattach           = false
+  enterprise_project_id = "%s"
+  charging_mode         = "prePaid"
+  period_unit           = "month"
+  period                = 1
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes/requests.go
@@ -161,6 +161,39 @@ func ExtendSize(client *golangsdk.ServiceClient, id string, opts ExtendOptsBuild
 	return
 }
 
+type RetypeOptsBuilder interface {
+	ToVolumeRetypeMap() (map[string]interface{}, error)
+}
+
+type RetypeOpts struct {
+	BssParam *BssParamOpts `json:"bssParam,omitempty"`
+	OSRetype OSRetypeOpts  `json:"os-retype" required:"true"`
+}
+
+type BssParamOpts struct {
+	IsAutoPay string `json:"isAutoPay,omitempty"`
+}
+
+type OSRetypeOpts struct {
+	NewType    string `json:"new_type" required:"true"`
+	Iops       int    `json:"iops,omitempty"`
+	Throughput int    `json:"throughput,omitempty"`
+}
+
+func (opts RetypeOpts) ToVolumeRetypeMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+func UpdateVolumeType(client *golangsdk.ServiceClient, id string, opts RetypeOptsBuilder) (r JobResult) {
+	b, err := opts.ToVolumeRetypeMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(retypeURL(client, id), b, &r.Body, nil)
+	return
+}
+
 // UpdateOptsBuilder allows extensions to add additional parameters to the
 // Update request.
 type UpdateOptsBuilder interface {

--- a/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes/urls.go
@@ -3,6 +3,7 @@ package cloudvolumes
 import "github.com/chnsz/golangsdk"
 
 const resourcePath = "cloudvolumes"
+const resourceVolumePath = "volumes"
 
 func createURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL(resourcePath)
@@ -10,6 +11,10 @@ func createURL(c *golangsdk.ServiceClient) string {
 
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL(resourcePath, id)
+}
+
+func retypeURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(resourceVolumePath, id, "retype")
 }
 
 func actionURL(c *golangsdk.ServiceClient, id string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Enhance evs resource capabilities.
- evs resource supports to update volume type.
- evs resource supports new attribute field `status`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run TestAccEvsVolume_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolume_ -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_postPaidWithoutServer
=== PAUSE TestAccEvsVolume_postPaidWithoutServer
=== RUN   TestAccEvsVolume_postPaidWithServer
=== PAUSE TestAccEvsVolume_postPaidWithServer
=== RUN   TestAccEvsVolume_prePaidWithoutServer
=== PAUSE TestAccEvsVolume_prePaidWithoutServer
=== RUN   TestAccEvsVolume_prePaidWithServer
=== PAUSE TestAccEvsVolume_prePaidWithServer
=== RUN   TestAccEvsVolume_postPaidEditDiskType
=== PAUSE TestAccEvsVolume_postPaidEditDiskType
=== RUN   TestAccEvsVolume_prePaidEditDiskType
=== PAUSE TestAccEvsVolume_prePaidEditDiskType
=== CONT  TestAccEvsVolume_postPaidWithoutServer
=== CONT  TestAccEvsVolume_prePaidWithServer
=== CONT  TestAccEvsVolume_prePaidWithoutServer
=== CONT  TestAccEvsVolume_prePaidEditDiskType
--- PASS: TestAccEvsVolume_postPaidWithoutServer (87.16s)
=== CONT  TestAccEvsVolume_postPaidEditDiskType
--- PASS: TestAccEvsVolume_prePaidWithoutServer (200.94s)
=== CONT  TestAccEvsVolume_postPaidWithServer
--- PASS: TestAccEvsVolume_postPaidWithServer (344.63s)
--- PASS: TestAccEvsVolume_prePaidWithServer (548.51s)
--- PASS: TestAccEvsVolume_postPaidEditDiskType (739.85s)
--- PASS: TestAccEvsVolume_prePaidEditDiskType (2245.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       2245.951s
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
