### PR TITLE
test(workspace/app): using server group resource to instead corresponding env

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -1544,13 +1544,6 @@ func TestAccPreCheckWorkspaceInternetAccessPort(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckWorkspaceAppServerGroupId(t *testing.T) {
-	if HW_WORKSPACE_APP_SERVER_GROUP_ID == "" {
-		t.Skip("HW_WORKSPACE_APP_SERVER_GROUP_ID must be set for Workspace service acceptance tests.")
-	}
-}
-
-// lintignore:AT003
 func TestAccPreCheckWorkspaceAppServerGroup(t *testing.T) {
 	if HW_WORKSPACE_AD_VPC_ID == "" || HW_WORKSPACE_AD_NETWORK_ID == "" ||
 		HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID == "" || HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID == "" ||

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_groups_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_groups_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceWorkspaceAppGroups_basic(t *testing.T) {
+func TestAccDataSourceAppGroups_basic(t *testing.T) {
 	var (
 		rName      = acceptance.RandomAccResourceName()
 		dataSource = "data.huaweicloud_workspace_app_groups.test"

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_group_authorization_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_group_authorization_test.go
@@ -74,7 +74,7 @@ func TestAccResourceAppGroupAuthorization_expectErr(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      nil,

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_group_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_group_test.go
@@ -41,7 +41,7 @@ func getResourceWorkspaceAppGroupFunc(cfg *config.Config, state *terraform.Resou
 	return resp, err
 }
 
-func TestAccResourceWorkspaceAppGroup_basic(t *testing.T) {
+func TestAccResourceAppGroup_basic(t *testing.T) {
 	var (
 		resourceName = "huaweicloud_workspace_app_group.test"
 		name         = acceptance.RandomAccResourceName()

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_policy_group_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_policy_group_test.go
@@ -37,7 +37,7 @@ func TestAccAppPolicyGroup_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_publishment_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_publishment_test.go
@@ -37,7 +37,7 @@ func TestAccAppPublishment_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -90,6 +90,33 @@ func TestAccAppPublishment_basic(t *testing.T) {
 	})
 }
 
+func testAccAppPublishment_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_app_group" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_workspace_app_server_group" "test" {
+  name             = "%[1]s"
+  os_type          = "Windows"
+  flavor_id        = "%[2]s"
+  vpc_id           = "%[3]s"
+  subnet_id        = "%[4]s"
+  system_disk_type = "SAS"
+  system_disk_size = 80
+  is_vdi           = true
+  app_type         = "COMMON_APP"
+  image_id         = "%[5]s"
+  image_type       = "gold"
+  image_product_id = "%[6]s"
+}
+`, name, acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
+		acceptance.HW_WORKSPACE_AD_VPC_ID,
+		acceptance.HW_WORKSPACE_AD_NETWORK_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID)
+}
+
 func testAccAppPublishment_basic_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -109,7 +136,7 @@ resource "huaweicloud_workspace_app_publishment" "test" {
   icon_index     = 0
   status         = "FORBIDDEN"
 }
-`, testResourceWorkspaceAppGroup_basic_step1(name), name)
+`, testAccAppPublishment_base(name), name)
 }
 
 func testAccAppPublishment_basic_step2(updateName string) string {
@@ -127,7 +154,7 @@ resource "huaweicloud_workspace_app_publishment" "test" {
   icon_index     = 0
   status         = "NORMAL"
 }
-`, testResourceWorkspaceAppGroup_basic_step1(updateName), updateName)
+`, testAccAppPublishment_base(updateName), updateName)
 }
 
 func testAppPublishmentImportState(rName string) resource.ImportStateIdFunc {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Adjust some acceptance tests.
+ Remove `HW_WORKSPACE_APP_SERVER_GROUP_ID` and use the server group resource instead.
+ Remove the service name (Workspace) from the test case name.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove HW_WORKSPACE_APP_SERVER_GROUP_ID and use the server group resource instead.
2. remove the service name (Workspace) from the test case name.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
/scripts/coverage.sh -o workspace -f '^(TestAccResourceAppGroupAuthorization_basic|ResourceAppGroupAuthorization_expectErr|TestAccAppPolicyGroup_basic|TestAccAppPublishment_basic|TestAccDataSourceAppGroups_basic|TestAccResourceAppGroup_basic)$'
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run ^(TestAccResourceAppGroupAuthorization_basic|ResourceAppGroupAuthorization_expectErr|TestAccAppPolicyGroup_basic|TestAccAppPublishment_basic|TestAccDataSourceAppGroups_basic|TestAccResourceAppGroup_basic)$ -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAppGroups_basic
=== PAUSE TestAccDataSourceAppGroups_basic
=== RUN   TestAccResourceAppGroupAuthorization_basic
=== PAUSE TestAccResourceAppGroupAuthorization_basic
=== RUN   TestAccResourceAppGroup_basic
=== PAUSE TestAccResourceAppGroup_basic
=== RUN   TestAccAppPolicyGroup_basic
=== PAUSE TestAccAppPolicyGroup_basic
=== RUN   TestAccAppPublishment_basic
=== PAUSE TestAccAppPublishment_basic
=== CONT  TestAccDataSourceAppGroups_basic
=== CONT  TestAccAppPolicyGroup_basic
=== CONT  TestAccAppPublishment_basic
=== CONT  TestAccResourceAppGroup_basic
=== CONT  TestAccResourceAppGroupAuthorization_basic
--- PASS: TestAccResourceAppGroup_basic (147.00s)
--- PASS: TestAccResourceAppGroupAuthorization_basic (169.56s)
--- PASS: TestAccAppPublishment_basic (176.32s)
--- PASS: TestAccDataSourceAppGroups_basic (185.95s)
--- PASS: TestAccAppPolicyGroup_basic (213.67s)
PASS
coverage: 19.2% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 213.737s        coverage: 19.2% of statements in ./huaweicloud/services/workspace
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
