### PR TITLE
feat(GaussDB): add gaussdb opengauss instance node startup and stop resource

### DIFF
--- a/docs/resources/gaussdb_opengauss_instance_node_startup.md
+++ b/docs/resources/gaussdb_opengauss_instance_node_startup.md
@@ -1,0 +1,48 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_opengauss_instance_node_startup"
+description: |-
+  Manages a GaussDB OpenGauss instance node startup resource within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_opengauss_instance_node_startup
+
+Manages a GaussDB OpenGauss instance node startup resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "node_id" {}
+
+resource "huaweicloud_gaussdb_opengauss_instance_node_startup" "test" {
+  instance_id = var.instance_id
+  node_id     = var.node_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the GaussDB OpenGauss instance. Changing this parameter
+  will create a new resource.
+
+* `node_id` - (Required, String, ForceNew) Specifies the ID of the GaussDB OpenGauss instance node that needs to be started.
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which equals to the `node_id`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/docs/resources/gaussdb_opengauss_instance_node_stop.md
+++ b/docs/resources/gaussdb_opengauss_instance_node_stop.md
@@ -1,0 +1,48 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_opengauss_instance_node_stop"
+description: |-
+  Manages a GaussDB OpenGauss instance node stop resource within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_opengauss_instance_node_stop
+
+Manages a GaussDB OpenGauss instance node stop resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "node_id" {}
+
+resource "huaweicloud_gaussdb_opengauss_instance_node_stop" "test" {
+  instance_id = var.instance_id
+  node_id     = var.node_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the GaussDB OpenGauss instance. Changing this parameter
+  will create a new resource.
+
+* `node_id` - (Required, String, ForceNew) Specifies the ID of the GaussDB OpenGauss instance node that needs to be stopped.
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which equals to the `node_id`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1776,6 +1776,8 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_gaussdb_opengauss_instance":                   gaussdb.ResourceOpenGaussInstance(),
 			"huaweicloud_gaussdb_opengauss_instance_restart":           gaussdb.ResourceOpenGaussInstanceRestart(),
+			"huaweicloud_gaussdb_opengauss_instance_node_startup":      gaussdb.ResourceOpenGaussInstanceNodeStartup(),
+			"huaweicloud_gaussdb_opengauss_instance_node_stop":         gaussdb.ResourceOpenGaussInstanceNodeStop(),
 			"huaweicloud_gaussdb_opengauss_database":                   gaussdb.ResourceOpenGaussDatabase(),
 			"huaweicloud_gaussdb_opengauss_backup":                     gaussdb.ResourceGaussDBOpenGaussBackup(),
 			"huaweicloud_gaussdb_opengauss_backup_stop":                gaussdb.ResourceOpenGaussBackupStop(),

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance_node_startup_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance_node_startup_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func TestAccOpenGaussInstanceRestart_basic(t *testing.T) {
+func TestAccOpenGaussInstanceNodeStartup_basic(t *testing.T) {
 	var obj interface{}
 	rName := acceptance.RandomAccResourceNameWithDash()
-	resourceName := "huaweicloud_gaussdb_opengauss_instance_restart.test"
+	resourceName := "huaweicloud_gaussdb_opengauss_instance.test"
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -31,7 +31,7 @@ func TestAccOpenGaussInstanceRestart_basic(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenGaussInstanceRestart_basic(rName),
+				Config: testAccOpenGaussInstanceNodeStartup_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 				),
@@ -40,7 +40,7 @@ func TestAccOpenGaussInstanceRestart_basic(t *testing.T) {
 	})
 }
 
-func testAccOpenGaussInstanceRestart_base(rName string) string {
+func testAccOpenGaussInstanceNodeStartup_base(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -94,14 +94,26 @@ resource "huaweicloud_gaussdb_opengauss_instance" "test" {
     size = 40
   }
 }
+
+data "huaweicloud_gaussdb_opengauss_instance_nodes" "test" {
+  instance_id = huaweicloud_gaussdb_opengauss_instance.test.id
+}
+
+resource "huaweicloud_gaussdb_opengauss_instance_node_stop" "test" {
+  instance_id = huaweicloud_gaussdb_opengauss_instance.test.id
+  node_id     = data.huaweicloud_gaussdb_opengauss_instance_nodes.test.nodes[0].id
+}
 `, common.TestBaseNetwork(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
-func testAccOpenGaussInstanceRestart_basic(rName string) string {
+func testAccOpenGaussInstanceNodeStartup_basic(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_gaussdb_opengauss_instance_restart" "test" {
+resource "huaweicloud_gaussdb_opengauss_instance_node_startup" "test" {
+  depends_on = [huaweicloud_gaussdb_opengauss_instance_node_stop.test]
+
   instance_id = huaweicloud_gaussdb_opengauss_instance.test.id
-}`, testAccOpenGaussInstanceRestart_base(rName))
+  node_id     = data.huaweicloud_gaussdb_opengauss_instance_nodes.test.nodes[0].id
+}`, testAccOpenGaussInstanceNodeStartup_base(rName))
 }

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance_node_stop_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance_node_stop_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func TestAccOpenGaussInstanceRestart_basic(t *testing.T) {
+func TestAccOpenGaussInstanceNodeStop_basic(t *testing.T) {
 	var obj interface{}
 	rName := acceptance.RandomAccResourceNameWithDash()
-	resourceName := "huaweicloud_gaussdb_opengauss_instance_restart.test"
+	resourceName := "huaweicloud_gaussdb_opengauss_instance.test"
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -31,7 +31,7 @@ func TestAccOpenGaussInstanceRestart_basic(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenGaussInstanceRestart_basic(rName),
+				Config: testAccOpenGaussInstanceNodeStop_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 				),
@@ -40,7 +40,7 @@ func TestAccOpenGaussInstanceRestart_basic(t *testing.T) {
 	})
 }
 
-func testAccOpenGaussInstanceRestart_base(rName string) string {
+func testAccOpenGaussInstanceNodeStop_base(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -94,14 +94,19 @@ resource "huaweicloud_gaussdb_opengauss_instance" "test" {
     size = 40
   }
 }
+
+data "huaweicloud_gaussdb_opengauss_instance_nodes" "test" {
+  instance_id = huaweicloud_gaussdb_opengauss_instance.test.id
+}
 `, common.TestBaseNetwork(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
-func testAccOpenGaussInstanceRestart_basic(rName string) string {
+func testAccOpenGaussInstanceNodeStop_basic(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_gaussdb_opengauss_instance_restart" "test" {
+resource "huaweicloud_gaussdb_opengauss_instance_node_stop" "test" {
   instance_id = huaweicloud_gaussdb_opengauss_instance.test.id
-}`, testAccOpenGaussInstanceRestart_base(rName))
+  node_id     = data.huaweicloud_gaussdb_opengauss_instance_nodes.test.nodes[0].id
+}`, testAccOpenGaussInstanceNodeStop_base(rName))
 }

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance__node_startup.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance__node_startup.go
@@ -1,0 +1,135 @@
+package gaussdb
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDB POST /v3/{project_id}/instances/{instance_id}/restart
+// @API GaussDB GET /v3/{project_id}/instances
+// @API GaussDB GET /v3/{project_id}/jobs
+func ResourceOpenGaussInstanceNodeStartup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceOpenGaussInstanceNodeStartupCreate,
+		ReadContext:   resourceOpenGaussInstanceNodeStartupRead,
+		DeleteContext: resourceOpenGaussInstanceNodeStartupDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceOpenGaussInstanceNodeStartupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/db-startup"
+		product = "opengauss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	nodeId := d.Get("node_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createOpt.JSONBody = utils.RemoveNil(buildCreateOpenGaussInstanceNodeStartupBodyParams(d))
+
+	retryFunc := func() (interface{}, bool, error) {
+		res, err := client.Request("POST", createPath, &createOpt)
+		retry, err := handleMultiOperationsError(err)
+		return res, retry, err
+	}
+	r, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     instanceStateRefreshFunc(client, instanceId),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return diag.Errorf("error starting up GaussDB OpenGauss instance(%s) node(%s): %s", instanceId, nodeId, err)
+	}
+
+	d.SetId(nodeId)
+
+	createRespBody, err := utils.FlattenResponse(r.(*http.Response))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", createRespBody, nil)
+	if jobId == nil {
+		return diag.Errorf("error starting up GaussDB OpenGauss instance(%s) node(%s), job_id is not found in "+
+			"the response", instanceId, nodeId)
+	}
+	err = checkGaussDBOpenGaussJobFinish(ctx, client, jobId.(string), 2, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func buildCreateOpenGaussInstanceNodeStartupBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"node_ids": []string{d.Get("node_id").(string)},
+	}
+	return bodyParams
+}
+
+func resourceOpenGaussInstanceNodeStartupRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceOpenGaussInstanceNodeStartupDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting GaussDB OpenGauss node startup resource is not supported. The resource is only removed from " +
+		"the state, the GaussDB OpenGauss instance remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance__node_stop.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance__node_stop.go
@@ -1,0 +1,135 @@
+package gaussdb
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDB POST /v3/{project_id}/instances/{instance_id}/restart
+// @API GaussDB GET /v3/{project_id}/instances
+// @API GaussDB GET /v3/{project_id}/jobs
+func ResourceOpenGaussInstanceNodeStop() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceOpenGaussInstanceNodeStopCreate,
+		ReadContext:   resourceOpenGaussInstanceNodeStopRead,
+		DeleteContext: resourceOpenGaussInstanceNodeStopDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceOpenGaussInstanceNodeStopCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/db-stop"
+		product = "opengauss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	nodeId := d.Get("node_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createOpt.JSONBody = utils.RemoveNil(buildCreateOpenGaussInstanceNodeStopBodyParams(d))
+
+	retryFunc := func() (interface{}, bool, error) {
+		res, err := client.Request("POST", createPath, &createOpt)
+		retry, err := handleMultiOperationsError(err)
+		return res, retry, err
+	}
+	r, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     instanceStateRefreshFunc(client, instanceId),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return diag.Errorf("error stopping GaussDB OpenGauss instance(%s) node(%s): %s", instanceId, nodeId, err)
+	}
+
+	d.SetId(nodeId)
+
+	createRespBody, err := utils.FlattenResponse(r.(*http.Response))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", createRespBody, nil)
+	if jobId == nil {
+		return diag.Errorf("error stopping GaussDB OpenGauss instance(%s) node(%s), job_id is not found in the "+
+			"response", instanceId, nodeId)
+	}
+	err = checkGaussDBOpenGaussJobFinish(ctx, client, jobId.(string), 2, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func buildCreateOpenGaussInstanceNodeStopBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"node_ids": []string{d.Get("node_id").(string)},
+	}
+	return bodyParams
+}
+
+func resourceOpenGaussInstanceNodeStopRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceOpenGaussInstanceNodeStopDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting GaussDB OpenGauss stop resource is not supported. The restart resource is only removed " +
+		"from the state, the GaussDB OpenGauss instance remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb opengauss instance node startup and stop resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb opengauss instance node startup and stop resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccOpenGaussInstanceNodeStartup_basic'   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccOpenGaussInstanceNodeStartup_basic -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussInstanceNodeStartup_basic
=== PAUSE TestAccOpenGaussInstanceNodeStartup_basic
=== CONT  TestAccOpenGaussInstanceNodeStartup_basic
--- PASS: TestAccOpenGaussInstanceNodeStartup_basic (2158.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   2158.227s

make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccOpenGaussInstanceNodeStop_basic'      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccOpenGaussInstanceNodeStop_basic -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussInstanceNodeStop_basic
=== PAUSE TestAccOpenGaussInstanceNodeStop_basic
=== CONT  TestAccOpenGaussInstanceNodeStop_basic
--- PASS: TestAccOpenGaussInstanceNodeStop_basic (2218.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   2218.581s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
