### PR TITLE
feat(live/origin_pull_configuration): support origin pull configuration resource

### DIFF
--- a/docs/resources/live_origin_pull_configuration.md
+++ b/docs/resources/live_origin_pull_configuration.md
@@ -1,0 +1,118 @@
+---
+subcategory: "Live"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_live_origin_pull_configuration"
+description: |-
+  Manages a Live origin pull configuration resource within HuaweiCloud.
+---
+
+# huaweicloud_live_origin_pull_configuration
+
+Manages a Live origin pull configuration resource within HuaweiCloud.
+
+-> This resource is an operational resource, and destroying it will not change the current origin pull configuration.
+
+## Example Usage
+
+### Create a customer source site with a domain name format for the source site address
+
+```hcl
+variable "domain_name" {}
+variable "sources" {}
+variable "schema" {}
+
+resource "huaweicloud_live_origin_pull_configuration" "test" {
+  domain_name = var.domain_name
+  source_type = "domain"
+  sources     = var.sources
+  scheme      = var.scheme
+}
+```
+
+### Create a customer source site with an IP format source address
+
+```hcl
+variable "domain_name" {}
+variable "sources_ip" {}
+variable "schema" {}
+
+resource "huaweicloud_live_origin_pull_configuration" "test" {
+  domain_name = var.domain_name
+  source_type = "ipaddr"
+  sources_ip  = var.sources_ip
+  scheme      = var.scheme
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `domain_name` - (Required, String, ForceNew) Specifies the streaming domain name.
+  Changing this parameter will create a new resource.
+
+* `source_type` - (Required, String) Specifies the type of return to the source.
+  The valid values are as follows:
+  + **domain**: Return to the source customer's source site, where the source site address is in domain name format.
+  + **ipaddr**: Return to the source customer's source site, where the source site address is in IP format.
+  + **huawei**: Return to the Huawei origin site, the default value after domain creation.
+
+* `sources` - (Optional, List) Specifies the list of domain names for returning to the source.
+  + When `source_type` is set to **domain**, this parameter is required and can be configured with up to `10` values.
+    When multiple domain names are configured, if the source return fails, it will be rotated according to the
+    configuration order.
+  + When `source_type` is set to **ipaddr**, a maximum of `1` value can be configured. If configured, the httpflv HOST
+    header should be filled with this domain name and the RTMP tcurl field should be filled with this domain name when
+    returning to the source. Otherwise, the current IP address should be used as the HOST.
+
+* `sources_ip` - (Optional, List) Specifies the list of IP addresses for returning to the source.
+  Up to `10` can be configured.
+  + When `source_type` is set to **ipaddr**, this parameter is required. When configuring multiple IPs, if the return to
+    the source fails, it will be rotated according to the configuration order.
+
+* `source_port` - (Optional, Int) Specifies the return port to the source.
+
+* `scheme` - (Optional, String) Specifies the source return protocol.
+  This parameter is required when the `source_type` is not **huawei**.
+  The valid values are as follows:
+  + **http**
+  + **rtmp**
+
+* `additional_args` - (Optional, Map) Specifies the parameters carried in the URL when returning to the source client's
+  website.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+## Import
+
+The resource can be imported using `domain_name`, e.g.
+
+```bash
+$ terraform import huaweicloud_live_origin_pull_configuration.test <domain_name>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `additional_args`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition
+should be updated to align with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_live_origin_pull_configuration" "test" { 
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      additional_args,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1883,6 +1883,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_live_transcoding":                live.ResourceTranscoding(),
 			"huaweicloud_live_url_authentication":         live.ResourceUrlAuthentication(),
 			"huaweicloud_live_url_validation":             live.ResourceUrlValidation(),
+			"huaweicloud_live_origin_pull_configuration":  live.ResourceOriginPullConfiguration(),
 
 			"huaweicloud_lts_aom_access":                       lts.ResourceAOMAccess(),
 			"huaweicloud_lts_group":                            lts.ResourceLTSGroup(),

