### PR TITLE
feat(cbr/policy): enable_acceleration is an internal param now

### DIFF
--- a/docs/resources/cbr_policy.md
+++ b/docs/resources/cbr_policy.md
@@ -80,10 +80,6 @@ The following arguments are supported:
 * `destination_region` - (Optional, String) Specifies the name of the replication destination region, which is mandatory
   for cross-region replication. Required if `protection_type` is **replication**.
 
-* `enable_acceleration` - (Optional, Bool, ForceNew) Specifies whether to enable the acceleration function to shorten
-  the replication time for cross-region.  
-  Changing this will create a new policy.
-
 * `destination_project_id` - (Optional, String) Specifies the ID of the replication destination project, which is
   mandatory for cross-region replication. Required if `protection_type` is **replication**.
 
@@ -151,22 +147,4 @@ Policies can be imported by their `id`, e.g.
 
 ```bash
 $ terraform import huaweicloud_cbr_policy.test <id>
-```
-
-Note that the imported state may not be identical to your resource definition, due to the attribute missing from the
-API response. The missing attribute is: `enable_acceleration`.
-It is generally recommended running `terraform plan` after importing a policy.
-You can then decide if changes should be applied to the policy, or the resource definition should be updated to align
-with the policy. Also you can ignore changes as below.
-
-```hcl
-resource "huaweicloud_cbr_policy" "test" {
-  ...
-
-  lifecycle {
-    ignore_changes = [
-      enable_acceleration,
-    ]
-  }
-}
 ```

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_policy_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_policy_test.go
@@ -252,7 +252,6 @@ func TestAccPolicy_replication(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "destination_region", acceptance.HW_DEST_REGION),
 					resource.TestCheckResourceAttr(resourceName, "destination_project_id", acceptance.HW_DEST_PROJECT_ID),
 					resource.TestCheckResourceAttr(resourceName, "time_period", "20"),
-					resource.TestCheckResourceAttr(resourceName, "enable_acceleration", "true"),
 					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.interval", "5"),
 					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.0", "06:00"),
 					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.1", "18:00"),
@@ -278,7 +277,6 @@ resource "huaweicloud_cbr_policy" "test" {
   destination_region     = "%[2]s"
   destination_project_id = "%[3]s"
   time_period            = 20
-  enable_acceleration    = true
 
   backup_cycle {
     interval        = 5

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_policy.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_policy.go
@@ -105,13 +105,6 @@ func ResourcePolicy() *schema.Resource {
 				Optional:    true,
 				Description: "The name of the replication destination region.",
 			},
-			"enable_acceleration": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Description: "Whether to enable the acceleration function to shorten the replication time for " +
-					"cross-region",
-			},
 			"destination_project_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -173,6 +166,17 @@ func ResourcePolicy() *schema.Resource {
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^UTC[+-]\d{2}:00$`),
 					"The time zone must be in UTC format, such as 'UTC+08:00'."),
 				Description: "The UTC time zone.",
+			},
+			"enable_acceleration": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Description: utils.SchemaDesc(
+					"Whether to enable the acceleration function to shorten the replication time for cross-region",
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update the behavior of parameter enable_acceleration from public optional to internal optional.
Because the permission `OP_GATED_CSBS_REP_ACCELERATION` cannot be disabled on the custom side.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update the behavior of parameter enable_acceleration from public optional to internal optional.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cbr -f TestAccPolicy
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccPolicy -timeout 360m -parallel 10
=== RUN   TestAccPolicy_basic
=== PAUSE TestAccPolicy_basic
=== RUN   TestAccPolicy_retention
=== PAUSE TestAccPolicy_retention
=== RUN   TestAccPolicy_replication
=== PAUSE TestAccPolicy_replication
=== CONT  TestAccPolicy_basic
=== CONT  TestAccPolicy_replication
=== CONT  TestAccPolicy_retention
--- PASS: TestAccPolicy_replication (12.74s)
--- PASS: TestAccPolicy_basic (20.61s)
--- PASS: TestAccPolicy_retention (20.91s)
PASS
coverage: 14.3% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       20.982s coverage: 14.3% of statements in ./huaweicloud/services/cbr
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
