### PR TITLE
refactor(live): refactor the Live domain resource code style

### DIFF
--- a/docs/resources/live_domain.md
+++ b/docs/resources/live_domain.md
@@ -57,8 +57,6 @@ The following arguments are supported:
   Defaults to **mainland_china**. Changing this parameter will create a new resource.
 
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID.
-  For enterprise users, if omitted, default enterprise project will be used.
-
   Changing this parameter will create a new resource.
 
 * `ingest_domain_name` - (Optional, String) Specifies the ingest domain name, which associates with the streaming

--- a/huaweicloud/services/acceptance/live/resource_huaweicloud_live_domain_test.go
+++ b/huaweicloud/services/acceptance/live/resource_huaweicloud_live_domain_test.go
@@ -7,45 +7,43 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/live"
 )
 
-func getDomainResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcLiveV1Client(acceptance.HW_REGION_NAME)
+func getResourceDomainFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("live", region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating Live v1 client: %s", err)
+		return nil, fmt.Errorf("error creating Live client: %s", err)
 	}
 
-	return client.ShowDomain(&model.ShowDomainRequest{Domain: &state.Primary.ID})
+	return live.GetDomain(client, state.Primary.ID)
 }
 
-func TestAccDomain_basic(t *testing.T) {
-	var obj model.CreateDomainMappingResponse
-
-	ingestDomainName := fmt.Sprintf("%s.huaweicloud.com", acceptance.RandomAccResourceNameWithDash())
-	streamingDomainName := fmt.Sprintf("%s.huaweicloud.com", acceptance.RandomAccResourceNameWithDash())
-	ingestResourceName := "huaweicloud_live_domain.ingestDomain"
-	streamingResourceName := "huaweicloud_live_domain.streamingDomain"
+func TestAccResourceDomain_basic(t *testing.T) {
+	var (
+		domainInfo         interface{}
+		ingestDomainName   = fmt.Sprintf("%s.huaweicloud.com", acceptance.RandomAccResourceNameWithDash())
+		ingestResourceName = "huaweicloud_live_domain.ingestDomain"
+	)
 
 	rc := acceptance.InitResourceCheck(
 		ingestResourceName,
-		&obj,
-		getDomainResourceFunc,
+		&domainInfo,
+		getResourceDomainFunc,
 	)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testDomain_basic(ingestDomainName, streamingDomainName),
+				Config: testAccIngestDomain_basic(ingestDomainName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(ingestResourceName, "name", ingestDomainName),
@@ -53,32 +51,69 @@ func TestAccDomain_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(ingestResourceName, "status", "on"),
 					resource.TestCheckResourceAttr(ingestResourceName, "service_area", "mainland_china"),
 					resource.TestCheckResourceAttr(ingestResourceName, "is_ipv6", "true"),
-					resource.TestCheckResourceAttr(ingestResourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
-
-					resource.TestCheckResourceAttr(streamingResourceName, "name", streamingDomainName),
-					resource.TestCheckResourceAttr(streamingResourceName, "type", "pull"),
-					resource.TestCheckResourceAttr(streamingResourceName, "status", "on"),
-					resource.TestCheckResourceAttr(streamingResourceName, "ingest_domain_name", ingestDomainName),
-					resource.TestCheckResourceAttr(streamingResourceName, "service_area", "outside_mainland_china"),
-					resource.TestCheckResourceAttr(streamingResourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(ingestResourceName, "enterprise_project_id", "0"),
 				),
 			},
 			{
-				Config: testDomain_basic_update(ingestDomainName, streamingDomainName),
+				Config: testAccIngestDomain_update(ingestDomainName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(ingestResourceName, "name", ingestDomainName),
-					resource.TestCheckResourceAttr(ingestResourceName, "type", "push"),
-					resource.TestCheckResourceAttr(ingestResourceName, "status", "on"),
-					resource.TestCheckResourceAttr(ingestResourceName, "service_area", "mainland_china"),
 					resource.TestCheckResourceAttr(ingestResourceName, "is_ipv6", "false"),
-					resource.TestCheckResourceAttr(ingestResourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				),
+			},
+			{
+				ResourceName:      ingestResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
 
+func TestAccResourceDomain_streamDomain(t *testing.T) {
+	var (
+		domainInfo            interface{}
+		streamingDomainName   = fmt.Sprintf("%s.huaweicloud.com", acceptance.RandomAccResourceNameWithDash())
+		streamingResourceName = "huaweicloud_live_domain.streamingDomain"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		streamingResourceName,
+		&domainInfo,
+		getResourceDomainFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLiveIngestDomainName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStreamDomain_basic(streamingDomainName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(streamingResourceName, "name", streamingDomainName),
 					resource.TestCheckResourceAttr(streamingResourceName, "type", "pull"),
-					resource.TestCheckResourceAttr(streamingResourceName, "status", "off"),
-					resource.TestCheckResourceAttr(streamingResourceName, "ingest_domain_name", ""),
+					resource.TestCheckResourceAttr(streamingResourceName, "status", "on"),
+					resource.TestCheckResourceAttr(streamingResourceName, "is_ipv6", "true"),
 					resource.TestCheckResourceAttr(streamingResourceName, "service_area", "outside_mainland_china"),
-					resource.TestCheckResourceAttr(streamingResourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(streamingResourceName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(streamingResourceName, "ingest_domain_name", acceptance.HW_LIVE_INGEST_DOMAIN_NAME),
+				),
+			},
+			{
+				Config: testAccStreamDomain_update_1(streamingDomainName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(streamingResourceName, "is_ipv6", "false"),
+					resource.TestCheckResourceAttr(streamingResourceName, "ingest_domain_name", ""),
+				),
+			},
+			{
+				Config: testAccStreamDomain_update_2(streamingDomainName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(streamingResourceName, "status", "off"),
 				),
 			},
 			{
@@ -90,42 +125,64 @@ func TestAccDomain_basic(t *testing.T) {
 	})
 }
 
-func testDomain_basic(pushDomain, pullDomain string) string {
+func testAccIngestDomain_basic(pushDomain string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_live_domain" "ingestDomain" {
-  name                  = "%[1]s"
+  name                  = "%s"
   type                  = "push"
   service_area          = "mainland_china"
+  enterprise_project_id = "0"
   is_ipv6               = true
-  enterprise_project_id = "%[3]s"
+}
+`, pushDomain)
 }
 
-resource "huaweicloud_live_domain" "streamingDomain" {
-  name                  = "%[2]s"
-  type                  = "pull"
-  ingest_domain_name    = huaweicloud_live_domain.ingestDomain.name
-  service_area          = "outside_mainland_china"
-  enterprise_project_id = "%[3]s"
-}
-`, pushDomain, pullDomain, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
-}
-
-func testDomain_basic_update(pushDomain, pullDomain string) string {
+func testAccIngestDomain_update(pushDomain string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_live_domain" "ingestDomain" {
-  name                  = "%[1]s"
+  name                  = "%s"
   type                  = "push"
   service_area          = "mainland_china"
+  enterprise_project_id = "0"
   is_ipv6               = false
-  enterprise_project_id = "%[3]s"
+}
+`, pushDomain)
 }
 
+func testAccStreamDomain_basic(streamDomain string) string {
+	return fmt.Sprintf(`
 resource "huaweicloud_live_domain" "streamingDomain" {
-  name                  = "%[2]s"
+  name                  = "%[1]s"
+  type                  = "pull"
+  ingest_domain_name    = "%[2]s"
+  service_area          = "outside_mainland_china"
+  enterprise_project_id = "0"
+  is_ipv6               = true
+}
+`, streamDomain, acceptance.HW_LIVE_INGEST_DOMAIN_NAME)
+}
+
+func testAccStreamDomain_update_1(streamDomain string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_domain" "streamingDomain" {
+  name                  = "%s"
+  type                  = "pull"
+  service_area          = "outside_mainland_china"
+  enterprise_project_id = "0"
+  is_ipv6               = false
+}
+`, streamDomain)
+}
+
+func testAccStreamDomain_update_2(streamDomain string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_domain" "streamingDomain" {
+  name                  = "%s"
   type                  = "pull"
   status                = "off"
   service_area          = "outside_mainland_china"
-  enterprise_project_id = "%[3]s"
+  enterprise_project_id = "0"
+  is_ipv6               = false
 }
-`, pushDomain, pullDomain, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, streamDomain)
 }

--- a/huaweicloud/services/live/resource_huaweicloud_live_domain.go
+++ b/huaweicloud/services/live/resource_huaweicloud_live_domain.go
@@ -3,7 +3,7 @@ package live
 import (
 	"context"
 	"fmt"
-	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -11,27 +11,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	livev1 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1"
-	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+// @API Live POST /v1/{project_id}/domain
+// @API Live GET /v1/{project_id}/domain
 // @API Live PUT /v1/{project_id}/domain
 // @API Live DELETE /v1/{project_id}/domain
-// @API Live GET /v1/{project_id}/domain
-// @API Live POST /v1/{project_id}/domain
-// @API Live DELETE /v1/{project_id}/domains_mapping
 // @API Live PUT /v1/{project_id}/domains_mapping
+// @API Live DELETE /v1/{project_id}/domains_mapping
 // @API Live PUT /v1/{project_id}/domain/ipv6-switch
 func ResourceDomain() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceDomainCreate,
+		ReadContext:   resourceDomainRead,
 		UpdateContext: resourceDomainUpdate,
 		DeleteContext: resourceDomainDelete,
-		ReadContext:   resourceDomainRead,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -94,47 +93,67 @@ func ResourceDomain() *schema.Resource {
 }
 
 func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	client, err := c.HcLiveV1Client(region)
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/domain"
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
 	if err != nil {
-		return diag.Errorf("error creating Live v1 client: %s", err)
+		return diag.Errorf("error creating Live client: %s", err)
 	}
 
-	createOpts, err := buildCreateParams(d, region, c)
-	if err != nil {
-		return diag.FromErr(err)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateDomainBodyParams(cfg, d, region)),
 	}
 
-	_, err = client.CreateDomain(createOpts)
+	resp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
 		return diag.Errorf("error creating Live domain: %s", err)
 	}
 
-	d.SetId(createOpts.Body.Domain)
-
-	err = waitingForDomainStatus(ctx, client, d.Id(), model.GetDecoupledLiveDomainInfoStatusEnum().ON,
-		d.Timeout(schema.TimeoutCreate))
+	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	// associate the streaming domain name with an ingest domain
-	err = associatingDomain(d, client)
-	if err != nil {
-		return diag.FromErr(err)
+	domainName := utils.PathSearch("domain", respBody, "").(string)
+	if domainName == "" {
+		return diag.Errorf("error creating Live domain: domain name is not found in API response")
 	}
 
-	// off the domain
-	if d.Get("status").(string) == "off" {
-		err = updateStatus(ctx, d, client, c)
+	d.SetId(domainName)
+
+	err = waitingForDomainStateCompleted(ctx, client, d.Timeout(schema.TimeoutCreate), domainName, "on")
+	if err != nil {
+		return diag.Errorf("error waiting for the Live domain (%s) creation to complete: %s", domainName, err)
+	}
+
+	// Associate the streaming domain name with an ingest domain.
+	domainType := d.Get("type").(string)
+	if ingestDomain, ok := d.GetOk("ingest_domain_name"); ok && domainType == "pull" {
+		err = associateIngestDomain(client, domainName, ingestDomain.(string))
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
+	// Disable the domain.
+	status := d.Get("status").(string)
+	if status == "off" {
+		err = updateDomainStatus(ctx, cfg, d, client, d.Timeout(schema.TimeoutCreate), status)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// Enable the IPv6.
 	if d.Get("is_ipv6").(bool) {
-		if err := updateIPv6Switch(client, d); err != nil {
+		if err := updateIPv6Switch(client, d, domainName); err != nil {
 			return diag.Errorf("error updating Live domain IPv6 switch in creation operation: %s", err)
 		}
 	}
@@ -142,84 +161,116 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	return resourceDomainRead(ctx, d, meta)
 }
 
-func resourceDomainRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	client, err := c.HcLiveV1Client(region)
-	if err != nil {
-		return diag.Errorf("error creating Live v1 client: %s", err)
+func buildCreateDomainBodyParams(cfg *config.Config, d *schema.ResourceData, region string) map[string]interface{} {
+	params := map[string]interface{}{
+		"domain":                d.Get("name"),
+		"domain_type":           d.Get("type"),
+		"region":                region,
+		"service_area":          utils.ValueIgnoreEmpty(d.Get("service_area")),
+		"enterprise_project_id": utils.ValueIgnoreEmpty(cfg.GetEnterpriseProjectID(d)),
 	}
 
-	domain := d.Id()
-	response, err := client.ShowDomain(&model.ShowDomainRequest{
-		Domain:              &domain,
-		EnterpriseProjectId: utils.StringIgnoreEmpty(c.GetEnterpriseProjectID(d)),
-	})
+	return params
+}
+
+func resourceDomainRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
+	if err != nil {
+		return diag.Errorf("error creating Live client: %s", err)
+	}
+
+	respBody, err := GetDomain(client, d.Id())
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "error retrieving Live domain")
 	}
 
-	if response.DomainInfo == nil || len(*response.DomainInfo) != 1 {
-		return diag.Errorf("error retrieving Live domain")
-	}
-	r := *response.DomainInfo
-	detail := r[0]
-
 	mErr := multierror.Append(
 		d.Set("region", region),
-		d.Set("name", detail.Domain),
-		d.Set("type", utils.MarshalValue(detail.DomainType)),
-		d.Set("status", utils.MarshalValue(detail.Status)),
-		d.Set("ingest_domain_name", detail.RelatedDomain),
-		d.Set("cname", detail.DomainCname),
-		d.Set("service_area", flattenServiceAreaAttribute(detail.ServiceArea)),
-		d.Set("enterprise_project_id", detail.EnterpriseProjectId),
-		d.Set("is_ipv6", detail.IsIpv6),
+		d.Set("name", utils.PathSearch("domain", respBody, nil)),
+		d.Set("type", utils.PathSearch("domain_type", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("ingest_domain_name", utils.PathSearch("related_domain", respBody, nil)),
+		d.Set("cname", utils.PathSearch("domain_cname", respBody, nil)),
+		d.Set("service_area", utils.PathSearch("service_area", respBody, nil)),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", respBody, nil)),
+		d.Set("is_ipv6", utils.PathSearch("is_ipv6", respBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func flattenServiceAreaAttribute(serviceArea *model.DecoupledLiveDomainInfoServiceArea) string {
-	if serviceArea == nil {
-		return ""
+func GetDomain(client *golangsdk.ServiceClient, domainName string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/domain"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = fmt.Sprintf("%s?domain=%s", getPath, domainName)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
 
-	return serviceArea.Value()
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	domainInfo := utils.PathSearch("domain_info|[0]", respBody, nil)
+	if domainInfo == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return domainInfo, nil
 }
 
 func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	client, err := c.HcLiveV1Client(region)
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		domainType = d.Get("type").(string)
+		domainName = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
 	if err != nil {
-		return diag.Errorf("error creating Live v1 client: %s", err)
+		return diag.Errorf("error creating Live client: %s", err)
 	}
 
-	// associate the streaming domain name with an ingest domain Or delete association
-	if d.HasChange("ingest_domain_name") {
-		ingetstDomainNameOld, ingetstDomainName := d.GetChange("ingest_domain_name")
+	// Associate the streaming domain name with an ingest domain or delete association.
+	if d.HasChange("ingest_domain_name") && domainType == "pull" {
+		oldIngetstDomain, newIngetstDomain := d.GetChange("ingest_domain_name")
 
-		if ingetstDomainName == "" {
-			err = deleteAssociation(client, d.Get("name").(string), ingetstDomainNameOld.(string))
+		if newIngetstDomain == "" {
+			err = disassociateIngestDomain(client, domainName, oldIngetstDomain.(string))
 		} else {
-			err = associatingDomain(d, client)
+			err = associateIngestDomain(client, domainName, newIngetstDomain.(string))
 		}
+
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	// update the domain status
+	// Update the domain status.
 	if d.HasChange("status") {
-		err = updateStatus(ctx, d, client, c)
+		status := d.Get("status").(string)
+		err = updateDomainStatus(ctx, cfg, d, client, d.Timeout(schema.TimeoutUpdate), status)
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
+	// Enable or disable IPv6
 	if d.HasChange("is_ipv6") {
-		if err := updateIPv6Switch(client, d); err != nil {
+		if err := updateIPv6Switch(client, d, domainName); err != nil {
 			return diag.Errorf("error updating Live domain IPv6 switch in update operation: %s", err)
 		}
 	}
@@ -228,175 +279,174 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func resourceDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	client, err := c.HcLiveV1Client(region)
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/domain"
+	)
+
+	client, err := cfg.NewServiceClient("live", region)
 	if err != nil {
-		return diag.Errorf("error creating Live v1 client: %s", err)
+		return diag.Errorf("error creating Live client: %s", err)
 	}
 
-	// 1. off the domain
-	reqStatus := model.GetLiveDomainModifyReqStatusEnum().OFF
-	_, err = client.UpdateDomain(&model.UpdateDomainRequest{Body: &model.LiveDomainModifyReq{
-		Domain: d.Get("name").(string),
-		Status: &reqStatus,
-	}})
-	if err != nil {
-		return diag.Errorf("error disabling Live domain: %s", err)
-	}
-
-	err = waitingForDomainStatus(ctx, client, d.Id(), model.GetDecoupledLiveDomainInfoStatusEnum().OFF,
-		d.Timeout(schema.TimeoutDelete))
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	// 2. delete the domain
-	deleteOpts := &model.DeleteDomainRequest{
-		Domain: d.Get("name").(string),
-	}
-	_, err = client.DeleteDomain(deleteOpts)
-	if err != nil {
-		return diag.Errorf("error deleting Live domain: %s", err)
-	}
-
-	return nil
-}
-
-func associatingDomain(d *schema.ResourceData, client *livev1.LiveClient) error {
-	if v, ok := d.GetOk("ingest_domain_name"); ok {
-		domainType := d.Get("type").(string)
-		if domainType == "push" {
-			return fmt.Errorf("the ingest domain cannot associate with an ingest domain")
-		}
-
-		_, err := client.CreateDomainMapping(&model.CreateDomainMappingRequest{
-			Body: &model.DomainMapping{
-				PullDomain: d.Get("name").(string),
-				PushDomain: v.(string),
-			},
-		})
+	// Disable the domain.
+	// Only the status is `off`, the domain can be deleted.
+	status := d.Get("status").(string)
+	if status != "off" {
+		err = updateDomainStatus(ctx, cfg, d, client, d.Timeout(schema.TimeoutDelete), "off")
 		if err != nil {
-			return fmt.Errorf("error associating the streaming domain name with an ingest domain: %s", err)
+			return diag.FromErr(err)
 		}
 	}
 
-	return nil
-}
+	// Call the deletion API, deleting the domain.
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = fmt.Sprintf("%s?domain=%s", deletePath, d.Id())
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
 
-func deleteAssociation(client *livev1.LiveClient, pullDomain, pushDomain string) error {
-	_, err := client.DeleteDomainMapping(&model.DeleteDomainMappingRequest{
-		PullDomain: pullDomain,
-		PushDomain: pushDomain,
-	})
+	_, err = client.Request("DELETE", deletePath, &deleteOpts)
 	if err != nil {
-		return fmt.Errorf("error deleting the association between the streaming domain and ingest domain: %s", err)
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", "LIVE.103011019"),
+			"error deleting Live domain")
 	}
 
 	return nil
 }
 
-func buildDomainTypeParams(d *schema.ResourceData) model.LiveDomainCreateReqDomainType {
-	if d.Get("type").(string) == "pull" {
-		return model.GetLiveDomainCreateReqDomainTypeEnum().PULL
+func associateIngestDomain(client *golangsdk.ServiceClient, pullDomain, pushDomain string) error {
+	httpUrl := "v1/{project_id}/domains_mapping"
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildAssociateDomainBodyParams(pullDomain, pushDomain)),
 	}
-	return model.GetLiveDomainCreateReqDomainTypeEnum().PUSH
-}
 
-func buildServiceAreaParams(d *schema.ResourceData) *model.LiveDomainCreateReqServiceArea {
-	if v, ok := d.GetOk("service_area"); ok {
-		var serviceArea model.LiveDomainCreateReqServiceArea
-		err := serviceArea.UnmarshalJSON([]byte(v.(string)))
-		if err != nil {
-			log.Printf("error getting the argument service_area: %s", err)
-			return nil
-		}
-		return &serviceArea
+	_, err := client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return fmt.Errorf("error associating the ingest domain for the streaming domain: %s", err)
 	}
+
 	return nil
 }
 
-func buildCreateParams(d *schema.ResourceData, region string, cfg *config.Config) (*model.CreateDomainRequest, error) {
-	req := model.CreateDomainRequest{
-		Body: &model.LiveDomainCreateReq{
-			Domain:              d.Get("name").(string),
-			DomainType:          buildDomainTypeParams(d),
-			Region:              region,
-			ServiceArea:         buildServiceAreaParams(d),
-			EnterpriseProjectId: utils.StringIgnoreEmpty(cfg.GetEnterpriseProjectID(d)),
-		},
+func buildAssociateDomainBodyParams(pullDomain, pushDomain string) map[string]interface{} {
+	params := map[string]interface{}{
+		"pull_domain": pullDomain,
+		"push_domain": pushDomain,
 	}
-	return &req, nil
+
+	return params
 }
 
-func waitingForDomainStatus(ctx context.Context, client *livev1.LiveClient, name string,
-	status model.DecoupledLiveDomainInfoStatus, timeout time.Duration) error {
+func disassociateIngestDomain(client *golangsdk.ServiceClient, pullDomain, pushDomain string) error {
+	httpUrl := "v1/{project_id}/domains_mapping"
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = fmt.Sprintf("%s?pull_domain=%s&push_domain=%s", requestPath, pullDomain, pushDomain)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err := client.Request("DELETE", requestPath, &requestOpts)
+	if err != nil {
+		return fmt.Errorf("error disassociating the ingest domain from the streaming domain: %s", err)
+	}
+
+	return nil
+}
+
+func updateDomainStatus(ctx context.Context, cfg *config.Config, d *schema.ResourceData, client *golangsdk.ServiceClient,
+	t time.Duration, status string) error {
+	httpUrl := "v1/{project_id}/domain"
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildUpdateaDomainStatusBodyParams(cfg, d, status)),
+	}
+
+	_, err := client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return fmt.Errorf("error updating the Live domain status: %s", err)
+	}
+
+	err = waitingForDomainStateCompleted(ctx, client, t, d.Id(), status)
+	if err != nil {
+		return fmt.Errorf("error waiting for the Live domain status update to complete: %s", err)
+	}
+
+	return nil
+}
+
+func buildUpdateaDomainStatusBodyParams(cfg *config.Config, d *schema.ResourceData,
+	status string) map[string]interface{} {
+	params := map[string]interface{}{
+		"domain":                d.Get("name"),
+		"status":                status,
+		"enterprise_project_id": utils.ValueIgnoreEmpty(cfg.GetEnterpriseProjectID(d)),
+	}
+
+	return params
+}
+
+func updateIPv6Switch(client *golangsdk.ServiceClient, d *schema.ResourceData, domainName string) error {
+	httpUrl := "v1/{project_id}/domain/ipv6-switch"
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildUpdateIPv6SwitchBodyParams(d, domainName)),
+	}
+
+	_, err := client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return fmt.Errorf("error enabling or disabling the IPv6: %s", err)
+	}
+
+	return nil
+}
+
+func buildUpdateIPv6SwitchBodyParams(d *schema.ResourceData, domainName string) map[string]interface{} {
+	params := map[string]interface{}{
+		"domain":  domainName,
+		"is_ipv6": utils.ValueIgnoreEmpty(d.Get("is_ipv6")),
+	}
+
+	return params
+}
+
+func waitingForDomainStateCompleted(ctx context.Context, client *golangsdk.ServiceClient, t time.Duration, domainName, status string) error {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"Pending"},
-		Target:  []string{"Done"},
-		Refresh: func() (interface{}, string, error) {
-			resp, err := client.ShowDomain(&model.ShowDomainRequest{Domain: &name})
-			if err != nil {
-				return nil, "failed", err
-			}
-
-			if resp.DomainInfo == nil || len(*resp.DomainInfo) != 1 {
-				return nil, "failed", fmt.Errorf("error retrieving Live domain")
-			}
-			r := *resp.DomainInfo
-			detail := r[0]
-
-			if detail.Status == status {
-				return resp, "Done", nil
-			}
-			return resp, "Pending", nil
-		},
-		Timeout:      timeout,
-		PollInterval: 5 * time.Second,
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      waitDomainStatusRefreshFunc(client, domainName, status),
+		Timeout:      t,
 		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
+
 	_, err := stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return fmt.Errorf("error waiting for Live domain (%s) status to become %v: %s", name, status, err)
-	}
-	return nil
-}
-
-func updateStatus(ctx context.Context, d *schema.ResourceData, client *livev1.LiveClient, cfg *config.Config) error {
-	var reqStatus model.LiveDomainModifyReqStatus
-	var respStatus model.DecoupledLiveDomainInfoStatus
-
-	if d.Get("status").(string) == "off" {
-		reqStatus = model.GetLiveDomainModifyReqStatusEnum().OFF
-		respStatus = model.GetDecoupledLiveDomainInfoStatusEnum().OFF
-	} else {
-		reqStatus = model.GetLiveDomainModifyReqStatusEnum().ON
-		respStatus = model.GetDecoupledLiveDomainInfoStatusEnum().ON
-	}
-
-	_, err := client.UpdateDomain(&model.UpdateDomainRequest{
-		Body: &model.LiveDomainModifyReq{
-			Domain:              d.Get("name").(string),
-			Status:              &reqStatus,
-			EnterpriseProjectId: utils.StringIgnoreEmpty(cfg.GetEnterpriseProjectID(d)),
-		},
-	})
-
-	if err != nil {
-		return fmt.Errorf("error updating Live domain: %s", err)
-	}
-
-	return waitingForDomainStatus(ctx, client, d.Id(), respStatus, d.Timeout(schema.TimeoutUpdate))
-}
-
-func updateIPv6Switch(client *livev1.LiveClient, d *schema.ResourceData) error {
-	switchRequest := model.UpdateDomainIp6SwitchRequest{
-		Body: &model.DomainIpv6SwitchReq{
-			Domain: d.Get("name").(string),
-			IsIpv6: utils.Bool(d.Get("is_ipv6").(bool)),
-		},
-	}
-
-	_, err := client.UpdateDomainIp6Switch(&switchRequest)
 	return err
+}
+
+func waitDomainStatusRefreshFunc(client *golangsdk.ServiceClient, domainName, status string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := GetDomain(client, domainName)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		domainStatus := utils.PathSearch("status", respBody, "").(string)
+
+		if domainStatus == status {
+			return respBody, "COMPLETED", nil
+		}
+
+		return respBody, "PENDING", nil
+	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactor the Live domain resource code style

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/live" TESTARGS="-run TestAccResourceDomain_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/live -v -run TestAccResourceDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDomain_basic
--- PASS: TestAccResourceDomain_basic (347.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      347.308s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/live" TESTARGS="-run TestAccResourceDomain_streamDomain"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/live -v -run TestAccResourceDomain_streamDomain -timeout 360m -parallel 4
=== RUN   TestAccResourceDomain_streamDomain
--- PASS: TestAccResourceDomain_streamDomain (580.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      580.257s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/80dcb268-0704-4381-b51e-2f7da3186ef6)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/18c659a8-583b-4373-9ce5-f7010ed8214a)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
