### PR TITLE
feat(apig/api): supports new request parameters

### DIFF
--- a/docs/resources/apig_api.md
+++ b/docs/resources/apig_api.md
@@ -153,6 +153,22 @@ The following arguments are supported:
 
 * `tags` - (Optional, List) Specifies the list of tags configuration.
 
+* `content_type` - (Optional, String) Specifies the content type of the request body.  
+  The valid values are as follows:
+  + **application/json**
+  + **application/xml**
+  + **multipart/form-data**
+  + **text/plain**
+
+* `is_send_fg_body_base64` - (Optional, Bool) Specifies whether to perform base64 encoding on the body for interaction
+  with FunctionGraph.  
+  Defaults to **true**.  
+  The body does not need to be encoded using base64 only when `content_type` is set to **application/json**.  
+  These scenarios which can be applied:
+  + Custom authentication.
+  + Bound circuit breaker plug-in with FunctionGraph backend downgrade policy.
+  + APIs with FunctionGraph backend.
+
 * `request_params` - (Optional, List) Specifies the configurations of the front-end parameters.  
   The [object](#apig_api_request_params) structure is documented below.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20241224061204-e794f144e5ec
+	github.com/chnsz/golangsdk v0.0.0-20241226031404-57791d6b2637
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20241224061204-e794f144e5ec h1:TzFxp/PH01bwLEDRrIEgTCffn+BqasKT8QGw1B2OeYI=
-github.com/chnsz/golangsdk v0.0.0-20241224061204-e794f144e5ec/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20241226031404-57791d6b2637 h1:AMk/Wr0ScKV9OO7rCsNLvFvkQTKibV3bznMhoB6El18=
+github.com/chnsz/golangsdk v0.0.0-20241226031404-57791d6b2637/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_test.go
@@ -61,8 +61,11 @@ func TestAccApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(webBackend, "request_protocol", "HTTP"),
 					resource.TestCheckResourceAttr(webBackend, "request_method", "GET"),
 					resource.TestCheckResourceAttr(webBackend, "request_path", "/web/test"),
-					resource.TestCheckResourceAttr(webBackend, "security_authentication", "APP"),
-					resource.TestCheckResourceAttr(webBackend, "simple_authentication", "true"),
+					resource.TestCheckResourceAttr(webBackend, "security_authentication", "AUTHORIZER"),
+					resource.TestCheckResourceAttrPair(webBackend, "authorizer_id", "huaweicloud_apig_custom_authorizer.front", "id"),
+					resource.TestCheckResourceAttr(webBackend, "simple_authentication", "false"),
+					resource.TestCheckResourceAttr(webBackend, "content_type", ""),
+					resource.TestCheckResourceAttr(webBackend, "is_send_fg_body_base64", "true"),
 					resource.TestCheckResourceAttr(webBackend, "matching", "Exact"),
 					resource.TestCheckResourceAttr(webBackend, "success_response", "Success response"),
 					resource.TestCheckResourceAttr(webBackend, "failure_response", "Failed response"),
@@ -90,7 +93,7 @@ func TestAccApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(webBackend, "web.0.request_protocol", "HTTP"),
 					resource.TestCheckResourceAttr(webBackend, "web.0.timeout", "30000"),
 					resource.TestCheckResourceAttr(webBackend, "web.0.retry_count", "1"),
-					resource.TestCheckResourceAttrPair(webBackend, "web.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttrPair(webBackend, "web.0.authorizer_id", "huaweicloud_apig_custom_authorizer.backend", "id"),
 					resource.TestCheckResourceAttr(webBackend, "web_policy.#", "1"),
 					resource.TestCheckResourceAttr(webBackend, "web_policy.0.name", name+"_web_policy"),
 					resource.TestCheckResourceAttr(webBackend, "web_policy.0.request_protocol", "HTTP"),
@@ -100,7 +103,7 @@ func TestAccApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(webBackend, "web_policy.0.timeout", "30000"),
 					resource.TestCheckResourceAttr(webBackend, "web_policy.0.retry_count", "1"),
 					resource.TestCheckResourceAttrPair(webBackend, "web_policy.0.vpc_channel_id", "huaweicloud_apig_channel.test", "id"),
-					resource.TestCheckResourceAttrPair(webBackend, "web_policy.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttrPair(webBackend, "web_policy.0.authorizer_id", "huaweicloud_apig_custom_authorizer.backend", "id"),
 					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.#", "1"),
 					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.type", "SYSTEM"),
 					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.name", "SerivceNum"),
@@ -137,7 +140,7 @@ func TestAccApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.request_protocol", "GRPCS"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.timeout", "5000"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.invocation_type", "sync"),
-					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph.0.authorizer_id", "huaweicloud_apig_custom_authorizer.backend", "id"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.#", "1"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.name", name+"_fgs_policy"),
 					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph_policy.0.function_urn", "huaweicloud_fgs_function.test.1", "urn"),
@@ -149,7 +152,7 @@ func TestAccApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.invocation_type", "sync"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.effective_mode", "ANY"),
 					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph_policy.0.authorizer_id",
-						"huaweicloud_apig_custom_authorizer.test", "id"),
+						"huaweicloud_apig_custom_authorizer.backend", "id"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.#", "1"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.0.source", "cookie"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.0.cookie_name", "regex_test"),
@@ -176,12 +179,13 @@ func TestAccApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(mockBackend, "mock.#", "1"),
 					resource.TestCheckResourceAttr(mockBackend, "mock.0.status_code", "201"),
 					resource.TestCheckResourceAttr(mockBackend, "mock.0.response", "{'message':'hello world'}"),
-					resource.TestCheckResourceAttrPair(mockBackend, "mock.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttrPair(mockBackend, "mock.0.authorizer_id", "huaweicloud_apig_custom_authorizer.backend", "id"),
 					resource.TestCheckResourceAttr(mockBackend, "mock_policy.#", "1"),
 					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.name", name+"_mock_policy"),
 					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.status_code", "201"),
 					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.response", "{'message':'hello world'}"),
-					resource.TestCheckResourceAttrPair(mockBackend, "mock_policy.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttrPair(mockBackend, "mock_policy.0.authorizer_id",
+						"huaweicloud_apig_custom_authorizer.backend", "id"),
 					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.effective_mode", "ANY"),
 					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.#", "1"),
 					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.0.source", "system"),
@@ -206,8 +210,11 @@ func TestAccApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(webBackend, "request_protocol", "HTTP"),
 					resource.TestCheckResourceAttr(webBackend, "request_method", "GET"),
 					resource.TestCheckResourceAttr(webBackend, "request_path", "/web/new/test"),
-					resource.TestCheckResourceAttr(webBackend, "security_authentication", "APP"),
+					resource.TestCheckResourceAttr(webBackend, "security_authentication", "AUTHORIZER"),
+					resource.TestCheckResourceAttrPair(webBackend, "authorizer_id", "huaweicloud_apig_custom_authorizer.front", "id"),
 					resource.TestCheckResourceAttr(webBackend, "simple_authentication", "false"),
+					resource.TestCheckResourceAttr(webBackend, "content_type", "application/json"),
+					resource.TestCheckResourceAttr(webBackend, "is_send_fg_body_base64", "false"),
 					resource.TestCheckResourceAttr(webBackend, "matching", "Exact"),
 					resource.TestCheckResourceAttr(webBackend, "success_response", "Updated success response"),
 					resource.TestCheckResourceAttr(webBackend, "failure_response", "Updated failed response"),
@@ -237,7 +244,7 @@ func TestAccApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(webBackend, "web.0.request_protocol", "HTTP"),
 					resource.TestCheckResourceAttr(webBackend, "web.0.timeout", "40000"),
 					resource.TestCheckResourceAttr(webBackend, "web.0.retry_count", "2"),
-					resource.TestCheckResourceAttrPair(webBackend, "web.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttrPair(webBackend, "web.0.authorizer_id", "huaweicloud_apig_custom_authorizer.backend", "id"),
 					resource.TestCheckResourceAttr(webBackend, "web_policy.#", "1"),
 					resource.TestCheckResourceAttr(webBackend, "web_policy.0.name", updateName+"_web_policy"),
 					resource.TestCheckResourceAttr(webBackend, "web_policy.0.request_protocol", "HTTP"),
@@ -247,7 +254,7 @@ func TestAccApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(webBackend, "web_policy.0.timeout", "40000"),
 					resource.TestCheckResourceAttr(webBackend, "web_policy.0.retry_count", "2"),
 					resource.TestCheckResourceAttrPair(webBackend, "web_policy.0.vpc_channel_id", "huaweicloud_apig_channel.test", "id"),
-					resource.TestCheckResourceAttrPair(webBackend, "web_policy.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttrPair(webBackend, "web_policy.0.authorizer_id", "huaweicloud_apig_custom_authorizer.backend", "id"),
 					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.#", "1"),
 					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.type", "SYSTEM"),
 					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.name", "ServiceName"),
@@ -274,8 +281,8 @@ func TestAccApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(fgsBackend, "request_path", "/fgs/new/test"),
 					resource.TestCheckResourceAttr(fgsBackend, "security_authentication", "APP"),
 					resource.TestCheckResourceAttr(fgsBackend, "simple_authentication", "false"),
-					resource.TestCheckResourceAttr(fgsBackend, "description", ""),
 					resource.TestCheckResourceAttr(fgsBackend, "matching", "Exact"),
+					resource.TestCheckResourceAttr(fgsBackend, "description", ""),
 					resource.TestCheckResourceAttr(fgsBackend, "request_params.#", "0"),
 					resource.TestCheckResourceAttr(fgsBackend, "backend_params.#", "0"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph.#", "1"),
@@ -285,7 +292,7 @@ func TestAccApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.request_protocol", "GRPCS"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.timeout", "6000"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.invocation_type", "sync"),
-					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph.0.authorizer_id", "huaweicloud_apig_custom_authorizer.backend", "id"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.#", "1"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.name", updateName+"_fgs_policy"),
 					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph_policy.0.function_urn", "huaweicloud_fgs_function.test.1", "urn"),
@@ -296,7 +303,7 @@ func TestAccApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.invocation_type", "sync"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.effective_mode", "ALL"),
 					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph_policy.0.authorizer_id",
-						"huaweicloud_apig_custom_authorizer.test", "id"),
+						"huaweicloud_apig_custom_authorizer.backend", "id"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.#", "1"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.0.source", "cookie"),
 					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.0.cookie_name", "regex_test"),
@@ -326,12 +333,13 @@ func TestAccApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(mockBackend, "mock.#", "1"),
 					resource.TestCheckResourceAttr(mockBackend, "mock.0.status_code", "202"),
 					resource.TestCheckResourceAttr(mockBackend, "mock.0.response", "{'message':'hello world!'}"),
-					resource.TestCheckResourceAttrPair(mockBackend, "mock.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttrPair(mockBackend, "mock.0.authorizer_id", "huaweicloud_apig_custom_authorizer.backend", "id"),
 					resource.TestCheckResourceAttr(mockBackend, "mock_policy.#", "1"),
 					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.name", updateName+"_mock_policy"),
 					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.status_code", "202"),
 					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.response", "{'message':'hello world!'}"),
-					resource.TestCheckResourceAttrPair(mockBackend, "mock_policy.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttrPair(mockBackend, "mock_policy.0.authorizer_id",
+						"huaweicloud_apig_custom_authorizer.backend", "id"),
 					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.effective_mode", "ALL"),
 					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.#", "1"),
 					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.0.source", "system"),
@@ -463,11 +471,30 @@ resource "huaweicloud_apig_channel" "test" {
   }
 }
 
-resource "huaweicloud_apig_custom_authorizer" "test" {
+resource "huaweicloud_apig_custom_authorizer" "front" {
   instance_id        = local.instance_id
-  name               = "%[2]s"
+  name               = "%[2]s_front"
   function_urn       = huaweicloud_fgs_function.test[0].urn
-  function_alias_uri = format("%%s:!%%s", huaweicloud_fgs_function.test[0].urn, tolist(huaweicloud_fgs_function.test[0].versions)[0].aliases[0].name)
+  function_alias_uri = format("%%s:!%%s", huaweicloud_fgs_function.test[0].urn,
+    tolist(huaweicloud_fgs_function.test[0].versions)[0].aliases[0].name)
+  network_type       = "V2"
+  type               = "FRONTEND"
+  is_body_send       = true
+  user_data          = "Demo"
+  cache_age          = 15
+
+  identity {
+    name     = "X-Service-Num"
+    location = "HEADER"
+  }
+}
+
+resource "huaweicloud_apig_custom_authorizer" "backend" {
+  instance_id        = local.instance_id
+  name               = "%[2]s_backend"
+  function_urn       = huaweicloud_fgs_function.test[0].urn
+  function_alias_uri = format("%%s:!%%s", huaweicloud_fgs_function.test[0].urn,
+    tolist(huaweicloud_fgs_function.test[0].versions)[0].aliases[0].name)
   network_type       = "V2"
   type               = "BACKEND"
   is_body_send       = true
@@ -491,8 +518,8 @@ resource "huaweicloud_apig_api" "web" {
   request_protocol        = "HTTP"
   request_method          = "GET"
   request_path            = "/web/test"
-  security_authentication = "APP"
-  simple_authentication   = true
+  security_authentication = "AUTHORIZER"
+  authorizer_id           = huaweicloud_apig_custom_authorizer.front.id
   matching                = "Exact"
   success_response        = "Success response"
   failure_response        = "Failed response"
@@ -524,7 +551,7 @@ resource "huaweicloud_apig_api" "web" {
     request_protocol = "HTTP"
     timeout          = 30000
     retry_count      = 1
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.backend.id
   }
 
   web_policy {
@@ -536,7 +563,7 @@ resource "huaweicloud_apig_api" "web" {
     timeout          = 30000
     retry_count      = 1
     vpc_channel_id   = huaweicloud_apig_channel.test.id
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.backend.id
 
     backend_params {
       type              = "SYSTEM"
@@ -575,7 +602,7 @@ resource "huaweicloud_apig_api" "func_graph" {
     request_protocol = "GRPCS"
     timeout          = 5000
     invocation_type  = "sync"
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.backend.id
   }
 
   func_graph_policy {
@@ -587,7 +614,7 @@ resource "huaweicloud_apig_api" "func_graph" {
     timeout          = 5000
     invocation_type  = "sync"
     effective_mode   = "ANY"
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.backend.id
 
     conditions {
       source      = "cookie"
@@ -616,14 +643,14 @@ resource "huaweicloud_apig_api" "mock" {
   mock {
     status_code   = 201
     response      = "{'message':'hello world'}"
-    authorizer_id = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id = huaweicloud_apig_custom_authorizer.backend.id
   }
 
   mock_policy {
     name           = "%[2]s_mock_policy"
     status_code    = 201
     response       = "{'message':'hello world'}"
-    authorizer_id  = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id  = huaweicloud_apig_custom_authorizer.backend.id
     effective_mode = "ANY"
 
     conditions {
@@ -649,12 +676,14 @@ resource "huaweicloud_apig_api" "web" {
   request_protocol        = "HTTP"
   request_method          = "GET"
   request_path            = "/web/new/test"
-  security_authentication = "APP"
-  simple_authentication   = false
+  security_authentication = "AUTHORIZER"
+  authorizer_id           = huaweicloud_apig_custom_authorizer.front.id
   matching                = "Exact"
   success_response        = "Updated success response"
   failure_response        = "Updated failed response"
   tags                    = ["key"]
+  content_type            = "application/json"
+  is_send_fg_body_base64  = false
 
   request_params {
     name         = "X-Service-Name"
@@ -683,7 +712,7 @@ resource "huaweicloud_apig_api" "web" {
     request_protocol = "HTTP"
     timeout          = 40000
     retry_count      = 2
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.backend.id
   }
 
   web_policy {
@@ -695,7 +724,7 @@ resource "huaweicloud_apig_api" "web" {
     timeout          = 40000
     retry_count      = 2
     vpc_channel_id   = huaweicloud_apig_channel.test.id
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.backend.id
 
     backend_params {
       type              = "SYSTEM"
@@ -734,7 +763,7 @@ resource "huaweicloud_apig_api" "func_graph" {
     request_protocol   = "GRPCS"
     timeout            = 6000
     invocation_type    = "sync"
-    authorizer_id      = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id      = huaweicloud_apig_custom_authorizer.backend.id
   }
 
   func_graph_policy {
@@ -747,7 +776,7 @@ resource "huaweicloud_apig_api" "func_graph" {
     timeout            = 6000
     invocation_type    = "sync"
     effective_mode     = "ALL"
-    authorizer_id      = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id      = huaweicloud_apig_custom_authorizer.backend.id
 
     conditions {
       source      = "cookie"
@@ -775,14 +804,14 @@ resource "huaweicloud_apig_api" "mock" {
   mock {
     status_code   = 202
     response      = "{'message':'hello world!'}"
-    authorizer_id = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id = huaweicloud_apig_custom_authorizer.backend.id
   }
 
   mock_policy {
     name           = "%[2]s_mock_policy"
     status_code    = 202
     response       = "{'message':'hello world!'}"
-    authorizer_id  = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id  = huaweicloud_apig_custom_authorizer.backend.id
     effective_mode = "ALL"
 
     conditions {
@@ -1012,7 +1041,7 @@ resource "huaweicloud_apig_api" "test" {
     request_protocol = "HTTP"
     timeout          = 40000
     retry_count      = 2
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.backend.id
   }
 
   web_policy {
@@ -1024,7 +1053,7 @@ resource "huaweicloud_apig_api" "test" {
     timeout          = 40000
     retry_count      = 2
     vpc_channel_id   = huaweicloud_apig_channel.test.id
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.backend.id
 
     backend_params {
       type              = "SYSTEM"
@@ -1088,7 +1117,7 @@ resource "huaweicloud_apig_api" "test" {
     request_protocol = "HTTP"
     timeout          = 40000
     retry_count      = 2
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.backend.id
   }
 
   web_policy {
@@ -1100,7 +1129,7 @@ resource "huaweicloud_apig_api" "test" {
     timeout          = 40000
     retry_count      = 2
     vpc_channel_id   = huaweicloud_apig_channel.test.id
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.backend.id
 
     backend_params {
       type              = "SYSTEM"

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_api.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_api.go
@@ -225,6 +225,18 @@ func ResourceApigAPIV2() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "The list of tags configuration.",
 			},
+			"content_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The content type of the request body.",
+			},
+			"is_send_fg_body_base64": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to perform Base64 encoding on the body for interaction with FunctionGraph.",
+			},
 			"request_params": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -1253,6 +1265,8 @@ func buildApiCreateOpts(d *schema.ResourceData) (apis.APIOpts, error) {
 		ResponseId:          d.Get("response_id").(string),
 		ReqParams:           buildRequestParameters(d.Get("request_params").(*schema.Set)),
 		Tags:                utils.ExpandToStringListBySet(d.Get("tags").((*schema.Set))),
+		ContentType:         d.Get("content_type").(string),
+		IsSendFgBodyBase64:  utils.Bool(d.Get("is_send_fg_body_base64").(bool)),
 	}
 	// build match mode
 	matchMode := d.Get("matching").(string)
@@ -1649,6 +1663,8 @@ func resourceApiRead(_ context.Context, d *schema.ResourceData, meta interface{}
 		d.Set("name", resp.Name),
 		d.Set("authorizer_id", resp.AuthorizerId),
 		d.Set("tags", resp.Tags),
+		d.Set("content_type", resp.ContentType),
+		d.Set("is_send_fg_body_base64", resp.IsSendFgBodyBase64),
 		d.Set("request_protocol", resp.ReqProtocol),
 		d.Set("request_method", resp.ReqMethod),
 		d.Set("request_path", resp.ReqURI),

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis/requests.go
@@ -72,6 +72,16 @@ type APIOpts struct {
 	// List of tags. The length of the tags list is range from 1 to 128.
 	// The value can contain only letters, digits, and underscores (_), and must start with a letter.
 	Tags []string `json:"tags,omitempty"`
+	// The content type of the request body.
+	ContentType string `json:"content_type,omitempty"`
+	// Whether to perform base64 encoding on the body for interaction with FunctionGraph.
+	// The body does not need to be encoded using Base64 only when content_type is set to application/json.
+	// The scenario which can be applied:
+	// + Custom authentication
+	// + Bound circuit breaker plug-in with FunctionGraph backend downgrade policy
+	// + APIs with FunctionGraph backend
+	// Defaults to true.
+	IsSendFgBodyBase64 *bool `json:"is_send_fg_body_base64,omitempty"`
 	// Group response ID.
 	ResponseId string `json:"response_id,omitempty"`
 	// Request parameters.

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis/results.go
@@ -88,6 +88,10 @@ type APIResp struct {
 	AuthorizerId string `json:"authorizer_id"`
 	// Tags.
 	Tags []string `json:"tags"`
+	// The content type of the request body.
+	ContentType string `json:"content_type"`
+	// Whether to perform base64 encoding on the body for interaction with FunctionGraph.
+	IsSendFgBodyBase64 bool `json:"is_send_fg_body_base64"`
 	// Group response ID.
 	ResponseId string `json:"response_id"`
 	// API ID.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20241224061204-e794f144e5ec
+# github.com/chnsz/golangsdk v0.0.0-20241226031404-57791d6b2637
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New resource parameters supported:
- content_type
- is_send_fg_body_base64: with ture default value, and this value will not trigger changes.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. API resource supports new parameters for the request body configuration.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccApi_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccApi_basic -timeout 360m -parallel 10
=== RUN   TestAccApi_basic
=== PAUSE TestAccApi_basic
=== CONT  TestAccApi_basic
--- PASS: TestAccApi_basic (171.90s)
PASS
coverage: 12.1% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      171.958s        coverage: 12.1% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
