### PR TITLE
feat(rms): RMS advanced query supports type field

### DIFF
--- a/docs/resources/rms_advanced_query.md
+++ b/docs/resources/rms_advanced_query.md
@@ -22,11 +22,16 @@ resource "huaweicloud_rms_advanced_query" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required, String, ForceNew) Specifies the advanced query name. It contains 1 to 64 characters.
-
-  Changing this parameter will create a new resource.
+* `name` - (Required, String) Specifies the advanced query name. It contains 1 to 64 characters.
 
 * `expression` - (Required, String) Specifies the advanced query expression. It contains 1 to 4096 characters.
+
+* `type` - (Optional, String) Specifies the advanced query type.
+  The valid values are as follows:
+  + **account**: means the customized query statement of a single account;
+  + **aggregator**: means the user-defined query statement of the aggregator.
+  
+  Defaults to **account**.
 
 * `description` - (Optional, String) Specifies the advanced query description. It contains 1 to 512 characters.
 

--- a/huaweicloud/services/acceptance/rms/resource_huaweicloud_rms_advanced_query_test.go
+++ b/huaweicloud/services/acceptance/rms/resource_huaweicloud_rms_advanced_query_test.go
@@ -78,8 +78,54 @@ func TestAccAdvancedQuery_basic(t *testing.T) {
 				Config: testAdvancedQuery_basic_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "name", name+"-update"),
 					resource.TestCheckResourceAttr(rName, "expression", "update table_1 set volume_1 = 5"),
+					resource.TestCheckResourceAttr(rName, "description", "test_description_update"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAdvancedQuery_aggregator(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_rms_advanced_query.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAdvancedQueryResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAdvancedQuery_aggregator(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "type", "aggregator"),
+					resource.TestCheckResourceAttr(rName, "expression", "SELECT set_agg(domain_id) AS domain_ids FROM aggregator_resources"),
+					resource.TestCheckResourceAttr(rName, "description", "test_description"),
+				),
+			},
+			{
+				Config: testAdvancedQuery_aggregator_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name+"-update"),
+					resource.TestCheckResourceAttr(rName, "type", "aggregator"),
+					resource.TestCheckResourceAttr(rName, "expression", "SELECT id FROM aggregator_resources WHERE ep_id = '0'"),
 					resource.TestCheckResourceAttr(rName, "description", "test_description_update"),
 				),
 			},
@@ -105,8 +151,30 @@ resource "huaweicloud_rms_advanced_query" "test" {
 func testAdvancedQuery_basic_update(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_rms_advanced_query" "test" {
-  name        = "%s"
+  name        = "%s-update"
   expression  = "update table_1 set volume_1 = 5"
+  description = "test_description_update"
+}
+`, name)
+}
+
+func testAdvancedQuery_aggregator(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rms_advanced_query" "test" {
+  name        = "%s"
+  type        = "aggregator"
+  expression  = "SELECT set_agg(domain_id) AS domain_ids FROM aggregator_resources"
+  description = "test_description"
+}
+`, name)
+}
+
+func testAdvancedQuery_aggregator_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rms_advanced_query" "test" {
+  name        = "%s-update"
+  type        = "aggregator"
+  expression  = "SELECT id FROM aggregator_resources WHERE ep_id = '0'"
   description = "test_description_update"
 }
 `, name)

--- a/huaweicloud/services/rms/resource_huaweicloud_rms_advanced_query.go
+++ b/huaweicloud/services/rms/resource_huaweicloud_rms_advanced_query.go
@@ -38,13 +38,18 @@ func ResourceAdvancedQuery() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `Specifies the ResourceQL name.`,
 			},
 			"expression": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: `Specifies the ResourceQL expression.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the ResourceQL type.`,
 			},
 			"description": {
 				Type:        schema.TypeString,
@@ -99,8 +104,9 @@ func resourceAdvancedQueryCreate(ctx context.Context, d *schema.ResourceData, me
 
 func buildCreateAdvancedQueryBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
-		"name":        utils.ValueIgnoreEmpty(d.Get("name")),
-		"expression":  utils.ValueIgnoreEmpty(d.Get("expression")),
+		"name":        d.Get("name"),
+		"expression":  d.Get("expression"),
+		"type":        utils.ValueIgnoreEmpty(d.Get("type")),
 		"description": utils.ValueIgnoreEmpty(d.Get("description")),
 	}
 	return bodyParams
@@ -145,6 +151,7 @@ func resourceAdvancedQueryRead(_ context.Context, d *schema.ResourceData, meta i
 		mErr,
 		d.Set("name", utils.PathSearch("name", getAdvancedQueryRespBody, nil)),
 		d.Set("expression", utils.PathSearch("expression", getAdvancedQueryRespBody, nil)),
+		d.Set("type", utils.PathSearch("type", getAdvancedQueryRespBody, nil)),
 		d.Set("description", utils.PathSearch("description", getAdvancedQueryRespBody, nil)),
 	)
 
@@ -156,7 +163,9 @@ func resourceAdvancedQueryUpdate(ctx context.Context, d *schema.ResourceData, me
 	region := cfg.GetRegion(d)
 
 	updateAdvancedQueryChanges := []string{
+		"name",
 		"expression",
+		"type",
 		"description",
 	}
 
@@ -190,9 +199,10 @@ func resourceAdvancedQueryUpdate(ctx context.Context, d *schema.ResourceData, me
 
 func buildUpdateAdvancedQueryBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
-		"name":        utils.ValueIgnoreEmpty(d.Get("name")),
-		"expression":  utils.ValueIgnoreEmpty(d.Get("expression")),
-		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+		"name":        d.Get("name"),
+		"expression":  d.Get("expression"),
+		"type":        utils.ValueIgnoreEmpty(d.Get("type")),
+		"description": d.Get("description"),
 	}
 	return bodyParams
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
RMS advanced query supports type field
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. RMS advanced query supports type field
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 make testacc TEST="./huaweicloud/services/acceptance/rms" TESTARGS="-run TestAccAdvancedQuery_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run TestAccAdvancedQuery_basic -timeout 360m -parallel 4
=== RUN   TestAccAdvancedQuery_basic
=== PAUSE TestAccAdvancedQuery_basic
=== CONT  TestAccAdvancedQuery_basic
--- PASS: TestAccAdvancedQuery_basic (34.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       34.584s

 make testacc TEST="./huaweicloud/services/acceptance/rms" TESTARGS="-run TestAccAdvancedQuery_aggregator"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run TestAccAdvancedQuery_aggregator -timeout 360m -parallel 4
=== RUN   TestAccAdvancedQuery_aggregator
=== PAUSE TestAccAdvancedQuery_aggregator
=== CONT  TestAccAdvancedQuery_aggregator
--- PASS: TestAccAdvancedQuery_aggregator (36.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       37.073s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
