### PR TITLE
feat(modelarts): add resource to operate devserver

### DIFF
--- a/docs/resources/modelarts_devserver_action.md
+++ b/docs/resources/modelarts_devserver_action.md
@@ -1,0 +1,44 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelarts_devserver_action"
+description: |-
+  Use this resource to operate ModelArts DevServer within HuaweiCloud.
+---
+# huaweicloud_modelarts_devserver_action
+
+Use this resource to operate ModelArts DevServer within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "devserver_id" {}
+
+resource "huaweicloud_modelarts_devserver_action" "test" {
+  devserver_id = var.devserver_id
+  action       = "start"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `devserver_id` - (Required, String, ForceNew) Specifies the ID of the DevServer.
+  Changing this creates a new resource.
+
+* `action` - (Required, String, ForceNew) Specifies the action type of the DevServer.
+  Changing this creates a new resource.  
+  The valid values are as follows:
+  + **start**: The DevServer can be started only when the DevServer is stopped, stop failure, or start failure.
+  + **stop**: The DevServer can be stopped only when it is running or stop failure.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1928,6 +1928,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_modelarts_dataset":                modelarts.ResourceDataset(),
 			"huaweicloud_modelarts_dataset_version":        modelarts.ResourceDatasetVersion(),
+			"huaweicloud_modelarts_devserver_action":       modelarts.ResourceDevServerAction(),
 			"huaweicloud_modelarts_devserver":              modelarts.ResourceDevServer(),
 			"huaweicloud_modelarts_notebook":               modelarts.ResourceNotebook(),
 			"huaweicloud_modelarts_notebook_mount_storage": modelarts.ResourceNotebookMountStorage(),

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver_action.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver_action.go
@@ -1,0 +1,136 @@
+package modelarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ModelArts PUT /v1/{project_id}/dev-servers/{id}/start
+// @API ModelArts PUT /v1/{project_id}/dev-servers/{id}/stop
+// @API ModelArts GET /v1/{project_id}/dev-servers/{id}
+func ResourceDevServerAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDevServerActionCreate,
+		ReadContext:   resourceDevServerActionRead,
+		DeleteContext: resourceDevServerActionDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"devserver_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the DevServer.`,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The action type of the DevServer.`,
+			},
+		},
+	}
+}
+
+func resourceDevServerActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                = meta.(*config.Config)
+		region             = cfg.GetRegion(d)
+		httpUrl            = "v1/{project_id}/dev-servers/{id}/{action}"
+		devServerId        = d.Get("devserver_id").(string)
+		action             = d.Get("action").(string)
+		actionCompletedMap = map[string]string{
+			"start": "RUNNING",
+			"stop":  "STOPPED",
+		}
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	actionPath := client.Endpoint + httpUrl
+	actionPath = strings.ReplaceAll(actionPath, "{project_id}", client.ProjectID)
+	actionPath = strings.ReplaceAll(actionPath, "{id}", devServerId)
+	actionPath = strings.ReplaceAll(actionPath, "{action}", action)
+	actionOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	if action == "start" {
+		// For the "start" type, the request body parameter must be specified, so set an empty object for it.
+		actionOpt.JSONBody = map[string]interface{}{}
+	}
+
+	_, err = client.Request("PUT", actionPath, &actionOpt)
+	if err != nil {
+		return diag.Errorf("unable to %s DevServer (%s): %s", action, devServerId, err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshDevServerActionStatusFunc(client, devServerId, actionCompletedMap[action]),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for DevServer (%s) to %s completed: %s", devServerId, action, err)
+	}
+
+	d.SetId(devServerId)
+
+	return nil
+}
+
+func refreshDevServerActionStatusFunc(client *golangsdk.ServiceClient, devServerId string, target string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := GetDevServerById(client, devServerId)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		status := utils.PathSearch("status", respBody, "").(string)
+		if utils.StrSliceContains([]string{"START_FAILED", "ERROR", "STOP_FAILED"}, status) {
+			return respBody, "ERROR", fmt.Errorf("unexpected status (%s)", status)
+		}
+
+		if status == target {
+			return respBody, "COMPLETED", nil
+		}
+		return "continue", "PENDING", nil
+	}
+}
+
+func resourceDevServerActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDevServerActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for operating the DevServer. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to start or stop DevService.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to operate DevService.
2. add related document and accptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o modelarts -f TestAccDevServer_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDevServer_basic -timeout 360m -parallel 10
=== RUN   TestAccDevServer_basic
=== PAUSE TestAccDevServer_basic
=== CONT  TestAccDevServer_basic
--- PASS: TestAccDevServer_basic (433.24s)
PASS
coverage: 10.1% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 433.329s        coverage: 10.1% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
