### PR TITLE
feat(CodeArts/Deploy): support to get groups and hosts

### DIFF
--- a/docs/data-sources/codearts_deploy_groups.md
+++ b/docs/data-sources/codearts_deploy_groups.md
@@ -1,0 +1,91 @@
+---
+subcategory: "CodeArts Deploy"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_codearts_deploy_groups"
+description: |-
+  Use this data source to get the list of CodeArts deploy groups.
+---
+
+# huaweicloud_codearts_deploy_groups
+
+Use this data source to get the list of CodeArts deploy groups.
+
+## Example Usage
+
+```hcl
+variable "project_id" {}
+
+data "huaweicloud_codearts_deploy_groups" "test" {
+  project_id = var.project_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `project_id` - (Required, String) Specifies the project ID.
+
+* `name` - (Optional, String) Specifies the name of host cluster.
+
+* `os_type` - (Optional, String) Specifies the operating system. Valid values are **windows**, **linux**.
+
+* `is_proxy_mode` - (Optional, String) Specifies whether the host is an agent host.
+  Valid values are as follows:
+  + **1**: Using proxy access mode.
+  + **0**: Without using proxy access mode.
+
+* `resource_pool_id` - (Optional, String) Specifies the customized resource pool ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `groups` - Indicates the host cluster list.
+
+  The [groups](#groups_struct) structure is documented below.
+
+<a name="groups_struct"></a>
+The `groups` block supports:
+
+* `id` - Indicates the host cluster ID.
+
+* `name` - Indicates the host cluster name.
+
+* `description` - Indicates the description of host cluster.
+
+* `env_count` - Indicates the number of environments.
+
+* `host_count` - Indicates the the number of hosts in a cluster.
+
+* `os_type` - Indicates the operating system.
+
+* `resource_pool_id` - Indicates the slave cluster ID.
+  + If the default value is null, the default slave cluster is used.
+  + If the value is user-defined, the slave cluster ID is used.
+
+* `permission` - Indicates the permission list.
+
+  The [permission](#groups_permission_struct) structure is documented below.
+
+* `created_by` - Indicates the creator name.
+
+<a name="groups_permission_struct"></a>
+The `permission` block supports:
+
+* `can_edit` - Indicates whether the user has the edit permission.
+
+* `can_delete` - Indicates whether the user has the deletion permission.
+
+* `can_add_host` - Indicates whether the user has the permission to add hosts.
+
+* `can_manage` - Indicates whether the user has the management permission.
+
+* `can_view` - Indicates whether the user has the view permission.
+
+* `can_copy` - Indicates whether the user has the permission to copy hosts.

--- a/docs/data-sources/codearts_deploy_hosts.md
+++ b/docs/data-sources/codearts_deploy_hosts.md
@@ -1,0 +1,99 @@
+---
+subcategory: "CodeArts Deploy"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_codearts_deploy_hosts"
+description: |-
+  Use this data source to get the list of CodeArts deploy hosts.
+---
+
+# huaweicloud_codearts_deploy_hosts
+
+Use this data source to get the list of CodeArts deploy hosts.
+
+## Example Usage
+
+```hcl
+variable "group_id" {}
+
+data "huaweicloud_codearts_deploy_hosts" "test" {
+  group_id = var.group_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `group_id` - (Required, String) Specifies the group ID.
+
+* `as_proxy` - (Optional, String) Specifies whether the host is proxy or not.
+  Valid values are **true** and **false**.
+
+* `environment_id` - (Optional, String) Specifies the environment ID.
+
+* `name` - (Optional, String) Specifies the name of host.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `hosts` - Indicates the host list.
+  The [hosts](#attrblock--hosts) structure is documented below.
+
+<a name="attrblock--hosts"></a>
+The `hosts` block supports:
+
+* `id` - Indicates the host ID.
+
+* `name` - Indicates the host name.
+
+* `as_proxy` - Indicates whether the host is an agent host.
+
+* `connection_status` - Indicates the connection status.
+
+* `env_count` - Indicates the number of environments.
+
+* `import_status` - Indicates the import status.
+
+* `ip_address` - Indicates the IP address.
+
+* `lastest_connection_at` - Indicates the last connection time.
+
+* `os_type` - Indicates the operating system.
+
+* `owner_id` - Indicates the owner ID.
+
+* `owner_name` - Indicates the owner name.
+
+* `created_at` - Indicates the create time.
+
+* `permission` - Indicates the permission.
+  The [permission](#attrblock--hosts--permission) structure is documented below.
+
+* `port` - Indicates the SSH port.
+
+* `proxy_host_id` - Indicates the agent ID.
+
+* `trusted_type` - Indicates the trusted type.
+  + **0** indicates password authentication.
+  + **1** indicates key authentication.
+
+* `username` - Indicates the username.
+
+<a name="attrblock--hosts--permission"></a>
+The `permission` block supports:
+
+* `can_add_host` - Indicates whether the user has the permission to add hosts.
+
+* `can_copy` - Indicates whether the user has the permission to copy hosts.
+
+* `can_delete` - Indicates whether the user has the deletion permission.
+
+* `can_edit` - Indicates whether the user has the edit permission.
+
+* `can_view` - Indicates whether the user has the view permission.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -575,6 +575,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_compute_servergroups":            ecs.DataSourceComputeServerGroups(),
 			"huaweicloud_compute_instance_remote_console": ecs.DataSourceComputeInstanceRemoteConsole(),
 
+			"huaweicloud_codearts_deploy_groups": codeartsdeploy.DataSourceCodeartsDeployGroups(),
+			"huaweicloud_codearts_deploy_hosts":  codeartsdeploy.DataSourceCodeartsDeployHosts(),
+
 			"huaweicloud_cts_notifications": cts.DataSourceNotifications(),
 			"huaweicloud_cts_traces":        cts.DataSourceCtsTraces(),
 			"huaweicloud_cts_trackers":      cts.DataSourceCtsTrackers(),

--- a/huaweicloud/services/acceptance/codeartsdeploy/data_source_huaweicloud_codearts_deploy_groups_test.go
+++ b/huaweicloud/services/acceptance/codeartsdeploy/data_source_huaweicloud_codearts_deploy_groups_test.go
@@ -1,0 +1,107 @@
+package codeartsdeploy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCodeartsDeployGroups_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_codearts_deploy_groups.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCodeartsDeployGroups_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.env_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.host_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.is_proxy_mode"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.os_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.created_by"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.permission.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.permission.0.can_view"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.permission.0.can_edit"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.permission.0.can_delete"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.permission.0.can_add_host"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.permission.0.can_manage"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.permission.0.can_copy"),
+
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_os_type_filter_useful", "true"),
+					resource.TestCheckOutput("is_proxy_mode_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCodeartsDeployGroups_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_codearts_deploy_groups" "test" {
+  depends_on = [huaweicloud_codearts_deploy_group.test]
+
+  project_id = huaweicloud_codearts_project.test.id
+}
+
+// filter by name
+data "huaweicloud_codearts_deploy_groups" "filter_by_name" {
+  project_id = huaweicloud_codearts_project.test.id
+  name       = huaweicloud_codearts_deploy_group.test.name
+}
+
+locals {
+  filter_result_by_name = [for v in data.huaweicloud_codearts_deploy_groups.filter_by_name.groups[*].name : 
+    v == huaweicloud_codearts_deploy_group.test.name]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.filter_result_by_name) > 0
+}
+
+// filter by os type
+data "huaweicloud_codearts_deploy_groups" "filter_by_os_type" {
+  project_id = huaweicloud_codearts_project.test.id
+  os_type    = huaweicloud_codearts_deploy_group.test.os_type
+}
+
+locals {
+  filter_result_by_os_type = [for v in data.huaweicloud_codearts_deploy_groups.filter_by_os_type.groups[*].os_type : 
+    v == huaweicloud_codearts_deploy_group.test.os_type]
+}
+
+output "is_os_type_filter_useful" {
+  value = length(local.filter_result_by_os_type) > 0 && alltrue(local.filter_result_by_os_type) 
+}
+
+// filter by proxy mode
+data "huaweicloud_codearts_deploy_groups" "filter_by_proxy_mode" {
+  project_id    = huaweicloud_codearts_project.test.id
+  is_proxy_mode = huaweicloud_codearts_deploy_group.test.is_proxy_mode
+}
+
+locals {
+  filter_result_by_proxy_mode = [for v in data.huaweicloud_codearts_deploy_groups.filter_by_proxy_mode.groups[*].is_proxy_mode : 
+    v == huaweicloud_codearts_deploy_group.test.is_proxy_mode]
+}
+
+output "is_proxy_mode_filter_useful" {
+  value = length(local.filter_result_by_proxy_mode) > 0 && alltrue(local.filter_result_by_proxy_mode) 
+}
+`, testDeployGroup_basic(name))
+}

--- a/huaweicloud/services/acceptance/codeartsdeploy/data_source_huaweicloud_codearts_deploy_hosts_test.go
+++ b/huaweicloud/services/acceptance/codeartsdeploy/data_source_huaweicloud_codearts_deploy_hosts_test.go
@@ -1,0 +1,98 @@
+package codeartsdeploy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCodeartsDeployHosts_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_codearts_deploy_hosts.test"
+	name := acceptance.RandomAccResourceName()
+	proxyName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCodeartsDeployHosts_basic(proxyName, name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.ip_address"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.port"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.username"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.trusted_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.as_proxy"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.lastest_connection_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.connection_status"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.permission.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.permission.0.can_view"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.permission.0.can_edit"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.permission.0.can_delete"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.permission.0.can_add_host"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.permission.0.can_copy"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.owner_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.owner_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.env_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.created_at"),
+
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_as_proxy_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCodeartsDeployHosts_basic(proxyName, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_codearts_deploy_hosts" "test" {
+  depends_on = [huaweicloud_codearts_deploy_host.test]
+
+  group_id = huaweicloud_codearts_deploy_group.test.id
+}
+
+// filter by name
+data "huaweicloud_codearts_deploy_hosts" "filter_by_name" {
+  group_id = huaweicloud_codearts_deploy_group.test.id
+  name     = huaweicloud_codearts_deploy_host.test.name
+}
+
+locals {
+  filter_result_by_name = [for v in data.huaweicloud_codearts_deploy_hosts.filter_by_name.hosts[*].name : 
+    v == huaweicloud_codearts_deploy_host.test.name]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.filter_result_by_name) > 0
+}
+
+// filter by as proxy
+data "huaweicloud_codearts_deploy_hosts" "filter_by_as_proxy" {
+  group_id = huaweicloud_codearts_deploy_group.test.id
+  as_proxy = huaweicloud_codearts_deploy_host.test.as_proxy
+}
+
+locals {
+  filter_result_by_as_proxy = [for v in data.huaweicloud_codearts_deploy_hosts.filter_by_as_proxy.hosts[*].as_proxy : 
+    v == huaweicloud_codearts_deploy_host.test.as_proxy]
+}
+
+output "is_as_proxy_filter_useful" {
+  value = length(local.filter_result_by_as_proxy) > 0 && alltrue(local.filter_result_by_as_proxy) 
+}
+`, testDeployHost_withProxyMode(proxyName, name))
+}

