### PR TITLE
test(dbss): modify the  test case

### DIFF
--- a/huaweicloud/services/acceptance/dbss/data_source_huaweicloud_dbss_audit_data_masking_rules_test.go
+++ b/huaweicloud/services/acceptance/dbss/data_source_huaweicloud_dbss_audit_data_masking_rules_test.go
@@ -12,18 +12,18 @@ import (
 func TestAccDataSourceAuditDataMaskingRules_basic(t *testing.T) {
 	var (
 		dataSourceName = "data.huaweicloud_dbss_audit_data_masking_rules.test"
-		name           = acceptance.RandomAccResourceName()
 		dc             = acceptance.InitDataSourceCheck(dataSourceName)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDbssInstanceId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceAuditDataMaskingRules_basic(name),
+				Config: testDataSourceAuditDataMaskingRules_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(dataSourceName, "rules.#"),
@@ -40,12 +40,10 @@ func TestAccDataSourceAuditDataMaskingRules_basic(t *testing.T) {
 	})
 }
 
-func testDataSourceAuditDataMaskingRules_basic(name string) string {
+func testDataSourceAuditDataMaskingRules_basic() string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_dbss_audit_data_masking_rules" "test" {
-  instance_id = huaweicloud_dbss_instance.test.instance_id
+  instance_id = "%s"
 }
-`, testInstance_basic(name))
+`, acceptance.HW_DBSS_INSATNCE_ID)
 }

--- a/huaweicloud/services/acceptance/dbss/data_source_huaweicloud_dbss_audit_risk_rules_test.go
+++ b/huaweicloud/services/acceptance/dbss/data_source_huaweicloud_dbss_audit_risk_rules_test.go
@@ -12,7 +12,6 @@ import (
 func TestAccDataSourceAuditRiskRules_basic(t *testing.T) {
 	var (
 		dataSourceName = "data.huaweicloud_dbss_audit_risk_rules.test"
-		name           = acceptance.RandomAccResourceName()
 		dc             = acceptance.InitDataSourceCheck(dataSourceName)
 
 		byName   = "data.huaweicloud_dbss_audit_risk_rules.filter_by_name"
@@ -25,11 +24,12 @@ func TestAccDataSourceAuditRiskRules_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDbssInstanceId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceAuditRiskRules_basic(name),
+				Config: testDataSourceAuditRiskRules_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(dataSourceName, "rules.#"),
@@ -52,12 +52,10 @@ func TestAccDataSourceAuditRiskRules_basic(t *testing.T) {
 	})
 }
 
-func testDataSourceAuditRiskRules_basic(name string) string {
+func testDataSourceAuditRiskRules_basic() string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_dbss_audit_risk_rules" "test" {
-  instance_id = huaweicloud_dbss_instance.test.instance_id
+  instance_id = "%[1]s"
 }
 
 locals {
@@ -65,7 +63,7 @@ locals {
 }
 
 data "huaweicloud_dbss_audit_risk_rules" "filter_by_name" {
-  instance_id = huaweicloud_dbss_instance.test.instance_id
+  instance_id = "%[1]s"
   name        = local.name
 }
 
@@ -80,7 +78,7 @@ locals {
 }
 
 data "huaweicloud_dbss_audit_risk_rules" "filter_by_risk_level" {
-  instance_id = huaweicloud_dbss_instance.test.instance_id
+  instance_id = "%[1]s"
   risk_level  = local.risk_level
 }
 
@@ -89,5 +87,5 @@ output "risk_level_filter_useful" {
     [for v in data.huaweicloud_dbss_audit_risk_rules.filter_by_risk_level.rules[*].risk_level : v == local.risk_level]
   )
 }
-`, testInstance_basic(name))
+`, acceptance.HW_DBSS_INSATNCE_ID)
 }

--- a/huaweicloud/services/acceptance/dbss/data_source_huaweicloud_dbss_audit_rule_scopes_test.go
+++ b/huaweicloud/services/acceptance/dbss/data_source_huaweicloud_dbss_audit_rule_scopes_test.go
@@ -12,18 +12,18 @@ import (
 func TestAccDataSourceAuditRuleScopes_basic(t *testing.T) {
 	var (
 		dataSourceName = "data.huaweicloud_dbss_audit_rule_scopes.test"
-		name           = acceptance.RandomAccResourceName()
 		dc             = acceptance.InitDataSourceCheck(dataSourceName)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDbssInstanceId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceAuditRuleScopes_basic(name),
+				Config: testDataSourceAuditRuleScopes_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(dataSourceName, "scopes.#"),
@@ -37,12 +37,10 @@ func TestAccDataSourceAuditRuleScopes_basic(t *testing.T) {
 	})
 }
 
-func testDataSourceAuditRuleScopes_basic(name string) string {
+func testDataSourceAuditRuleScopes_basic() string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_dbss_audit_rule_scopes" "test" {
-  instance_id = huaweicloud_dbss_instance.test.instance_id
+  instance_id = "%s"
 }
-`, testInstance_basic(name))
+`, acceptance.HW_DBSS_INSATNCE_ID)
 }

