### PR TITLE
feat(apig/response): rule supports headers configuration

### DIFF
--- a/docs/resources/apig_response.md
+++ b/docs/resources/apig_response.md
@@ -15,6 +15,12 @@ Manages an APIG (API) custom response resource within HuaweiCloud.
 variable "instance_id" {}
 variable "group_id" {}
 variable "response_name" {}
+variable "response_headers" {
+  type = list(object({
+    key   = string
+    value = string
+  }))
+}
 
 resource "huaweicloud_apig_response" "test" {
   instance_id = var.instance_id
@@ -25,6 +31,15 @@ resource "huaweicloud_apig_response" "test" {
     error_type  = "AUTHORIZER_FAILURE"
     body        = "{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"
     status_code = 401
+  
+    dynamic "headers" {
+      for_each = var.response_headers
+
+      content {
+        key   = headers.value["key"]
+        value = headers.value["value"]
+      }
+    }
   }
 }
 ```
@@ -48,7 +63,7 @@ The following arguments are supported:
   The valid length is limited from `1` to `64`, letters, digits, hyphens (-) and underscores (_) are allowed.
 
 * `rule` - (Optional, List) Specifies the API custom response rules definition.  
-  The [object](#custom_response_rule) structure is documented below.
+  The [rule](#custom_response_rule) structure is documented below.
 
 <a name="custom_response_rule"></a>
 The `rule` block supports:
@@ -78,6 +93,18 @@ The `rule` block supports:
 
 * `status_code` - (Optional, Int) Specifies the HTTP status code of the API response rule.
   The valid value is range from `200` to `599`.
+
+* `headers` - (Optional, List) Specifies the configuration of the custom response headers.  
+  The [headers](#custom_response_rule_headers) structure is documented below.
+
+<a name="custom_response_rule_headers"></a>
+The `headers` block supports:
+
+* `key` - (Required, String) Specifies the key name of the response header.
+   The valid length is limited from `1` to `128`, only English letters, digits and hyphens (-) are allowed.
+
+* `value` - (Required, String) Specifies the value for the specified response header key.
+  The valid length is limited from `1` to `1,024`.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20241223075604-9d56447e0fa3
+	github.com/chnsz/golangsdk v0.0.0-20241224015804-3881691a8961
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20241223075604-9d56447e0fa3 h1:JbrUK2HgqDQrzX3tytXeuLrwEdZ6P1HLoli61XmhIgk=
-github.com/chnsz/golangsdk v0.0.0-20241223075604-9d56447e0fa3/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20241224015804-3881691a8961 h1:fz4oQHt1QyL3r5sP1sHNiwysBqyk7Z+Paq5mGothiRw=
+github.com/chnsz/golangsdk v0.0.0-20241224015804-3881691a8961/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_response_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_response_test.go
@@ -49,7 +49,17 @@ func TestAccResponse_basic(t *testing.T) {
 				Config: testAccResponse_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
 					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttr(rName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(rName, "rule.0.error_type", "AUTHORIZER_FAILURE"),
+					resource.TestCheckResourceAttr(rName, "rule.0.body",
+						"{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"),
+					resource.TestCheckResourceAttr(rName, "rule.0.status_code", "401"),
+					resource.TestCheckResourceAttr(rName, "rule.0.headers.#", "1"),
+					resource.TestCheckResourceAttr(rName, "rule.0.headers.0.key", "test-0"),
+					resource.TestCheckResourceAttr(rName, "rule.0.headers.0.value", "test-value-0"),
 				),
 			},
 			{
@@ -94,7 +104,17 @@ func TestAccResponse_customRules(t *testing.T) {
 				Config: testAccResponse_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
 					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttr(rName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(rName, "rule.0.error_type", "AUTHORIZER_FAILURE"),
+					resource.TestCheckResourceAttr(rName, "rule.0.body",
+						"{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"),
+					resource.TestCheckResourceAttr(rName, "rule.0.status_code", "401"),
+					resource.TestCheckResourceAttr(rName, "rule.0.headers.#", "1"),
+					resource.TestCheckResourceAttr(rName, "rule.0.headers.0.key", "test-0"),
+					resource.TestCheckResourceAttr(rName, "rule.0.headers.0.value", "test-value-0"),
 				),
 			},
 			{
@@ -111,6 +131,11 @@ func TestAccResponse_customRules(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(rName, "rule.0.error_type", "AUTHORIZER_FAILURE"),
+					resource.TestCheckResourceAttr(rName, "rule.0.body",
+						"{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"),
+					resource.TestCheckResourceAttr(rName, "rule.0.status_code", "403"),
+					resource.TestCheckResourceAttr(rName, "rule.0.headers.#", "0"),
 				),
 			},
 			{
@@ -155,6 +180,11 @@ resource "huaweicloud_apig_response" "test" {
     error_type  = "AUTHORIZER_FAILURE"
     body        = "{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"
     status_code = 401
+
+    headers {
+      key   = "test-0"
+      value = "test-value-0" 
+    }
   }
 }
 `, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
@@ -181,6 +211,15 @@ resource "huaweicloud_apig_response" "test" {
     error_type  = "AUTHORIZER_FAILURE"
     body        = "{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"
     status_code = 401
+
+    headers {
+      key   = "test-0"
+      value = "test-value-0" 
+    }
+    headers {
+      key   = "test-1"
+      value = "test-value-1" 
+    }
   }
 }
 `, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/responses/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/responses/requests.go
@@ -38,9 +38,20 @@ type ResponseInfo struct {
 	Body string `json:"body" required:"true"`
 	// HTTP status code of the response. If omitted, the status will be cancelled.
 	Status int `json:"status,omitempty"`
+	// The configuration of the custom response headers.
+	Headers []ResponseInfoHeader `json:"headers,omitempty"`
 	// Indicates whether the response is the default response.
 	// Only the response of the API call is supported.
 	IsDefault bool `json:"default,omitempty"`
+}
+
+type ResponseInfoHeader struct {
+	// The key name of the response header.
+	// The valid length is limited from 1 to 128, only English letters, digits and hyphens (-) are allowed.
+	Key string `json:"key,omitempty"`
+	// The value for the specified response header key.
+	// The valid length is limited from 1 to 1,024.
+	Value string `json:"value,omitempty"`
 }
 
 type ResponseOptsBuilder interface {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20241223075604-9d56447e0fa3
+# github.com/chnsz/golangsdk v0.0.0-20241224015804-3881691a8961
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Now, API response resource (during corresponding OpenAPIs) supports the headers configuration.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. rule supports headers configuration.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccResponse_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccResponse_basic -timeout 360m -parallel 10
=== RUN   TestAccResponse_basic
=== PAUSE TestAccResponse_basic
=== CONT  TestAccResponse_basic
--- PASS: TestAccResponse_basic (29.82s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      29.875s coverage: 4.2% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
