### PR TITLE
feat(cae): add new resource to manage event notification rule

### DIFF
--- a/docs/resources/cae_notification_rule.md
+++ b/docs/resources/cae_notification_rule.md
@@ -1,0 +1,165 @@
+---
+subcategory: "Cloud Application Engine (CAE)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cae_notification_rule"
+description: |-
+  Manage an event notification rule resource within HuaweiCloud.
+---
+
+# huaweicloud_cae_notification_rule
+
+Manage an event notification rule resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "notification_rule_name" {}
+variable "notification_event_name" {}
+variable "application_ids" {
+  type = list(string)
+}
+variable "notification_email" {}
+
+resource "huaweicloud_cae_notification_rule" "test" {
+  name       = var.notification_rule_name
+  event_name = var.notification_event_name
+
+  scope {
+    type         = "applications"
+    applications = var.application_ids
+  }
+
+  trigger_policy {
+    type = "immediately"
+  }
+
+  notification {
+    protocol = "email"
+    endpoint = var.notification_email
+    template = "EN"
+  }
+
+  enabled = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the event notification rule. The name must be unique.  
+  Changing this creates a new resource.  
+  The valid length is limited from `1` to `64`, only English letters, digits, underscores (_) and hyphens (-) are
+  allowed.  
+  The name must start and end with an English letter or a digit.
+  
+* `event_name` - (Required, String) Specifies the trigger event of the event notification.  
+  Multiple events are separated by commas (,). e.g. **Healthy,Pulled**.  
+  The valid values are as follows:
+  + **Healthy**: Healthy checked.
+  + **Unhealthy**: Healthy check failed.
+  + **Pulled**: Image pulled.
+  + **FailedPullImage**: Pull image failed.
+  + **Started**: Container started up.
+  + **BackOffStart**: Container startup failed.
+  + **SuccessfulMountVolume**: Volume mounted.
+  + **FailedMount**: Attach volume failed.
+
+* `scope` - (Required, List) Specifies the scope in which event notification rule takes effect.  
+  The [scope](#notification_rule_scope) structure is documented below.
+
+* `trigger_policy` - (Required, List) Specifies the trigger policy of the event notification rule.  
+  The [trigger_policy](#notification_rule_trigger_policy) structure is documented below.
+
+* `notification` - (Required, List, ForceNew) Specifies the configuration of the event notification.
+  Changing this creates a new resource.  
+  The [notification](#notification_rule_notification) structure is documented below.
+
+* `enabled` - (Optional, Bool) Specifies whether to enable the event notification rule. Defaults to **false**.
+
+<a name="notification_rule_notification"></a>
+The `notification` block supports:
+
+* `protocol` - (Required, String, ForceNew) Specifies the protocol of the event notification.
+  Changing this creates a new resource.  
+  The valid values are as follows:
+  + **sms**
+  + **email**
+  + **wechat**
+
+* `endpoint` - (Required, String, ForceNew) Specifies the endpoint of the event notification.
+  Changing this creates a new resource.
+  + If `notification.type` is set to **sms**, the endpoint is a phone number.
+  + If `notification.type` is set to **email**, the endpoint is a email address.
+  + If `notification.type` is set to **wechat**, the endpoint is a webhook address starting with
+    `https://qyapi.weixin.qq.com/cgi-bin/webhook/send`.
+    you want to use this parameter, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/usermanual-ticket/topic_0065264094.html)
+    to submit a service ticket to apply for it.
+    For details about how to obtain a WeCom subscription endpoint, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/smn_faq/smn_faq_0027.html).
+  
+* `template` - (Required, String, ForceNew) Specifies the template language of the event notification.
+  Changing this creates a new resource.  
+  The valid values are as follows:
+  + **EN**
+  + **ZH**
+
+<a name="notification_rule_scope"></a>
+The `scope` block supports:
+
+* `type` - (Required, String) Specifies the type to which the event notification rule takes effect.  
+  The valid values are as follows:
+  + **environments**: The rule takes effect for all components in the environment.
+  + **applications**: The rule takes effect for all components in the application.
+  + **components**: The rule takes effect for the specified components.
+
+* `environments` - (Optional, List) Specifies the list of the environment IDs.  
+  This parameter is required and available only when the `scope.type` parameter is set to **environments**.
+
+* `applications` - (Optional, List) Specifies the list of the applications IDs.  
+  This parameter is required and available only when the `scope.type` parameter is set to **applications**.
+
+* `components` - (Optional, List) Specifies the list of the components IDs.  
+  This parameter is required and available only when the `scope.type` parameter is set to **components**.
+
+<a name="notification_rule_trigger_policy"></a>
+The `trigger_policy` block supports:
+
+* `type` - (Required, String) Specifies the type of the trigger.  
+  The valid values are as follows:
+  + **accumulative**
+  + **immediately**
+
+* `period` - (Optional, Int) Specifies the trigger period of the event. The unit is second.  
+  This parameter is required and available only when the `trigger_policy.type` parameter is set to **accumulative**.  
+  The valid values are as follows:
+  + **300**
+  + **1200**
+  + **3600**
+  + **14400**
+  + **86400**
+
+* `count` - (Optional, Int) Specifies the number of times the event occurred.  
+  The valid value ranges from `1` to `100`.  
+  This parameter is required and available only when the `trigger_policy.type` parameter is set to **accumulative**.
+
+* `operator` - (Optional, String) Specifies the condition of the event notification.  
+  The valid values are **>** and **>=**.  
+  This parameter is required and available only when the `trigger_policy.type` parameter is set to **accumulative**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also event notification rule ID.
+
+## Import
+
+The event notification rule resource can be imported using `name`, e.g.
+
+```bash
+$ terraform import huaweicloud_cae_notification_rule.test <name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1399,6 +1399,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cae_component":                cae.ResourceComponent(),
 			"huaweicloud_cae_component_configurations": cae.ResourceComponentConfigurations(),
 			"huaweicloud_cae_component_deployment":     cae.ResourceComponentDeployment(),
+			"huaweicloud_cae_notification_rule":        cae.ResourceNotificationRule(),
 
 			"huaweicloud_cbr_backup_share_accepter": cbr.ResourceBackupShareAccepter(),
 			"huaweicloud_cbr_backup_share":          cbr.ResourceBackupShare(),

--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_notification_rule_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_notification_rule_test.go
@@ -1,0 +1,341 @@
+package cae
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cae"
+)
+
+func getResourceCaeNotificationRuleFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("cae", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CAE client: %s", err)
+	}
+
+	return cae.GetEventNotificationRuleById(client, state.Primary.ID)
+}
+
+func TestAccResourceNotificationRule_basic(t *testing.T) {
+	var (
+		rNameWithEnv = "huaweicloud_cae_notification_rule.env"
+		rNameWithApp = "huaweicloud_cae_notification_rule.app"
+		rNameWithCom = "huaweicloud_cae_notification_rule.com"
+		name         = acceptance.RandomAccResourceNameWithDash()
+		obj          interface{}
+		rcWithEnv    = acceptance.InitResourceCheck(rNameWithEnv, &obj, getResourceCaeNotificationRuleFunc)
+		rcWithApp    = acceptance.InitResourceCheck(rNameWithApp, &obj, getResourceCaeNotificationRuleFunc)
+		rcWithCom    = acceptance.InitResourceCheck(rNameWithCom, &obj, getResourceCaeNotificationRuleFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCaeEnvironment(t)
+			acceptance.TestAccPreCheckCaeApplication(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rcWithEnv.CheckResourceDestroy(),
+
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceNotificationRule_basic_step1(name),
+				// For all components in the environment.
+				Check: resource.ComposeTestCheckFunc(
+					rcWithEnv.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameWithEnv, "name", name),
+					resource.TestCheckResourceAttr(rNameWithEnv, "event_name", "Started,Healthy"),
+					resource.TestCheckResourceAttr(rNameWithEnv, "scope.0.type", "environments"),
+					resource.TestCheckResourceAttr(rNameWithEnv, "scope.0.environments.0", acceptance.HW_CAE_ENVIRONMENT_ID),
+					resource.TestCheckResourceAttr(rNameWithEnv, "trigger_policy.0.type", "accumulative"),
+					resource.TestCheckResourceAttr(rNameWithEnv, "trigger_policy.0.period", "300"),
+					resource.TestCheckResourceAttr(rNameWithEnv, "trigger_policy.0.count", "50"),
+					resource.TestCheckResourceAttr(rNameWithEnv, "trigger_policy.0.operator", ">="),
+					resource.TestCheckResourceAttr(rNameWithEnv, "notification.0.protocol", "email"),
+					resource.TestCheckResourceAttr(rNameWithEnv, "notification.0.endpoint", "terraform@test.com"),
+					resource.TestCheckResourceAttr(rNameWithEnv, "notification.0.template", "EN"),
+					resource.TestCheckResourceAttr(rNameWithEnv, "enabled", "true"),
+					// For all components in the application.
+					rcWithApp.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameWithApp, "event_name", "Unhealthy"),
+					resource.TestCheckResourceAttr(rNameWithApp, "scope.0.type", "applications"),
+					resource.TestCheckResourceAttr(rNameWithApp, "scope.0.applications.0", acceptance.HW_CAE_APPLICATION_ID),
+					resource.TestCheckResourceAttr(rNameWithApp, "trigger_policy.0.type", "immediately"),
+					resource.TestCheckResourceAttr(rNameWithApp, "notification.0.protocol", "sms"),
+					resource.TestCheckResourceAttr(rNameWithApp, "notification.0.endpoint", "12345678987"),
+					resource.TestCheckResourceAttr(rNameWithApp, "notification.0.template", "ZH"),
+					resource.TestCheckResourceAttr(rNameWithApp, "enabled", "false"),
+					// For specified components.
+					rcWithCom.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameWithCom, "event_name", "Started,BackOffStart,SuccessfulMountVolume"),
+					resource.TestCheckResourceAttr(rNameWithCom, "scope.0.type", "components"),
+					resource.TestCheckResourceAttr(rNameWithCom, "scope.0.components.#", "2"),
+					resource.TestCheckResourceAttr(rNameWithCom, "trigger_policy.0.type", "accumulative"),
+					resource.TestCheckResourceAttr(rNameWithCom, "trigger_policy.0.period", "300"),
+					resource.TestCheckResourceAttr(rNameWithCom, "trigger_policy.0.count", "100"),
+					resource.TestCheckResourceAttr(rNameWithCom, "trigger_policy.0.operator", ">"),
+					resource.TestCheckResourceAttr(rNameWithCom, "notification.0.protocol", "email"),
+					resource.TestCheckResourceAttr(rNameWithCom, "notification.0.endpoint", "terraform@test.com"),
+					resource.TestCheckResourceAttr(rNameWithCom, "notification.0.template", "ZH"),
+				),
+			},
+			{
+				Config: testAccResourceNotificationRule_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Updates from all components in the environment to the specified components.
+					rcWithEnv.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameWithEnv, "event_name", "FailedPullImage,FailedMount"),
+					resource.TestCheckResourceAttr(rNameWithEnv, "scope.0.type", "components"),
+					resource.TestCheckResourceAttr(rNameWithEnv, "scope.0.components.#", "2"),
+					resource.TestCheckResourceAttr(rNameWithEnv, "trigger_policy.0.type", "immediately"),
+					resource.TestCheckResourceAttr(rNameWithEnv, "enabled", "false"),
+					// Updates from all components in the application to all components in the environments.
+					rcWithApp.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameWithApp, "event_name", "FailedPullImage"),
+					resource.TestCheckResourceAttr(rNameWithApp, "scope.0.type", "environments"),
+					resource.TestCheckResourceAttr(rNameWithApp, "scope.0.environments.0", acceptance.HW_CAE_ENVIRONMENT_ID),
+					resource.TestCheckResourceAttr(rNameWithApp, "trigger_policy.0.type", "accumulative"),
+					resource.TestCheckResourceAttr(rNameWithApp, "trigger_policy.0.period", "86400"),
+					resource.TestCheckResourceAttr(rNameWithApp, "trigger_policy.0.count", "10"),
+					resource.TestCheckResourceAttr(rNameWithApp, "trigger_policy.0.operator", ">"),
+					resource.TestCheckResourceAttr(rNameWithApp, "enabled", "true"),
+					// Updates from the specified components to all components in the application.
+					rcWithCom.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameWithCom, "event_name", "FailedMount"),
+					resource.TestCheckResourceAttr(rNameWithCom, "scope.0.type", "applications"),
+					resource.TestCheckResourceAttr(rNameWithCom, "scope.0.applications.0", acceptance.HW_CAE_APPLICATION_ID),
+					resource.TestCheckResourceAttr(rNameWithCom, "trigger_policy.0.type", "immediately"),
+				),
+			},
+			{
+				ResourceName:      rNameWithEnv,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccNotificationRuleImportFunc(rNameWithEnv),
+			},
+			{
+				ResourceName:      rNameWithApp,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccNotificationRuleImportFunc(rNameWithApp),
+			},
+			{
+				ResourceName:      rNameWithCom,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccNotificationRuleImportFunc(rNameWithCom),
+			},
+		},
+	})
+}
+
+func testAccResourceNotificationRule_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# For all components in the environment.
+resource "huaweicloud_cae_notification_rule" "env" {
+  name       = "%[2]s"
+  event_name = "Started,Healthy"
+
+  scope {
+    type         = "environments"
+    environments = ["%[3]s"]
+  }
+
+  trigger_policy {
+    type     = "accumulative"
+    period   = 300
+    count    = 50
+    operator = ">="
+  }
+
+  notification {
+    protocol = "email"
+    endpoint = "terraform@test.com"
+    template = "EN"
+  }
+
+  enabled = true
+}
+
+# For all components in the application.
+resource "huaweicloud_cae_notification_rule" "app" {
+  name       = "%[2]s-app"
+  event_name = "Unhealthy"
+
+  scope {
+    type         = "applications"
+    applications = ["%[4]s"]
+  }
+
+  trigger_policy {
+    type = "immediately"
+  }
+
+  notification {
+    protocol = "sms"
+    endpoint = "12345678987"
+    template = "ZH"
+  }
+}
+
+# For specified components.
+resource "huaweicloud_cae_notification_rule" "com" {
+  name       = "%[2]s-com"
+  event_name = "Started,BackOffStart,SuccessfulMountVolume"
+
+  scope {
+    type       = "components"
+    components = huaweicloud_cae_component.test[*].id
+  }
+
+  trigger_policy {
+    type     = "accumulative"
+    period   = 300
+    count    = 100
+    operator = ">"
+  }
+
+  notification {
+    protocol = "email"
+    endpoint = "terraform@test.com"
+    template = "ZH"
+  }
+}
+`, testAccResourceNotificationRule_base(name), name, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID)
+}
+
+func testAccResourceNotificationRule_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Updates from all components in the environment to the specified components.
+ resource "huaweicloud_cae_notification_rule" "env" {
+  name       = "%[2]s"
+  event_name = "FailedPullImage,FailedMount"
+
+  scope {
+    type       = "components"
+    components = huaweicloud_cae_component.test[*].id
+  }
+
+  trigger_policy {
+    type = "immediately"
+  }
+
+  notification {
+    protocol = "email"
+    endpoint = "terraform@test.com"
+    template = "EN"
+  }
+
+  enabled = false
+}
+
+# Updates from all components in the application to all components in the environments.
+resource "huaweicloud_cae_notification_rule" "app" {
+  name       = "%[2]s-app"
+  event_name = "FailedPullImage"
+
+  scope {
+    type         = "environments"
+    environments = ["%[4]s"]
+  }
+
+  trigger_policy {
+    type     = "accumulative"
+    period   = 86400
+    count    = 10
+    operator = ">"
+  }
+
+  notification {
+    protocol = "sms"
+    endpoint = "12345678987"
+    template = "ZH"
+  }
+
+  enabled = true
+}
+
+# Updates from the specified components to the application.
+resource "huaweicloud_cae_notification_rule" "com" {
+  name       = "%[2]s-com"
+  event_name = "FailedMount"
+
+  scope {
+    type         = "applications"
+    applications = ["%[3]s"]
+  }
+
+  trigger_policy {
+    type = "immediately"
+  }
+
+  notification {
+    protocol = "email"
+    endpoint = "terraform@test.com"
+    template = "ZH"
+  }
+}
+`, testAccResourceNotificationRule_base(name), name, acceptance.HW_CAE_APPLICATION_ID, acceptance.HW_CAE_ENVIRONMENT_ID)
+}
+
+func testAccResourceNotificationRule_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_swr_repositories" "test" {}
+
+locals {
+  swr_repositories = [for v in data.huaweicloud_swr_repositories.test.repositories : v if length(v.tags) > 0][0]
+}
+
+resource "huaweicloud_cae_component" "test" {
+  count          = 2
+  environment_id = "%[1]s"
+  application_id = "%[2]s"
+
+  metadata {
+    name = "%[3]s${count.index}"
+
+    annotations = {
+      version = "1.0.0"
+    }
+  }
+
+  spec {
+    replica = 1
+    runtime = "Docker"
+
+    source {
+      type = "image"
+      url  = format("%%s:%%s", local.swr_repositories.path, local.swr_repositories.tags[0])
+    }
+
+    resource_limit {
+      cpu    = "1000m"
+      memory = "4Gi"
+    }
+  }
+}
+`, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID, name)
+}
+func testAccNotificationRuleImportFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		if name == "" {
+			return "", fmt.Errorf("attribute (name) of resource (%s) not found: %s", name, rs)
+		}
+		return name, nil
+	}
+}

