### PR TITLE
test(workspace): using obs resource to upload app file

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -224,7 +224,7 @@ var (
 	HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID")
 	HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_SPEC_CODE  = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_SPEC_CODE")
 	HW_WORKSPACE_OU_NAME                           = os.Getenv("HW_WORKSPACE_OU_NAME")
-	HW_WORKSPACE_APP_FILE_STRORE_OBS_PATH          = os.Getenv("HW_WORKSPACE_APP_FILE_STRORE_OBS_PATH")
+	HW_WORKSPACE_APP_FILE_NAME                     = os.Getenv("HW_WORKSPACE_APP_FILE_NAME")
 	HW_WORKSPACE_USER_NAMES                        = os.Getenv("HW_WORKSPACE_USER_NAMES")
 
 	HW_FGS_AGENCY_NAME         = os.Getenv("HW_FGS_AGENCY_NAME")
@@ -1581,9 +1581,9 @@ func TestAccPreCheckWorkspaceOUName(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckWorkspaceFileStorePath(t *testing.T) {
-	if HW_WORKSPACE_APP_FILE_STRORE_OBS_PATH == "" {
-		t.Skip("HW_WORKSPACE_APP_FILE_STRORE_OBS_PATH must be set for Workspace service acceptance tests.")
+func TestAccPreCheckWorkspaceAppFileName(t *testing.T) {
+	if HW_WORKSPACE_APP_FILE_NAME == "" {
+		t.Skip("HW_WORKSPACE_APP_FILE_NAME must be set for Workspace service acceptance tests.")
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Using OBS resources to upload APP file, we will not spend a lot of time uploading before each test execution.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
using obs resource to upload app file
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccAppWarehouseApp_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppWarehouseApp_basic -timeout 360m -parallel 10
=== RUN   TestAccAppWarehouseApp_basic
=== PAUSE TestAccAppWarehouseApp_basic
=== CONT  TestAccAppWarehouseApp_basic
    acceptance.go:1586: HW_WORKSPACE_APP_FILE_NAME must be set for Workspace service acceptance tests.
--- SKIP: TestAccAppWarehouseApp_basic (0.00s)
PASS
coverage: 1.5% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 0.059s  coverage: 1.5% of statements in ./huaweicloud/services/workspace
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
