### PR TITLE
feat(live): live domain resource support new field is_ipv6

### DIFF
--- a/docs/resources/live_domain.md
+++ b/docs/resources/live_domain.md
@@ -64,6 +64,9 @@ The following arguments are supported:
 * `ingest_domain_name` - (Optional, String) Specifies the ingest domain name, which associates with the streaming
   domain name to push streams to nearby CDN nodes.
 
+* `is_ipv6` - (Optional, Bool) Specifies whether enable IPv6 switch. Defaults to **false**.
+  This field can only be edited when `status` is **on**.
+
 * `status` - (Optional, String) Specifies status of the domain name. The options are as follows:
   + **on**: enable the domain name.
   + **off**: disable the domain name.

--- a/huaweicloud/services/acceptance/live/resource_huaweicloud_live_domain_test.go
+++ b/huaweicloud/services/acceptance/live/resource_huaweicloud_live_domain_test.go
@@ -25,13 +25,13 @@ func getDomainResourceFunc(conf *config.Config, state *terraform.ResourceState) 
 func TestAccDomain_basic(t *testing.T) {
 	var obj model.CreateDomainMappingResponse
 
-	pushDomainName := fmt.Sprintf("%s.huaweicloud.com", acceptance.RandomAccResourceNameWithDash())
-	pullDomainName := fmt.Sprintf("%s.huaweicloud.com", acceptance.RandomAccResourceNameWithDash())
-	pushResourceName := "huaweicloud_live_domain.ingestDomain"
-	pullResourceName := "huaweicloud_live_domain.streamingDomain"
+	ingestDomainName := fmt.Sprintf("%s.huaweicloud.com", acceptance.RandomAccResourceNameWithDash())
+	streamingDomainName := fmt.Sprintf("%s.huaweicloud.com", acceptance.RandomAccResourceNameWithDash())
+	ingestResourceName := "huaweicloud_live_domain.ingestDomain"
+	streamingResourceName := "huaweicloud_live_domain.streamingDomain"
 
 	rc := acceptance.InitResourceCheck(
-		pushResourceName,
+		ingestResourceName,
 		&obj,
 		getDomainResourceFunc,
 	)
@@ -45,42 +45,44 @@ func TestAccDomain_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testDomain_basic(pushDomainName, pullDomainName),
+				Config: testDomain_basic(ingestDomainName, streamingDomainName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(pushResourceName, "name", pushDomainName),
-					resource.TestCheckResourceAttr(pushResourceName, "type", "push"),
-					resource.TestCheckResourceAttr(pushResourceName, "status", "on"),
-					resource.TestCheckResourceAttr(pushResourceName, "service_area", "mainland_china"),
-					resource.TestCheckResourceAttr(pushResourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(ingestResourceName, "name", ingestDomainName),
+					resource.TestCheckResourceAttr(ingestResourceName, "type", "push"),
+					resource.TestCheckResourceAttr(ingestResourceName, "status", "on"),
+					resource.TestCheckResourceAttr(ingestResourceName, "service_area", "mainland_china"),
+					resource.TestCheckResourceAttr(ingestResourceName, "is_ipv6", "true"),
+					resource.TestCheckResourceAttr(ingestResourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 
-					resource.TestCheckResourceAttr(pullResourceName, "name", pullDomainName),
-					resource.TestCheckResourceAttr(pullResourceName, "type", "pull"),
-					resource.TestCheckResourceAttr(pullResourceName, "status", "on"),
-					resource.TestCheckResourceAttr(pullResourceName, "ingest_domain_name", pushDomainName),
-					resource.TestCheckResourceAttr(pullResourceName, "service_area", "outside_mainland_china"),
-					resource.TestCheckResourceAttr(pullResourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(streamingResourceName, "name", streamingDomainName),
+					resource.TestCheckResourceAttr(streamingResourceName, "type", "pull"),
+					resource.TestCheckResourceAttr(streamingResourceName, "status", "on"),
+					resource.TestCheckResourceAttr(streamingResourceName, "ingest_domain_name", ingestDomainName),
+					resource.TestCheckResourceAttr(streamingResourceName, "service_area", "outside_mainland_china"),
+					resource.TestCheckResourceAttr(streamingResourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
 			},
 			{
-				Config: testDomain_basic_update(pushDomainName, pullDomainName),
+				Config: testDomain_basic_update(ingestDomainName, streamingDomainName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(pushResourceName, "name", pushDomainName),
-					resource.TestCheckResourceAttr(pushResourceName, "type", "push"),
-					resource.TestCheckResourceAttr(pushResourceName, "status", "on"),
-					resource.TestCheckResourceAttr(pushResourceName, "service_area", "mainland_china"),
-					resource.TestCheckResourceAttr(pushResourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(ingestResourceName, "name", ingestDomainName),
+					resource.TestCheckResourceAttr(ingestResourceName, "type", "push"),
+					resource.TestCheckResourceAttr(ingestResourceName, "status", "on"),
+					resource.TestCheckResourceAttr(ingestResourceName, "service_area", "mainland_china"),
+					resource.TestCheckResourceAttr(ingestResourceName, "is_ipv6", "false"),
+					resource.TestCheckResourceAttr(ingestResourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 
-					resource.TestCheckResourceAttr(pullResourceName, "name", pullDomainName),
-					resource.TestCheckResourceAttr(pullResourceName, "type", "pull"),
-					resource.TestCheckResourceAttr(pullResourceName, "status", "off"),
-					resource.TestCheckResourceAttr(pullResourceName, "ingest_domain_name", ""),
-					resource.TestCheckResourceAttr(pullResourceName, "service_area", "outside_mainland_china"),
-					resource.TestCheckResourceAttr(pullResourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(streamingResourceName, "name", streamingDomainName),
+					resource.TestCheckResourceAttr(streamingResourceName, "type", "pull"),
+					resource.TestCheckResourceAttr(streamingResourceName, "status", "off"),
+					resource.TestCheckResourceAttr(streamingResourceName, "ingest_domain_name", ""),
+					resource.TestCheckResourceAttr(streamingResourceName, "service_area", "outside_mainland_china"),
+					resource.TestCheckResourceAttr(streamingResourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
 			},
 			{
-				ResourceName:      pullResourceName,
+				ResourceName:      streamingResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -94,6 +96,7 @@ resource "huaweicloud_live_domain" "ingestDomain" {
   name                  = "%[1]s"
   type                  = "push"
   service_area          = "mainland_china"
+  is_ipv6               = true
   enterprise_project_id = "%[3]s"
 }
 
@@ -113,6 +116,7 @@ resource "huaweicloud_live_domain" "ingestDomain" {
   name                  = "%[1]s"
   type                  = "push"
   service_area          = "mainland_china"
+  is_ipv6               = false
   enterprise_project_id = "%[3]s"
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

live domain resource support new field is_ipv6

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
go test -v -coverprofile=coverage_1735183334773_TestAccDomain_basic.cov -coverpkg=./huaweicloud/services/live ./huaweicloud/services/acceptance/live -run TestAccDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccDomain_basic
--- PASS: TestAccDomain_basic (390.59s)
PASS
coverage: 10.0% of statements in ./huaweicloud/services/live
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      390.646s        coverage: 10.0% of statements in ./huaweicloud/services/live
```
![image](https://github.com/user-attachments/assets/6c58385b-ff17-4e24-9e5a-efb05f7f8784)



* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
