### PR TITLE
refactor(cdn): refactor the billing_option resource and dataSource code style

### DIFF
--- a/docs/data-sources/cdn_billing_option.md
+++ b/docs/data-sources/cdn_billing_option.md
@@ -2,12 +2,13 @@
 subcategory: Content Delivery Network (CDN)
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_cdn_billing_option"
-description: "Use this data source to get CDN billing option."
+description: |-
+  Use this data source to get CDN billing option within HuaweiCloud.
 ---
 
 # huaweicloud_cdn_billing_option
 
-Use this data source to get CDN billing option.
+Use this data source to get CDN billing option within HuaweiCloud.
 
 ## Example Usage
 

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_billing_option_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_billing_option_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDatasourceBillingOption_basic(t *testing.T) {
+func TestAccDataSourceBillingOption_basic(t *testing.T) {
 	var (
 		rName = "data.huaweicloud_cdn_billing_option.test"
 		dc    = acceptance.InitDataSourceCheck(rName)
@@ -19,11 +19,13 @@ func TestAccDatasourceBillingOption_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceBillingOption_basic,
+				Config: testDataSourceBillingOption_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(rName, "product_type"),
@@ -43,7 +45,7 @@ func TestAccDatasourceBillingOption_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDatasourceBillingOption_expectError,
+				Config: testDataSourceBillingOption_expectError,
 				ExpectError: regexp.MustCompile("Your query returned no results. " +
 					"Please change your search criteria and try again."),
 			},
@@ -51,7 +53,7 @@ func TestAccDatasourceBillingOption_basic(t *testing.T) {
 	})
 }
 
-const testAccDatasourceBillingOption_basic = `
+const testDataSourceBillingOption_basic = `
 data "huaweicloud_cdn_billing_option" "test" {
   product_type = "base"
 }
