### PR TITLE
test(rms): segment the target ID to ensure smooth execution of test cases

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -111,7 +111,8 @@ var (
 	HW_RAM_SHARE_INVITATION_ID       = os.Getenv("HW_RAM_SHARE_INVITATION_ID")
 	HW_RAM_SHARE_ID                  = os.Getenv("HW_RAM_SHARE_ID")
 
-	HW_RMS_TARGET_ID          = os.Getenv("HW_RMS_TARGET_ID")
+	HW_RMS_TARGET_ID_FOR_FGS  = os.Getenv("HW_RMS_TARGET_ID_FOR_FGS")
+	HW_RMS_TARGET_ID_FOR_RFS  = os.Getenv("HW_RMS_TARGET_ID_FOR_RFS")
 	HW_RMS_EXCLUDED_ACCOUNT_1 = os.Getenv("HW_RMS_EXCLUDED_ACCOUNT_1")
 	HW_RMS_EXCLUDED_ACCOUNT_2 = os.Getenv("HW_RMS_EXCLUDED_ACCOUNT_2")
 
@@ -1134,9 +1135,16 @@ func TestAccPreCheckRAMSharedPrincipalsQueryFields(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckRMSTargetID(t *testing.T) {
-	if HW_RMS_TARGET_ID == "" {
-		t.Skip("HW_RMS_TARGET_ID must be set for the acceptance tests.")
+func TestAccPreCheckRMSTargetIDForFGS(t *testing.T) {
+	if HW_RMS_TARGET_ID_FOR_FGS == "" {
+		t.Skip("HW_RMS_TARGET_ID_FOR_FGS must be set for the acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckRMSTargetIDForRFS(t *testing.T) {
+	if HW_RMS_TARGET_ID_FOR_RFS == "" {
+		t.Skip("HW_RMS_TARGET_ID_FOR_RFS must be set for the acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/rms/data_source_huaweicloud_rms_remediation_execution_statuses_test.go
+++ b/huaweicloud/services/acceptance/rms/data_source_huaweicloud_rms_remediation_execution_statuses_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceRemediationExecutionStatuses_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckRMSTargetID(t)
+			acceptance.TestAccPreCheckRMSTargetIDForFGS(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/rms/resource_huaweicloud_rms_remediation_configuration_test.go
+++ b/huaweicloud/services/acceptance/rms/resource_huaweicloud_rms_remediation_configuration_test.go
@@ -43,7 +43,7 @@ func TestAccResourceRmsRemediationConfiguration_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckRMSTargetID(t)
+			acceptance.TestAccPreCheckRMSTargetIDForRFS(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -53,7 +53,7 @@ func TestAccResourceRmsRemediationConfiguration_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "target_type", "rfs"),
-					resource.TestCheckResourceAttr(resourceName, "target_id", acceptance.HW_RMS_TARGET_ID),
+					resource.TestCheckResourceAttr(resourceName, "target_id", acceptance.HW_RMS_TARGET_ID_FOR_RFS),
 					resource.TestCheckResourceAttr(resourceName, "resource_parameter.0.resource_id", "file_prefix"),
 					resource.TestCheckResourceAttr(resourceName, "static_parameter.0.var_key", "bucket_name"),
 					resource.TestCheckResourceAttr(resourceName, "auth_type", "agency"),
@@ -68,7 +68,7 @@ func TestAccResourceRmsRemediationConfiguration_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "target_type", "rfs"),
-					resource.TestCheckResourceAttr(resourceName, "target_id", acceptance.HW_RMS_TARGET_ID),
+					resource.TestCheckResourceAttr(resourceName, "target_id", acceptance.HW_RMS_TARGET_ID_FOR_RFS),
 					resource.TestCheckResourceAttr(resourceName, "resource_parameter.0.resource_id", "file_prefix"),
 					resource.TestCheckResourceAttr(resourceName, "static_parameter.0.var_key", "bucket_name"),
 					resource.TestCheckResourceAttr(resourceName, "static_parameter.1.var_key", "compress_type"),
@@ -110,7 +110,7 @@ resource "huaweicloud_rms_remediation_configuration" "test" {
   auth_value            = "test_RFS_CTS" 
   maximum_attempts      = 5  
   retry_attempt_seconds = 3600  
-}`, testResourceRmsRemediationConfiguration_base(), acceptance.HW_RMS_TARGET_ID)
+}`, testResourceRmsRemediationConfiguration_base(), acceptance.HW_RMS_TARGET_ID_FOR_RFS)
 }
 
 func testResourceRmsRemediationConfiguration_update() string {
@@ -139,7 +139,7 @@ resource "huaweicloud_rms_remediation_configuration" "test" {
   auth_value            = "test_RFS_CTS" 
   maximum_attempts      = 6  
   retry_attempt_seconds = 60  
-}`, testResourceRmsRemediationConfiguration_base(), acceptance.HW_RMS_TARGET_ID)
+}`, testResourceRmsRemediationConfiguration_base(), acceptance.HW_RMS_TARGET_ID_FOR_RFS)
 }
 
 func testResourceRmsRemediationConfiguration_base() string {

--- a/huaweicloud/services/acceptance/rms/resource_huaweicloud_rms_remediation_exception_test.go
+++ b/huaweicloud/services/acceptance/rms/resource_huaweicloud_rms_remediation_exception_test.go
@@ -36,7 +36,7 @@ func TestAccResourceRemediationException_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckRMSTargetID(t)
+			acceptance.TestAccPreCheckRMSTargetIDForFGS(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -164,5 +164,5 @@ resource "huaweicloud_rms_remediation_configuration" "test" {
   provisioner "local-exec" {
     command = "sleep 10"
   }
-}`, name, acceptance.HW_REGION_NAME, acceptance.HW_RMS_TARGET_ID)
+}`, name, acceptance.HW_REGION_NAME, acceptance.HW_RMS_TARGET_ID_FOR_FGS)
 }

--- a/huaweicloud/services/acceptance/rms/resource_huaweicloud_rms_remediation_execution_test.go
+++ b/huaweicloud/services/acceptance/rms/resource_huaweicloud_rms_remediation_execution_test.go
@@ -15,7 +15,7 @@ func TestAccResourceRemediationExecution_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckRMSTargetID(t)
+			acceptance.TestAccPreCheckRMSTargetIDForFGS(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      nil,
@@ -33,7 +33,7 @@ func TestAccResourceRemediationExecution_specifyResources(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckRMSTargetID(t)
+			acceptance.TestAccPreCheckRMSTargetIDForFGS(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      nil,
@@ -142,5 +142,5 @@ resource "huaweicloud_rms_remediation_configuration" "test" {
   provisioner "local-exec" {
     command = "sleep 15"
   }
-}`, name, acceptance.HW_REGION_NAME, acceptance.HW_RMS_TARGET_ID)
+}`, name, acceptance.HW_REGION_NAME, acceptance.HW_RMS_TARGET_ID_FOR_FGS)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
segment the target ID to ensure smooth execution of test cases
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. segment the target ID to ensure smooth execution of test cases
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/rms" TESTARGS="-run TestAccResourceRmsRemediationConfiguration_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run TestAccResourceRmsRemediationConfiguration_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceRmsRemediationConfiguration_basic
=== PAUSE TestAccResourceRmsRemediationConfiguration_basic
=== CONT  TestAccResourceRmsRemediationConfiguration_basic
--- PASS: TestAccResourceRmsRemediationConfiguration_basic (88.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       88.423s

make testacc TEST="./huaweicloud/services/acceptance/rms" TESTARGS="-run TestAccResourceRemediationExecution_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run TestAccResourceRemediationExecution_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceRemediationExecution_basic
=== PAUSE TestAccResourceRemediationExecution_basic
=== CONT  TestAccResourceRemediationExecution_basic
--- PASS: TestAccResourceRemediationExecution_basic (96.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       96.112s

make testacc TEST="./huaweicloud/services/acceptance/rms" TESTARGS="-run TestAccResourceRemediationExecution_specifyResources"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run TestAccResourceRemediationExecution_specifyResources -timeout 360m -parallel 4
=== RUN   TestAccResourceRemediationExecution_specifyResources
=== PAUSE TestAccResourceRemediationExecution_specifyResources
=== CONT  TestAccResourceRemediationExecution_specifyResources
--- PASS: TestAccResourceRemediationExecution_specifyResources (103.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       103.453s

make testacc TEST="./huaweicloud/services/acceptance/rms" TESTARGS="-run TestAccResourceRemediationException_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run TestAccResourceRemediationException_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceRemediationException_basic
=== PAUSE TestAccResourceRemediationException_basic
=== CONT  TestAccResourceRemediationException_basic
--- PASS: TestAccResourceRemediationException_basic (139.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       139.232s

make testacc TEST="./huaweicloud/services/acceptance/rms" TESTARGS="-run TestAccDataSourceRemediationExecutionStatuses_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run TestAccDataSourceRemediationExecutionStatuses_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRemediationExecutionStatuses_basic
=== PAUSE TestAccDataSourceRemediationExecutionStatuses_basic
=== CONT  TestAccDataSourceRemediationExecutionStatuses_basic
--- PASS: TestAccDataSourceRemediationExecutionStatuses_basic (167.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       167.532s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
