### PR TITLE
feat(cse/kv): add new data source to query configurations

### DIFF
--- a/docs/data-sources/cse_microservice_engine_configurations.md
+++ b/docs/data-sources/cse_microservice_engine_configurations.md
@@ -1,0 +1,89 @@
+---
+subcategory: "Cloud Service Engine (CSE)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cse_microservice_engine_configurations"
+description: |-
+  Use this data source to query managed microservice engine configurations within HuaweiCloud.
+---
+
+# huaweicloud_cse_microservice_engine_configurations
+
+Use this data source to query managed microservice engine configurations within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "microservice_engine_id" {} // Enable the EIP access
+
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  fileter_engines = [for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == var.microservice_engine_id]
+}
+
+data "huaweicloud_cse_microservice_engine_configurations" "test" {
+  auth_address    = local.fileter_engines[0].service_registry_addresses[0].public
+  connect_address = local.fileter_engines[0].config_center_addresses[0].public
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `auth_address` - (Required, String) Specifies the address that used to request the access token.
+
+* `connect_address` - (Required, String) Specifies the address that used to access engine and manages
+  configuration.
+
+-> We are only support IPv4 addresses yet (for `auth_address` and `connect_address`).
+
+* `admin_user` - (Optional, String) Specifies the account name for **RBAC** login.
+
+* `admin_pass` - (Optional, String) Specifies the account password for **RBAC** login.
+  The password format must meet the following conditions:
+  + Must be `8` to `32` characters long.
+  + A password must contain at least one digit, one uppercase letter, one lowercase letter, and one special character
+    (-~!@#%^*_=+?$&()|<>{}[]).
+  + Cannot be the account name or account name spelled backwards.
+  + The password can only start with a letter.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `configurations` - All queried configurations of the dedicated microservice engine.  
+  The [configurations](#cse_microservice_engine_configurations) structure is documented below.
+
+<a name="cse_microservice_engine_configurations"></a>
+The `configurations` block supports:
+
+* `id` - The ID of the microservice engine configuration.
+
+* `key` - The configuration key (item name).
+
+* `value_type` - The type of the configuration value.
+  + **ini**
+  + **json**
+  + **text**
+  + **yaml**
+  + **properties**
+  + **xml**
+
+* `value` - The configuration value.
+
+* `status` - The configuration status.
+  + **enabled**
+  + **disabled**
+
+* `tags` - The key/value pairs to associate with the configuration.
+
+* `created_at` - The creation time of the configuration, in RFC3339 format.
+
+* `updated_at` - The latest update time of the configuration, in RFC3339 format.
+
+* `create_revision` - The create version of the configuration.
+
+* `update_revision` - The update version of the configuration.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -612,9 +612,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_cph_server_bandwidths":   cph.DataSourceCphServerBandwidths(),
 			"huaweicloud_cph_encode_servers":      cph.DataSourceCphEncodeServers(),
 
-			"huaweicloud_cse_microservice_engine_flavors": cse.DataSourceMicroserviceEngineFlavors(),
-			"huaweicloud_cse_microservice_engines":        cse.DataSourceMicroserviceEngines(),
-			"huaweicloud_cse_nacos_namespaces":            cse.DataSourceNacosNamespaces(),
+			"huaweicloud_cse_microservice_engine_configurations": cse.DataSourceMicroserviceEngineConfigurations(),
+			"huaweicloud_cse_microservice_engine_flavors":        cse.DataSourceMicroserviceEngineFlavors(),
+			"huaweicloud_cse_microservice_engines":               cse.DataSourceMicroserviceEngines(),
+			"huaweicloud_cse_nacos_namespaces":                   cse.DataSourceNacosNamespaces(),
 
 			"huaweicloud_csms_events":                   dew.DataSourceDewCsmsEvents(),
 			"huaweicloud_csms_secrets":                  dew.DataSourceDewCsmsSecrets(),

--- a/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservice_engine_configurations_test.go
+++ b/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservice_engine_configurations_test.go
@@ -1,0 +1,89 @@
+package cse
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataMicroserviceEngineConfigurations_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_cse_microservice_engine_configurations.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCSEMicroserviceEngineID(t)
+			acceptance.TestAccPreCheckCSEMicroserviceEngineAdminPassword(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataMicroserviceEngineConfigurations_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_configuration_queried", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataMicroserviceEngineConfigurations_basic() string {
+	name := acceptance.RandomAccResourceNameWithDash()
+
+	return fmt.Sprintf(`
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  id_filter_result = [
+    for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[1]s"
+  ]
+}
+
+resource "huaweicloud_cse_microservice_engine_configuration" "test" {
+  auth_address    = local.id_filter_result[0].service_registry_addresses.0.public
+  connect_address = local.id_filter_result[0].config_center_addresses.0.public
+  admin_user      = "root"
+  admin_pass      = "%[2]s"
+
+  key        = "%[3]s"
+  value_type = "json"
+  value      = jsonencode({
+    "foo": "baar"
+  })
+  status = "disabled"
+
+  tags = {
+    owner = "terraform"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      admin_pass,
+    ]
+  }
+}
+
+data "huaweicloud_cse_microservice_engine_configurations" "test" {
+  depends_on = [huaweicloud_cse_microservice_engine_configuration.test]
+
+  auth_address    = try(local.id_filter_result[0].service_registry_addresses.0.public, "")
+  connect_address = try(local.id_filter_result[0].config_center_addresses.0.public, "")
+  admin_user      = "root"
+  admin_pass      = "%[2]s"
+}
+
+output "is_configuration_queried" {
+  value = contains(data.huaweicloud_cse_microservice_engine_configurations.test.configurations[*].id,
+    huaweicloud_cse_microservice_engine_configuration.test.id)
+}
+`, acceptance.HW_CSE_MICROSERVICE_ENGINE_ID,
+		acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD,
+		name)
+}

--- a/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_engine_configurations.go
+++ b/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_engine_configurations.go
@@ -1,0 +1,179 @@
+package cse
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CSE GET /v1/{project_id}/kie/kv
+func DataSourceMicroserviceEngineConfigurations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceMicroserviceEngineConfigurationsRead,
+
+		Schema: map[string]*schema.Schema{
+			// Authentication and request parameters.
+			"auth_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The address that used to request the access token.`,
+			},
+			"connect_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The address that used to send requests and manage configuration.`,
+			},
+			"admin_user": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The user name that used to pass the RBAC control.`,
+			},
+			"admin_pass": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				RequiredWith: []string{"admin_user"},
+				Description:  `The user password that used to pass the RBAC control.`,
+			},
+			// Attributes.
+			"configurations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the microservice engine configuration.`,
+						},
+						"key": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The configuration key (item name).",
+						},
+						"value_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the configuration value.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The configuration value.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The configuration status.`,
+						},
+						"tags": common.TagsComputedSchema(
+							`The key/value pairs to associate with the configuration.`,
+						),
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the configuration, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the configuration, in RFC3339 format.`,
+						},
+						"create_revision": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The create version of the configuration.`,
+						},
+						"update_revision": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The update version of the configuration.`,
+						},
+					},
+				},
+				Description: `All queried configurations of the dedicated microservice engine.`,
+			},
+		},
+	}
+}
+
+func queryMicroserviceEngineConfigurations(d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		client    = common.NewCustomClient(true, d.Get("connect_address").(string), "v1", "default")
+		httpUrl   = "kie/kv"
+		queryPath = client.ResourceBase + httpUrl
+	)
+
+	token, err := GetAuthorizationToken(d.Get("auth_address").(string), d.Get("admin_user").(string),
+		d.Get("admin_pass").(string))
+	if err != nil {
+		return nil, err
+	}
+
+	queryOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	if token != "" {
+		queryOpts.MoreHeaders = map[string]string{
+			"Authorization": token,
+		}
+	}
+
+	requestResp, err := client.Request("GET", queryPath, &queryOpts)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+	return utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenMicroserviceEngineConfigurations(configurations []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(configurations))
+
+	for _, configuration := range configurations {
+		result = append(result, map[string]interface{}{
+			"id":              utils.PathSearch("id", configuration, nil),
+			"key":             utils.PathSearch("key", configuration, nil),
+			"value_type":      utils.PathSearch("value_type", configuration, nil),
+			"value":           utils.PathSearch("value", configuration, nil),
+			"status":          utils.PathSearch("status", configuration, nil),
+			"tags":            utils.PathSearch("labels", configuration, nil),
+			"created_at":      utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", configuration, float64(0)).(float64)), false),
+			"updated_at":      utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time", configuration, float64(0)).(float64)), false),
+			"create_revision": utils.PathSearch("create_revision", configuration, nil),
+			"update_revision": utils.PathSearch("update_revision", configuration, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceMicroserviceEngineConfigurationsRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	configurations, err := queryMicroserviceEngineConfigurations(d)
+	if err != nil {
+		return diag.Errorf("error querying microservice engine configurations: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("configurations", flattenMicroserviceEngineConfigurations(configurations)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New data source supported for the CSE service that used to query managed engine configurations (KVs).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new data source.
2. supports corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cse -f TestAccDataMicroserviceEngineConfigurations_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccDataMicroserviceEngineConfigurations_basic -timeout 360m -parallel 10
=== RUN   TestAccDataMicroserviceEngineConfigurations_basic
=== PAUSE TestAccDataMicroserviceEngineConfigurations_basic
=== CONT  TestAccDataMicroserviceEngineConfigurations_basic
--- PASS: TestAccDataMicroserviceEngineConfigurations_basic (10.14s)
PASS
coverage: 20.9% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       10.189s coverage: 20.9% of statements in ./huaweicloud/services/cse
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.
