### PR TITLE
refactor(vpc): change eps ID to optional in network_acl

### DIFF
--- a/docs/resources/vpc_network_acl.md
+++ b/docs/resources/vpc_network_acl.md
@@ -79,7 +79,7 @@ The following arguments are supported:
 * `name` - (Required, String) Specifies the network ACL name. The value can contain no more than 64 characters,
   including letters, digits, underscores (_), hyphens (-), and periods (.).
 
-* `enterprise_project_id` - (Required, String) Specifies the enterprise project ID of the network ACL.
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the network ACL.
 
 * `description` - (Optional, String) Specifies the network ACL description. The value can contain no more
   than 255 characters and cannot contain angle brackets (< or >).

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_network_acl_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_network_acl_test.go
@@ -168,9 +168,8 @@ resource "huaweicloud_vpc_subnet" "test" {
 }
 
 resource "huaweicloud_vpc_network_acl" "test" {
-  name                  = "%s"
-  description           = "created by terraform"
-  enterprise_project_id = 0
+  name        = "%s"
+  description = "created by terraform"
 
   ingress_rules {
     action                 = "allow"
@@ -222,10 +221,9 @@ resource "huaweicloud_vpc_subnet" "test" {
 }
 
 resource "huaweicloud_vpc_network_acl" "test" {
-  name                  = "%s-update"
-  description           = "created by terraform update"
-  enterprise_project_id = 0
-  enabled               = false
+  name        = "%s-update"
+  description = "created by terraform update"
+  enabled     = false
 
   ingress_rules {
     action                 = "allow"
@@ -297,10 +295,9 @@ resource "huaweicloud_vpc_subnet" "test" {
 }
 
 resource "huaweicloud_vpc_network_acl" "test" {
-  name                  = "%s-update"
-  description           = "created by terraform update"
-  enterprise_project_id = 0
-  enabled               = false
+  name        = "%s-update"
+  description = "created by terraform update"
+  enabled     = false
 
   ingress_rules {
     action                 = "allow"

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_network_acl.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_network_acl.go
@@ -55,7 +55,8 @@ func ResourceNetworkAcl() *schema.Resource {
 			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -185,7 +186,7 @@ func resourceNetworkAclCreate(ctx context.Context, d *schema.ResourceData, meta 
 		},
 	}
 
-	createNetworkAclOpt.JSONBody = utils.RemoveNil(buildCreateNetworkAclBodyParams(d))
+	createNetworkAclOpt.JSONBody = utils.RemoveNil(buildCreateNetworkAclBodyParams(d, cfg))
 	createNetworkAclResp, err := client.Request("POST", createNetworkAclPath, &createNetworkAclOpt)
 	if err != nil {
 		return diag.Errorf("error creating network ACL: %s", err)
@@ -324,11 +325,11 @@ func networkAclDisassociatSubnets(client *golangsdk.ServiceClient, subnets []int
 	return nil
 }
 
-func buildCreateNetworkAclBodyParams(d *schema.ResourceData) map[string]interface{} {
+func buildCreateNetworkAclBodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"firewall": map[string]interface{}{
 			"name":                  d.Get("name"),
-			"enterprise_project_id": d.Get("enterprise_project_id"),
+			"enterprise_project_id": utils.ValueIgnoreEmpty(cfg.GetEnterpriseProjectID(d)),
 			"description":           utils.ValueIgnoreEmpty(d.Get("description")),
 			"admin_state_up":        d.Get("enabled"),
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #5911

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccNetworkAcl_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccNetworkAcl_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkAcl_basic
=== PAUSE TestAccNetworkAcl_basic
=== CONT  TestAccNetworkAcl_basic
--- PASS: TestAccNetworkAcl_basic (161.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       161.882s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
