### PR TITLE
chore(servicestage/auth): host parameter is no longer required

### DIFF
--- a/docs/resources/servicestage_repo_token_authorization.md
+++ b/docs/resources/servicestage_repo_token_authorization.md
@@ -13,14 +13,12 @@ token with various types of the Open-Source repository.
 ## Example Usage
 
 ```hcl
-variable "authorization_name"
-variable "repository_host"
-variable "personal_access_token"
+variable "authorization_name" {}
+variable "personal_access_token" {}
 
 resource "huaweicloud_servicestage_repo_token_authorization" "test" {
   type  = "github"
   name  = var.authorization_name
-  host  = var.repository_host
   token = var.personal_access_token
 }
 ```
@@ -43,11 +41,13 @@ The following arguments are supported:
 
   Changing this parameter will create a new authorization.
 
-* `host` - (Required, String, ForceNew) Specified the host name of the repository.
-  Changing this parameter will create a new authorization.
-
 * `token` - (Required, String, ForceNew) Specified the personal access token of the repository.
   Changing this parameter will create a new authorization.
+
+<!-- markdownlint-disable MD034 -->
+* `host` - (Optional, String, ForceNew) Specified the host name of the repository, e.g. **https://api.github.com**.
+  Changing this parameter will create a new authorization.
+<!-- markdownlint-enable MD034 -->
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20241224015804-3881691a8961
+	github.com/chnsz/golangsdk v0.0.0-20241224061204-e794f144e5ec
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20241224015804-3881691a8961 h1:fz4oQHt1QyL3r5sP1sHNiwysBqyk7Z+Paq5mGothiRw=
-github.com/chnsz/golangsdk v0.0.0-20241224015804-3881691a8961/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20241224061204-e794f144e5ec h1:TzFxp/PH01bwLEDRrIEgTCffn+BqasKT8QGw1B2OeYI=
+github.com/chnsz/golangsdk v0.0.0-20241224061204-e794f144e5ec/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -161,7 +161,6 @@ var (
 	HW_DLI_FLINK_STREAM_GRAPH           = os.Getenv("HW_DLI_FLINK_STREAM_GRAPH")
 	HW_DLI_ELASTIC_RESOURCE_POOL        = os.Getenv("HW_DLI_ELASTIC_RESOURCE_POOL")
 
-	HW_GITHUB_REPO_HOST        = os.Getenv("HW_GITHUB_REPO_HOST")        // Repository host (Github, Gitlab, Gitee)
 	HW_GITHUB_PERSONAL_TOKEN   = os.Getenv("HW_GITHUB_PERSONAL_TOKEN")   // Personal access token (Github, Gitlab, Gitee)
 	HW_GITHUB_REPO_PWD         = os.Getenv("HW_GITHUB_REPO_PWD")         // Repository password (DevCloud, BitBucket)
 	HW_GITHUB_REPO_URL         = os.Getenv("HW_GITHUB_REPO_URL")         // Repository URL (Github, Gitlab, Gitee)
@@ -1254,8 +1253,8 @@ func TestAccPreCheckDliElasticResourcePool(t *testing.T) {
 
 // lintignore:AT003
 func TestAccPreCheckRepoTokenAuth(t *testing.T) {
-	if HW_GITHUB_REPO_HOST == "" || HW_GITHUB_PERSONAL_TOKEN == "" {
-		t.Skip("Repository configurations are not completed for acceptance test of personal access token authorization.")
+	if HW_GITHUB_PERSONAL_TOKEN == "" {
+		t.Skip("HW_GITHUB_PERSONAL_TOKEN must be set for token authorization test within ServiceStage.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_component_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_component_test.go
@@ -267,10 +267,9 @@ resource "huaweicloud_cce_node" "test" {
 resource "huaweicloud_servicestage_repo_token_authorization" "test" {
   type  = "github"
   name  = "%[1]s"
-  host  = "%[2]s"
-  token = "%[3]s"
+  token = "%[2]s"
 }
-`, rName, acceptance.HW_GITHUB_REPO_HOST, acceptance.HW_GITHUB_PERSONAL_TOKEN)
+`, rName, acceptance.HW_GITHUB_PERSONAL_TOKEN)
 }
 
 func testAccComponent_web(rName string) string {

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_repo_token_authorization.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_repo_token_authorization.go
@@ -46,16 +46,17 @@ func ResourceRepoTokenAuth() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"host": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
 			"token": {
 				Type:      schema.TypeString,
 				Required:  true,
 				ForceNew:  true,
 				Sensitive: true,
+			},
+			"host": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				// Have not setting code, computed is unnecessary.
 			},
 		},
 	}
@@ -71,8 +72,8 @@ func resourceRepoTokenAuthCreate(ctx context.Context, d *schema.ResourceData, me
 
 	opt := repositories.PersonalAuthOpts{
 		Name:  d.Get("name").(string),
-		Host:  d.Get("host").(string),
 		Token: d.Get("token").(string),
+		Host:  d.Get("host").(string),
 	}
 	auth, err := repositories.CreatePersonalAuth(client, d.Get("type").(string), opt)
 	if err != nil {

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_repo_token_authorization.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_repo_token_authorization.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories"
@@ -46,9 +45,6 @@ func ResourceRepoTokenAuth() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"github", "gitlab", "gitee",
-				}, false),
 			},
 			"host": {
 				Type:     schema.TypeString,

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories/requests.go
@@ -33,10 +33,10 @@ func CreatePwdAuth(c *golangsdk.ServiceClient, rType string, opts PwdAuthOpts) (
 type PersonalAuthOpts struct {
 	// Specified the authorization name.
 	Name string `json:"name" required:"true"`
-	// Specified the repository address.
-	Host string `json:"host" required:"true"`
 	// Specified the repository token.
 	Token string `json:"token" required:"true"`
+	// Specified the repository address.
+	Host string `json:"host,omitempty"`
 }
 
 // CreatePersonalAuth is a method to create the personal access token authorization.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20241224015804-3881691a8961
+# github.com/chnsz/golangsdk v0.0.0-20241224061204-e794f144e5ec
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
During the OpenAPI upgradation, the behavior of parameter host is changed from required to optional.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update the behavior of the parameter host from required to optional.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o servicestage -f TestAccRepoTokenAuth_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccRepoTokenAuth_basic -timeout 360m -parallel 10
=== RUN   TestAccRepoTokenAuth_basic
=== PAUSE TestAccRepoTokenAuth_basic
=== CONT  TestAccRepoTokenAuth_basic
--- PASS: TestAccRepoTokenAuth_basic (10.58s)
PASS
coverage: 3.9% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      10.630s coverage: 3.9% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