--- a/huaweicloud/services/codeartsdeploy/data_source_huaweicloud_codearts_deploy_groups.go
+++ b/huaweicloud/services/codeartsdeploy/data_source_huaweicloud_codearts_deploy_groups.go
@@ -1,0 +1,206 @@
+package codeartsdeploy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const pageSize = 10
+
+// @API CodeArtsDeploy GET /v1/resources/host-groups
+func DataSourceCodeartsDeployGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCodeartsDeployGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the project ID.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the name of host cluster.`,
+			},
+			"os_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the operating system. Valid values are **windows**, **linux**.`,
+			},
+			"is_proxy_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies whether the host is an agent host.`,
+			},
+			"resource_pool_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the customized resource pool ID.`,
+			},
+			"groups": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Indicates the host cluster list.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the host cluster ID.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the host cluster name.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the description of host cluster.`,
+						},
+						"env_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the number of environments.`,
+						},
+						"host_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the the number of hosts in a cluster.`,
+						},
+						"is_proxy_mode": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates whether the host is an agent host.`,
+						},
+						"os_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the operating system.`,
+						},
+						"resource_pool_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the slave cluster ID.`,
+						},
+						"permission": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `Indicates the permission list.`,
+							Elem:        deployGroupPermissionSchema(),
+						},
+						"created_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the creator name.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceCodeartsDeployGroupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("codearts_deploy", region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	getHttpUrl := "v1/resources/host-groups"
+	getPath := client.Endpoint + getHttpUrl
+	getPath += buildCodeartsDeployGroupsQueryParams(d)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	// pageSize is `10`
+	getPath += fmt.Sprintf("&page_size=%v", pageSize)
+	pageIndex := 1
+
+	rst := make([]map[string]interface{}, 0)
+	for {
+		currentPath := getPath + fmt.Sprintf("&page_index=%d", pageIndex)
+		getResp, err := client.Request("GET", currentPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving groups: %s", err)
+		}
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.Errorf("error flatten response: %s", err)
+		}
+
+		groups := utils.PathSearch("result", getRespBody, make([]interface{}, 0)).([]interface{})
+		for _, group := range groups {
+			rst = append(rst, map[string]interface{}{
+				"id":               utils.PathSearch("id", group, nil),
+				"name":             utils.PathSearch("name", group, nil),
+				"description":      utils.PathSearch("description", group, nil),
+				"env_count":        utils.PathSearch("env_count", group, nil),
+				"host_count":       utils.PathSearch("host_count", group, nil),
+				"is_proxy_mode":    utils.PathSearch("is_proxy_mode", group, nil),
+				"os_type":          utils.PathSearch("os", group, nil),
+				"resource_pool_id": utils.PathSearch("slave_cluster_id", group, nil),
+				"created_by":       utils.PathSearch("nick_name", group, nil),
+				"permission":       flattenDeployGroupPermission(group),
+			})
+		}
+
+		total := utils.PathSearch("total", getRespBody, float64(0)).(float64)
+		if pageSize*(pageIndex-1)+len(groups) >= int(total) {
+			break
+		}
+		pageIndex++
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("groups", rst),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildCodeartsDeployGroupsQueryParams(d *schema.ResourceData) string {
+	res := fmt.Sprintf("?project_id=%v", d.Get("project_id"))
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("os_type"); ok {
+		res = fmt.Sprintf("%s&os=%v", res, v)
+	}
+	if v, ok := d.GetOk("is_proxy_mode"); ok {
+		res = fmt.Sprintf("%s&is_proxy_mode=%v", res, v)
+	}
+	if v, ok := d.GetOk("resource_pool_id"); ok {
+		res = fmt.Sprintf("%s&slave_cluster_id=%v", res, v)
+	}
+
+	return res
+}

