### PR TITLE
feat(CodeArts/Deploy): support to get application groups

### DIFF
--- a/docs/data-sources/codearts_deploy_application_groups.md
+++ b/docs/data-sources/codearts_deploy_application_groups.md
@@ -1,0 +1,60 @@
+---
+subcategory: "CodeArts Deploy"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_codearts_deploy_application_groups"
+description: |-
+  Use this data source to get the list of CodeArts deploy application groups.
+---
+
+# huaweicloud_codearts_deploy_application_groups
+
+Use this data source to get the list of CodeArts deploy application groups.
+
+## Example Usage
+
+```hcl
+variable "project_id" {}
+
+data "huaweicloud_codearts_deploy_application_groups" "test" {
+  project_id = var.project_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `project_id` - (Required, String) Specifies the project ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `groups` - Indicates the application group list.
+  The [groups](#attrblock--groups) structure is documented below.
+
+<a name="attrblock--groups"></a>
+The `groups` block supports:
+
+* `id` - Indicates the application group ID.
+
+* `name` - Indicates the application group name.
+
+* `application_count` - Indicates the total number of applications in the group.
+
+* `ordinal` - Indicates the group sorting field.
+
+* `parent_id` - Indicates the parent application group ID.
+
+* `path` - Indicates the group path.
+
+* `children` - Indicates the child group name list.
+
+* `created_by` - Indicates the ID of the group creator.
+
+* `updated_by` - Indicates the ID of the user who last updates the group.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -575,8 +575,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_compute_servergroups":            ecs.DataSourceComputeServerGroups(),
 			"huaweicloud_compute_instance_remote_console": ecs.DataSourceComputeInstanceRemoteConsole(),
 
-			"huaweicloud_codearts_deploy_groups": codeartsdeploy.DataSourceCodeartsDeployGroups(),
-			"huaweicloud_codearts_deploy_hosts":  codeartsdeploy.DataSourceCodeartsDeployHosts(),
+			"huaweicloud_codearts_deploy_groups":             codeartsdeploy.DataSourceCodeartsDeployGroups(),
+			"huaweicloud_codearts_deploy_hosts":              codeartsdeploy.DataSourceCodeartsDeployHosts(),
+			"huaweicloud_codearts_deploy_application_groups": codeartsdeploy.DataSourceCodeartsDeployApplicationGroups(),
 
 			"huaweicloud_cts_notifications": cts.DataSourceNotifications(),
 			"huaweicloud_cts_traces":        cts.DataSourceCtsTraces(),

--- a/huaweicloud/services/acceptance/codeartsdeploy/data_source_huaweicloud_codearts_deploy_application_groups_test.go
+++ b/huaweicloud/services/acceptance/codeartsdeploy/data_source_huaweicloud_codearts_deploy_application_groups_test.go
@@ -1,0 +1,52 @@
+package codeartsdeploy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCodeartsDeployApplicationGroups_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_codearts_deploy_application_groups.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCodeartsDeployApplicationGroups_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSource, "groups.#", "3"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.path"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.ordinal"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.created_by"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.updated_by"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.application_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.children.0"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCodeartsDeployApplicationGroups_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_codearts_deploy_application_groups" "test" {
+  depends_on = [huaweicloud_codearts_deploy_application_group.level2]
+
+  project_id = huaweicloud_codearts_project.test.id
+}
+`, testDeployApplicationGroup_secondLevel(name))
+}

--- a/huaweicloud/services/codeartsdeploy/data_source_huaweicloud_codearts_deploy_application_groups.go
+++ b/huaweicloud/services/codeartsdeploy/data_source_huaweicloud_codearts_deploy_application_groups.go
@@ -1,0 +1,142 @@
+package codeartsdeploy
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CodeArtsDeploy GET /v1/projects/{project_id}/applications/groups
+func DataSourceCodeartsDeployApplicationGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCodeartsDeployApplicationGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the project ID.`,
+			},
+			"groups": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Indicates the application group list.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the application group ID.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the application group name.`,
+						},
+						"parent_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the parent application group ID.`,
+						},
+						"path": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the group path.`,
+						},
+						"ordinal": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the group sorting field.`,
+						},
+						"created_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the ID of the group creator.`,
+						},
+						"updated_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the ID of the user who last updates the group.`,
+						},
+						"application_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the total number of applications in the group.`,
+						},
+						"children": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `Indicates the child group name list.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceCodeartsDeployApplicationGroupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("codearts_deploy", region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	groups, err := getDeployApplicationGroup(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("groups", flattenCodeartsDeployApplicationGroups(groups.([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCodeartsDeployApplicationGroups(currentList []interface{}) []map[string]interface{} {
+	groups := currentList
+	rst := make([]map[string]interface{}, 0)
+
+	for _, group := range groups {
+		rst = append(rst, map[string]interface{}{
+			"id":                utils.PathSearch("id", group, nil),
+			"name":              utils.PathSearch("name", group, nil),
+			"parent_id":         utils.PathSearch("parent_id", group, nil),
+			"path":              utils.PathSearch("path", group, nil),
+			"ordinal":           utils.PathSearch("ordinal", group, nil),
+			"application_count": utils.PathSearch("application_count", group, nil),
+			"children":          utils.PathSearch("children[*].name", group, nil),
+			"updated_by":        utils.PathSearch("last_update_user_id", group, nil),
+			"created_by":        utils.PathSearch("create_user_id", group, nil),
+		})
+	}
+
+	children := utils.PathSearch("[*].children[]", currentList, make([]interface{}, 0)).([]interface{})
+	if len(children) != 0 {
+		rst = append(rst, flattenCodeartsDeployApplicationGroups(children)...)
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to get application groups
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support to get application groups
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/codeartsdeploy" TESTARGS="-run TestAccDataSourceCodeartsDeployApplicationGroups_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codeartsdeploy -v -run TestAccDataSourceCodeartsDeployApplicationGroups_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCodeartsDeployApplicationGroups_basic
=== PAUSE TestAccDataSourceCodeartsDeployApplicationGroups_basic
=== CONT  TestAccDataSourceCodeartsDeployApplicationGroups_basic
--- PASS: TestAccDataSourceCodeartsDeployApplicationGroups_basic (42.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codeartsdeploy    42.527s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
