### PR TITLE
refactor(DEW): refactor KPS keypair resource by automatically generate styles

### DIFF
--- a/docs/resources/kps_keypair.md
+++ b/docs/resources/kps_keypair.md
@@ -2,14 +2,15 @@
 subcategory: "Data Encryption Workshop (DEW)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_kps_keypair"
-description: ""
+description: |-
+  Manages a keypair resource within HuaweiCloud.
 ---
 
 # huaweicloud_kps_keypair
 
 Manages a keypair resource within HuaweiCloud.
 
-By default, key pairs use the SSH-2 (RSA, 2048) algorithm for encryption and decryption.
+By default, keypair use the SSH-2 (RSA, 2048) algorithm for encryption and decryption.
 
 Keys imported support the following cryptographic algorithms:
 
@@ -19,54 +20,50 @@ Keys imported support the following cryptographic algorithms:
 
 ## Example Usage
 
-### Create a new keypair and export private key to current folder
+### Create a new KPS keypair
 
 ```hcl
-resource "huaweicloud_kps_keypair" "test-keypair" {
-  name     = "my-keypair"
-  key_file = "private_key.pem"
-}
-```
+variable "kms_key_id" {}
+variable "kms_key_name" {}
+variable "key_file" {}
 
-### Create a new keypair which scope is Tenant-level and the private key is managed by HuaweiCloud
-
-```hcl
-resource "huaweicloud_kms_key" "test" {
-  key_alias = "kms_test"
-}
-
-resource "huaweicloud_kps_keypair" "test-keypair" {
-  name            = "my-keypair"
-  scope           = "account"
+resource "huaweicloud_kps_keypair" "test" {
+  name            = "test-name"
+  scope           = "user"
   encryption_type = "kms"
-  kms_key_name    = huaweicloud_kms_key.test.key_alias
+  kms_key_id      = var.kms_key_id
+  kms_key_name    = var.kms_key_name
+  description     = "test description"
+  key_file        = var.key_file
 }
 ```
 
-### Import an existing keypair
+### Import an existing KPS keypair
 
 ```hcl
 variable "public_key" {}
-variable "kms_key_name" {}
 variable "private_key" {}
 
-resource "huaweicloud_kps_keypair" "test-keypair" {
-  name            = "my-keypair"
+resource "huaweicloud_kps_keypair" "test" {
+  name            = "test-name"
+  scope           = "account"
+  encryption_type = "default"
+  description     = "test description"
   public_key      = var.public_key
-  encryption_type = "kms"
-  kms_key_name    = var.kms_key_name
   private_key     = var.private_key
 }
 ```
 
-### Import a keypair without a platform-managed private key
+### Import an existing KPS keypair without private key
 
 ```hcl
 variable "public_key" {}
 
-resource "huaweicloud_kps_keypair" "test-keypair" {
-  name       = "my-keypair"
-  public_key = var.public_key
+resource "huaweicloud_kps_keypair" "test" {
+  name        = "test-name"
+  scope       = "account"
+  description = "test description"
+  public_key  = var.public_key
 }
 ```
 
@@ -81,36 +78,46 @@ The following arguments are supported:
   characters, including letters, digits, underscores (_) and hyphens (-).
   Changing this parameter will create a new resource.
 
-* `scope` - (Optional, String, ForceNew) Specifies the scope of key pair. The options are as follows:
-  - **account**: Tenant-level, available to all users under the same account.
-  - **user**: User-level, only available to that user.
-  The default value is `user`.
-  Changing this parameter will create a new resource.
+* `scope` - (Optional, String, ForceNew) Specifies the scope of keypair. The options are as follows:
+  + **account**: Tenant-level, available to all users under the same account.
+  + **user**: User-level, only available to user.
+
+  Defaults to `user`. Changing this parameter will create a new resource.
 
 * `user_id` - (Optional, String) Specifies the user ID to which the keypair belongs.
 
-  -> If the `scope` set to **user**, this parameter value must be the ID of the user who creates the resource.
+  -> 1. If the `scope` set to **user**, this parameter value must be the ID of the user who creates the resource.
+  <br/>2. Due to API restrictions, `private_key` and `encryption_type` must be configured when editing this field.
 
-* `encryption_type` - (Optional, String) Specifies encryption mode if manages the private key by HuaweiCloud.
-  The options are as follows:
-  - **default**: The default encryption mode. Applicable to sites where KMS is not deployed.
-  - **kms**: KMS encryption mode.
+* `encryption_type` - (Optional, String) Specifies encryption mode. The options are as follows:
+  + **default**: The default encryption mode. Applicable to sites where KMS is not deployed.
+  + **kms**: KMS encryption mode.
+
+  -> 1. Please configure this field to **default** if the KMS service is not available at the site.
+  <br/>2. Due to API restrictions, `private_key` must be configured when editing this field.
 
 * `kms_key_id` - (Optional, String) Specifies the KMS key ID to encrypt private keys.
 
 * `kms_key_name` - (Optional, String) Specifies the KMS key name to encrypt private keys.
 
--> When the `encryption_type` set to **kms**, exactly one of `kms_key_id` or `kms_key_name` must be set.
+-> 1. At least one of `kms_key_id` or `kms_key_name` must be set when `encryption_type` is set to **kms**.
+  <br/>2. Due to API restrictions, `private_key` and `encryption_type` must be configured when editing `kms_key_id` or
+  `kms_key_name`.
 
-* `description` - (Optional, String) Specifies the description of key pair.
+* `description` - (Optional, String) Specifies the description of keypair.
 
 * `public_key` - (Optional, String, ForceNew) Specifies the imported OpenSSH-formatted public key.
   It is required when import keypair. Changing this parameter will create a new resource.
 
 * `private_key` - (Optional, String) Specifies the imported OpenSSH-formatted private key.
 
+  -> 1. Setting this field to empty during editing will clear the private key.
+  <br/>2. Due to API restrictions, `encryption_type` must be configured when configuring this field.
+
 * `key_file` - (Optional, String, ForceNew) Specifies the path of the created private key.
-  The private key file (**.pem**) is created only after the resource is created.
+  The private key file (**.pem**) is created only when creating a KPS keypair.
+  Importing an existing keypair will not obtain the private key information.
+
   Changing this parameter will create a new resource.
 
   ->**NOTE:** If the private key file already exists, it will be overwritten after a new keypair is created.
@@ -121,9 +128,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID which equals to name.
 
-* `created_at` - The key pair creation time.
+* `created_at` - The keypair creation time.
 
-* `fingerprint` - Fingerprint information about an key pair.
+* `fingerprint` - Fingerprint information about a keypair.
 
 * `is_managed` - Whether the private key is managed by HuaweiCloud.
 
@@ -137,17 +144,17 @@ This resource provides the following timeouts configuration options:
 
 ## Import
 