--- a/huaweicloud/services/acceptance/live/resource_huaweicloud_live_origin_pull_configuration_test.go
+++ b/huaweicloud/services/acceptance/live/resource_huaweicloud_live_origin_pull_configuration_test.go
@@ -1,0 +1,174 @@
+package live
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/live"
+)
+
+func getOriginPullConfigurationFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region     = acceptance.HW_REGION_NAME
+		domainName = state.Primary.Attributes["domain_name"]
+	)
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Live client: %s", err)
+	}
+
+	getRespBody, err := live.ReadOriginPullConfiguration(client, domainName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Live origin pull configuration: %s", err)
+	}
+
+	return getRespBody, nil
+}
+
+func TestAccOriginPullConfiguration_basic(t *testing.T) {
+	var (
+		originPullConfigurationObj interface{}
+		rName                      = "huaweicloud_live_origin_pull_configuration.test"
+		domainName                 = fmt.Sprintf("%s.huaweicloud.com", acceptance.RandomAccResourceNameWithDash())
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&originPullConfigurationObj,
+		getOriginPullConfigurationFunc,
+	)
+
+	// Avoid CheckDestroy, because there is nothing in the resource destroy method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOriginPullConfiguration_basic(domainName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "domain_name", domainName),
+					resource.TestCheckResourceAttr(rName, "source_type", "domain"),
+					resource.TestCheckResourceAttr(rName, "sources.#", "2"),
+					resource.TestCheckResourceAttr(rName, "source_port", "8888"),
+					resource.TestCheckResourceAttr(rName, "scheme", "rtmp"),
+					resource.TestCheckResourceAttr(rName, "additional_args.param1", "value1"),
+					resource.TestCheckResourceAttr(rName, "additional_args.param2", "value2"),
+				),
+			},
+			{
+				Config: testAccOriginPullConfiguration_update1(domainName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "domain_name", domainName),
+					resource.TestCheckResourceAttr(rName, "source_type", "ipaddr"),
+					resource.TestCheckResourceAttr(rName, "sources_ip.#", "2"),
+					resource.TestCheckResourceAttr(rName, "source_port", "9999"),
+					resource.TestCheckResourceAttr(rName, "scheme", "http"),
+					resource.TestCheckResourceAttr(rName, "additional_args.param1", "value1"),
+					resource.TestCheckResourceAttr(rName, "additional_args.param2", "value2"),
+					resource.TestCheckResourceAttr(rName, "additional_args.param3", "value3"),
+				),
+			},
+			{
+				Config: testAccOriginPullConfiguration_update2(domainName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "domain_name", domainName),
+					resource.TestCheckResourceAttr(rName, "source_type", "huawei"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       false,
+				ImportStateVerifyIgnore: []string{"additional_args"},
+				ImportStateIdFunc:       testAccOriginPullConfigurationImportState(rName),
+			},
+		},
+	})
+}
+
+func testAccOriginPullConfiguration_base(domainName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_domain" "test" {
+  name = "%s"
+  type = "pull"
+}
+`, domainName)
+}
+
+func testAccOriginPullConfiguration_basic(domainName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_live_origin_pull_configuration" "test" {
+  domain_name = huaweicloud_live_domain.test.name
+  source_type = "domain"
+  sources     = ["play.tftest.huaweicloud1.com", "play.tftest.huaweicloud2.com"]
+  source_port = 8888
+  scheme      = "rtmp"
+
+  additional_args = {
+    param1 = "value1"
+    param2 = "value2"
+  }
+}
+`, testAccOriginPullConfiguration_base(domainName))
+}
+
+func testAccOriginPullConfiguration_update1(domainName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_live_origin_pull_configuration" "test" {
+  domain_name = huaweicloud_live_domain.test.name
+  source_type = "ipaddr"
+  sources     = ["play.tftest.huaweicloud1.com"]
+  sources_ip  = ["192.127.0.124", "192.168.0.123"]
+  source_port = 9999
+  scheme      = "http"
+
+  additional_args = {
+    param1 = "value1"
+    param3 = "value3"
+    param2 = "value2"
+  }
+}
+`, testAccOriginPullConfiguration_base(domainName))
+}
+
+func testAccOriginPullConfiguration_update2(domainName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_live_origin_pull_configuration" "test" {
+  domain_name = huaweicloud_live_domain.test.name
+  source_type = "huawei"
+}
+`, testAccOriginPullConfiguration_base(domainName))
+}
+
+func testAccOriginPullConfigurationImportState(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var domainName string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", rName)
+		}
+
+		domainName = rs.Primary.Attributes["domain_name"]
+		if domainName == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, `domain_name` is empty")
+		}
+		return domainName, nil
+	}
+}