--- a/huaweicloud/services/cae/resource_huaweicloud_cae_notification_rule.go
+++ b/huaweicloud/services/cae/resource_huaweicloud_cae_notification_rule.go
@@ -1,0 +1,419 @@
+package cae
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CAE POST /v1/{project_id}/cae/notice-rules
+// @API CAE GET /v1/{project_id}/cae/notice-rules/{rule_id}
+// @API CAE GET /v1/{project_id}/cae/notice-rules
+// @API CAE PUT /v1/{project_id}/cae/notice-rules
+// @API CAE DELETE /v1/{project_id}/cae/notice-rules/{rule_id}
+func ResourceNotificationRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNotificationRuleCreate,
+		ReadContext:   resourceNotificationRuleRead,
+		UpdateContext: resourceNotificationRuleUpdate,
+		DeleteContext: resourceNotificationRuleDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceNotificationRuleImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The name of the event notification rule.`,
+			},
+			"event_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The trigger event of the event notification.`,
+			},
+			"scope": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The type to which the event notification rule takes effect.`,
+						},
+						"environments": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The list of the environment IDs.`,
+						},
+						"applications": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The list of the applications IDs.`,
+						},
+						"components": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The list of the components IDs.`,
+						},
+					},
+				},
+				Description: `The scope in which event notification rule takes effect.`,
+			},
+			"trigger_policy": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The type of the trigger.`,
+						},
+						"period": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: `The trigger period of the event.`,
+						},
+						"count": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: `The number of times the event occurred.`,
+						},
+						"operator": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The condition of the event notification.`,
+						},
+					},
+				},
+				Description: `The trigger policy of the event notification rule.`,
+			},
+			"notification": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protocol": {
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+							Description: `The protocol of the event notification.`,
+						},
+						"endpoint": {
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+							Description: `The endpoint of the event notification.`,
+						},
+						"template": {
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+							Description: `The template language of the event notification.`,
+						},
+					},
+				},
+				Description: `The configuration of the event notification.`,
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to enable the event notification rule.`,
+			},
+		},
+	}
+}
+
+func buildCreateEventNotificationRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"api_version": "v1",
+		"kind":        "NoticeRule",
+		"spec": map[string]interface{}{
+			"name":           d.Get("name"),
+			"event_name":     d.Get("event_name"),
+			"scope":          buildNotificationRuleScope(d.Get("scope.0")),
+			"trigger_policy": buildNotificationRuleTriggerPolicy(d.Get("trigger_policy.0")),
+			"notification":   buildRuleNotification(d.Get("notification.0")),
+			"enable":         d.Get("enabled"),
+		},
+	}
+}
+
+func buildNotificationRuleScope(scope interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"type": utils.PathSearch("type", scope, nil),
+		"environments": utils.ValueIgnoreEmpty(utils.ExpandToStringList(utils.PathSearch("environments", scope,
+			make([]interface{}, 0)).([]interface{}))),
+		"applications": utils.ValueIgnoreEmpty(utils.ExpandToStringList(utils.PathSearch("applications", scope,
+			make([]interface{}, 0)).([]interface{}))),
+		"components": utils.ValueIgnoreEmpty(utils.ExpandToStringList(utils.PathSearch("components", scope,
+			make([]interface{}, 0)).([]interface{}))),
+	}
+}
+
+func buildNotificationRuleTriggerPolicy(triggerPolicy interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"trigger_type": utils.PathSearch("type", triggerPolicy, nil),
+		"period":       utils.ValueIgnoreEmpty(utils.PathSearch("period", triggerPolicy, nil)),
+		"count":        utils.ValueIgnoreEmpty(utils.PathSearch("count", triggerPolicy, nil)),
+		"operator":     utils.ValueIgnoreEmpty(utils.PathSearch("operator", triggerPolicy, nil)),
+	}
+}
+
+func buildRuleNotification(notification interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"protocol": utils.PathSearch("protocol", notification, nil),
+		"endpoint": utils.PathSearch("endpoint", notification, nil),
+		"template": utils.PathSearch("template", notification, nil),
+	}
+}
+
+func resourceNotificationRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v1/{project_id}/cae/notice-rules"
+	)
+
+	client, err := cfg.NewServiceClient("cae", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateEventNotificationRuleBodyParams(d)),
+	}
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating event notification rule: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	notificationRuleId := utils.PathSearch("spec.id", respBody, "").(string)
+	if notificationRuleId == "" {
+		return diag.Errorf("unable to find the event notification rule ID from the API response")
+	}
+
+	d.SetId(notificationRuleId)
+
+	return resourceNotificationRuleRead(ctx, d, meta)
+}
+
+func resourceNotificationRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("cae", region)
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	notificationRule, err := GetEventNotificationRuleById(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error retrieving event notification rule (%s)", d.Get("name").(string)))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("spec.name", notificationRule, nil)),
+		d.Set("event_name", utils.PathSearch("spec.event_name", notificationRule, nil)),
+		d.Set("scope", flattenNotificationRuleScope(utils.PathSearch("spec.scope", notificationRule, nil))),
+		d.Set("trigger_policy", flattenNotificationRuleTriggerPolicy(utils.PathSearch("spec.trigger_policy", notificationRule, nil))),
+		d.Set("notification", flattenRuleNotification(utils.PathSearch("spec.notification", notificationRule, nil))),
+		d.Set("enabled", utils.PathSearch("spec.enable", notificationRule, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenNotificationRuleScope(scope interface{}) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"type":         utils.PathSearch("type", scope, nil),
+			"environments": utils.PathSearch("environments", scope, nil),
+			"applications": utils.PathSearch("applications", scope, nil),
+			"components":   utils.PathSearch("components", scope, nil),
+		},
+	}
+}
+
+func flattenNotificationRuleTriggerPolicy(triggerPolicy interface{}) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"type":     utils.PathSearch("trigger_type", triggerPolicy, nil),
+			"period":   utils.PathSearch("period", triggerPolicy, nil),
+			"count":    utils.PathSearch("count", triggerPolicy, nil),
+			"operator": utils.PathSearch("operator", triggerPolicy, nil),
+		},
+	}
+}
+
+func flattenRuleNotification(notification interface{}) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"protocol": utils.PathSearch("protocol", notification, nil),
+			"endpoint": utils.PathSearch("endpoint", notification, nil),
+			"template": utils.PathSearch("template", notification, nil),
+		},
+	}
+}
+
+func GetEventNotificationRuleById(client *golangsdk.ServiceClient, notificationRuleId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/cae/notice-rules/{rule_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{rule_id}", notificationRuleId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func buildUpdateEventNotificationRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"api_version": "v1",
+		"kind":        "NoticeRule",
+		"spec": map[string]interface{}{
+			"event_name":     d.Get("event_name"),
+			"scope":          buildNotificationRuleScope(d.Get("scope.0")),
+			"trigger_policy": buildNotificationRuleTriggerPolicy(d.Get("trigger_policy.0")),
+			"enable":         d.Get("enabled"),
+		},
+	}
+}
+
+func resourceNotificationRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v1/{project_id}/cae/notice-rules/{rule_id}"
+	)
+
+	client, err := cfg.NewServiceClient("cae", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	if d.HasChanges("event_name", "scope", "trigger_policy", "enabled") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{rule_id}", d.Id())
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody:         utils.RemoveNil(buildUpdateEventNotificationRuleBodyParams(d)),
+		}
+		_, err = client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating event notification rule: %s", err)
+		}
+	}
+
+	return resourceNotificationRuleRead(ctx, d, meta)
+}
+
+func resourceNotificationRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v1/{project_id}/cae/notice-rules/{rule_id}"
+	)
+
+	client, err := cfg.NewServiceClient("cae", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{rule_id}", d.Id())
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	// When deleting a non-existent event notification rule, the response status code is 204, in order to avoid
+	// the possibility of returning a 404 status code in the future, the CheckDeleted design is retained here.
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting event notification rule (%s)", d.Get("name").(string)))
+	}
+	return nil
+}
+
+func getEventNotificationRules(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v1/{project_id}/cae/notice-rules"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	getListOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	resp, err := client.Request("GET", listPath, &getListOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+// Since the ID cannot be found on the console, so we need to import by the event notification rule name.
+func resourceNotificationRuleImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	var (
+		cfg                  = meta.(*config.Config)
+		notificationRuleName = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("cae", cfg.GetRegion(d))
+	if err != nil {
+		return nil, fmt.Errorf("error creating CAE client: %s", err)
+	}
+
+	notificationRules, err := getEventNotificationRules(client)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving event notification rules: %s", err)
+	}
+
+	notificationRuleId := utils.PathSearch(fmt.Sprintf("items[?name=='%s']|[0].id", notificationRuleName), notificationRules, "").(string)
+	if notificationRuleId == "" {
+		return []*schema.ResourceData{d},
+			fmt.Errorf("unable to find event notification rule ID (%s) from API response : %s", notificationRuleName, err)
+	}
+
+	d.SetId(notificationRuleId)
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to manage an event notification rule.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new resource.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cae -f TestAccResourceNotificationRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccResourceNotificationRule_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceNotificationRule_basic
=== PAUSE TestAccResourceNotificationRule_basic
=== CONT  TestAccResourceNotificationRule_basic
--- PASS: TestAccResourceNotificationRule_basic (537.18s)
PASS
coverage: 34.3% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       539.147s        coverage: 34.3% of statements in ./huaweicloud/services/cae
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found   
![image](https://github.com/user-attachments/assets/76a7b3e1-2959-4311-93ab-6d41843bbec4)


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
