### PR TITLE
feat(cae): add new resource to manage cae environment access vpc

### DIFF
--- a/docs/resources/cae_vpc_egress.md
+++ b/docs/resources/cae_vpc_egress.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Cloud Application Engine (CAE)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cae_vpc_egress"
+description: |-
+  Manage a CAE environment to access VPC resource within HuaweiCloud.
+---
+
+# huaweicloud_cae_vpc_egress
+
+Manage a CAE environment to access VPC resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "environment_id" {}
+variable "route_table_id" {}
+variable "cidr" {}
+
+resource "huaweicloud_cae_vpc_egress" "test" {
+  environment_id = var.environment_id
+  route_table_id = var.route_table_id
+  cidr           = var.cidr
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `environment_id` - (Required, String, ForceNew) Specifies the ID of the CAE environment.
+  Changing this creates a new resource.
+
+* `route_table_id` - (Required, String, ForceNew) Specifies the ID of the route table corresponding to the subnet to which
+  the CAE environment belongs.  
+  Changing this creates a new resource.
+
+* `cidr` - (Required, String, ForceNew) Specifies the destination CIDR of the routing table corresponding to the subnet
+  to which the CAE environment belongs.  
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, in UUID format.
+
+## Import
+
+The resource can be imported using `environment_id`, `route_table_id`, and `cidr`, separated by commas (,), e.g.
+
+```bash
+$ terraform import huaweicloud_cae_vpc_egress.test <environment_id>,<route_table_id>,<cidr>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1408,6 +1408,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cae_component_configurations": cae.ResourceComponentConfigurations(),
 			"huaweicloud_cae_component_deployment":     cae.ResourceComponentDeployment(),
 			"huaweicloud_cae_notification_rule":        cae.ResourceNotificationRule(),
+			"huaweicloud_cae_vpc_egress":               cae.ResourceVpcEgress(),
 
 			"huaweicloud_cbr_backup_share_accepter": cbr.ResourceBackupShareAccepter(),
 			"huaweicloud_cbr_backup_share":          cbr.ResourceBackupShare(),

--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_vpc_egress_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_vpc_egress_test.go
@@ -1,0 +1,141 @@
+package cae
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cae"
+)
+
+func getVpcEgressFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("cae", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CAE client: %s", err)
+	}
+
+	environmentId := state.Primary.Attributes["environment_id"]
+	return cae.GetVpcEgressById(client, environmentId, state.Primary.ID)
+}
+
+func TestAccVpcEgress_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		name = acceptance.RandomAccResourceName()
+
+		rName = "huaweicloud_cae_vpc_egress.test"
+		rc    = acceptance.InitResourceCheck(
+			rName,
+			&obj,
+			getVpcEgressFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCaeEnvironment(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcEgress_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "environment_id", acceptance.HW_CAE_ENVIRONMENT_ID),
+					resource.TestCheckResourceAttrPair(rName, "route_table_id", "huaweicloud_vpc_route_table.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "cidr", "huaweicloud_vpc_route_table.test", "route.0.destination"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccVpcEgressImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccVpcEgress_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_cae_environments" "test" {
+  environment_id = "%[1]s"
+}
+
+locals {
+  vpc_id = data.huaweicloud_cae_environments.test.environments[0].annotations.vpc_id
+}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[2]s"
+  cidr = "192.168.10.0/24"
+}
+
+resource "huaweicloud_vpc_peering_connection" "test" {
+  name        = "%[2]s"
+  vpc_id      = local.vpc_id
+  peer_vpc_id = huaweicloud_vpc.test.id
+}
+
+resource "huaweicloud_vpc_route_table" "test" {
+  name   = "%[2]s"
+  vpc_id = local.vpc_id
+
+  subnets = [
+    data.huaweicloud_cae_environments.test.environments[0].annotations.subnet_id,
+  ]
+
+  route {
+    destination = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1)
+    type        = "peering"
+    nexthop     = huaweicloud_vpc_peering_connection.test.id
+  }
+  route {
+    destination = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 2)
+    type        = "peering"
+    nexthop     = huaweicloud_vpc_peering_connection.test.id
+  }
+}
+`, acceptance.HW_CAE_ENVIRONMENT_ID, name)
+}
+
+func testAccVpcEgress_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cae_vpc_egress" "test" {
+  environment_id = "%[2]s"
+  route_table_id = huaweicloud_vpc_route_table.test.id
+  cidr           = tolist(huaweicloud_vpc_route_table.test.route)[0].destination
+}
+ `, testAccVpcEgress_base(name), acceptance.HW_CAE_ENVIRONMENT_ID)
+}
+
+func testAccVpcEgressImportStateFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		var (
+			environmentId = rs.Primary.Attributes["environment_id"]
+			routeTableId  = rs.Primary.Attributes["route_table_id"]
+			cidr          = rs.Primary.Attributes["cidr"]
+		)
+
+		if environmentId == "" || routeTableId == "" || cidr == "" {
+			return "", fmt.Errorf("some import IDs are missing, want '<environment_id>,<route_table_id>,<cidr>', but got '%s,%s,%s'",
+				environmentId, routeTableId, cidr)
+		}
+
+		return fmt.Sprintf("%s,%s,%s", environmentId, routeTableId, cidr), nil
+	}
+}

--- a/huaweicloud/services/cae/resource_huaweicloud_cae_vpc_egress.go
+++ b/huaweicloud/services/cae/resource_huaweicloud_cae_vpc_egress.go
@@ -1,0 +1,254 @@
+package cae
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var vpcEgressResourceNotFoundCodes = []string{
+	"CAE.01500404", // The environment not found, and status code is 400.
+	"CAE.01500000", // The resource not found, and status code is 500.
+}
+
+// @API CAE POST /v1/{project_id}/cae/vpc-egress
+// @API CAE GET /v1/{project_id}/cae/vpc-egress
+// @API CAE DELETE /v1/{project_id}/cae/vpc-egress/{vpc_egress_id}
+func ResourceVpcEgress() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVpcEgressCreate,
+		ReadContext:   resourceVpcEgressRead,
+		DeleteContext: resourceVpcEgressDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVpcEgressImportState,
+		},
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"environment_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the CAE environment.`,
+			},
+			"route_table_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the route table corresponding to the subnet to which the CAE environment belongs.`,
+			},
+			"cidr": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The destination CIDR of the routing table corresponding to the subnet to which the CAE environment belongs.`,
+			},
+		},
+	}
+}
+
+func buildCreateVpcEgressBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"api_version": "v1",
+		"kind":        "VpcEgress",
+		"spec": map[string]interface{}{
+			"cidrs": []map[string]interface{}{
+				{
+					"route_table_id": d.Get("route_table_id"),
+					"cidr":           d.Get("cidr"),
+				},
+			},
+		},
+	}
+}
+
+func resourceVpcEgressCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		httpUrl       = "v1/{project_id}/cae/vpc-egress"
+		environmentId = d.Get("environment_id").(string)
+	)
+	client, err := cfg.NewServiceClient("cae", region)
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"X-Environment-Id": environmentId,
+		},
+		JSONBody: buildCreateVpcEgressBodyParams(d),
+	}
+	createResp, err := client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return diag.Errorf("error creating CAE environment (%s) access VPC: %s", environmentId, err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	vpcEgressId := utils.PathSearch("spec.cidrs|[0].id", createRespBody, "").(string)
+	if vpcEgressId == "" {
+		return diag.Errorf("unable to find the egress ID of the CAE environment access VPC from the API response")
+	}
+
+	d.SetId(vpcEgressId)
+	return resourceVpcEgressRead(ctx, d, meta)
+}
+
+func GetVpcEgressById(client *golangsdk.ServiceClient, environmentId, vpcEgressId string) (interface{}, error) {
+	vpcEgresses, err := getVpcEgresses(client, environmentId)
+	if err != nil {
+		return nil, common.ConvertExpected400ErrInto404Err(err, "error_code", vpcEgressResourceNotFoundCodes...)
+	}
+
+	vpcEgress := utils.PathSearch(fmt.Sprintf("[?id=='%s']|[0]", vpcEgressId), vpcEgresses, nil)
+	if vpcEgress == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return vpcEgress, nil
+}
+
+func getVpcEgresses(client *golangsdk.ServiceClient, environmentId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/cae/vpc-egress"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"X-Environment-Id": environmentId,
+		},
+	}
+	resp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("spec.cidrs", respBody, nil), nil
+}
+
+func resourceVpcEgressRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("cae", region)
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	vpcEgress, err := GetVpcEgressById(client, d.Get("environment_id").(string), d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CAE environment access VPC configuration")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("route_table_id", utils.PathSearch("route_table_id", vpcEgress, nil)),
+		d.Set("cidr", utils.PathSearch("cidr", vpcEgress, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceVpcEgressDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v1/{project_id}/cae/vpc-egress/{vpc_egress_id}"
+		vpcEgressId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("cae", region)
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{vpc_egress_id}", vpcEgressId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"X-Environment-Id": d.Get("environment_id").(string),
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(
+			common.ConvertExpected500ErrInto404Err(err, "error_code", vpcEgressResourceNotFoundCodes...),
+			"error_code",
+			vpcEgressResourceNotFoundCodes...), fmt.Sprintf("error deleting CAE environment access VPC (%s)", vpcEgressId))
+	}
+
+	return nil
+}
+
+func resourceVpcEgressImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	var (
+		cfg        = meta.(*config.Config)
+		importedId = d.Id()
+		// The resource ID cannot be obtained on the console. so we need to import by the <environment_id>,<route_table_id>,<cidr>.
+		// The cidr contains a slash (/), so use commas (,) to separate the imported IDs.
+		parts = strings.Split(importedId, ",")
+	)
+
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<environment_id>,<route_table_id>,<cidr>', but got '%s'",
+			importedId)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("environment_id", parts[0]),
+		d.Set("route_table_id", parts[1]),
+		d.Set("cidr", parts[2]),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return nil, mErr
+	}
+
+	client, err := cfg.NewServiceClient("cae", cfg.GetRegion(d))
+	if err != nil {
+		return nil, fmt.Errorf("error creating CAE client: %s", err)
+	}
+
+	vpcEgresses, err := getVpcEgresses(client, parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving the list of the CAE environment access VPC configurations: %s", err)
+	}
+
+	vpcEgressId := utils.PathSearch(fmt.Sprintf("[?route_table_id=='%s'&&cidr=='%s']|[0].id", parts[1], parts[2]), vpcEgresses, "").(string)
+	if vpcEgressId == "" {
+		return nil, fmt.Errorf("unable to find the egress ID of the CAE environment access VPC from API response : %s", err)
+	}
+
+	d.SetId(vpcEgressId)
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource (**huaweicloud_cae_vpc_egress**) to manage CAE environment access to VPC.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cae -f TestAccVpcEgress_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccVpcEgress_basic -timeout 360m -parallel 10
=== RUN   TestAccVpcEgress_basic
=== PAUSE TestAccVpcEgress_basic
=== CONT  TestAccVpcEgress_basic
--- PASS: TestAccVpcEgress_basic (115.32s)
PASS
coverage: 19.8% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       115.377s        coverage: 19.8% of statements in ./huaweicloud/services/cae
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/bc9f22fe-9914-4a4e-8311-b14c98738428)

    ab. Related resources (parent resources) not found
   ![image](https://github.com/user-attachments/assets/4ea08038-423a-4f8b-a661-9fd852418698)
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![image](https://github.com/user-attachments/assets/7855c9f4-a1a3-4d34-b586-fbbcf28c4a44)

    bb. Related resources (parent resources) not found
![image](https://github.com/user-attachments/assets/bf01b981-559b-4e8b-9985-d29e1080e68e)