--- a/huaweicloud/services/acceptance/dbss/data_source_huaweicloud_dbss_audit_sql_injection_rules_test.go
+++ b/huaweicloud/services/acceptance/dbss/data_source_huaweicloud_dbss_audit_sql_injection_rules_test.go
@@ -12,7 +12,6 @@ import (
 func TestAccDataSourceAuditSqlInjectionRules_basic(t *testing.T) {
 	var (
 		dataSourceName = "data.huaweicloud_dbss_audit_sql_injection_rules.test"
-		name           = acceptance.RandomAccResourceName()
 		dc             = acceptance.InitDataSourceCheck(dataSourceName)
 
 		byRiskLevels   = "data.huaweicloud_dbss_audit_sql_injection_rules.filter_by_risk_levels"
@@ -22,11 +21,12 @@ func TestAccDataSourceAuditSqlInjectionRules_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDbssInstanceId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceAuditSqlInjectionRules_basic(name),
+				Config: testDataSourceAuditSqlInjectionRules_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(dataSourceName, "rules.#"),
@@ -47,12 +47,10 @@ func TestAccDataSourceAuditSqlInjectionRules_basic(t *testing.T) {
 	})
 }
 
-func testDataSourceAuditSqlInjectionRules_basic(name string) string {
+func testDataSourceAuditSqlInjectionRules_basic() string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_dbss_audit_sql_injection_rules" "test" {
-  instance_id = huaweicloud_dbss_instance.test.instance_id
+  instance_id = "%[1]s"
 }
 
 locals {
@@ -60,7 +58,7 @@ locals {
 }
 
 data "huaweicloud_dbss_audit_sql_injection_rules" "filter_by_risk_levels" {
-  instance_id = huaweicloud_dbss_instance.test.instance_id
+  instance_id = "%[1]s"
   risk_levels = local.risk_levels
 }
 
@@ -70,5 +68,5 @@ output "risk_levels_filter_useful" {
     v == local.risk_levels]
   )
 }
-`, testInstance_basic(name))
+`, acceptance.HW_DBSS_INSATNCE_ID)
 }

