### PR TITLE
feat(live): support a new resource to manage live stream delay

### DIFF
--- a/docs/resources/live_stream_delay.md
+++ b/docs/resources/live_stream_delay.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Live"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_live_stream_delay"
+description: |-
+  Manages a Live stream delay resource within HuaweiCloud.
+---
+
+# huaweicloud_live_stream_delay
+
+Manages a Live stream delay resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "domain_name" {}
+
+resource "huaweicloud_live_stream_delay" "test" {
+  domain_name = var.domain_name
+  app_name    = "live"
+  delay       = 2000
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+
+  Changing this will create a new resource.
+
+* `domain_name` - (Required, String, ForceNew) Specifies the streaming domain name.
+
+  Changing this will create a new resource.
+
+* `delay` - (Required, Int, ForceNew) Specifies the delay time, in ms. The options are as follows:
+  + `2,000` (low).
+  + `4,000` (medium).
+  + `6,000` (high).
+
+* `app_name` - (Optional, String, ForceNew) Specifies the application name. Defaults to **live**.
+
+  Changing this will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+## Import
+
+The resource can be imported using `domain_name`, e.g.
+
+```bash
+$ terraform import huaweicloud_live_stream_delay.test <domain_name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1885,6 +1885,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_live_url_authentication":         live.ResourceUrlAuthentication(),
 			"huaweicloud_live_url_validation":             live.ResourceUrlValidation(),
 			"huaweicloud_live_origin_pull_configuration":  live.ResourceOriginPullConfiguration(),
+			"huaweicloud_live_stream_delay":               live.ResourceStreamDelay(),
 
 			"huaweicloud_lts_aom_access":                       lts.ResourceAOMAccess(),
 			"huaweicloud_lts_group":                            lts.ResourceLTSGroup(),

--- a/huaweicloud/services/acceptance/live/resource_huaweicloud_live_stream_delay_test.go
+++ b/huaweicloud/services/acceptance/live/resource_huaweicloud_live_stream_delay_test.go
@@ -1,0 +1,115 @@
+package live
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/live"
+)
+
+func getResourceStreamDelayFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region     = acceptance.HW_REGION_NAME
+		domainName = state.Primary.Attributes["domain_name"]
+	)
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Live client: %s", err)
+	}
+
+	respBody, err := live.ReadStreamDelay(client, domainName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Live stream delay time: %s", err)
+	}
+
+	return respBody, nil
+}
+
+func TestAccResourceStreamDelay_basic(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_live_stream_delay.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getResourceStreamDelayFunc,
+	)
+
+	// Avoid CheckDestroy, because there is nothing in the resource destroy method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLiveStreamingDomainName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceStreamDelay_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", acceptance.HW_LIVE_STREAMING_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(resourceName, "delay", "2000"),
+					resource.TestCheckResourceAttr(resourceName, "app_name", "live"),
+				),
+			},
+			{
+				Config: testResourceStreamDelay_basic_update(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", acceptance.HW_LIVE_STREAMING_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(resourceName, "delay", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "app_name", "live"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testStreamDelayImportState(resourceName),
+			},
+		},
+	})
+}
+
+func testResourceStreamDelay_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_stream_delay" "test" {
+  domain_name = "%s"
+  delay       = 2000
+  app_name    = "live"
+}
+`, acceptance.HW_LIVE_STREAMING_DOMAIN_NAME)
+}
+
+func testResourceStreamDelay_basic_update() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_stream_delay" "test" {
+  domain_name = "%s"
+  delay       = 4000
+  app_name    = "live"
+}
+`, acceptance.HW_LIVE_STREAMING_DOMAIN_NAME)
+}
+
+func testStreamDelayImportState(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var domainName string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", rName)
+		}
+
+		domainName = rs.Primary.Attributes["domain_name"]
+		if domainName == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, `domain_name` is empty")
+		}
+		return domainName, nil
+	}
+}

--- a/huaweicloud/services/live/resource_huaweicloud_live_stream_delay.go
+++ b/huaweicloud/services/live/resource_huaweicloud_live_stream_delay.go
@@ -1,0 +1,188 @@
+package live
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API LIVE GET /v1/{project_id}/domain/delay
+// @API LIVE PUT /v1/{project_id}/domain/delay
+func ResourceStreamDelay() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceStreamDelayCreate,
+		ReadContext:   resourceStreamDelayRead,
+		UpdateContext: resourceStreamDelayUpdate,
+		DeleteContext: resourceStreamDelayDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceStreamDelayImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"domain_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the streaming domain name.`,
+			},
+			"delay": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the delay time, in ms.`,
+			},
+			"app_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `Specifies the application name.`,
+			},
+		},
+	}
+}
+
+func buildStreamDelayBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"play_domain": d.Get("domain_name"),
+		"delay":       d.Get("delay"),
+		"app":         utils.ValueIgnoreEmpty(d.Get("app_name")),
+	}
+}
+
+func updateStreamDelay(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v1/{project_id}/domain/delay"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildStreamDelayBodyParams(d)),
+	}
+
+	_, err := client.Request("PUT", requestPath, &requestOpt)
+	return err
+}
+
+func resourceStreamDelayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	if err := updateStreamDelay(client, d); err != nil {
+		return diag.Errorf("error configuring Live stream delay time in creation operation: %s", err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	return resourceStreamDelayRead(ctx, d, meta)
+}
+
+func ReadStreamDelay(client *golangsdk.ServiceClient, domainName string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/domain/delay"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?play_domain=%s", domainName)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		// When the `domain_name` does not exist, calling the query API will return a `400` status code.
+		return nil, common.ConvertExpected400ErrInto404Err(err, "error_code", domainNameNotExistsCode)
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceStreamDelayRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		domainName = d.Get("domain_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	respBody, err := ReadStreamDelay(client, domainName)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving Live stream delay time")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("domain_name", utils.PathSearch("play_domain", respBody, nil)),
+		d.Set("app_name", utils.PathSearch("delay_config|[0].app", respBody, nil)),
+		d.Set("delay", utils.PathSearch("delay_config|[0].delay", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceStreamDelayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	if err := updateStreamDelay(client, d); err != nil {
+		return diag.Errorf("error configuring Live stream delay time in update operation: %s", err)
+	}
+
+	return resourceStreamDelayRead(ctx, d, meta)
+}
+
+// This resource always has value and cannot be deleted.
+func resourceStreamDelayDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceStreamDelayImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	if importedId == "" {
+		return nil, fmt.Errorf("invalid format specified for import ID, `domain_name` is empty")
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+	return []*schema.ResourceData{d}, d.Set("domain_name", importedId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support a new resource to manage live stream delay

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/live' TESTARGS='-run TestAccResourceStreamDelay_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/live -v -run TestAccResourceStreamDelay_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceStreamDelay_basic
=== PAUSE TestAccResourceStreamDelay_basic
=== CONT  TestAccResourceStreamDelay_basic
--- PASS: TestAccResourceStreamDelay_basic (14.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      15.020s
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