-Keypairs can be imported using the `name`, e.g.
+Keypair can be imported using the `name`, e.g.
 
 ```bash
-$ terraform import huaweicloud_kps_keypair.my-keypair test-keypair
+$ terraform import huaweicloud_kps_keypair.test <name>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `encryption_type`, `kms_key_id`,
-`kms_key_name` and `private_key`. It is generally recommended running `terraform plan` after importing a key pair.
-You can then decide if changes should be applied to the key pair, or the resource definition
-should be updated to align with the key pair. Also you can ignore changes as below.
+`kms_key_name`, `key_file` and `private_key`. It is generally recommended running `terraform plan` after importing a keypair.
+You can then decide if changes should be applied to the keypair, or the resource definition
+should be updated to align with the keypair. Also, you can ignore changes as below.
 
 ```hcl
 resource "huaweicloud_kps_keypair" "test" {
@@ -155,7 +162,7 @@ resource "huaweicloud_kps_keypair" "test" {
 
   lifecycle {
     ignore_changes = [
-      encryption_type, kms_key_id, kms_key_name, private_key
+      encryption_type, kms_key_id, kms_key_name, key_file, private_key
     ]
   }
 }

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -94,7 +94,8 @@ var (
 
 	HW_DBSS_INSATNCE_ID = os.Getenv("HW_DBSS_INSATNCE_ID")
 
-	HW_DEW_ENABLE_FLAG = os.Getenv("HW_DEW_ENABLE_FLAG")
+	HW_DEW_ENABLE_FLAG   = os.Getenv("HW_DEW_ENABLE_FLAG")
+	HW_KPS_KEY_FILE_PATH = os.Getenv("HW_KPS_KEY_FILE_PATH")
 
 	HW_DEST_REGION          = os.Getenv("HW_DEST_REGION")
 	HW_DEST_PROJECT_ID      = os.Getenv("HW_DEST_PROJECT_ID")
@@ -2825,6 +2826,13 @@ func TestAccPrecheckDewFlag(t *testing.T) {
 	// Query the task execution status(running or failed)
 	if HW_DEW_ENABLE_FLAG == "" {
 		t.Skip("HW_DEW_ENABLE_FLAG must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckKPSKeyFilePath(t *testing.T) {
+	if HW_KPS_KEY_FILE_PATH == "" {
+		t.Skip("HW_KPS_KEY_FILE_PATH must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_keypair_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_keypair_test.go
@@ -2,96 +2,55 @@ package dew
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	kps "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kps/v3/model"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-)
-
-const (
-	publicKeyValue = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCDXP+kuDyXeZxf3p58VY/WH8yjzMAmNHXXxQKdHsvEy" +
-		"3mU4Egb7ANhDHXHFue0aywhY0XSVULVW1O7qwEtHHcJYBnbt7pKPWrE0rzSpvpvGy9BqxRV44AsHK2VTsXoKGEbXsImwgFwt/q" +
-		"5FkAqHMzWB3HJr8tb2rPs7mKjTHs9d1lFxHGehPYgjiFtCGcEOwxJnchGRKgPPa8Tcqkdy3poJ9JrGi6IgXcKtnhS/rZQ+naEG" +
-		"VdnC3Qi1Onu0ZixApdbplNcHiw/YBovImSf3JTyCn4U32o+dSFmOuUMovTvysfqtgbouJWEqwG1bQhIzGijW93vDIjjHu/vk/aet7sD rsa-key-20240321"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 func getKpsKeypairResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcKmsV3Client(acceptance.HW_REGION_NAME)
-	if err != nil {
-		return nil, fmt.Errorf("error creating KMS v3 client: %s", err)
-	}
-
-	request := &kps.ListKeypairDetailRequest{
-		KeypairName: state.Primary.ID,
-	}
-
-	return client.ListKeypairDetail(request)
-}
-
-func TestAccKpsKeypair_basic(t *testing.T) {
-	var group kps.ListKeypairDetailResponse
-
-	rName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_kps_keypair.test"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&group,
-		getKpsKeypairResourceFunc,
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v3/{project_id}/keypairs/{keypair_name}"
+		product = "kms"
 	)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testKeypair_basic(rName, "created by acc test"),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "description", "created by acc test"),
-					resource.TestCheckResourceAttr(resourceName, "scope", "user"),
-					resource.TestCheckResourceAttr(resourceName, "is_managed", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "fingerprint"),
-				),
-			},
-			{
-				Config: testKeypair_basic(rName, ""),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "description", ""),
-					resource.TestCheckResourceAttr(resourceName, "scope", "user"),
-					resource.TestCheckResourceAttr(resourceName, "is_managed", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "fingerprint"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
+	client, err := conf.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating KMS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{keypair_name}", state.Primary.ID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
 }
 
-func TestAccKpsKeypair_domain(t *testing.T) {
-	var group kps.ListKeypairDetailResponse
+func TestAccKeypair_basic(t *testing.T) {
+	var obj interface{}
 
-	rName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_kps_keypair.test"
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_kps_keypair.test"
 
 	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&group,
+		rName,
+		&obj,
 		getKpsKeypairResourceFunc,
 	)
 
@@ -99,153 +58,370 @@ func TestAccKpsKeypair_domain(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckUserId(t)
+			// Please provide a file path to write the private key file, for example: /temp/XXX/temp.crt.
+			acceptance.TestAccPreCheckKPSKeyFilePath(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeypair_domain(rName),
+				Config: testAccKeypair_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "scope", "account"),
-					resource.TestCheckResourceAttr(resourceName, "encryption_type", "kms"),
-					resource.TestCheckResourceAttr(resourceName, "user_id", acceptance.HW_USER_ID),
-					resource.TestCheckResourceAttr(resourceName, "is_managed", "true"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "fingerprint"),
-					resource.TestCheckResourceAttrPair(resourceName, "kms_key_name",
-						"huaweicloud_kms_key.test", "key_alias"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "encryption_type", "kms"),
+					resource.TestCheckResourceAttr(rName, "key_file", acceptance.HW_KPS_KEY_FILE_PATH),
+					resource.TestCheckResourceAttr(rName, "user_id", acceptance.HW_USER_ID),
+					resource.TestCheckResourceAttr(rName, "scope", "user"),
+
+					resource.TestCheckResourceAttrPair(rName, "kms_key_id", "huaweicloud_kms_key.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "kms_key_name", "huaweicloud_kms_key.test", "key_alias"),
+
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "fingerprint"),
+					resource.TestCheckResourceAttrSet(rName, "is_managed"),
+					resource.TestCheckResourceAttrSet(rName, "public_key"),
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"encryption_type", "kms_key_name"},
-			},
-		},
-	})
-}
-
-func TestAccKpsKeypair_publicKey(t *testing.T) {
-	var group kps.ListKeypairDetailResponse
-
-	rName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_kps_keypair.test"
-	publicKey, _, _ := acctest.RandSSHKeyPair("Generated-by-AccTest")
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&group,
-		getKpsKeypairResourceFunc,
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testKeypair_publicKey(rName, publicKey),
+				Config: testAccKeypair_basic_update1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "scope", "user"),
-					resource.TestCheckResourceAttr(resourceName, "public_key", publicKey),
-					resource.TestCheckResourceAttr(resourceName, "is_managed", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "fingerprint"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "encryption_type", "default"),
+					resource.TestCheckResourceAttr(rName, "key_file", acceptance.HW_KPS_KEY_FILE_PATH),
+					resource.TestCheckResourceAttr(rName, "user_id", acceptance.HW_USER_ID),
+					resource.TestCheckResourceAttr(rName, "scope", "user"),
+					resource.TestCheckResourceAttr(rName, "kms_key_id", ""),
+					resource.TestCheckResourceAttr(rName, "kms_key_name", ""),
+
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "fingerprint"),
+					resource.TestCheckResourceAttrSet(rName, "is_managed"),
+					resource.TestCheckResourceAttrSet(rName, "public_key"),
+					resource.TestCheckResourceAttrSet(rName, "private_key"),
 				),
 			},
 			{
-				Config: testKeypair_basic(rName, "updated by acc test"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "scope", "user"),
-					resource.TestCheckResourceAttr(resourceName, "public_key", publicKey),
-					resource.TestCheckResourceAttr(resourceName, "is_managed", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "fingerprint"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccKpsKeypair_privateKey(t *testing.T) {
-	var group kps.ListKeypairDetailResponse
-
-	rName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_kps_keypair.test"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&group,
-		getKpsKeypairResourceFunc,
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testKeypair_privateKey(rName, publicKeyValue),
+				Config: testAccKeypair_basic_update2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "scope", "user"),
-					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", "huaweicloud_kms_key.test", "id"),
-					resource.TestCheckResourceAttr(resourceName, "public_key", publicKeyValue),
-					resource.TestCheckResourceAttr(resourceName, "is_managed", "true"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "fingerprint"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "encryption_type", "default"),
+					resource.TestCheckResourceAttr(rName, "key_file", acceptance.HW_KPS_KEY_FILE_PATH),
+					resource.TestCheckResourceAttr(rName, "user_id", acceptance.HW_USER_ID),
+					resource.TestCheckResourceAttr(rName, "scope", "user"),
+					resource.TestCheckResourceAttr(rName, "kms_key_id", ""),
+					resource.TestCheckResourceAttr(rName, "kms_key_name", ""),
+					resource.TestCheckResourceAttr(rName, "private_key", ""),
+
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "fingerprint"),
+					resource.TestCheckResourceAttrSet(rName, "is_managed"),
+					resource.TestCheckResourceAttrSet(rName, "public_key"),
 				),
 			},
 			{
-				Config: testKeypair_updatePrivateKey1(rName),
+				Config: testAccKeypair_basic_update3(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "public_key", publicKeyValue),
-					resource.TestCheckResourceAttr(resourceName, "is_managed", "false"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "encryption_type", "kms"),
+					resource.TestCheckResourceAttr(rName, "key_file", acceptance.HW_KPS_KEY_FILE_PATH),
+					resource.TestCheckResourceAttr(rName, "user_id", acceptance.HW_USER_ID),
+					resource.TestCheckResourceAttr(rName, "scope", "user"),
+
+					resource.TestCheckResourceAttrPair(rName, "kms_key_id", "huaweicloud_kms_key.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "kms_key_name", "huaweicloud_kms_key.test", "key_alias"),
+
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "fingerprint"),
+					resource.TestCheckResourceAttrSet(rName, "is_managed"),
+					resource.TestCheckResourceAttrSet(rName, "public_key"),
+					resource.TestCheckResourceAttrSet(rName, "private_key"),
 				),
 			},
 			{
-				Config: testKeypair_updatePrivateKey2(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttrPair(resourceName, "kms_key_name", "huaweicloud_kms_key.test", "key_alias"),
-					resource.TestCheckResourceAttr(resourceName, "public_key", publicKeyValue),
-					resource.TestCheckResourceAttr(resourceName, "is_managed", "true"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
+				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"private_key", "encryption_type", "kms_key_id", "kms_key_name",
+					"private_key",
+					"encryption_type",
+					"kms_key_id",
+					"kms_key_name",
+					"key_file",
 				},
 			},
 		},
 	})
 }
 