@@ -63,7 +65,7 @@ data "huaweicloud_cdn_billing_option" "all_filter" {
 }
 `
 
-const testAccDatasourceBillingOption_expectError = `
+const testDataSourceBillingOption_expectError = `
 data "huaweicloud_cdn_billing_option" "test" {
   product_type = "base"
 }

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_billing_option.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_billing_option.go
@@ -7,7 +7,6 @@ package cdn
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
@@ -15,8 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	cdnv2 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2"
-	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -71,105 +69,136 @@ func ResourceBillingOption() *schema.Resource {
 	}
 }
 
+func buildChangeBillingOptionBodyParams(d *schema.ResourceData) interface{} {
+	return map[string]interface{}{
+		"charge_mode":  d.Get("charge_mode").(string),
+		"product_type": d.Get("product_type").(string),
+		"service_area": d.Get("service_area").(string),
+	}
+}
+
+func changeBillingOption(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	chargePath := client.Endpoint + "v1.0/cdn/charge/charge-modes"
+	chargeOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildChangeBillingOptionBodyParams(d),
+	}
+	_, err := client.Request("PUT", chargePath, &chargeOpt)
+
+	return err
+}
+
 func resourceBillingOptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	hcCdnClient, err := cfg.HcCdnV2Client(region)
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cdn"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating CDN v2 client: %s", err)
+		return diag.Errorf("error creating CDN client: %s", err)
 	}
 
-	if err := changeBillingOption(hcCdnClient, d); err != nil {
-		return diag.FromErr(err)
+	if err := changeBillingOption(client, d); err != nil {
+		return diag.Errorf("error modifying CDN billing option in creation operation: %s", err)
 	}
 
 	generateUUID, err := uuid.GenerateUUID()
 	if err != nil {
 		return diag.Errorf("unable to generate ID: %s", err)
 	}
+
 	d.SetId(generateUUID)
 
 	return resourceBillingOptionRead(ctx, d, meta)
 }
 
-func resourceBillingOptionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	hcCdnClient, err := cfg.HcCdnV2Client(region)
-	if err != nil {
-		return diag.Errorf("error creating CDN v2 client: %s", err)
-	}
-
-	if err := changeBillingOption(hcCdnClient, d); err != nil {
-		return diag.FromErr(err)
-	}
-
-	return resourceBillingOptionRead(ctx, d, meta)
+func buildBillingOptionQueryParams(productType string) string {
+	return fmt.Sprintf("?product_type=%v", productType)
 }
 
-func changeBillingOption(hcCdnClient *cdnv2.CdnClient, d *schema.ResourceData) error {
-	req := model.SetChargeModesRequest{
-		Body: &model.SetChargeModesBody{
-			ChargeMode:  d.Get("charge_mode").(string),
-			ProductType: d.Get("product_type").(string),
-			ServiceArea: d.Get("service_area").(string),
-		},
+func GetBillingOptionDetail(client *golangsdk.ServiceClient, productType string) (interface{}, error) {
+	getPath := client.Endpoint + "v1.0/cdn/charge/charge-modes"
+	getPath += buildBillingOptionQueryParams(productType)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 	}
-	_, err := hcCdnClient.SetChargeModes(&req)
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return fmt.Errorf("error modifying CDN billing options: %s", err)
+		// The billing model is always valuable and there is no need to pay attention to scenarios where resource does
+		// not exist.
+		return nil, fmt.Errorf("error retrieving CDN billing option: %s", err)
 	}
-	return nil
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	result := utils.PathSearch("result[0]", getRespBody, nil)
+	if result == nil {
+		return nil, fmt.Errorf("error retrieving CDN billing option: result is not found in API response")
+	}
+
+	return result, nil
 }
 
 func resourceBillingOptionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	hcCdnClient, err := cfg.HcCdnV2Client(region)
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cdn"
+		mErr    *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating CDN v2 client: %s", err)
+		return diag.Errorf("error creating CDN client: %s", err)
 	}
 
-	request := model.ShowChargeModesRequest{
-		ProductType: d.Get("product_type").(string),
-	}
-
-	resp, err := hcCdnClient.ShowChargeModes(&request)
+	result, err := GetBillingOptionDetail(client, d.Get("product_type").(string))
 	if err != nil {
-		// The billing model is always valuable and there is no need to pay attention to scenarios where resources do not exist.
-		return diag.Errorf("error retrieving CDN billing option: %s", err)
+		return diag.FromErr(err)
 	}
-
-	if resp == nil || resp.Result == nil || len(*resp.Result) == 0 {
-		return diag.Errorf("error retrieving CDN billing option: Result is not found in API response")
-	}
-
-	var mErr *multierror.Error
-	resultArray := *resp.Result
-	resultMap := resultArray[0]
 
 	mErr = multierror.Append(
 		mErr,
-		d.Set("product_type", resultMap["product_type"]),
-		d.Set("service_area", resultMap["service_area"]),
-		d.Set("created_at", flattenTimeStamp(resultMap["create_time"])),
-		d.Set("effective_time", flattenTimeStamp(resultMap["effective_time"])),
-		d.Set("status", resultMap["status"]),
-		d.Set("current_charge_mode", resultMap["charge_mode"]),
+		d.Set("product_type", utils.PathSearch("product_type", result, nil)),
+		d.Set("service_area", utils.PathSearch("service_area", result, nil)),
+		d.Set("created_at", flattenCreatedAt(result)),
+		d.Set("effective_time", flattenEffectiveTime(result)),
+		d.Set("status", utils.PathSearch("status", result, nil)),
+		d.Set("current_charge_mode", utils.PathSearch("charge_mode", result, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func flattenTimeStamp(timestamp interface{}) string {
-	if timestamp == nil {
-		return ""
-	}
-	timeInt64, err := timestamp.(json.Number).Int64()
+func flattenEffectiveTime(result interface{}) string {
+	effectiveTime := utils.PathSearch("effective_time", result, float64(0)).(float64)
+	return utils.FormatTimeStampRFC3339(int64(effectiveTime)/1000, false)
+}
+
+func resourceBillingOptionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cdn"
+	)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return ""
+		return diag.Errorf("error creating CDN client: %s", err)
 	}
-	return utils.FormatTimeStampRFC3339(timeInt64/1000, false)
+
+	if err := changeBillingOption(client, d); err != nil {
+		return diag.Errorf("error modifying CDN billing option in update operation: %s", err)
+	}
+
+	return resourceBillingOptionRead(ctx, d, meta)
 }
 
 func resourceBillingOptionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

commit1: refactor the `billing_option` resource code style.
commit2: refactor the `billing_option` data source code style.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

 refactor the `billing_option` resource and dataSource code style

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

### Resource Test
```
$ make testacc TEST="./huaweicloud/services/acceptance/cdn" TESTARGS="-run TestAccBillingOption_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccBillingOption_basic -timeout 360m -parallel 4
=== RUN   TestAccBillingOption_basic
=== PAUSE TestAccBillingOption_basic
=== CONT  TestAccBillingOption_basic
--- PASS: TestAccBillingOption_basic (15.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       15.467s

```

### DataSource Test
```
$ make testacc TEST="./huaweicloud/services/acceptance/cdn" TESTARGS="-run TestAccDataSourceBillingOption_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccDataSourceBillingOption_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceBillingOption_basic
=== PAUSE TestAccDataSourceBillingOption_basic
=== CONT  TestAccDataSourceBillingOption_basic
--- PASS: TestAccDataSourceBillingOption_basic (8.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       8.862s

```

### Test case coverage
![image](https://github.com/user-attachments/assets/c7da44d0-51db-43d9-9686-07136eb56724)

![image](https://github.com/user-attachments/assets/9b93da78-9360-4fae-9cc0-454ccbac8877)


* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