--- a/huaweicloud/services/codeartsdeploy/data_source_huaweicloud_codearts_deploy_hosts.go
+++ b/huaweicloud/services/codeartsdeploy/data_source_huaweicloud_codearts_deploy_hosts.go
@@ -1,0 +1,240 @@
+package codeartsdeploy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CodeArtsDeploy GET /v1/resources/host-groups/{group_id}/hosts
+func DataSourceCodeartsDeployHosts() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCodeartsDeployHostsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the group ID.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the name of host.`,
+			},
+			"environment_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the environment ID.`,
+			},
+			"as_proxy": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies whether the host is proxy or not.`,
+			},
+			"hosts": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Indicates the host list.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the host ID.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the host name.`,
+						},
+						"ip_address": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the IP address.`,
+						},
+						"port": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the SSH port.`,
+						},
+						"os_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the operating system.`,
+						},
+						"username": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the username.`,
+						},
+						"trusted_type": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the trusted type.`,
+						},
+						"as_proxy": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Indicates whether the host is an agent host.`,
+						},
+						"proxy_host_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the agent ID.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the create time.`,
+						},
+						"lastest_connection_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the last connection time.`,
+						},
+						"connection_status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the connection status.`,
+						},
+						"permission": {
+							Type:        schema.TypeList,
+							Elem:        deployHostPermissionSchema(),
+							Computed:    true,
+							Description: `Indicates the permission.`,
+						},
+						"owner_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the owner ID.`,
+						},
+						"owner_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the owner name.`,
+						},
+						"env_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the number of environments.`,
+						},
+						"import_status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the import status.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceCodeartsDeployHostsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("codearts_deploy", region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	getHttpUrl := "v1/resources/host-groups/{group_id}/hosts"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{group_id}", d.Get("group_id").(string))
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	// pageSize is `10`
+	getPath += fmt.Sprintf("?page_size=%v", pageSize)
+	getPath += buildCodeartsDeployHostsQueryParams(d)
+	pageIndex := 1
+
+	rst := make([]map[string]interface{}, 0)
+	for {
+		currentPath := getPath + fmt.Sprintf("&page_index=%d", pageIndex)
+		getResp, err := client.Request("GET", currentPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving hosts: %s", err)
+		}
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.Errorf("error flatten response: %s", err)
+		}
+
+		hosts := utils.PathSearch("result", getRespBody, make([]interface{}, 0)).([]interface{})
+		for _, host := range hosts {
+			rst = append(rst, map[string]interface{}{
+				"id":                    utils.PathSearch("uuid", host, nil),
+				"name":                  utils.PathSearch("host_name", host, nil),
+				"ip_address":            utils.PathSearch("ip", host, nil),
+				"port":                  utils.PathSearch("port", host, nil),
+				"os_type":               utils.PathSearch("os", host, nil),
+				"username":              utils.PathSearch("authorization.username", host, nil),
+				"trusted_type":          utils.PathSearch("authorization.trusted_type", host, nil),
+				"as_proxy":              utils.PathSearch("as_proxy", host, nil),
+				"proxy_host_id":         utils.PathSearch("proxy_host_id", host, nil),
+				"created_at":            utils.PathSearch("create_time", host, nil),
+				"lastest_connection_at": utils.PathSearch("lastest_connection_time", host, nil),
+				"connection_status":     utils.PathSearch("connection_status", host, nil),
+				"owner_id":              utils.PathSearch("owner_id", host, nil),
+				"owner_name":            utils.PathSearch("owner_name", host, nil),
+				"permission":            flattenDeployHostPermission(host),
+				"env_count":             utils.PathSearch("env_count", host, nil),
+				"import_status":         utils.PathSearch("import_status", host, nil),
+			})
+		}
+
+		total := utils.PathSearch("total", getRespBody, float64(0)).(float64)
+		if pageSize*(pageIndex-1)+len(hosts) >= int(total) {
+			break
+		}
+		pageIndex++
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("hosts", rst),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildCodeartsDeployHostsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&key_field=%v", res, v)
+	}
+	if v, ok := d.GetOk("environment_id"); ok {
+		res = fmt.Sprintf("%s&environment_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("as_proxy"); ok {
+		res = fmt.Sprintf("%s&as_proxy=%v", res, v)
+	}
+
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to get groups and hosts
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support to get CodeArts deploy groups and hosts
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/codeartsdeploy" TESTARGS="-run TestAccDataSourceCodeartsDeploy"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codeartsdeploy -v -run TestAccDataSourceCodeartsDeploy -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCodeartsDeployGroups_basic
=== PAUSE TestAccDataSourceCodeartsDeployGroups_basic
=== RUN   TestAccDataSourceCodeartsDeployHosts_basic
=== PAUSE TestAccDataSourceCodeartsDeployHosts_basic
=== CONT  TestAccDataSourceCodeartsDeployGroups_basic
=== CONT  TestAccDataSourceCodeartsDeployHosts_basic
--- PASS: TestAccDataSourceCodeartsDeployGroups_basic (70.40s)
--- PASS: TestAccDataSourceCodeartsDeployHosts_basic (278.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codeartsdeploy    279.048s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
