### PR TITLE
test(workspace): adjust the resource references and definitions

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -220,7 +220,6 @@ var (
 	HW_WORKSPACE_AD_NETWORK_ID = os.Getenv("HW_WORKSPACE_AD_NETWORK_ID") // The network ID to which the AD servers belong.
 	// The internet access port to which the Workspace service.
 	HW_WORKSPACE_INTERNET_ACCESS_PORT              = os.Getenv("HW_WORKSPACE_INTERNET_ACCESS_PORT")
-	HW_WORKSPACE_APP_SERVER_GROUP_ID               = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_ID")
 	HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID        = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID")
 	HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID         = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID")
 	HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID")
@@ -1556,8 +1555,7 @@ func TestAccPreCheckWorkspaceInternetAccessPort(t *testing.T) {
 
 // lintignore:AT003
 func TestAccPreCheckWorkspaceAppServerGroup(t *testing.T) {
-	if HW_WORKSPACE_AD_VPC_ID == "" || HW_WORKSPACE_AD_NETWORK_ID == "" ||
-		HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID == "" || HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID == "" ||
+	if HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID == "" || HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID == "" ||
 		HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID == "" {
 		t.Skip("Workspace APP server group acceptance test missing configuration parameters.")
 	}

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_groups_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_groups_test.go
@@ -130,5 +130,5 @@ locals {
 output "is_type_filter_useful" {
   value = length(local.type_result) > 0 && alltrue(local.type_result)
 }
-`, testResourceWorkspaceAppGroup_basic_step1(name))
+`, testResourceWorkspaceAppGroup_basic_step1(testResourceWorkspaceAppGroup_base(name), name))
 }

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_image_servers_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_image_servers_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
+// Before running this test, please enable a service that connects to LocalAD and the corresponding OU is created.
 func TestAccDataSourceAppImageServers_basic(t *testing.T) {
 	var (
 		dataSource = "data.huaweicloud_workspace_app_image_servers.test"
@@ -31,9 +32,8 @@ func TestAccDataSourceAppImageServers_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
 			acceptance.TestAccPreCheckWorkspaceAppImageSpecCode(t)
-			acceptance.TestAccPrecheckWorkspaceUserNames(t)
 			acceptance.TestAccPreCheckWorkspaceOUName(t)
-			acceptance.TestAccPreCheckWorkspaceADDomainNames(t)
+			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_publishable_apps_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_publishable_apps_test.go
@@ -67,19 +67,21 @@ data "huaweicloud_workspace_app_publishable_apps" "not_found" {
 
 func testDataSourceAppPublishableApps_base(name string) string {
 	return fmt.Sprintf(`
+data "huaweicloud_workspace_service" "test" {}
+
 resource "huaweicloud_workspace_app_server_group" "test" {
   name             = "%[1]s"
   os_type          = "Windows"
   flavor_id        = "%[2]s"
-  vpc_id           = "%[3]s"
-  subnet_id        = "%[4]s"
+  vpc_id           = data.huaweicloud_workspace_service.test.vpc_id
+  subnet_id        = data.huaweicloud_workspace_service.test.network_ids[0]
   system_disk_type = "SAS"
   system_disk_size = 80
   is_vdi           = true
   app_type         = "COMMON_APP"
-  image_id         = "%[5]s"
+  image_id         = "%[3]s"
   image_type       = "gold"
-  image_product_id = "%[6]s"
+  image_product_id = "%[4]s"
 }
 
 resource "huaweicloud_workspace_app_server" "test" {
@@ -105,8 +107,6 @@ resource "huaweicloud_workspace_app_group" "test" {
   server_group_id = huaweicloud_workspace_app_server_group.test.id
 }
 `, name, acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
-		acceptance.HW_WORKSPACE_AD_VPC_ID,
-		acceptance.HW_WORKSPACE_AD_NETWORK_ID,
 		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
 		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID)
 }

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_group_authorization_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_group_authorization_test.go
@@ -29,19 +29,44 @@ func TestAccResourceAppGroupAuthorization_basic(t *testing.T) {
 
 func testAccAppGroupAuthorization_base(name string) string {
 	return fmt.Sprintf(`
-%[1]s
+data "huaweicloud_workspace_service" "test" {}
+
+resource "huaweicloud_workspace_app_server_group" "test" {
+  name             = "%[1]s"
+  os_type          = "Windows"
+  flavor_id        = "%[2]s"
+  vpc_id           = data.huaweicloud_workspace_service.test.vpc_id
+  subnet_id        = data.huaweicloud_workspace_service.test.network_ids[0]
+  system_disk_type = "SAS"
+  system_disk_size = 80
+  is_vdi           = true
+  app_type         = "SESSION_DESKTOP_APP"
+  image_id         = "%[3]s"
+  image_type       = "gold"
+  image_product_id = "%[4]s"
+}
+
+resource "huaweicloud_workspace_app_group" "test" {
+  server_group_id = huaweicloud_workspace_app_server_group.test.id
+  name            = "%[1]s"
+  type            = "SESSION_DESKTOP_APP"
+  description     = "Created APP group by script"
+}
 
 resource "huaweicloud_workspace_user" "test" {
-  name  = "%[2]s"
+  name  = "%[1]s"
   email = "tf@example.com"
 }
 
 resource "huaweicloud_workspace_user_group" "test" {
   count = 2
-  name  = "%[2]s${count.index}"
+
+  name  = "%[1]s${count.index}"
   type  = "LOCAL"
 }
-`, testResourceWorkspaceAppGroup_basic_step1(name), name)
+`, name, acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID)
 }
 
 func testAccAppGroupAuthorization_basic(name string) string {
@@ -114,5 +139,5 @@ resource "huaweicloud_workspace_app_group_authorization" "test" {
     type    = "USER"
   }
 }
-`, testResourceWorkspaceAppGroup_basic_step1(name), name)
+`, testResourceWorkspaceAppGroup_basic_step1(testResourceWorkspaceAppGroup_base(name), name), name)
 }

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_image_server_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_image_server_test.go
@@ -2,7 +2,6 @@ package workspace
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -29,6 +28,7 @@ func getAcceptanceEpsId() string {
 	return acceptance.HW_ENTERPRISE_PROJECT_ID_TEST
 }
 
+// Before running this test, please enable a service that connects to LocalAD and the corresponding OU is created.
 func TestAccResourceAppImageServer_basic(t *testing.T) {
 	var (
 		resourceName = "huaweicloud_workspace_app_image_server.test"
@@ -42,14 +42,14 @@ func TestAccResourceAppImageServer_basic(t *testing.T) {
 			getResourceAppImageServerFunc,
 		)
 	)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
 			acceptance.TestAccPreCheckWorkspaceAppImageSpecCode(t)
-			acceptance.TestAccPrecheckWorkspaceUserNames(t)
 			acceptance.TestAccPreCheckWorkspaceOUName(t)
-			acceptance.TestAccPreCheckWorkspaceADDomainNames(t)
+			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -59,16 +59,41 @@ func TestAccResourceAppImageServer_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "authorize_accounts.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "authorize_accounts.0.type", "USER"),
-					resource.TestCheckResourceAttr(resourceName, "authorize_accounts.0.domain",
-						retrieveActiveDomainName(strings.Split(acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES, ","))),
+					resource.TestCheckResourceAttr(resourceName, "flavor_id", acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id",
+						"data.huaweicloud_workspace_service.test", "vpc_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_id",
+						"data.huaweicloud_workspace_service.test", "network_ids.0"),
 					resource.TestCheckResourceAttr(resourceName, "image_id", acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID),
 					resource.TestCheckResourceAttr(resourceName, "image_type", "gold"),
+					resource.TestCheckResourceAttr(resourceName, "image_source_product_id",
+						acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID),
 					resource.TestCheckResourceAttr(resourceName, "spec_code",
 						acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_SPEC_CODE),
+					resource.TestCheckResourceAttr(resourceName, "authorize_accounts.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "authorize_accounts.0.account",
+						"data.huaweicloud_workspace_service.test", "ad_domain.0.admin_account"),
+					resource.TestCheckResourceAttr(resourceName, "authorize_accounts.0.type", "USER"),
+					resource.TestCheckResourceAttrPair(resourceName, "authorize_accounts.0.domain",
+						"data.huaweicloud_workspace_service.test", "ad_domain.0.name"),
+					resource.TestCheckResourceAttr(resourceName, "root_volume.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_volume.0.type", "SAS"),
+					resource.TestCheckResourceAttr(resourceName, "root_volume.0.size", "80"),
+					resource.TestCheckResourceAttr(resourceName, "is_vdi", "false"),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Created by script"),
+					resource.TestCheckResourceAttr(resourceName, "ou_name", acceptance.HW_WORKSPACE_OU_NAME),
+					resource.TestCheckResourceAttr(resourceName, "extra_session_type", "CPU"),
+					resource.TestCheckResourceAttr(resourceName, "extra_session_size", "2"),
+					resource.TestCheckResourceAttr(resourceName, "route_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "route_policy.0.max_session", "3"),
+					resource.TestCheckResourceAttr(resourceName, "route_policy.0.cpu_threshold", "80"),
+					resource.TestCheckResourceAttr(resourceName, "route_policy.0.mem_threshold", "80"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", getAcceptanceEpsId()),
+					resource.TestCheckResourceAttr(resourceName, "is_delete_associated_resources", "true"),
 				),
 			},
 			{
@@ -109,21 +134,23 @@ func testResourceAppImageServer_basic(name, description string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
 
+data "huaweicloud_workspace_service" "test" {}
+
 resource "huaweicloud_workspace_app_image_server" "test" {
   name                    = "%[1]s"
   flavor_id               = "%[2]s"
-  vpc_id                  = "%[3]s"
-  subnet_id               = "%[4]s"
-  image_id                = "%[5]s"
+  vpc_id                  = data.huaweicloud_workspace_service.test.vpc_id
+  subnet_id               = data.huaweicloud_workspace_service.test.network_ids[0]
+  image_id                = "%[3]s"
   image_type              = "gold"
-  image_source_product_id = "%[6]s"
-  spec_code               = "%[7]s"
+  image_source_product_id = "%[4]s"
+  spec_code               = "%[5]s"
 
   # Currently only one user can be set.
   authorize_accounts {
-    account = split(",", "%[8]s")[0]
+    account = data.huaweicloud_workspace_service.test.ad_domain[0].admin_account
     type    = "USER"
-    domain  = element(split(",", "%[9]s"), 0)
+    domain  = data.huaweicloud_workspace_service.test.ad_domain[0].name
   }
 
   root_volume {
@@ -133,8 +160,8 @@ resource "huaweicloud_workspace_app_image_server" "test" {
 
   is_vdi             = false
   availability_zone  = data.huaweicloud_availability_zones.test.names[0]
-  description        = "%[10]s"
-  ou_name            = "%[11]s"
+  description        = "%[6]s"
+  ou_name            = "%[7]s"
   extra_session_type = "CPU"
   extra_session_size = 2
 
@@ -148,19 +175,16 @@ resource "huaweicloud_workspace_app_image_server" "test" {
     foo = "bar"
   }
 
-  enterprise_project_id          = "%[12]s"
+  enterprise_project_id          = "%[8]s"
   is_delete_associated_resources = true
 }
-`, name, acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
-		acceptance.HW_WORKSPACE_AD_VPC_ID,
-		acceptance.HW_WORKSPACE_AD_NETWORK_ID,
+`,
+		name,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
 		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
 		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID,
 		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_SPEC_CODE,
-		acceptance.HW_WORKSPACE_USER_NAMES,
-		acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES,
 		description,
 		acceptance.HW_WORKSPACE_OU_NAME,
-		acceptance.HW_ENTERPRISE_PROJECT_ID_TEST,
-	)
+		acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_policy_group_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_policy_group_test.go
@@ -110,7 +110,7 @@ resource "huaweicloud_workspace_app_policy_group" "test" {
     }
   })
 }
-`, testResourceWorkspaceAppGroup_basic_step1(name), name)
+`, testResourceWorkspaceAppGroup_basic_step1(testResourceWorkspaceAppGroup_base(name), name), name)
 }
 
 func testAccAppPolicyGroup_basic_step2(name string) string {
@@ -136,7 +136,7 @@ resource "huaweicloud_workspace_app_policy_group" "test" {
     }
   })
 }
-`, testResourceWorkspaceAppGroup_basic_step1(name), name)
+`, testResourceWorkspaceAppGroup_basic_step1(testResourceWorkspaceAppGroup_base(name), name), name)
 }
 
 func testAccAppPolicyGroup_basic_step3(name string) string {
@@ -155,5 +155,5 @@ resource "huaweicloud_workspace_app_policy_group" "test" {
     }
   })
 }
-`, testResourceWorkspaceAppGroup_basic_step1(name), name)
+`, testResourceWorkspaceAppGroup_basic_step1(testResourceWorkspaceAppGroup_base(name), name), name)
 }

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_publishment_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_publishment_test.go
@@ -27,6 +27,9 @@ func TestAccAppPublishment_basic(t *testing.T) {
 		resourceName = "huaweicloud_workspace_app_publishment.test"
 		name         = acceptance.RandomAccResourceName()
 		updateName   = acceptance.RandomAccResourceName()
+		baseConfig   = testResourceWorkspaceAppGroup_basic_step1(
+			testResourceWorkspaceAppGroup_base(name, "COMMON_APP"),
+			name, "COMMON_APP")
 	)
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -43,7 +46,7 @@ func TestAccAppPublishment_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppPublishment_basic_step1(name),
+				Config: testAccAppPublishment_basic_step1(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(resourceName, "app_group_id", "huaweicloud_workspace_app_group.test", "id"),
@@ -63,7 +66,7 @@ func TestAccAppPublishment_basic(t *testing.T) {
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`))),
 			},
 			{
-				Config: testAccAppPublishment_basic_step2(updateName),
+				Config: testAccAppPublishment_basic_step2(baseConfig, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
@@ -90,34 +93,7 @@ func TestAccAppPublishment_basic(t *testing.T) {
 	})
 }
 
