### PR TITLE
refactor(cce): remove set func of not returned parameters

### DIFF
--- a/docs/resources/cce_autopilot_cluster.md
+++ b/docs/resources/cce_autopilot_cluster.md
@@ -293,10 +293,10 @@ The autopilot cluster can be imported using the cluster ID, e.g.
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include:
-`eip_id`, `delete_efs`, `delete_eni`, `delete_net`, `delete_obs`, `delete_sfs30` and `lts_reclaim_policy`. It is generally
-recommended running `terraform plan` after importing a cluster. You can then decide if changes should be applied to
-the cluster, or the resource definition should be updated to align with the cluster. Also you can ignore changes as
-below.
+`enable_snat`, `enable_swr_image_access`, `eip_id`, `delete_efs`, `delete_eni`, `delete_net`, `delete_obs`, `delete_sfs30`
+and `lts_reclaim_policy`. It is generally recommended running `terraform plan` after importing a cluster.
+You can then decide if changes should be applied to the cluster, or the resource definition should be updated to align
+with the cluster. Also you can ignore changes as below.
 
 ```hcl
 resource "huaweicloud_cce_autopilot_cluster" "mycluster" {
@@ -304,7 +304,7 @@ resource "huaweicloud_cce_autopilot_cluster" "mycluster" {
 
   lifecycle {
     ignore_changes = [
-      delete_efs, delete_obs,
+      enable_snat, delete_efs, delete_obs,
     ]
   }
 }

--- a/huaweicloud/services/cceautopilot/resource_huaweicloud_cce_autopilot_cluster.go
+++ b/huaweicloud/services/cceautopilot/resource_huaweicloud_cce_autopilot_cluster.go
@@ -148,12 +148,10 @@ func ResourceAutopilotCluster() *schema.Resource {
 			"enable_snat": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
 			},
 			"enable_swr_image_access": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
 			},
 			"enable_autopilot": {
 				Type:     schema.TypeBool,
@@ -613,6 +611,7 @@ func resourceAutopilotClusterRead(_ context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
+	// enable_snat and enable_swr_image_access not saved, because thay are not returned
 	mErr := multierror.Append(nil,
 		d.Set("region", cfg.GetRegion(d)),
 		d.Set("name", utils.PathSearch("metadata.name", getClusterRespBody, nil)),
@@ -624,8 +623,6 @@ func resourceAutopilotClusterRead(_ context.Context, d *schema.ResourceData, met
 		d.Set("version", utils.PathSearch("spec.version", getClusterRespBody, nil)),
 		d.Set("description", utils.PathSearch("spec.description", getClusterRespBody, nil)),
 		d.Set("custom_san", utils.PathSearch("spec.customSan", getClusterRespBody, nil)),
-		d.Set("enable_snat", utils.PathSearch("spec.enableSnat", getClusterRespBody, nil)),
-		d.Set("enable_swr_image_access", utils.PathSearch("spec.enableSWRImageAccess", getClusterRespBody, nil)),
 		d.Set("enable_autopilot", utils.PathSearch("spec.enableAutopilot", getClusterRespBody, nil)),
 		d.Set("ipv6_enable", utils.PathSearch("spec.ipv6enable", getClusterRespBody, nil)),
 		d.Set("host_network", flattenHostNetwork(getClusterRespBody)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

don't save `enable_snat` and `enable_swr_image_access`, because thay are not returned by GET API

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cceautopilot' TESTARGS='-run TestAccAutopilotCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cceautopilot -v -run TestAccAutopilotCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccAutopilotCluster_basic
=== PAUSE TestAccAutopilotCluster_basic
=== CONT  TestAccAutopilotCluster_basic
--- PASS: TestAccAutopilotCluster_basic (708.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cceautopilot      708.680s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
