### PR TITLE
fix(rms): fix the failing test cases in RMS

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -111,10 +111,11 @@ var (
 	HW_RAM_SHARE_INVITATION_ID       = os.Getenv("HW_RAM_SHARE_INVITATION_ID")
 	HW_RAM_SHARE_ID                  = os.Getenv("HW_RAM_SHARE_ID")
 
-	HW_RMS_TARGET_ID_FOR_FGS  = os.Getenv("HW_RMS_TARGET_ID_FOR_FGS")
-	HW_RMS_TARGET_ID_FOR_RFS  = os.Getenv("HW_RMS_TARGET_ID_FOR_RFS")
-	HW_RMS_EXCLUDED_ACCOUNT_1 = os.Getenv("HW_RMS_EXCLUDED_ACCOUNT_1")
-	HW_RMS_EXCLUDED_ACCOUNT_2 = os.Getenv("HW_RMS_EXCLUDED_ACCOUNT_2")
+	HW_RMS_TARGET_ID_FOR_FGS        = os.Getenv("HW_RMS_TARGET_ID_FOR_FGS")
+	HW_RMS_TARGET_ID_FOR_RFS        = os.Getenv("HW_RMS_TARGET_ID_FOR_RFS")
+	HW_RMS_EXCLUDED_ACCOUNT_1       = os.Getenv("HW_RMS_EXCLUDED_ACCOUNT_1")
+	HW_RMS_EXCLUDED_ACCOUNT_2       = os.Getenv("HW_RMS_EXCLUDED_ACCOUNT_2")
+	HW_RMS_RESOURCE_RECORDER_CLOSED = os.Getenv("HW_RMS_RESOURCE_RECORDER_CLOSED")
 
 	HW_CDN_DOMAIN_NAME = os.Getenv("HW_CDN_DOMAIN_NAME")
 	// `HW_CDN_CERT_DOMAIN_NAME` Configure the domain name environment variable of the certificate type.
@@ -1152,6 +1153,13 @@ func TestAccPreCheckRMSTargetIDForRFS(t *testing.T) {
 func TestAccPreCheckRMSExcludedAccounts(t *testing.T) {
 	if HW_RMS_EXCLUDED_ACCOUNT_1 == "" || HW_RMS_EXCLUDED_ACCOUNT_2 == "" {
 		t.Skip("HW_RMS_EXCLUDED_ACCOUNT_1 and HW_RMS_EXCLUDED_ACCOUNT_2 must be set for the acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckRMSResourceRecorder(t *testing.T) {
+	if HW_RMS_RESOURCE_RECORDER_CLOSED == "" {
+		t.Skip("HW_RMS_RESOURCE_RECORDER_CLOSED must be set for the acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/rms/data_source_huaweicloud_rms_organizational_assignment_packages_test.go
+++ b/huaweicloud/services/acceptance/rms/data_source_huaweicloud_rms_organizational_assignment_packages_test.go
@@ -21,6 +21,7 @@ func TestAccDataSourceRmsOrganizationalAssignmentPackages_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOrganizationsOpen(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/rms/data_source_huaweicloud_rms_resource_aggregator_advanced_query_test.go
+++ b/huaweicloud/services/acceptance/rms/data_source_huaweicloud_rms_resource_aggregator_advanced_query_test.go
@@ -20,12 +20,6 @@ func TestAccDataSourceAggregatorAdvancedQuery_basic(t *testing.T) {
 			acceptance.TestAccPrecheckDomainId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"null": {
-				Source:            "hashicorp/null",
-				VersionConstraint: "3.2.1",
-			},
-		},
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceAggregatorAdvancedQuery_basic(rName),
@@ -46,15 +40,11 @@ resource "huaweicloud_rms_resource_aggregator" "test" {
   name        = "%[1]s"
   type        = "ACCOUNT"
   account_ids = ["%[2]s"]
-}
 
-# wait 30 seconds to let the policies evaluate
-resource "null_resource" "test" {
+  # wait 30 seconds to let the policies evaluate
   provisioner "local-exec" {
     command = "sleep 30"
   }
-
-  depends_on = [ huaweicloud_rms_resource_aggregator.test ]
 }
 `, name, acceptance.HW_DOMAIN_ID)
 }
@@ -66,8 +56,6 @@ func testDataSourceAggregatorAdvancedQuery_basic(name string) string {
 data "huaweicloud_rms_resource_aggregator_advanced_query" "test" {
   aggregator_id = huaweicloud_rms_resource_aggregator.test.id
   expression    = "select name, id from aggregator_resources where provider = 'ecs' and type = 'cloudservers'"
-
-  depends_on = [ null_resource.test ]
 }
 
 locals {

--- a/huaweicloud/services/acceptance/rms/data_source_huaweicloud_rms_resource_aggregator_discovered_resources_test.go
+++ b/huaweicloud/services/acceptance/rms/data_source_huaweicloud_rms_resource_aggregator_discovered_resources_test.go
@@ -26,12 +26,6 @@ func TestAccDataSourceAggregatorDiscoveredResources_basic(t *testing.T) {
 			acceptance.TestAccPrecheckDomainId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"null": {
-				Source:            "hashicorp/null",
-				VersionConstraint: "3.2.1",
-			},
-		},
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceAggregatorDiscoveredResources_basic(rName),
@@ -63,15 +57,11 @@ resource "huaweicloud_rms_resource_aggregator" "test" {
   account_ids = ["%[2]s"]
 
   depends_on = [huaweicloud_vpc.test]
-}
 
-# wait 30 seconds to let the aggregator discover resources
-resource "null_resource" "test" {
+  # wait 30 seconds to let the aggregator discover resources
   provisioner "local-exec" {
     command = "sleep 30"
   }
-
-  depends_on = [ huaweicloud_rms_resource_aggregator.test ]
 }
 `, name, acceptance.HW_DOMAIN_ID)
 }
@@ -82,22 +72,16 @@ func testDataSourceAggregatorDiscoveredResources_basic(name string) string {
 
 data "huaweicloud_rms_resource_aggregator_discovered_resources" "basic" {
   aggregator_id = huaweicloud_rms_resource_aggregator.test.id
-
-  depends_on = [ null_resource.test ]
 }
 
 data "huaweicloud_rms_resource_aggregator_discovered_resources" "filter_by_service_type" {
   aggregator_id = huaweicloud_rms_resource_aggregator.test.id
   service_type  = "vpc"
-
-  depends_on = [ null_resource.test ]
 }
 
 data "huaweicloud_rms_resource_aggregator_discovered_resources" "filter_by_resource_type" {
   aggregator_id = huaweicloud_rms_resource_aggregator.test.id
   resource_type = "vpcs"
-
-  depends_on = [ null_resource.test ]
 }
 
 data "huaweicloud_rms_resource_aggregator_discovered_resources" "filter_by_resource_id" {
@@ -106,8 +90,6 @@ data "huaweicloud_rms_resource_aggregator_discovered_resources" "filter_by_resou
   filter {
     resource_id = huaweicloud_vpc.test.id
   }
-
-  depends_on = [ null_resource.test ]
 }
 
 locals {

--- a/huaweicloud/services/acceptance/rms/data_source_huaweicloud_rms_resource_aggregator_policy_assignments_test.go
+++ b/huaweicloud/services/acceptance/rms/data_source_huaweicloud_rms_resource_aggregator_policy_assignments_test.go
@@ -24,12 +24,6 @@ func TestAccDataSourceAggregatorPolicyAssignments_basic(t *testing.T) {
 			acceptance.TestAccPrecheckDomainId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"null": {
-				Source:            "hashicorp/null",
-				VersionConstraint: "3.2.1",
-			},
-		},
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceAggregatorPolicyAssignments_basic(rName),
@@ -52,15 +46,11 @@ resource "huaweicloud_rms_resource_aggregator" "test" {
   name        = "%[1]s"
   type        = "ACCOUNT"
   account_ids = ["%[2]s"]
-}
 
-# wait 30 seconds to let the policies evaluate
-resource "null_resource" "test" {
+  # wait 30 seconds to let the policies evaluate
   provisioner "local-exec" {
     command = "sleep 30"
   }
-
-  depends_on = [ huaweicloud_rms_resource_aggregator.test ]
 }
 `, name, acceptance.HW_DOMAIN_ID)
 }
@@ -71,8 +61,6 @@ func testDataSourceAggregatorPolicyAssignments_basic(name string) string {
 
 data "huaweicloud_rms_resource_aggregator_policy_assignments" "basic" {
   aggregator_id = huaweicloud_rms_resource_aggregator.test.id
-
-  depends_on = [ null_resource.test ]
 }
 
 data "huaweicloud_rms_resource_aggregator_policy_assignments" "filter_by_compliance_state" {
@@ -81,8 +69,6 @@ data "huaweicloud_rms_resource_aggregator_policy_assignments" "filter_by_complia
   filter {
     compliance_state = "Compliant"
   }
-
-  depends_on = [ null_resource.test ]
 }
 
 data "huaweicloud_rms_resource_aggregator_policy_assignments" "filter_by_policy_assignment_name" {
@@ -91,8 +77,6 @@ data "huaweicloud_rms_resource_aggregator_policy_assignments" "filter_by_policy_
   filter {
     policy_assignment_name = "iam-password-policy"
   }
-
-  depends_on = [ null_resource.test ]
 }
 
 locals {

--- a/huaweicloud/services/acceptance/rms/data_source_huaweicloud_rms_resource_aggregator_policy_states_test.go
+++ b/huaweicloud/services/acceptance/rms/data_source_huaweicloud_rms_resource_aggregator_policy_states_test.go
@@ -27,12 +27,6 @@ func TestAccDataSourceAggregatorPolicyStates_basic(t *testing.T) {
 			acceptance.TestAccPrecheckDomainId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"null": {
-				Source:            "hashicorp/null",
-				VersionConstraint: "3.2.1",
-			},
-		},
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceAggregatorPolicyStates_basic(rName, password),
@@ -66,15 +60,11 @@ resource "huaweicloud_rms_resource_aggregator" "test" {
   account_ids = ["%[3]s"]
 
   depends_on = [huaweicloud_identity_user.test]
-}
 
-# wait 30 seconds to let the policies evaluate
-resource "null_resource" "test" {
+  # wait 40 seconds to let the policies evaluate
   provisioner "local-exec" {
-    command = "sleep 30"
+    command = "sleep 40"
   }
-
-  depends_on = [ huaweicloud_rms_resource_aggregator.test ]
 }
 `, name, password, acceptance.HW_DOMAIN_ID)
 }
@@ -85,29 +75,21 @@ func testDataSourceAggregatorPolicyStates_basic(name, password string) string {
 
 data "huaweicloud_rms_resource_aggregator_policy_states" "basic" {
   aggregator_id = huaweicloud_rms_resource_aggregator.test.id
-
-  depends_on = [ null_resource.test ]
 }
 
 data "huaweicloud_rms_resource_aggregator_policy_states" "filter_by_compliance_state" {
   aggregator_id     = huaweicloud_rms_resource_aggregator.test.id
   compliance_state  = "Compliant"
-
-  depends_on = [ null_resource.test ]
 }
 
 data "huaweicloud_rms_resource_aggregator_policy_states" "filter_by_policy_assignment_name" {
   aggregator_id          = huaweicloud_rms_resource_aggregator.test.id
   policy_assignment_name = "iam-password-policy"
-
-  depends_on = [ null_resource.test ]
 }
 
 data "huaweicloud_rms_resource_aggregator_policy_states" "filter_by_resource_id" {
   aggregator_id = huaweicloud_rms_resource_aggregator.test.id
   resource_id   = huaweicloud_identity_user.test.id
-
-  depends_on = [ null_resource.test ]
 }
 
 locals {

--- a/huaweicloud/services/acceptance/rms/resource_huaweicloud_rms_resource_recorder_test.go
+++ b/huaweicloud/services/acceptance/rms/resource_huaweicloud_rms_resource_recorder_test.go
@@ -55,7 +55,12 @@ func TestAccRecorder_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Some test cases in RMS require the resource recorder to be enabled.
+			// Skip this test case during batch execution to ensure other test cases execute smoothly.
+			acceptance.TestAccPreCheckRMSResourceRecorder(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
@@ -65,7 +70,7 @@ func TestAccRecorder_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "agency_name", "rms_tracker_agency"),
 					resource.TestCheckResourceAttr(rName, "selector.0.all_supported", "false"),
-					resource.TestCheckResourceAttr(rName, "selector.0.resource_types.#", "5"),
+					resource.TestCheckResourceAttr(rName, "selector.0.resource_types.#", "8"),
 					resource.TestCheckResourceAttrSet(rName, "obs_channel.0.region"),
 					resource.TestCheckResourceAttrPair(rName, "obs_channel.0.bucket",
 						"huaweicloud_obs_bucket.test", "bucket"),
@@ -144,7 +149,11 @@ resource "huaweicloud_rms_resource_recorder" "test" {
 
   selector {
     all_supported  = false
-    resource_types = ["vpc.vpcs", "rds.instances", "dms.kafkas", "dms.rabbitmqs", "dms.queues"]
+
+    resource_types = [
+      "vpc.vpcs", "rds.instances", "dms.kafkas", "dms.rabbitmqs", "dms.queues",
+      "config.trackers", "config.policyAssignments", "config.conformancePacks",
+    ]
   }
 
   obs_channel {

--- a/huaweicloud/services/rms/data_source_huaweicloud_rms_assignment_packages.go
+++ b/huaweicloud/services/rms/data_source_huaweicloud_rms_assignment_packages.go
@@ -197,7 +197,7 @@ func (w *AssignmentPackagesDSWrapper) listConformancePacksToSchema(body *gjson.R
 						func(varStr gjson.Result) any {
 							return map[string]any{
 								"var_key":   varStr.Get("var_key").Value(),
-								"var_value": varStr.Get("var_value").Value(),
+								"var_value": utils.JsonToString(varStr.Get("var_value").Value()),
 							}
 						},
 					),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix the failing test cases in RMS
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Data Source Organizational Assignment Packages: add a prechecker to skip the test case if there are no organizations permissions
2. Data Source Aggregator Advanced Query: remove external providers to avoid network instability issues
3. Data Source Aggregator Discovered Resources: remove external providers to avoid network instability issues
4. Data Source Aggregator Policy Assignments: remove external providers to avoid network instability issues
5. Data Source Aggregator Policy States: remove external providers to avoid network instability issues
6. Resource Recorder: add a prechecker to skip the test case 
7. Data Source Assignment Packages: convert var_value to JSON format
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 make testacc TEST="./huaweicloud/services/acceptance/rms" TESTARGS="-run TestAccDataSourceRmsOrganizationalAssignmentPackages_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run TestAccDataSourceRmsOrganizationalAssignmentPackages_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRmsOrganizationalAssignmentPackages_basic
=== PAUSE TestAccDataSourceRmsOrganizationalAssignmentPackages_basic
=== CONT  TestAccDataSourceRmsOrganizationalAssignmentPackages_basic
    acceptance.go:617: HW_ORGANIZATIONS_OPEN must be set for the acceptance test
--- SKIP: TestAccDataSourceRmsOrganizationalAssignmentPackages_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       0.055s

make testacc TEST="./huaweicloud/services/acceptance/rms" TESTARGS="-run TestAccDataSourceAggregatorAdvancedQuery_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run TestAccDataSourceAggregatorAdvancedQuery_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAggregatorAdvancedQuery_basic
=== PAUSE TestAccDataSourceAggregatorAdvancedQuery_basic
=== CONT  TestAccDataSourceAggregatorAdvancedQuery_basic
--- PASS: TestAccDataSourceAggregatorAdvancedQuery_basic (111.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       111.213s


 make testacc TEST="./huaweicloud/services/acceptance/rms" TESTARGS="-run TestAccDataSourceAggregatorDiscoveredResources_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run TestAccDataSourceAggregatorDiscoveredResources_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAggregatorDiscoveredResources_basic
=== PAUSE TestAccDataSourceAggregatorDiscoveredResources_basic
=== CONT  TestAccDataSourceAggregatorDiscoveredResources_basic
--- PASS: TestAccDataSourceAggregatorDiscoveredResources_basic (123.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       123.288s

make testacc TEST="./huaweicloud/services/acceptance/rms" TESTARGS="-run TestAccDataSourceAggregatorPolicyAssignments_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run TestAccDataSourceAggregatorPolicyAssignments_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAggregatorPolicyAssignments_basic
=== PAUSE TestAccDataSourceAggregatorPolicyAssignments_basic
=== CONT  TestAccDataSourceAggregatorPolicyAssignments_basic
--- PASS: TestAccDataSourceAggregatorPolicyAssignments_basic (87.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       87.550s

 make testacc TEST="./huaweicloud/services/acceptance/rms" TESTARGS="-run TestAccDataSourceAggregatorPolicyStates_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run TestAccDataSourceAggregatorPolicyStates_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAggregatorPolicyStates_basic
=== PAUSE TestAccDataSourceAggregatorPolicyStates_basic
=== CONT  TestAccDataSourceAggregatorPolicyStates_basic
--- PASS: TestAccDataSourceAggregatorPolicyStates_basic (110.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       110.799s

make testacc TEST="./huaweicloud/services/acceptance/rms" TESTARGS="-run TestAccRecorder_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run TestAccRecorder_basic -timeout 360m -parallel 4
=== RUN   TestAccRecorder_basic
=== PAUSE TestAccRecorder_basic
=== CONT  TestAccRecorder_basic
--- PASS: TestAccRecorder_basic (117.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       117.143s


 make testacc TEST="./huaweicloud/services/acceptance/rms" TESTARGS="-run TestAccDataSourceRmsAssignmentPackages_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run TestAccDataSourceRmsAssignmentPackages_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRmsAssignmentPackages_basic
=== PAUSE TestAccDataSourceRmsAssignmentPackages_basic
=== CONT  TestAccDataSourceRmsAssignmentPackages_basic
--- PASS: TestAccDataSourceRmsAssignmentPackages_basic (100.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       100.108s


```

* [] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