--- a/huaweicloud/services/live/resource_huaweicloud_live_origin_pull_configuration.go
+++ b/huaweicloud/services/live/resource_huaweicloud_live_origin_pull_configuration.go
@@ -1,0 +1,235 @@
+package live
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Live PUT /v1/{project_id}/domain/pull-sources
+// @API Live GET /v1/{project_id}/domain/pull-sources
+func ResourceOriginPullConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceOriginPullConfigurationCreate,
+		ReadContext:   resourceOriginPullConfigurationRead,
+		UpdateContext: resourceOriginPullConfigurationUpdate,
+		DeleteContext: resourceOriginPullConfigurationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceOriginPullConfigurationImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"source_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"sources": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"sources_ip": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"source_port": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"scheme": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"additional_args": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func buildOriginPullConfigurationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"play_domain":     d.Get("domain_name"),
+		"source_type":     d.Get("source_type"),
+		"sources":         utils.ExpandToStringList(d.Get("sources").([]interface{})),
+		"sources_ip":      utils.ExpandToStringList(d.Get("sources_ip").([]interface{})),
+		"source_port":     utils.ValueIgnoreEmpty(d.Get("source_port")),
+		"scheme":          utils.ValueIgnoreEmpty(d.Get("scheme")),
+		"additional_args": utils.ExpandToStringMap(d.Get("additional_args").(map[string]interface{})),
+	}
+
+	return params
+}
+
+func updateOriginPullConfiguration(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	validationHttpUrl := "v1/{project_id}/domain/pull-sources"
+	validationPath := client.Endpoint + validationHttpUrl
+	validationPath = strings.ReplaceAll(validationPath, "{project_id}", client.ProjectID)
+
+	validationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildOriginPullConfigurationBodyParams(d)),
+	}
+
+	_, err := client.Request("PUT", validationPath, &validationOpt)
+	return err
+}
+
+func resourceOriginPullConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	err = updateOriginPullConfiguration(client, d)
+	if err != nil {
+		return diag.Errorf("error creating Live origin pull configuration: %s", err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	return resourceOriginPullConfigurationRead(ctx, d, meta)
+}
+
+func ReadOriginPullConfiguration(client *golangsdk.ServiceClient, domainName string) (interface{}, error) {
+	getPath := client.Endpoint + "v1/{project_id}/domain/pull-sources"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += fmt.Sprintf("?play_domain=%s", domainName)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		// When the `domain_name` does not exist, calling the query API will return a `400` status code.
+		return nil, common.ConvertExpected400ErrInto404Err(err, "error_code", domainNameNotExistsCode)
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+func resourceOriginPullConfigurationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		domainName = d.Get("domain_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	getRespBody, err := ReadOriginPullConfiguration(client, domainName)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving Live origin pull configuration")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("domain_name", domainName),
+		d.Set("source_type", utils.PathSearch("source_type", getRespBody, nil)),
+		d.Set("sources", flattenSourcesOrSourcesIp(utils.PathSearch("sources", getRespBody, nil))),
+		d.Set("sources_ip", flattenSourcesOrSourcesIp(utils.PathSearch("sources_ip", getRespBody, nil))),
+		d.Set("source_port", utils.PathSearch("source_port", getRespBody, float64(0))),
+		d.Set("scheme", utils.PathSearch("scheme", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSourcesOrSourcesIp(sources interface{}) []string {
+	if sources == nil {
+		return nil
+	}
+
+	result := make([]string, 0)
+	for _, v := range sources.([]interface{}) {
+		result = append(result, v.(string))
+	}
+
+	return result
+}
+
+func resourceOriginPullConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	err = updateOriginPullConfiguration(client, d)
+	if err != nil {
+		return diag.Errorf("error updating Live origin pull configuration: %s", err)
+	}
+
+	return resourceOriginPullConfigurationRead(ctx, d, meta)
+}
+
+func resourceOriginPullConfigurationDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceOriginPullConfigurationImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	if importedId == "" {
+		return nil, fmt.Errorf("invalid format specified for import ID, `domain_name` is empty")
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("domain_name", importedId),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support origin pull configuration resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Support origin pull configuration resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/live" TESTARGS="-run TestAccOriginPullConfiguration_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/live -v -run TestAccOriginPullConfiguration_basic -timeout 360m -parallel 4
=== RUN   TestAccOriginPullConfiguration_basic
=== PAUSE TestAccOriginPullConfiguration_basic
=== CONT  TestAccOriginPullConfiguration_basic
--- PASS: TestAccOriginPullConfiguration_basic (204.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      204.575s

```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found

    ab. Related resources (parent resources) not found

When the `domain_name` does not exist.
![image](https://github.com/user-attachments/assets/e37c106b-4b9e-4571-8020-b86e30ea7bc1)


  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
