### PR TITLE
feat(lts): the host access supports structuring parsing feature

### DIFF
--- a/docs/resources/lts_host_access.md
+++ b/docs/resources/lts_host_access.md
@@ -58,6 +58,34 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) Specifies the key/value to attach to the host access.
 
+* `processor_type` - (Optional, String) Specifies the type of the ICAgent structuring parsing.  
+  This parameter must be set together with the `processors` parameter.  
+  The valid values are as follows:
+  + **SINGLE_LINE**
+  + **MULTI_LINE**
+  + **REGEX**
+  + **MULTI_REGEX**
+  + **SPLIT**
+  + **JSON**
+  + **NGINX**
+  + **COMPOSE**
+
+* `processors` - (Optional, List) Specifies the list of the ICAgent structuring parsing rules.  
+  The [processors](#HostAccessProcessors) structure is documented below.  
+  This parameter must be set together with the `processor_type` parameter.  
+  Please refer to the [Setting ICAgent Structuring Parsing Rules](https://support.huaweicloud.com/intl/en-us/usermanual-lts/lts_07_0072.html).
+
+ -> For the same log stream, If you have configured cloud structuring parsing, delete its configurations before configuring
+    ICAgent structuring parsing.
+
+* `demo_log` - (Optional, String) Specifies the example log of the ICAgent structuring parsing.  
+  This parameter is available when the `processor_type` parameter is specified.
+
+* `demo_fields` - (Optional, List) Specifies the list of the parsed fields of the example log.  
+  The [demo_fields](#HostAccessDemoFields) structure is documented below.  
+  This parameter must be set together with the `demo_log` parameter.  
+  This parameter is available when the `processor_type` parameter is specified.
+
 <a name="HostAccessConfigDeatil"></a>
 The `access_config` block supports:
 
@@ -139,6 +167,29 @@ The `windows_log_info` block supports:
   + When `time_offset_unit` is set to **hour**, the value ranges from `1` to `168` hours.
   + When `time_offset_unit` is set to **sec**, the value ranges from `1` to `604,800` seconds.
 
+<a name="HostAccessProcessors"></a>
+The `processors` block supports:
+
+* `type` - (Optional, String) Specifies the type of the parser.  
+  The valid values are as follows:
+  + **processor_regex**
+  + **processor_split_string**
+  + **processor_json**
+  + **processor_gotime**
+  + **processor_filter_regex**
+  + **processor_drop**
+  + **processor_rename**
+
+* `detail` - (Optional, String) Specifies the configuration of the parser, in JSON format.  
+  For the keys, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/api-lts/CreateAccessConfig.html#CreateAccessConfig__request_Detail).
+
+<a name="HostAccessDemoFields"></a>
+The `demo_fields` block supports:
+
+* `name` - (Optional, String) Specifies the name of the parsed field.
+
+* `value` - (Optional, String) Specifies the value of the parsed field.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -157,4 +208,23 @@ The host access can be imported using the `name`, e.g.
 
 ```bash
 $ terraform import huaweicloud_lts_host_access.test <name>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes include: `processors`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the instance, or the resource definition should be updated to
+align with the instance. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_lts_host_access" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      processors,
+    ]
+  }
+}
 ```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The host access resource (`huaweicloud_lts_host_access`) supports configuration structuring parsing feature.
The parameters provided are as follows:
+ **demo_log**
+ **demo_fields**: In the API documentation, `demo_fields.name` is optional, but after testing, this field is required, so it is set to **Required** in the schema.
+ **processor_type**
+ **processors** : The parameter corresponding to the query interface will contain unset fields, so it is not Set.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. the host access supports structuring parsing feature.
2. provide corresponding documentation and acceptance test for the added parameters.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lts -f TestAccHostAccessConfig_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccHostAccessConfig_basic -timeout 360m -parallel 10
=== RUN   TestAccHostAccessConfig_basic
=== PAUSE TestAccHostAccessConfig_basic
=== CONT  TestAccHostAccessConfig_basic
--- PASS: TestAccHostAccessConfig_basic (102.64s)
PASS
coverage: 14.3% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       102.723s        coverage: 14.3% of statements in ./huaweicloud/services/lts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