-func testKeypair_basic(rName, desc string) string {
+func testAccKeypair_base(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_kps_keypair" "test" {
-  name        = "%s"
-  description = "%s"
+resource "huaweicloud_kms_key" "test" {
+  key_alias    = "%[1]s"
+  pending_days = "7"
 }
-`, rName, desc)
+`, name)
+}
+
+func testAccKeypair_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_kps_keypair" "test" {
+  name            = "%[2]s"
+  scope           = "user"
+  user_id         = "%[3]s"
+  encryption_type = "kms"
+  kms_key_id      = huaweicloud_kms_key.test.id
+  kms_key_name    = huaweicloud_kms_key.test.key_alias
+  description     = "test description"
+  key_file        = "%[4]s"
+}
+`, testAccKeypair_base(name), name, acceptance.HW_USER_ID, acceptance.HW_KPS_KEY_FILE_PATH)
+}
+
+func testAccKeypair_basic_update1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_kps_keypair" "test" {
+  name            = "%[2]s"
+  scope           = "user"
+  user_id         = "%[3]s"
+  encryption_type = "default"
+  private_key     = file("%[4]s")
+  description     = "test description update"
+  key_file        = "%[4]s"
+}
+`, testAccKeypair_base(name), name, acceptance.HW_USER_ID, acceptance.HW_KPS_KEY_FILE_PATH)
+}
+
+func testAccKeypair_basic_update2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_kps_keypair" "test" {
+  name            = "%[2]s"
+  scope           = "user"
+  user_id         = "%[3]s"
+  encryption_type = "default"
+  description     = "test description update"
+  key_file        = "%[4]s"
+}
+`, testAccKeypair_base(name), name, acceptance.HW_USER_ID, acceptance.HW_KPS_KEY_FILE_PATH)
+}
+
+func testAccKeypair_basic_update3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_kps_keypair" "test" {
+  name            = "%[2]s"
+  scope           = "user"
+  user_id         = "%[3]s"
+  encryption_type = "kms"
+  private_key     = file("%[4]s")
+  kms_key_id      = huaweicloud_kms_key.test.id
+  kms_key_name    = huaweicloud_kms_key.test.key_alias
+  description     = "test description update"
+  key_file        = "%[4]s"
+}
+`, testAccKeypair_base(name), name, acceptance.HW_USER_ID, acceptance.HW_KPS_KEY_FILE_PATH)
+}
+
+func TestAccKeypair_existKeypair(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_kps_keypair.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getKpsKeypairResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please provide a file path to write the private key file, for example: /temp/XXX/temp.crt.
+			acceptance.TestAccPreCheckKPSKeyFilePath(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKeypair_import(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "scope", "account"),
+
+					resource.TestCheckResourceAttrPair(rName, "public_key", "huaweicloud_kps_keypair.test-base", "public_key"),
+
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "fingerprint"),
+					resource.TestCheckResourceAttrSet(rName, "is_managed"),
+					resource.TestCheckResourceAttrSet(rName, "user_id"),
+				),
+			},
+			{
+				Config: testAccKeypair_import_update1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "encryption_type", "kms"),
+					resource.TestCheckResourceAttr(rName, "scope", "account"),
+
+					resource.TestCheckResourceAttrPair(rName, "kms_key_id", "huaweicloud_kms_key.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "kms_key_name", "huaweicloud_kms_key.test", "key_alias"),
+					resource.TestCheckResourceAttrPair(rName, "public_key", "huaweicloud_kps_keypair.test-base", "public_key"),
+
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "fingerprint"),
+					resource.TestCheckResourceAttrSet(rName, "is_managed"),
+					resource.TestCheckResourceAttrSet(rName, "private_key"),
+					resource.TestCheckResourceAttrSet(rName, "user_id"),
+				),
+			},
+			{
+				Config: testAccKeypair_import_update2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "encryption_type", "default"),
+					resource.TestCheckResourceAttr(rName, "scope", "account"),
+					resource.TestCheckResourceAttr(rName, "kms_key_id", ""),
+					resource.TestCheckResourceAttr(rName, "kms_key_name", ""),
+
+					resource.TestCheckResourceAttrPair(rName, "public_key", "huaweicloud_kps_keypair.test-base", "public_key"),
+
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "fingerprint"),
+					resource.TestCheckResourceAttrSet(rName, "is_managed"),
+					resource.TestCheckResourceAttrSet(rName, "private_key"),
+					resource.TestCheckResourceAttrSet(rName, "user_id"),
+				),
+			},
+			{
+				Config: testAccKeypair_import_update3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "encryption_type", "default"),
+					resource.TestCheckResourceAttr(rName, "scope", "account"),
+					resource.TestCheckResourceAttr(rName, "kms_key_id", ""),
+					resource.TestCheckResourceAttr(rName, "kms_key_name", ""),
+					resource.TestCheckResourceAttr(rName, "private_key", ""),
+
+					resource.TestCheckResourceAttrPair(rName, "public_key", "huaweicloud_kps_keypair.test-base", "public_key"),
+
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "fingerprint"),
+					resource.TestCheckResourceAttrSet(rName, "is_managed"),
+					resource.TestCheckResourceAttrSet(rName, "user_id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"encryption_type",
+					"kms_key_id",
+					"kms_key_name",
+					"private_key",
+				},
+			},
+		},
+	})
+}
+
+func testAccKeypair_import_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kms_key" "test" {
+  key_alias    = "%[1]s"
+  pending_days = "7"
+}
+
+resource "huaweicloud_kps_keypair" "test-base" {
+  name            = "%[1]s-base"
+  scope           = "user"
+  encryption_type = "default"
+  description     = "test description"
+  key_file        = "%[2]s"
+}
+`, name, acceptance.HW_KPS_KEY_FILE_PATH)
+}
+
+func testAccKeypair_import(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_kps_keypair" "test" {
+  name        = "%[2]s"
+  scope       = "account"
+  description = "test description"
+  public_key  = huaweicloud_kps_keypair.test-base.public_key
+}
+`, testAccKeypair_import_base(name), name)
+}
+
+func testAccKeypair_import_update1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_kps_keypair" "test" {
+  name            = "%[2]s"
+  scope           = "account"
+  encryption_type = "kms"
+  kms_key_id      = huaweicloud_kms_key.test.id
+  kms_key_name    = huaweicloud_kms_key.test.key_alias
+  description     = "test description update"
+  private_key     = file("%[3]s")
+  public_key      = huaweicloud_kps_keypair.test-base.public_key
+}
+`, testAccKeypair_import_base(name), name, acceptance.HW_KPS_KEY_FILE_PATH)
+}
+
+func testAccKeypair_import_update2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_kps_keypair" "test" {
+  name            = "%[2]s"
+  scope           = "account"
+  encryption_type = "default"
+  description     = "test description update"
+  private_key     = file("%[3]s")
+  public_key      = huaweicloud_kps_keypair.test-base.public_key
+}
+`, testAccKeypair_import_base(name), name, acceptance.HW_KPS_KEY_FILE_PATH)
+}
+
+func testAccKeypair_import_update3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_kps_keypair" "test" {
+  name            = "%[2]s"
+  scope           = "account"
+  encryption_type = "default"
+  description     = "test description update"
+  public_key      = huaweicloud_kps_keypair.test-base.public_key
+}
+`, testAccKeypair_import_base(name), name)
 }
 
 func testKeypair_publicKey(rName, key string) string {
@@ -255,124 +431,4 @@ resource "huaweicloud_kps_keypair" "test" {
   public_key = "%s"
 }
 `, rName, key)
