### PR TITLE
fix(cfw): add the fw_instance_id query parameter in the URL for the create domain name group request

### DIFF
--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_domain_name_group.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_domain_name_group.go
@@ -144,6 +144,7 @@ func resourceDomainNameGroupCreate(ctx context.Context, d *schema.ResourceData, 
 
 	createDomainNameGroupPath := createDomainNameGroupClient.Endpoint + createDomainNameGroupHttpUrl
 	createDomainNameGroupPath = strings.ReplaceAll(createDomainNameGroupPath, "{project_id}", createDomainNameGroupClient.ProjectID)
+	createDomainNameGroupPath += fmt.Sprintf("?fw_instance_id=%v", d.Get("fw_instance_id"))
 
 	createDomainNameGroupOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add the fw_instance_id query parameter in the URL for the create domain name group request
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add the fw_instance_id query parameter in the URL for the create domain name group request
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccDomainNameGroup_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccDomainNameGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccDomainNameGroup_basic
=== PAUSE TestAccDomainNameGroup_basic
=== CONT  TestAccDomainNameGroup_basic
--- PASS: TestAccDomainNameGroup_basic (442.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       442.323s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
