### PR TITLE
feat(CodeArts/Deploy): support environment permission management

### DIFF
--- a/docs/resources/codearts_deploy_environment_permission.md
+++ b/docs/resources/codearts_deploy_environment_permission.md
@@ -1,0 +1,66 @@
+---
+subcategory: "CodeArts Deploy"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_codearts_deploy_environment_permission"
+description: |-
+  Manages a CodeArts deploy environment permission resource within HuaweiCloud.
+---
+
+# huaweicloud_codearts_deploy_environment_permission
+
+Manages a CodeArts deploy environment permission resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "application_id" {}
+variable "environment_id" {}
+variable "role_id" {}
+
+resource "huaweicloud_codearts_deploy_environment_permission" "test" {
+  application_id   = var.application_id
+  environment_id   = var.environment_id
+  role_id          = var.role_id
+  permission_name  = "can_delete"
+  permission_value = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `application_id` - (Required, String, ForceNew) Specifies the application ID.
+  Changing this creates a new resource.
+
+* `environment_id` - (Required, String, ForceNew) Specifies the environment ID.
+  Changing this creates a new resource.
+
+* `role_id` - (Required, String, ForceNew) Specifies the role ID.
+  Changing this creates a new resource.
+
+* `permission_name` - (Required, String, ForceNew) Specifies the permission name.
+  Valid values are **can_view**, **can_edit**, **can_delete**, **can_deploy** and **can_manage**.
+
+  Changing this creates a new resource.
+
+* `permission_value` - (Optional, Bool) Specifies whether to enable the permission.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The CodeArts deploy environment permission resource can be imported using the `application_id`, `environment_id`,
+`role_id` and `permission_name`, separated by slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_codearts_deploy_environment_permission.test <app_id>/<env_id>/<role_id>/<permission_name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2239,6 +2239,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_codearts_deploy_application_group":      codeartsdeploy.ResourceDeployApplicationGroup(),
 			"huaweicloud_codearts_deploy_application_group_move": codeartsdeploy.ResourceDeployApplicationGroupMove(),
 			"huaweicloud_codearts_deploy_environment":            codeartsdeploy.ResourceDeployEnvironment(),
+			"huaweicloud_codearts_deploy_environment_permission": codeartsdeploy.ResourceDeployEnvironmentPermission(),
 			"huaweicloud_codearts_deploy_group":                  codeartsdeploy.ResourceDeployGroup(),
 			"huaweicloud_codearts_deploy_group_permission":       codeartsdeploy.ResourceDeployGroupPermission(),
 			"huaweicloud_codearts_deploy_host":                   codeartsdeploy.ResourceDeployHost(),

--- a/huaweicloud/services/acceptance/codeartsdeploy/resource_huaweicloud_codearts_deploy_environment_permission_test.go
+++ b/huaweicloud/services/acceptance/codeartsdeploy/resource_huaweicloud_codearts_deploy_environment_permission_test.go
@@ -1,0 +1,46 @@
+package codeartsdeploy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDeployEnvironmentPermissionModify_basic(t *testing.T) {
+	resourceName := "huaweicloud_codearts_deploy_environment_permission.test"
+	rName := acceptance.RandomAccResourceName()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeployEnvironmentPermissionModify_basic(rName, false),
+			},
+			{
+				Config: testAccDeployEnvironmentPermissionModify_basic(rName, true),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDeployEnvironmentPermissionModify_basic(rName string, value bool) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_codearts_deploy_environment_permission" "test" {
+  application_id   = huaweicloud_codearts_deploy_application.test.id
+  environment_id   = huaweicloud_codearts_deploy_environment.test.id
+  role_id          = try(huaweicloud_codearts_deploy_environment.test.permission_matrix[2].role_id, "")
+  permission_name  = "can_delete"
+  permission_value = %t
+}`, testDeployEnvironment_basic(rName), value)
+}

--- a/huaweicloud/services/codeartsdeploy/resource_huaweicloud_codearts_deploy_environment_permission.go
+++ b/huaweicloud/services/codeartsdeploy/resource_huaweicloud_codearts_deploy_environment_permission.go
@@ -1,0 +1,178 @@
+package codeartsdeploy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CodeArtsDeploy PUT /v2/applications/{application_id}/environments/{environment_id}/permissions
+// @API CodeArtsDeploy GET /v2/applications/{application_id}/environments/{environment_id}/permissions
+func ResourceDeployEnvironmentPermission() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDeployEnvironmentPermissionCreateOrUpdate,
+		ReadContext:   resourceDeployEnvironmentPermissionRead,
+		UpdateContext: resourceDeployEnvironmentPermissionCreateOrUpdate,
+		DeleteContext: resourceDeployEnvironmentPermissionDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDeployEnvironmentPermissionImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"application_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the application ID.`,
+			},
+			"environment_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the environment ID.`,
+			},
+			"role_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the role ID.`,
+			},
+			"permission_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the permission name.`,
+			},
+			"permission_value": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Specifies whether to enable the permission.`,
+			},
+		},
+	}
+}
+
+func resourceDeployEnvironmentPermissionCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("codearts_deploy", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	err = modifyDeployEnvironmentPermission(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if d.IsNewResource() {
+		d.SetId(d.Get("application_id").(string) + "/" + d.Get("environment_id").(string) + "/" +
+			d.Get("role_id").(string) + "/" + d.Get("permission_name").(string))
+	}
+
+	return resourceDeployEnvironmentPermissionRead(ctx, d, meta)
+}
+
+func modifyDeployEnvironmentPermission(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v2/applications/{application_id}/environments/{environment_id}/permissions"
+	modifyPath := client.Endpoint + httpUrl
+	modifyPath = strings.ReplaceAll(modifyPath, "{application_id}", d.Get("application_id").(string))
+	modifyPath = strings.ReplaceAll(modifyPath, "{environment_id}", d.Get("environment_id").(string))
+
+	modifyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+		JSONBody: buildDeployEnvironmentPermissionBodyParams(d),
+	}
+
+	_, err := client.Request("PUT", modifyPath, &modifyOpt)
+	if err != nil {
+		return fmt.Errorf("error modifying CodeArts deploy environment permission")
+	}
+
+	return nil
+}
+
+func buildDeployEnvironmentPermissionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"role_id":          d.Get("role_id"),
+		"permission_name":  d.Get("permission_name"),
+		"permission_value": d.Get("permission_value"),
+	}
+}
+
+func resourceDeployEnvironmentPermissionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("codearts_deploy", region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	permissionMatrix, err := getDeployEnvironmentPermissionMatrix(client, d.Get("application_id").(string), d.Get("environment_id").(string))
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CodeArts deploy environment permission")
+	}
+
+	roleId := d.Get("role_id").(string)
+	permissionName := d.Get("permission_name").(string)
+	expression := fmt.Sprintf("[?role_id=='%s']|[0]", roleId)
+	role := utils.PathSearch(expression, permissionMatrix, nil)
+	if role == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "unable to find role from API response")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("permission_value", utils.PathSearch(permissionName, role, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDeployEnvironmentPermissionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting permission resource is not supported. The resource is only removed from the state," +
+		" the environment permission matrix remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}
+
+func resourceDeployEnvironmentPermissionImportState(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want "+
+			"'<application_id>/<environment_id>/<role_id>/<permission_name>', but got '%s'", d.Id())
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("application_id", parts[0]),
+		d.Set("environment_id", parts[1]),
+		d.Set("role_id", parts[2]),
+		d.Set("permission_name", parts[3]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support environment permission management
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support environment permission management
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/codeartsdeploy" TESTARGS="-run TestAccDeployEnvironmentPermissionModify_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codeartsdeploy -v -run TestAccDeployEnvironmentPermissionModify_basic -timeout 360m -parallel 4
=== RUN   TestAccDeployEnvironmentPermissionModify_basic
=== PAUSE TestAccDeployEnvironmentPermissionModify_basic
=== CONT  TestAccDeployEnvironmentPermissionModify_basic
--- PASS: TestAccDeployEnvironmentPermissionModify_basic (398.35s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codeartsdeploy    398.410s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