-}
-
-func testKeypair_privateKey_base(name string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_kms_key" "test" {
-  key_alias    = "%s"
-  pending_days = "7"
-}
-`, name)
-}
-
-func testKeypair_privateKey(rName, publicKeyValue string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_kps_keypair" "test" {
-  name            = "%[2]s"
-  encryption_type = "kms"
-  kms_key_id      = huaweicloud_kms_key.test.id
-  public_key      = "%[3]s"
-
-  private_key = <<EOT
------BEGIN RSA PRIVATE KEY-----
-MIIEogIBAAKCAQEAg1z/pLg8l3mcX96efFWP1h/Mo8zAJjR118UCnR7LxMt5lOBI
-G+wDYQx1xxbntGssIWNF0lVC1VtTu6sBLRx3CWAZ27e6Sj1qxNK80qb6bxsvQasU
-VeOALBytlU7F6ChhG17CJsIBcLf6uRZAKhzM1gdxya/LW9qz7O5io0x7PXdZRcRx
-noT2II4hbQhnBDsMSZ3IRkSoDz2vE3KpHct6aCfSaxouiIF3CrZ4Uv62UPp2hBlX
-Zwt0ItTp7tGYsQKXW6ZTXB4sP2AaLyJkn9yU8gp+FN9qPnUhZjrlDKL078rH6rYG
-6LiVhKsBtW0ISMxoo1vd7wyI4x7v75P2nre7AwIDAQABAoIBAHxBcJM3riC96JuK
-cTE8ocSx6Zka6Lp6ruk9Mj66zZZFvaiECdFXis62wYVjdiJjqaefRoExIvm73FVM
-6Nzp6vMUUwFRJcZpl9+7Ut6TEZodBbNBBwhDHI8dRVhQ3cS+xTPlixKsOj6L2H5Q
-vLrY6SyeeBSF0378PWslBmpewsgdATi5hBl0j7/MoxtvHo7l8Fvyt1pMxpGBWDET
-7vXERTjmJCqN8zEejR6j6NpT+SY3DU3Xq+wj/1j3k038noBPrM90ECNkv8t9g85g
-n3VczkGBlzYkqEmk0Y1/OEJ4CrnZAQ8WlkgwIuIILz5u3vWF069fEr9LmyMQILpX
-KAqVyVECgYEA7JK3MqqJIp+5e4Jh6HlPElmekiB5DSAAWonBmMKiRDxwCHCZYD0W
-8HC5HaGl8R3opGuNVnGBJnCO3TYyuHeICI5Iv0GZA42yrGyYBmhIj2i8g5N90tAR
-Xv6bHKRiutalEgO1IRj67zHSBLBOc3UXUyYUDB8wdVn0RQAzctQ6ylsCgYEAjiaK
-x3h1pTVlr29jYByAa0NoK0MJZs0HsiFNZBTcftfkph45Vugaibf2YJWzGISmT9TK
-yIuGUP8ApFBBwkj0tBznG/3Kb9etUwRR02daUvDdL+PnAogu1D9j3OZV5w9foyUr
-Fq/FiGqH4IsrxAGjVG2jdKM+7O7xyXrifDGKInkCgYA9Rpc7AV753+M8MX5Ip7sq
-ZpojAVQ5aROOX+YMOkWrZPgjx36CpfAeISRhn3AK7xNGGzGFtWqdWUQ32gTzMMrE
-ZI5FM6l9eSNRc+NArZw1wQwrDHXnt8r4DvyAQ7fq6xPggaNVylGcyQu7+SqozyhW
-eiNxLFbx3nXdtXqeAIilxwKBgEuCg8PT5EJ/K+XWOKasXTcdVm9sq8jU7tqbwB2C
-y2IB0u6/LVxR7Q7tDs5dlwZWKHZNpe6D1zSdULz3+QZ4dKxckhOXa/qfSe3IZKL0
-ytE2K3iuCl+Y8a9DgQutu0IDM51ZOBtUAY0mcclAhF4ZNKa7mtFxihKYFw4c3cR1
-GFiZAoGAMIf+7j8AedEnJRiAzbA4ScFdFLGEcN8G0ENQ/VLe9XnwDy27mMiFsVj0
-WMzXvWX6JEkuu4bf/oZ16Uz95IkSocvURuRjSpNexC9efQPH38GUY89Rgf9fl2un
-elBITIidTQ9uv/yhqiJmEuVDNncL1W+GvHXk599FLXZpYOr24X4=
------END RSA PRIVATE KEY-----
-EOT
-}
-`, testKeypair_privateKey_base(rName), rName, publicKeyValue)
-}
-
-func testKeypair_updatePrivateKey1(rName string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_kps_keypair" "test" {
-  name = "%[2]s"
-}
-`, testKeypair_privateKey_base(rName), rName)
-}
-
-func testKeypair_updatePrivateKey2(rName string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_kps_keypair" "test" {
-  name            = "%[2]s"
-  encryption_type = "kms"
-  kms_key_name    = huaweicloud_kms_key.test.key_alias
-  private_key = <<EOT
------BEGIN RSA PRIVATE KEY-----
-MIIEogIBAAKCAQEAg1z/pLg8l3mcX96efFWP1h/Mo8zAJjR118UCnR7LxMt5lOBI
-G+wDYQx1xxbntGssIWNF0lVC1VtTu6sBLRx3CWAZ27e6Sj1qxNK80qb6bxsvQasU
-VeOALBytlU7F6ChhG17CJsIBcLf6uRZAKhzM1gdxya/LW9qz7O5io0x7PXdZRcRx
-noT2II4hbQhnBDsMSZ3IRkSoDz2vE3KpHct6aCfSaxouiIF3CrZ4Uv62UPp2hBlX
-Zwt0ItTp7tGYsQKXW6ZTXB4sP2AaLyJkn9yU8gp+FN9qPnUhZjrlDKL078rH6rYG
-6LiVhKsBtW0ISMxoo1vd7wyI4x7v75P2nre7AwIDAQABAoIBAHxBcJM3riC96JuK
-cTE8ocSx6Zka6Lp6ruk9Mj66zZZFvaiECdFXis62wYVjdiJjqaefRoExIvm73FVM
-6Nzp6vMUUwFRJcZpl9+7Ut6TEZodBbNBBwhDHI8dRVhQ3cS+xTPlixKsOj6L2H5Q
-vLrY6SyeeBSF0378PWslBmpewsgdATi5hBl0j7/MoxtvHo7l8Fvyt1pMxpGBWDET
-7vXERTjmJCqN8zEejR6j6NpT+SY3DU3Xq+wj/1j3k038noBPrM90ECNkv8t9g85g
-n3VczkGBlzYkqEmk0Y1/OEJ4CrnZAQ8WlkgwIuIILz5u3vWF069fEr9LmyMQILpX
-KAqVyVECgYEA7JK3MqqJIp+5e4Jh6HlPElmekiB5DSAAWonBmMKiRDxwCHCZYD0W
-8HC5HaGl8R3opGuNVnGBJnCO3TYyuHeICI5Iv0GZA42yrGyYBmhIj2i8g5N90tAR
-Xv6bHKRiutalEgO1IRj67zHSBLBOc3UXUyYUDB8wdVn0RQAzctQ6ylsCgYEAjiaK
-x3h1pTVlr29jYByAa0NoK0MJZs0HsiFNZBTcftfkph45Vugaibf2YJWzGISmT9TK
-yIuGUP8ApFBBwkj0tBznG/3Kb9etUwRR02daUvDdL+PnAogu1D9j3OZV5w9foyUr
-Fq/FiGqH4IsrxAGjVG2jdKM+7O7xyXrifDGKInkCgYA9Rpc7AV753+M8MX5Ip7sq
-ZpojAVQ5aROOX+YMOkWrZPgjx36CpfAeISRhn3AK7xNGGzGFtWqdWUQ32gTzMMrE
-ZI5FM6l9eSNRc+NArZw1wQwrDHXnt8r4DvyAQ7fq6xPggaNVylGcyQu7+SqozyhW
-eiNxLFbx3nXdtXqeAIilxwKBgEuCg8PT5EJ/K+XWOKasXTcdVm9sq8jU7tqbwB2C
-y2IB0u6/LVxR7Q7tDs5dlwZWKHZNpe6D1zSdULz3+QZ4dKxckhOXa/qfSe3IZKL0
-ytE2K3iuCl+Y8a9DgQutu0IDM51ZOBtUAY0mcclAhF4ZNKa7mtFxihKYFw4c3cR1
-GFiZAoGAMIf+7j8AedEnJRiAzbA4ScFdFLGEcN8G0ENQ/VLe9XnwDy27mMiFsVj0
-WMzXvWX6JEkuu4bf/oZ16Uz95IkSocvURuRjSpNexC9efQPH38GUY89Rgf9fl2un
-elBITIidTQ9uv/yhqiJmEuVDNncL1W+GvHXk599FLXZpYOr24X4=
------END RSA PRIVATE KEY-----
-EOT
-}
-`, testKeypair_privateKey_base(rName), rName)
-}
-
-func testKeypair_domain(rName string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_kms_key" "test" {
-  key_alias    = "%[1]s"
-  pending_days = "7"
-}
-
-resource "huaweicloud_kps_keypair" "test" {
-  name            = "%[1]s"
-  scope           = "account"
-  encryption_type = "kms"
-  user_id         = "%[2]s"
-  kms_key_name    = huaweicloud_kms_key.test.key_alias
-}
-`, rName, acceptance.HW_USER_ID)
 }

--- a/huaweicloud/services/dew/resource_huaweicloud_kps_keypair.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kps_keypair.go
@@ -4,16 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	kps "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kps/v3"
-	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kps/v3/model"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -21,7 +22,6 @@ import (
 )
 
 const (
-	scopeUser        = "user"
 	scopeDomainValue = "domain"
 	scopeDomainLabel = "account"
 )
@@ -61,11 +61,10 @@ func ResourceKeypair() *schema.Resource {
 				ForceNew: true,
 			},
 			"scope": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{scopeUser, scopeDomainLabel}, false),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"user_id": {
 				Type:     schema.TypeString,
@@ -73,10 +72,9 @@ func ResourceKeypair() *schema.Resource {
 				Computed: true,
 			},
 			"encryption_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice([]string{"default", "kms"}, false),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"kms_key_id": {
 				Type:     schema.TypeString,
@@ -127,105 +125,376 @@ func ResourceKeypair() *schema.Resource {
 	}
 }
 
-func resourceKeypairCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	client, err := c.HcKmsV3Client(region)
-	if err != nil {
-		return diag.Errorf("error creating KMS v3 client: %s", err)
+func buildKeypairScopeParams(d *schema.ResourceData) string {
+	scope := d.Get("scope").(string)
+	if scope == scopeDomainLabel {
+		return scopeDomainValue
 	}
 
-	createOpts, err := buildCreateParams(d)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	response, err := client.CreateKeypair(createOpts)
-	if err != nil {
-		return diag.Errorf("error creating KeyPair: %s", err)
-	}
-
-	d.SetId(*response.Keypair.Name)
-
-	// update description
-	if v, ok := d.GetOk("description"); ok {
-		updateErr := updateDesc(client, d.Id(), v.(string))
-		if updateErr != nil {
-			return updateErr
-		}
-	}
-
-	// write private key to local. only when it is not import public_key and the key_file is not empty
-	if fp, ok := d.GetOk("key_file"); ok {
-		if err = utils.WriteToPemFile(fp.(string), *response.Keypair.PrivateKey); err != nil {
-			return diag.Errorf("unable to generate private key: %s", err)
-		}
-		d.Set("key_file", fp)
-	}
-
-	return resourceKeypairRead(ctx, d, meta)
+	return scope
 }
 
-func resourceKeypairRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	client, err := c.HcKmsV3Client(region)
-	if err != nil {
-		return diag.Errorf("error creating KMS v3 client: %s", err)
+func buildKeypairKeyProtectionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	// The API requires that `encryption_type` must be configured before other fields can be configured.
+	encryptionType, ok := d.GetOk("encryption_type")
+	if !ok {
+		return nil
 	}
 
-	response, err := client.ListKeypairDetail(&model.ListKeypairDetailRequest{
-		KeypairName: d.Id(),
-	})
-	if err != nil {
-		return common.CheckDeletedDiag(d, err, "Error fetching keypair")
+	encryptionBodyParams := map[string]interface{}{
+		"type":         encryptionType,
+		"kms_key_name": utils.ValueIgnoreEmpty(d.Get("kms_key_name")),
+		"kms_key_id":   utils.ValueIgnoreEmpty(d.Get("kms_key_id")),
 	}
 
-	scope, err := parseEncodeValue(response.Keypair.Scope.MarshalJSON())
-	if err != nil {
-		return diag.Errorf("can not parse the value of %q from response: %s", "scope", err)
+	return map[string]interface{}{
+		"private_key": utils.ValueIgnoreEmpty(d.Get("private_key")),
+		"encryption":  encryptionBodyParams,
 	}
-	if scope == scopeDomainValue {
-		scope = scopeDomainLabel
+}
+
+func buildKeypairBodyParams(d *schema.ResourceData) map[string]interface{} {
+	keypairParams := map[string]interface{}{
+		"name":           d.Get("name"),
+		"type":           "ssh",
+		"public_key":     utils.ValueIgnoreEmpty(d.Get("public_key")),
+		"user_id":        utils.ValueIgnoreEmpty(d.Get("user_id")),
+		"scope":          utils.ValueIgnoreEmpty(buildKeypairScopeParams(d)),
+		"key_protection": buildKeypairKeyProtectionBodyParams(d),
 	}
 
-	mErr := multierror.Append(nil,
-		d.Set("region", region),
-		d.Set("name", response.Keypair.Name),
-		d.Set("scope", scope),
-		d.Set("public_key", response.Keypair.PublicKey),
-		d.Set("description", response.Keypair.Description),
-		d.Set("user_id", response.Keypair.UserId),
-		d.Set("created_at", utils.FormatTimeStampUTC(*response.Keypair.CreateTime/1000)),
-		d.Set("fingerprint", response.Keypair.Fingerprint),
-		d.Set("is_managed", response.Keypair.IsKeyProtection),
-	)
+	return map[string]interface{}{
+		"keypair": keypairParams,
+	}
+}
 
-	if err := mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error saving keypair fields: %s", err)
+func preCheckCreateArguments(d *schema.ResourceData) error {
+	if v, ok := d.GetOk("encryption_type"); ok && v.(string) == "kms" {
+		kmsKeyID := d.Get("kms_key_id").(string)
+		kmsKeyName := d.Get("kms_key_name").(string)
+
+		if kmsKeyID == "" && kmsKeyName == "" {
+			return fmt.Errorf("'kms_key_name' or 'kms_key_id' is mandatory when the 'encryption_type' value is 'kms'")
+		}
 	}
 
 	return nil
 }
 
-func resourceKeypairUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	client, err := c.HcKmsV3Client(region)
+func buildUpdateKeypairDescriptionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	descriptionBodyParam := map[string]interface{}{
+		"description": d.Get("description"),
+	}
+
+	return map[string]interface{}{
+		"keypair": descriptionBodyParam,
+	}
+}
+
+func updateKeypairDescription(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v3/{project_id}/keypairs/{keypair_name}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{keypair_name}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildUpdateKeypairDescriptionBodyParams(d),
+	}
+
+	_, err := client.Request("PUT", requestPath, &requestOpt)
 	if err != nil {
-		return diag.Errorf("error creating KMS v3 client: %s", err)
+		return fmt.Errorf("error updating keypair description: %s", err)
 	}
 
-	desc := d.Get("description").(string)
-	updateErr := updateDesc(client, d.Id(), desc)
-	if updateErr != nil {
-		return updateErr
+	return nil
+}
+
+func writePrivateToKeyFile(respBody interface{}, d *schema.ResourceData, filePath string) error {
+	privateKey := utils.PathSearch("keypair.private_key", respBody, "").(string)
+	if privateKey == "" {
+		log.Printf("[DEBUG] unable to write private key to key file: Private key is empty in API response")
+		return nil
 	}
 
-	if d.HasChanges("encryption_type", "kms_key_name", "private_key") {
-		diagErr := updatePrivateKey(client, d)
-		if err != nil {
-			return diagErr
+	if err := utils.WriteToPemFile(filePath, privateKey); err != nil {
+		return fmt.Errorf("unable to generate private key: %s", err)
+	}
+
+	if err := d.Set("key_file", filePath); err != nil {
+		log.Printf("[DEBUG] error setting key_file attribute to local state: %s", err)
+	}
+
+	return nil
+}
+
+func resourceKeypairCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/keypairs"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	if err := preCheckCreateArguments(d); err != nil {
+		return diag.FromErr(err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildKeypairBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating KPS keypair: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	keyPairName := utils.PathSearch("keypair.name", respBody, "").(string)
+	if keyPairName == "" {
+		return diag.Errorf("error creating KPS key pair: keypair name is not found in API response")
+	}
+	d.SetId(keyPairName)
+
+	// update description
+	if _, ok := d.GetOk("description"); ok {
+		if err := updateKeypairDescription(client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// write private key to local. only when it is not import public_key and the key_file is not empty
+	if filePath, ok := d.GetOk("key_file"); ok {
+		if err := writePrivateToKeyFile(respBody, d, filePath.(string)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceKeypairRead(ctx, d, meta)
+}
+
+func flattenScopeAttribute(scope string) string {
+	if scope == scopeDomainValue {
+		scope = scopeDomainLabel
+	}
+
+	return scope
+}
+
+func resourceKeypairRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/keypairs/{keypair_name}"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{keypair_name}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving KPS keypair")
+	}
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	createTime := utils.PathSearch("keypair.create_time", respBody, float64(0)).(float64)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("keypair.name", respBody, nil)),
+		d.Set("scope", flattenScopeAttribute(utils.PathSearch("keypair.scope", respBody, "").(string))),
+		d.Set("public_key", utils.PathSearch("keypair.public_key", respBody, nil)),
+		d.Set("description", utils.PathSearch("keypair.description", respBody, nil)),
+		d.Set("user_id", utils.PathSearch("keypair.user_id", respBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampUTC(int64(createTime)/1000)),
+		d.Set("fingerprint", utils.PathSearch("keypair.fingerprint", respBody, nil)),
+		d.Set("is_managed", utils.PathSearch("keypair.is_key_protection", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func clearKeypairPrivateKey(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v3/{project_id}/keypairs/{keypair_name}/private-key"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{keypair_name}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err := client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		var errDefault404 golangsdk.ErrDefault404
+		if errors.As(err, &errDefault404) {
+			log.Printf("[DEBUG] The KPS keypair private key has already been cleared")
+			return nil
+		}
+		return fmt.Errorf("error clearing KPS keypair private key: %s", err)
+	}
+
+	return nil
+}
+
+func buildImportPrivateKeyKeyProtectionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	encryptionBodyParams := map[string]interface{}{
+		"type":         d.Get("encryption_type"),
+		"kms_key_name": utils.ValueIgnoreEmpty(d.Get("kms_key_name")),
+		"kms_key_id":   utils.ValueIgnoreEmpty(d.Get("kms_key_id")),
+	}
+
+	return map[string]interface{}{
+		"private_key": d.Get("private_key"),
+		"encryption":  encryptionBodyParams,
+	}
+}
+
+func buildImportPrivateKeyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParam := map[string]interface{}{
+		"name":           d.Get("name"),
+		"user_id":        utils.ValueIgnoreEmpty(d.Get("user_id")),
+		"key_protection": buildImportPrivateKeyKeyProtectionBodyParams(d),
+	}
+
+	return map[string]interface{}{
+		"keypair": bodyParam,
+	}
+}
+
+func importKeypairPrivateKey(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v3/{project_id}/keypairs/private-key/import"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildImportPrivateKeyBodyParams(d)),
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return fmt.Errorf("error importing KPS keypair private key: %s", err)
+	}
+
+	return nil
+}
+
+func preCheckUpdatePrivateKeyArguments(d *schema.ResourceData) error {
+	encryptionType := d.Get("encryption_type").(string)
+	if encryptionType == "" {
+		return fmt.Errorf("'encryption_type' is mandatory when importing private key")
+	}
+
+	if encryptionType == "kms" {
+		kmsKeyID := d.Get("kms_key_id").(string)
+		kmsKeyName := d.Get("kms_key_name").(string)
+
+		if kmsKeyID == "" && kmsKeyName == "" {
+			return fmt.Errorf("'kms_key_name' or 'kms_key_id' is mandatory when the 'encryption_type' value is 'kms'")
+		}
+	}
+
+	return nil
+}
+
+func updateKeypairPrivateKey(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	privateKey := d.Get("private_key").(string)
+	if privateKey == "" {
+		if err := clearKeypairPrivateKey(client, d); err != nil {
+			return err
+		}
+	}
+
+	if privateKey != "" {
+		if err := preCheckUpdatePrivateKeyArguments(d); err != nil {
+			return err
+		}
+
+		if err := importKeypairPrivateKey(client, d); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func preCheckUpdateEncryptionAndUserIDArguments(d *schema.ResourceData) error {
+	privateKey := d.Get("private_key").(string)
+	if privateKey == "" {
+		return fmt.Errorf("'private_key' is mandatory when updating encryption values or user ID")
+	}
+
+	encryptionType := d.Get("encryption_type").(string)
+	if encryptionType == "" {
+		return fmt.Errorf("'encryption_type' is mandatory when updating encryption values or user ID")
+	}
+
+	if encryptionType == "kms" {
+		kmsKeyID := d.Get("kms_key_id").(string)
+		kmsKeyName := d.Get("kms_key_name").(string)
+
+		if kmsKeyID == "" && kmsKeyName == "" {
+			return fmt.Errorf("'kms_key_name' or 'kms_key_id' is mandatory when the 'encryption_type' value is 'kms'")
+		}
+	}
+
+	return nil
+}
+
+func updateKeypairEncryptionAndUserID(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	if err := preCheckUpdateEncryptionAndUserIDArguments(d); err != nil {
+		return err
+	}
+
+	// Edit 'encryption_type', 'kms_key_id', 'kms_key_name', or 'user_id' by importing private key API
+	return importKeypairPrivateKey(client, d)
+}
+
+func resourceKeypairUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	if d.HasChange("description") {
+		if err := updateKeypairDescription(client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("private_key") {
+		if err := updateKeypairPrivateKey(client, d); err != nil {
+			return diag.Errorf("error updating KPS keypair private key: %s", err)
+		}
+	}
+
+	// The API parameter restriction logic for importing private key is relatively complex.
+	// For readability and maintainability, the logic for editing 'private_key' and other fields is separated.
+	if d.HasChanges("encryption_type", "kms_key_name", "kms_key_id", "user_id") {
+		if err := updateKeypairEncryptionAndUserID(client, d); err != nil {
+			return diag.Errorf("error updating KPS keypair encryption type: %s", err)
 		}
 	}
 
@@ -233,98 +502,30 @@ func resourceKeypairUpdate(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func resourceKeypairDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	client, err := c.HcKmsV3Client(region)
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/keypairs/{keypair_name}"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating KMS v3 client: %s", err)
+		return diag.Errorf("error creating KMS client: %s", err)
 	}
 
-	deleteOpts := &model.DeleteKeypairRequest{
-		KeypairName: d.Id(),
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{keypair_name}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
 
-	_, err = client.DeleteKeypair(deleteOpts)
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
 	if err != nil {
-		return diag.Errorf("error deleting keypair: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting KPS keypair")
 	}
 
 	return nil
-}
-
-func buildCreateParams(d *schema.ResourceData) (*model.CreateKeypairRequest, error) {
-	var importPublicKey *string
-	if v, ok := d.GetOk("public_key"); ok {
-		importPublicKey = utils.String(v.(string))
-	}
-
-	var userId *string
-	if v, ok := d.GetOk("user_id"); ok {
-		userId = utils.String(v.(string))
-	}
-
-	kType := model.GetCreateKeypairActionTypeEnum().SSH
-	createOpts := &model.CreateKeypairRequest{
-		Body: &model.CreateKeypairRequestBody{
-			Keypair: &model.CreateKeypairAction{
-				Name:      d.Get("name").(string),
-				Type:      &kType,
-				PublicKey: importPublicKey,
-				UserId:    userId,
-			},
-		},
-	}
-
-	if v, ok := d.GetOk("scope"); ok {
-		var actionScope model.CreateKeypairActionScope
-		value := v.(string)
-		if value == scopeDomainLabel {
-			value = scopeDomainValue
-		}
-		err := actionScope.UnmarshalJSON([]byte(value))
-		if err != nil {
-			return nil, fmt.Errorf("error parsing the argument %q: %s", "scope", err)
-		}
-		createOpts.Body.Keypair.Scope = &actionScope
-	}
-
-	if v, ok := d.GetOk("encryption_type"); ok {
-		t := v.(string)
-		var encryptionType model.EncryptionType
-		err := encryptionType.UnmarshalJSON([]byte(t))
-		if err != nil {
-			return nil, fmt.Errorf("error parsing the argument %q: %s", "encryption_type", err)
-		}
-
-		keyProtection := model.KeyProtection{
-			Encryption: &model.Encryption{
-				Type: encryptionType,
-			},
-		}
-
-		// the kms key ID or name is required when encryption_type="kms"
-		keyId, keyIdExist := d.GetOk("kms_key_id")
-		keyName, keyNameExist := d.GetOk("kms_key_name")
-		if t == "kms" && !keyNameExist && !keyIdExist {
-			return nil, fmt.Errorf("'kms_key_name' or 'kms_key_id' is mandatory when the 'encryption_type' value is 'kms'")
-		}
-
-		if keyIdExist {
-			keyProtection.Encryption.KmsKeyId = utils.String(keyId.(string))
-		}
-
-		if keyNameExist {
-			keyProtection.Encryption.KmsKeyName = utils.String(keyName.(string))
-		}
-
-		if v, ok := d.GetOk("private_key"); ok {
-			keyProtection.PrivateKey = utils.String(v.(string))
-		}
-
-		createOpts.Body.Keypair.KeyProtection = &keyProtection
-	}
-
-	return createOpts, nil
 }
 
 func parseEncodeValue(b []byte, err error) (string, error) {
@@ -339,95 +540,4 @@ func parseEncodeValue(b []byte, err error) (string, error) {
 	}
 
 	return *rst, nil
-}
-
-func updateDesc(client *kps.KpsClient, id, desc string) diag.Diagnostics {
-	updateOpts := &model.UpdateKeypairDescriptionRequest{
-		KeypairName: id,
-		Body: &model.UpdateKeypairDescriptionRequestBody{
-			Keypair: &model.UpdateKeypairDescriptionReq{
-				Description: desc,
-			},
-		},
-	}
-
-	_, err := client.UpdateKeypairDescription(updateOpts)
-	if err != nil {
-		return diag.Errorf("error updating keypair: %s", err)
-	}
-
-	return nil
-}
-
-func updatePrivateKey(client *kps.KpsClient, d *schema.ResourceData) diag.Diagnostics {
-	privateKey := d.Get("private_key").(string)
-	// clear kps keypair privateKey
-	if privateKey == "" {
-		clearOps := &model.ClearPrivateKeyRequest{
-			KeypairName: d.Get("name").(string),
-		}
-		_, err := client.ClearPrivateKey(clearOps)
-		if err != nil {
-			return diag.Errorf("error deleting KPS keypair privateKey: %s", err)
-		}
-	}
-
-	// import kps keypair privateKey
-	if privateKey != "" {
-		importOps, err := buildImportPrivateKeyParams(d)
-		if err != nil {
-			diag.Errorf("error building KPS keypair import privateKey params: %s", err)
-		}
-		_, importError := client.ImportPrivateKey(importOps)
-		if importError != nil {
-			return diag.Errorf("error importing KPS keypair privateKey: %s", err)
-		}
-	}
-
-	return nil
-}
-
-func buildImportPrivateKeyParams(d *schema.ResourceData) (*model.ImportPrivateKeyRequest, error) {
-	importOps := &model.ImportPrivateKeyRequest{
-		Body: &model.ImportPrivateKeyRequestBody{
-			Keypair: &model.ImportPrivateKeyKeypairBean{
-				Name: d.Get("name").(string),
-			},
-		},
-	}
-
-	t := d.Get("encryption_type").(string)
-	if t == "" {
-		return nil, fmt.Errorf("field encryption_type is required when import a private key")
-	}
-	var encryptionType model.EncryptionType
-	err := encryptionType.UnmarshalJSON([]byte(t))
-	if err != nil {
-		return nil, fmt.Errorf("error parsing the argument %q: %s", "encryption_type", err)
-	}
-
-	importPrivateKeyProtection := model.ImportPrivateKeyProtection{
-		Encryption: &model.Encryption{
-			Type: encryptionType,
-		},
-		PrivateKey: d.Get("private_key").(string),
-	}
-
-	keyId, keyIdExist := d.GetOk("kms_key_id")
-	keyName, keyNameExist := d.GetOk("kms_key_name")
-	if t == "kms" && !keyNameExist && !keyIdExist {
-		return nil, fmt.Errorf("'kms_key_name' or 'kms_key_id' is mandatory when the 'encryption_type' value is 'kms'")
-	}
-
-	if keyIdExist {
-		importPrivateKeyProtection.Encryption.KmsKeyId = utils.String(keyId.(string))
-	}
-
-	if keyNameExist {
-		importPrivateKeyProtection.Encryption.KmsKeyName = utils.String(keyName.(string))
-	}
-
-	importOps.Body.Keypair.KeyProtection = &importPrivateKeyProtection
-
-	return importOps, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactor KPS keypair resource by automatically generate styles.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
go test -v -coverprofile=coverage_1736426244628_TestAccKeypair_.cov -coverpkg=./huaweicloud/services/dew ./huaweicloud/services/acceptance/dew -run TestAccKeypair_ -timeout 360m -parallel 4
=== RUN   TestAccKeypair_basic
--- PASS: TestAccKeypair_basic (42.08s)
=== RUN   TestAccKeypair_existKeypair
--- PASS: TestAccKeypair_existKeypair (38.87s)
PASS
coverage: 17.2% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       81.032s coverage: 17.2% of statements in ./huaweicloud/services/dew
```
![image](https://github.com/user-attachments/assets/e766883d-110c-4122-b464-1d917e94cd27)

- Create a keypair resource using the old code package：
  
  
![image](https://github.com/user-attachments/assets/ac5bc6f9-81a3-4d25-80ee-231f282c20f7)



- Switch to the new code package and execute terraform plan：

![image](https://github.com/user-attachments/assets/21fe48df-ba47-4419-92ce-cb944bec398c)


In summary, the code refactoring has no impact on existing users.





* [X] Documentation updated.
* [X] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/0ea5000b-b87f-4dad-91cd-af1ffca158f4)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
   ![image](https://github.com/user-attachments/assets/7678a322-5b3d-4ac5-85a9-fe33ce45a76f)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