--- a/huaweicloud/services/acceptance/dbss/data_source_huaweicloud_dbss_flavors_test.go
+++ b/huaweicloud/services/acceptance/dbss/data_source_huaweicloud_dbss_flavors_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDatasourceDbssFlavors_basic(t *testing.T) {
+func TestAccDataSourceDbssFlavors_basic(t *testing.T) {
 	rName := "data.huaweicloud_dbss_flavors.test"
 	dc := acceptance.InitDataSourceCheck(rName)
 

--- a/huaweicloud/services/acceptance/dbss/data_source_huaweicloud_dbss_instances_test.go
+++ b/huaweicloud/services/acceptance/dbss/data_source_huaweicloud_dbss_instances_test.go
@@ -1,7 +1,6 @@
 package dbss
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -12,18 +11,18 @@ import (
 func TestAccDataSourceInstances_basic(t *testing.T) {
 	var (
 		dataSource = "data.huaweicloud_dbss_instances.test"
-		rName      = acceptance.RandomAccResourceName()
 		dc         = acceptance.InitDataSourceCheck(dataSource)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDbssInstanceId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceDataSourceInstances_basic(rName),
+				Config: testDataSourceDataSourceInstances_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(dataSource, "instances.#"),
@@ -59,12 +58,4 @@ func TestAccDataSourceInstances_basic(t *testing.T) {
 	})
 }
 
-func testDataSourceDataSourceInstances_basic(name string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_dbss_instances" "test" {
-  depends_on = [huaweicloud_dbss_instance.test]
-}
-`, testInstance_basic(name))
-}
+const testDataSourceDataSourceInstances_basic = `data "huaweicloud_dbss_instances" "test" {}`

--- a/huaweicloud/services/acceptance/dbss/resource_huaweicloud_dbss_audit_risk_rule_action_test.go
+++ b/huaweicloud/services/acceptance/dbss/resource_huaweicloud_dbss_audit_risk_rule_action_test.go
@@ -10,16 +10,18 @@ import (
 )
 
 func TestAccRiskRuleAction_basic(t *testing.T) {
-	name := acceptance.RandomAccResourceName()
 	// Avoid CheckDestroy because this resource is a one-time resource and there is nothing in the destroy method.
 	// lintignore:AT001
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDbssInstanceId(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				// The ont-time resource do not need to be checked and no processing is performed in the Read method.
-				Config: testAccRiskRuleAction_basic(name),
+				Config: testAccRiskRuleAction_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckOutput("result_is_success", "true"),
 				),
@@ -28,16 +30,14 @@ func TestAccRiskRuleAction_basic(t *testing.T) {
 	})
 }
 
-func testAccRiskRuleAction_basic(name string) string {
+func testAccRiskRuleAction_basic() string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_dbss_audit_risk_rules" "test" {
-  instance_id = huaweicloud_dbss_instance.test.instance_id
+  instance_id = "%[1]s"
 }
 
 resource "huaweicloud_dbss_audit_risk_rule_action" "test" {
-  instance_id = huaweicloud_dbss_instance.test.instance_id
+  instance_id = "%[1]s"
   risk_ids    = data.huaweicloud_dbss_audit_risk_rules.test.rules[0].id
   action      = "OFF"
 }
@@ -45,5 +45,5 @@ resource "huaweicloud_dbss_audit_risk_rule_action" "test" {
 output "result_is_success" {
   value = (huaweicloud_dbss_audit_risk_rule_action.test.result == "SUCCESS")
 }
-`, testInstance_basic(name))
+`, acceptance.HW_DBSS_INSATNCE_ID)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

modify the  test case.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dbss" TESTARGS="-run TestAccInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dbss -v -run TestAccInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== CONT  TestAccInstance_basic
--- PASS: TestAccInstance_basic (2430.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dbss      2430.271s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/dbss" TESTARGS="-run TestAccRiskRuleAction_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dbss -v -run TestAccRiskRuleAction_basic -timeout 360m -parallel 4
=== RUN   TestAccRiskRuleAction_basic
=== PAUSE TestAccRiskRuleAction_basic
=== CONT  TestAccRiskRuleAction_basic
--- PASS: TestAccRiskRuleAction_basic (31.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dbss      31.584s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/dbss" TESTARGS="-run TestAccDataSource.*"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dbss -v -run TestAccDataSource.* -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAuditDataMaskingRules_basic
=== PAUSE TestAccDataSourceAuditDataMaskingRules_basic
=== RUN   TestAccDataSourceAuditRiskRules_basic
=== PAUSE TestAccDataSourceAuditRiskRules_basic
=== RUN   TestAccDataSourceAuditRuleScopes_basic
=== PAUSE TestAccDataSourceAuditRuleScopes_basic
=== RUN   TestAccDataSourceAuditSqlInjectionRules_basic
=== PAUSE TestAccDataSourceAuditSqlInjectionRules_basic
=== RUN   TestAccDataSourceAvailabilityZones_basic
=== PAUSE TestAccDataSourceAvailabilityZones_basic
=== RUN   TestAccDataSourceDbssDatabases_basic
=== PAUSE TestAccDataSourceDbssDatabases_basic
=== RUN   TestAccDataSourceDbssFlavors_basic
=== PAUSE TestAccDataSourceDbssFlavors_basic
=== RUN   TestAccDataSourceInstances_basic
=== PAUSE TestAccDataSourceInstances_basic
=== RUN   TestAccDataSourceOperationLogs_basic
=== PAUSE TestAccDataSourceOperationLogs_basic
=== RUN   TestAccDataSourceRdsDatabases_basic
=== PAUSE TestAccDataSourceRdsDatabases_basic
=== CONT  TestAccDataSourceAuditDataMaskingRules_basic
=== CONT  TestAccDataSourceDbssDatabases_basic
=== CONT  TestAccDataSourceAuditSqlInjectionRules_basic
=== CONT  TestAccDataSourceAvailabilityZones_basic
--- PASS: TestAccDataSourceAvailabilityZones_basic (29.86s)
=== CONT  TestAccDataSourceAuditRuleScopes_basic
--- PASS: TestAccDataSourceAuditDataMaskingRules_basic (33.53s)
=== CONT  TestAccDataSourceAuditRiskRules_basic
--- PASS: TestAccDataSourceAuditRuleScopes_basic (40.02s)
=== CONT  TestAccDataSourceOperationLogs_basic
--- PASS: TestAccDataSourceAuditSqlInjectionRules_basic (75.87s)
=== CONT  TestAccDataSourceRdsDatabases_basic
--- PASS: TestAccDataSourceDbssDatabases_basic (79.04s)
=== CONT  TestAccDataSourceInstances_basic
--- PASS: TestAccDataSourceInstances_basic (44.69s)
=== CONT  TestAccDataSourceDbssFlavors_basic
--- PASS: TestAccDataSourceAuditRiskRules_basic (104.93s)
--- PASS: TestAccDataSourceOperationLogs_basic (120.00s)
--- PASS: TestAccDataSourceDbssFlavors_basic (111.06s)
--- PASS: TestAccDataSourceRdsDatabases_basic (618.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dbss      694.709s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