-func testAccAppPublishment_base(name string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_workspace_app_group" "test" {
-  name = "%[1]s"
-}
-
-resource "huaweicloud_workspace_app_server_group" "test" {
-  name             = "%[1]s"
-  os_type          = "Windows"
-  flavor_id        = "%[2]s"
-  vpc_id           = "%[3]s"
-  subnet_id        = "%[4]s"
-  system_disk_type = "SAS"
-  system_disk_size = 80
-  is_vdi           = true
-  app_type         = "COMMON_APP"
-  image_id         = "%[5]s"
-  image_type       = "gold"
-  image_product_id = "%[6]s"
-}
-`, name, acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
-		acceptance.HW_WORKSPACE_AD_VPC_ID,
-		acceptance.HW_WORKSPACE_AD_NETWORK_ID,
-		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
-		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID)
-}
-
-func testAccAppPublishment_basic_step1(name string) string {
+func testAccAppPublishment_basic_step1(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -136,10 +112,10 @@ resource "huaweicloud_workspace_app_publishment" "test" {
   icon_index     = 0
   status         = "FORBIDDEN"
 }
-`, testAccAppPublishment_base(name), name)
+`, baseConfig, name)
 }
 
-func testAccAppPublishment_basic_step2(updateName string) string {
+func testAccAppPublishment_basic_step2(baseConfig, updateName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -154,7 +130,7 @@ resource "huaweicloud_workspace_app_publishment" "test" {
   icon_index     = 0
   status         = "NORMAL"
 }
-`, testAccAppPublishment_base(updateName), updateName)
+`, baseConfig, updateName)
 }
 
 func testAppPublishmentImportState(rName string) resource.ImportStateIdFunc {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adjust the resource references and definitions.
- acceptance tests (except service resource) using service data source to query network configuration instead of the corresponding environment variables.
- app group supports type input, not the fixed type.
- using group resource instead of the corresponding environment variables.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
adjust the workspace tests
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccResourceAppImageServer_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceAppImageServer_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceAppImageServer_basic
=== PAUSE TestAccResourceAppImageServer_basic
=== CONT  TestAccResourceAppImageServer_basic
--- PASS: TestAccResourceAppImageServer_basic (845.96s)
PASS
coverage: 7.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 846.020s        coverage: 7.0% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccResourceAppImage_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceAppImage_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceAppImage_basic
=== PAUSE TestAccResourceAppImage_basic
=== CONT  TestAccResourceAppImage_basic
--- PASS: TestAccResourceAppImage_basic (1843.31s)
PASS
coverage: 8.3% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 1843.406s       coverage: 8.3% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccResourceAppServerGroup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceAppServerGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceAppServerGroup_basic
=== PAUSE TestAccResourceAppServerGroup_basic
=== CONT  TestAccResourceAppServerGroup_basic
--- PASS: TestAccResourceAppServerGroup_basic (54.60s)
PASS
coverage: 6.2% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 54.710s coverage: 6.2% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataSourceAppPublishableApps_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataSourceAppPublishableApps_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAppPublishableApps_basic
=== PAUSE TestAccDataSourceAppPublishableApps_basic
=== CONT  TestAccDataSourceAppPublishableApps_basic
--- PASS: TestAccDataSourceAppPublishableApps_basic (683.11s)
PASS
coverage: 12.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 683.167s        coverage: 12.0% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccResourceWorkspaceAppGroup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceWorkspaceAppGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceWorkspaceAppGroup_basic
=== PAUSE TestAccResourceWorkspaceAppGroup_basic
=== CONT  TestAccResourceWorkspaceAppGroup_basic
--- PASS: TestAccResourceWorkspaceAppGroup_basic (45.46s)
PASS
coverage: 7.5% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 45.512s coverage: 7.5% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccAppPolicyGroup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppPolicyGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccAppPolicyGroup_basic
=== PAUSE TestAccAppPolicyGroup_basic
=== CONT  TestAccAppPolicyGroup_basic
--- PASS: TestAccAppPolicyGroup_basic (67.55s)
PASS
coverage: 11.2% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 67.650s coverage: 11.2% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccAppPublishment_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppPublishment_basic -timeout 360m -parallel 10
=== RUN   TestAccAppPublishment_basic
=== PAUSE TestAccAppPublishment_basic
=== CONT  TestAccAppPublishment_basic
--- PASS: TestAccAppPublishment_basic (49.99s)
PASS
coverage: 10.4% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 50.046s coverage: 10.4% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccResourceAppServer_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceAppServer_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceAppServer_basic
=== PAUSE TestAccResourceAppServer_basic
=== CONT  TestAccResourceAppServer_basic
--- PASS: TestAccResourceAppServer_basic (781.13s)
PASS
coverage: 9.9% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 781.209s        coverage: 9.9% of statements in ./huaweicloud/services/workspace
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
