### PR TITLE
feat(modelarts): add new reource to manage devserver

### DIFF
--- a/docs/resources/modelarts_devserver.md
+++ b/docs/resources/modelarts_devserver.md
@@ -1,0 +1,204 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelarts_devserver"
+description: |-
+  Manages a ModelArts DevServer resource within HuaweiCloud.
+---
+
+# huaweicloud_modelarts_devserver
+
+Manages a ModelArts DevServer resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "server_name" {}
+variable "server_flavor" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+variable "security_group_id" {}
+variable "image_id" {}
+variable "admin_pass" {}
+
+resource "huaweicloud_modelarts_devserver" "test" {
+  name              = var.server_name
+  flavor            = var.server_flavor
+  vpc_id            = var.vpc_id
+  subnet_id         = var.subnet_id
+  security_group_id = var.security_group_id
+  image_id          = var.image_id
+  admin_pass        = var.admin_pass
+
+  root_volume {
+    size = 100
+    type = "SSD"
+  }
+
+  charging_mode = "PRE_PAID"
+  period        = 1
+  period_unit   = "MONTH"
+  auto_renew    = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the DevServer.
+  Changing this creates a new resource.  
+  The name valid length is limited from `1` to `64`, only English letters, digits, underscores (_) and hyphens (-) are
+  allowed.
+
+* `flavor` - (Required, String, ForceNew) Specifies the flavor of the DevServer.
+  Changing this creates a new resource.  
+  For the flavor, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/usermanual-ticket/topic_0065264094.html)
+  to submit a service ticket to apply for the flavor.
+
+* `architecture` - (Optional, String, ForceNew) Specifies the architecture of the DevServer.
+  Changing this creates a new resource.  
+  This parameter value is related to the `flavor` parameter.  
+  The valid values are as follows:
+  + **X86**
+  + **ARM**
+  
+* `vpc_id` - (Required, String, ForceNew) Specifies the ID of the VPC to which the DevServer belongs.
+  Changing this creates a new resource.
+
+* `subnet_id` - (Required, String, ForceNew) Specifies the ID of the subnet to which the DevServer belongs.
+  Changing this creates a new resource.
+
+* `security_group_id` - (Required, String, ForceNew) Specifies the ID of security group to which the DevServer belongs.
+  Changing this creates a new resource.
+
+* `image_id` - (Required, String, ForceNew) Specifies the image ID of the DevServer.
+  Changing this creates a new resource.
+
+* `type` - (Optional, String, ForceNew) Specifies the type of the DevServer.
+  Changing this creates a new resource.  
+  This parameter value is related to the `flavor` parameter.  
+  The valid values are as follows:
+  + **BMS**
+  + **ECS**
+
+* `availability_zone` - (Optional, String, ForceNew) Specifies the availability zone where the DevServer is located.
+  Changing this creates a new resource.
+
+* `admin_pass` - (Optional, String, ForceNew) Specifies the login password for logging in to the server.
+  Changing this creates a new resource.  
+  The password format must meet the following conditions:
+  + Must be `8` to `26` characters.
+  + The password must contain at least three types of the following characters: digit, uppercase letter, lowercase letter
+    and special characters (!@%-_=+[{}]:,./?).
+  + The password cannot be the username or the username spelled backwards
+  + The password cannot contain root, administrator or their reverse order.
+
+-> Exactly one of `admin_pass` and `key_pair_name` must be provided.
+
+* `key_pair_name` - (Optional, String, ForceNew) Specifies the key pair name for logging in to the server.
+  Changing this creates a new resource.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the DevServer belongs.
+  Changing this creates a new resource.  
+  This parameter is only valid for enterprise users, if omitted, default enterprise project will be used.  
+
+* `root_volume` - (Optional, List, ForceNew) Specifies the system disk configuration of the DevServer.
+  Changing this creates a new resource.  
+  This parameter is related to the `flavor` parameter.  
+  The [root_volume](#devServer_root_volume) structure is documented below.
+
+* `ipv6_enable` - (Optional, Bool, ForceNew) Specifies whether to enable IPv6.
+  Changing this creates a new resource.  
+  This parameter is available only when the current subnet, flavor and image all support IPv6.
+
+* `roce_id` - (Optional, String, ForceNew) Specifies the RoCE network ID of the DevServer.
+  Changing this creates a new resource.  
+  This parameter value is related to the `flavor` parameter.
+
+* `user_data` - (Optional, String, ForceNew) Specifies the user data defined for the server.
+  Changing this creates a new resource.
+
+* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the DevServer.
+  Changing this creates a new resource.  
+  The valid values are as follows:
+  + **PRE_PAID**: The yearly/monthly billing mode.
+  + **POST_PAID**: The pay-per-use billing mode.
+  
+* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the DevServer.
+  Changing this creates a new resource.  
+  This parameter is required and available if `charging_mode` is set to **PRE_PAID**.  
+  The valid values are as follows:
+  + **MONTH**
+  + **YEAR**
+
+* `period` - (Optional, Int, ForceNew) Specifies the charging period of the DevServer.
+  Changing this creates a new resource.  
+  This parameter is required and available if `charging_mode` is set to **PRE_PAID**.
+
+* `auto_renew` - (Optional, String) Specifies whether auto-renew is enabled. Defaults to **false**.  
+  This parameter is available if `charging_mode` is set to **PRE_PAID**.  
+  The valid values are **true** and **false**.
+
+<a name="devServer_root_volume"></a>
+The `root_volume` block supports:
+
+* `type` - (Optional, String, ForceNew) Specifies the type of system disk.
+  Changing this creates a new resource.  
+  The valid values are as follows:
+  + **ESSD**: Extreme SSD type.
+  + **SSD**: Ultra-high I/O type.
+  + **GPSSD**: General purpose SSD type.
+  + **SAS**: High I/O type.
+  + **SATA**: Common I/O type.
+
+* `size` - (Optional, Int, ForceNew) Specifies the size of system disk.
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also DevServer ID.
+
+* `created_at` - The creation time of the DevServer, in RFC3339 format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.
+* `delete` - Default is 30 minutes.
+
+## Import
+
+The DevServer resource can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_modelarts_devserver.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes include: `subnet_id`, `security_group_id`, `availability_zone`, `admin_pass`,
+`enterprise_project_id`, `root_volume`, `ipv6_enable`, `roce_id`, `user_data`, `period_unit`, `period`, `auto_renew`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the instance, or the resource definition should be updated to
+align with the instance. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_modelarts_devserver" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      subnet_id, security_group_id, availability_zone, admin_pass, enterprise_project_id, root_volume, ipv6_enable,
+      roce_id, user_data, period_unit, period, auto_renew,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1909,6 +1909,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_modelarts_dataset":                modelarts.ResourceDataset(),
 			"huaweicloud_modelarts_dataset_version":        modelarts.ResourceDatasetVersion(),
+			"huaweicloud_modelarts_devserver":              modelarts.ResourceDevServer(),
 			"huaweicloud_modelarts_notebook":               modelarts.ResourceNotebook(),
 			"huaweicloud_modelarts_notebook_mount_storage": modelarts.ResourceNotebookMountStorage(),
 			"huaweicloud_modelarts_model":                  modelarts.ResourceModelartsModel(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -340,6 +340,8 @@ var (
 
 	HW_MODELARTS_HAS_SUBSCRIBE_MODEL = os.Getenv("HW_MODELARTS_HAS_SUBSCRIBE_MODEL")
 	HW_MODELARTS_USER_LOGIN_PASSWORD = os.Getenv("HW_MODELARTS_USER_LOGIN_PASSWORD")
+	HW_MODELARTS_DEVSERVER_FLAVOR    = os.Getenv("HW_MODELARTS_DEVSERVER_FLAVOR")
+	HW_MODELARTS_DEVSERVER_IMAGE_ID  = os.Getenv("HW_MODELARTS_DEVSERVER_IMAGE_ID")
 
 	// The CMDB sub-application ID of AOM service
 	HW_AOM_SUB_APPLICATION_ID                    = os.Getenv("HW_AOM_SUB_APPLICATION_ID")
@@ -1902,6 +1904,13 @@ func TestAccPreCheckModelArtsHasSubscribeModel(t *testing.T) {
 func TestAccPreCheckModelartsUserLoginPassword(t *testing.T) {
 	if HW_MODELARTS_USER_LOGIN_PASSWORD == "" {
 		t.Skip("HW_MODELARTS_USER_LOGIN_PASSWORD must be set for modelarts privilege resource pool acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckModelartsDevServer(t *testing.T) {
+	if HW_MODELARTS_DEVSERVER_FLAVOR == "" || HW_MODELARTS_DEVSERVER_IMAGE_ID == "" {
+		t.Skip("HW_MODELARTS_DEVSERVER_FLAVOR and HW_MODELARTS_DEVSERVER_IMAGE_ID must be set for ModelArts DevServer acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_devserver_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_devserver_test.go
@@ -1,0 +1,116 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
+)
+
+func getDevServerResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	return modelarts.GetDevServerById(client, state.Primary.ID)
+}
+
+func TestAccDevServer_basic(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_modelarts_devserver.test"
+		name         = acceptance.RandomAccResourceName()
+		password     = acceptance.RandomPassword("!@%-_=+[{}]:,./?")
+		rc           = acceptance.InitResourceCheck(
+			resourceName,
+			&obj,
+			getDevServerResourceFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckModelartsDevServer(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDevServer_basic(name, password, true),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "flavor", acceptance.HW_MODELARTS_DEVSERVER_FLAVOR),
+					resource.TestCheckResourceAttrSet(resourceName, "architecture"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", "huaweicloud_networking_secgroup.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "image_id", acceptance.HW_MODELARTS_DEVSERVER_IMAGE_ID),
+					resource.TestCheckResourceAttrSet(resourceName, "type"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "PRE_PAID"),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "true"),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testDevServer_basic(name, password, false),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"subnet_id",
+					"security_group_id",
+					"admin_pass",
+					"root_volume",
+					"period_unit",
+					"period",
+					"auto_renew",
+				},
+			},
+		},
+	})
+}
+
+func testDevServer_basic(name, password string, autoRenew bool) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_modelarts_devserver" "test" {
+  name              = "%[2]s"
+  flavor            = "%[3]s"
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  image_id          = "%[4]s"
+  admin_pass        = "%[5]s"
+
+  root_volume {
+    size = 100
+    type = "SSD"
+  }
+
+  charging_mode = "PRE_PAID"
+  period_unit   = "MONTH"
+  period        = 1
+  auto_renew    = "%[6]v"
+}
+`, common.TestBaseNetwork(name), name,
+		acceptance.HW_MODELARTS_DEVSERVER_FLAVOR, acceptance.HW_MODELARTS_DEVSERVER_IMAGE_ID, password, autoRenew)
+}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver.go
@@ -1,0 +1,608 @@
+package modelarts
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var devServerNotExistCode = "ModelArts.6404" // DevServer does not exist.
+
+// @API ModelArts POST /v1/{project_id}/dev-servers
+// @API ModelArts GET /v1/{project_id}/dev-servers
+// @API ModelArts GET /v1/{project_id}/dev-servers/{id}
+// @API ModelArts DELETE /v1/{project_id}/dev-servers/{id}
+func ResourceDevServer() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDevServerCreate,
+		ReadContext:   resourceDevServerRead,
+		UpdateContext: resourceDevServerUpdate,
+		DeleteContext: resourceDevServerDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The name of the DevServer.`,
+			},
+			"flavor": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The flavor of the DevServer.`,
+			},
+			"architecture": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The architecture of the DevServer.`,
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the VPC to which the DevServer belongs.`,
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the subnet to which the DevServer belongs.`,
+			},
+			"security_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of security group to which the DevServer belongs.`,
+			},
+			"image_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The image ID of the DevServer.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The type of the DevServer.`,
+			},
+			"availability_zone": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The availability zone where the DevServer is located.`,
+			},
+			"admin_pass": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Sensitive:     true,
+				ForceNew:      true,
+				ConflictsWith: []string{"key_pair_name"},
+				Description:   `The login password for logging in to the server.`,
+			},
+			"key_pair_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The key pair name for logging in to the server.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The enterprise project ID to which the DevServer belongs.`,
+			},
+			"root_volume": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"size": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `The size of system disk.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `The type of system disk.`,
+						},
+					},
+				},
+				Description: `The system disk configuration of the DevServer.`,
+			},
+			"ipv6_enable": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Whether to enable IPv6.`,
+			},
+			"roce_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The RoCE network ID of the DevServer.`,
+			},
+			"user_data": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The user data defined for the server.`,
+			},
+			"charging_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The charging mode of the DevServer.`,
+			},
+			"period_unit": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"period"},
+				Description:  `The charging period unit of the DevServer.`,
+			},
+			"period": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"period_unit"},
+				Description:  `The charging period of the DevServer.`,
+			},
+			"auto_renew": common.SchemaAutoRenewUpdatable(nil),
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the DevServer, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func buildCreateDevServerBodyParams(d *schema.ResourceData, epsId string) map[string]interface{} {
+	params := map[string]interface{}{
+		"name":                  d.Get("name"),
+		"flavor":                d.Get("flavor"),
+		"network":               buildDevServerNetwork(d),
+		"image_id":              d.Get("image_id"),
+		"server_type":           utils.ValueIgnoreEmpty(d.Get("type")),
+		"root_volume":           buildDevServerRootVolume(d.Get("root_volume").([]interface{})),
+		"admin_pass":            utils.ValueIgnoreEmpty(d.Get("admin_pass")),
+		"arch":                  utils.ValueIgnoreEmpty(d.Get("architecture")),
+		"availability_zone":     utils.ValueIgnoreEmpty(d.Get("availability_zone")),
+		"enterprise_project_id": utils.ValueIgnoreEmpty(epsId),
+		"key_pair_name":         utils.ValueIgnoreEmpty(d.Get("key_pair_name")),
+		"userdata":              utils.ValueIgnoreEmpty(d.Get("user_data")),
+	}
+
+	if d.Get("charging_mode").(string) == "PRE_PAID" {
+		params["charging_info"] = buildPrepaidOptionsBodyParams(d)
+	}
+
+	return params
+}
+
+func buildDevServerNetwork(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"security_group_id": d.Get("security_group_id"),
+		"vpc_id":            d.Get("vpc_id"),
+		"subnet_id":         d.Get("subnet_id"),
+		"ipv6_enable":       d.Get("ipv6_enable"),
+		"roce_id":           utils.ValueIgnoreEmpty(d.Get("roce_id")),
+	}
+}
+
+func buildDevServerRootVolume(rootVolume []interface{}) map[string]interface{} {
+	if len(rootVolume) == 0 || rootVolume[0] == nil {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"type": utils.PathSearch("type", rootVolume[0], nil),
+		"size": utils.PathSearch("size", rootVolume[0], nil),
+	}
+}
+
+func buildPrepaidOptionsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"charging_mode": d.Get("charging_mode"),
+		"period_type":   d.Get("period_unit"),
+		"period_num":    d.Get("period"),
+		"is_auto_renew": parseAutoRenewValue(d.Get("auto_renew").(string)),
+		"is_auto_pay":   true,
+	}
+}
+
+func parseAutoRenewValue(autoRenew string) bool {
+	result, err := strconv.ParseBool(autoRenew)
+	if err != nil {
+		log.Printf("[ERROR] unable to convert auto_renew to bool value")
+		return false
+	}
+	return result
+}
+
+func resourceDevServerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/dev-servers"
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateDevServerBodyParams(d, cfg.GetEnterpriseProjectID(d))),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts DevServer: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if d.Get("charging_mode").(string) == "PRE_PAID" {
+		bssClient, err := cfg.NewServiceClient("bssv2", region)
+		if err != nil {
+			return diag.Errorf("error creating BSS client: %s", err)
+		}
+
+		orderId := utils.PathSearch("order_id", respBody, "").(string)
+		devServerId, err := waitForPrePaidDevServerComplete(ctx, client, bssClient, d.Timeout(schema.TimeoutCreate), orderId)
+		if devServerId != "" {
+			// When a DevServer fails to be created, the failed server will exist in the cloud. so set the resource ID in advance to
+			// prevent dirty data.
+			d.SetId(devServerId)
+		}
+
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		devServerId := utils.PathSearch("id", respBody, "").(string)
+		if devServerId == "" {
+			return diag.Errorf("unable to find DevServer ID from API response")
+		}
+
+		d.SetId(devServerId)
+		err := waitForDevServerCreated(ctx, client, d.Timeout(schema.TimeoutCreate), devServerId)
+		if err != nil {
+			return diag.Errorf("error waiting for the DevServer (%s) creation to complete: %s", devServerId, err)
+		}
+	}
+	return resourceDevServerRead(ctx, d, meta)
+}
+
+func waitForDevServerCreated(ctx context.Context, client *golangsdk.ServiceClient, timeout time.Duration, devServerId string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshDevServerStatusFunc(client, devServerId, []string{"RUNNING"}),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func refreshDevServerStatusFunc(client *golangsdk.ServiceClient, serverId string, targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := GetDevServerById(client, serverId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return "deleted", "DELETED", nil
+			}
+			return nil, "ERROR", err
+		}
+
+		status := utils.PathSearch("status", respBody, "").(string)
+		if utils.StrSliceContains([]string{"CREATE_FAILED", "ERROR", "DELETE_FAILED"}, status) {
+			return respBody, "ERROR", fmt.Errorf("unexpected status (%s)", status)
+		}
+
+		if utils.StrSliceContains(targets, status) {
+			return respBody, "COMPLETED", nil
+		}
+		return "continue", "PENDING", nil
+	}
+}
+
+func waitForPrePaidDevServerComplete(ctx context.Context, client, bssClient *golangsdk.ServiceClient, timeOut time.Duration,
+	orderId string) (string, error) {
+	if orderId == "" {
+		return "", fmt.Errorf("unable to find order ID from API response")
+	}
+
+	if err := common.WaitOrderComplete(ctx, bssClient, orderId, timeOut); err != nil {
+		return "", err
+	}
+
+	// When DevServer creation fails, the `common.WaitOrderResourceComplete` method cannot obtain the resource ID.
+	// so the Devserver list query interface is called here.
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			devServers, err := getDevServersByOrderId(client, orderId)
+			if err != nil {
+				return "", "ERROR", err
+			}
+
+			devServer := utils.PathSearch(fmt.Sprintf("[?order_id=='%s']|[0]", orderId), devServers, nil)
+			devServerId := utils.PathSearch("id", devServer, "").(string)
+			status := utils.PathSearch("status", devServer, "").(string)
+			if utils.StrSliceContains([]string{"CREATE_FAILED", "ERROR"}, status) {
+				return devServerId, "ERROR", fmt.Errorf("unexpected status (%s)", status)
+			}
+
+			if status == "RUNNING" {
+				return devServerId, "COMPLETED", nil
+			}
+			return devServerId, "PENDING", nil
+		},
+		Timeout:      timeOut,
+		Delay:        10 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+
+	devServerId, err := stateConf.WaitForStateContext(ctx)
+	resourceId := devServerId.(string)
+	if err != nil {
+		return resourceId, fmt.Errorf("error waiting for DevService order (%s) to complete: %s", orderId, err)
+	}
+
+	if resourceId == "" {
+		return "", fmt.Errorf("unable to find DevServer ID from API response")
+	}
+	return resourceId, nil
+}
+
+func GetDevServerById(client *golangsdk.ServiceClient, serverId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/dev-servers/{id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", serverId)
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, common.ConvertExpected400ErrInto404Err(err, "error_code", devServerNotExistCode)
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func getDevServersByOrderId(client *golangsdk.ServiceClient, orderId string) (interface{}, error) {
+	var (
+		httpUrl  = "v1/{project_id}/dev-servers?limit=100"
+		offset   = 0
+		result   = make([]interface{}, 0)
+		listOpts = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &listOpts)
+		if err != nil {
+			return nil, fmt.Errorf("error getting list of the DevServers by order ID (%s): %s", orderId, err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		devServers := utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{})
+		if len(devServers) < 1 {
+			break
+		}
+		result = append(result, devServers...)
+		if len(result) == int(utils.PathSearch("total", respBody, float64(0)).(float64)) {
+			break
+		}
+		offset += len(devServers)
+	}
+
+	return result, nil
+}
+
+func resourceDevServerRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		devServerId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	respBody, err := GetDevServerById(client, devServerId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "ModelArts DevServer")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("flavor", utils.PathSearch("flavor", respBody, nil)),
+		d.Set("architecture", utils.PathSearch("image.arch", respBody, nil)),
+		d.Set("vpc_id", utils.PathSearch("vpc_id", respBody, nil)),
+		d.Set("image_id", utils.PathSearch("image.image_id", respBody, nil)),
+		d.Set("type", utils.PathSearch("cloud_server.type", respBody, nil)),
+		d.Set("key_pair_name", utils.PathSearch("key_pair_name", respBody, nil)),
+		d.Set("charging_mode", utils.PathSearch("charging_mode", respBody, nil)),
+		d.Set("created_at",
+			utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_at", respBody, float64(0)).(float64))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDevServerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	if d.HasChange("auto_renew") {
+		var (
+			cfg         = meta.(*config.Config)
+			region      = cfg.GetRegion(d)
+			devServerId = d.Id()
+		)
+		bssClient, err := cfg.NewServiceClient("bssv2", region)
+		if err != nil {
+			return diag.Errorf("error creating BSS client: %s", err)
+		}
+		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), devServerId); err != nil {
+			return diag.Errorf("error updating the auto_renew of the DevServer (%s): %s", devServerId, err)
+		}
+	}
+	return resourceDevServerRead(ctx, d, meta)
+}
+
+func resourceDevServerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		devServerId = d.Id()
+	)
+
+	bssV2Client, err := cfg.NewServiceClient("bssv2", region)
+	if err != nil {
+		return diag.Errorf("error creating BSS client: %s", err)
+	}
+	resources, err := getPrePaidResourcesById(bssV2Client, devServerId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	if len(resources) != 0 {
+		if err := common.UnsubscribePrePaidResource(d, cfg, []string{devServerId}); err != nil {
+			// CBC.30000067: The resource has been unsubscribed
+			return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", "CBC.30000067"),
+				fmt.Sprintf("error unsubscribing DevServer (%s)", devServerId))
+		}
+	} else {
+		if err := deleteDevServerById(client, devServerId); err != nil {
+			return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting DevServer (%s)", devServerId))
+		}
+	}
+
+	err = waitForDevServerDeleted(ctx, client, devServerId, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		diag.Errorf("error waiting for the DevServer (%s) deletion to complete: %s", devServerId, err)
+	}
+
+	return nil
+}
+
+func getPrePaidResourcesById(client *golangsdk.ServiceClient, devServerId string) ([]interface{}, error) {
+	httpUrl := "v2/orders/suscriptions/resources/query"
+	getPath := client.Endpoint + httpUrl
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"resource_ids": []string{devServerId},
+		},
+	}
+
+	requestResp, err := client.Request("POST", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func deleteDevServerById(client *golangsdk.ServiceClient, devServerId string) error {
+	httpUrl := "v1/{project_id}/dev-servers/{id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{id}", devServerId)
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpts)
+	if err != nil {
+		return common.ConvertExpected400ErrInto404Err(err, "error_code", devServerNotExistCode)
+	}
+
+	return nil
+}
+
+func waitForDevServerDeleted(ctx context.Context, client *golangsdk.ServiceClient, devServerId string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"RUNNING", "DELETING"},
+		Target:       []string{"DELETED"},
+		Refresh:      refreshDevServerStatusFunc(client, devServerId, nil),
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new reource `huaweicloud_modelarts_devserver`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new reource to manage devserver.
2. add corresponding to document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o modelarts -f TestAccDevServer_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDevServer_basic -timeout 360m -parallel 10
=== RUN   TestAccDevServer_basic
=== PAUSE TestAccDevServer_basic
=== CONT  TestAccDevServer_basic
--- PASS: TestAccDevServer_basic (317.46s)
PASS
coverage: 8.9% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 317.548s        coverage: 8.9% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
   ![image](https://github.com/user-attachments/assets/12d08162-6d29-4f6f-bf08-086b2a6dbe68)


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
   ![image](https://github.com/user-attachments/assets/b3f70c57-5130-4779-95e5-a31309a4a7ac)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
