### PR TITLE
feat(cae): add new resource to manage domain name

### DIFF
--- a/docs/resources/cae_domain.md
+++ b/docs/resources/cae_domain.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Cloud Application Engine (CAE)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cae_domain"
+description: |-
+  Manage a CAE domain name resource within HuaweiCloud.
+---
+
+# huaweicloud_cae_domain
+
+Manage a CAE domain name resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "environment_id" {}
+variable "domain_name" {}
+
+resource "huaweicloud_cae_domain" "test" {
+  environment_id = var.environment_id
+  name           = var.domain_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `environment_id` - (Required, String, ForceNew) Specifies the ID of the CAE environment.
+  Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the domain name to be associated with the CAE environment.
+  Changing this creates a new resource.  
+  The maximum length of the domain name is `254` characters.  
+  The domain name consists of multiple strings separated by dots (.), and the maximum length of a single string is `63` characters.
+  Only letters, digits, and hyphens (-) allowed, and must start with a letter or a digit.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, in UUID format.
+
+* `created_at` - The time when the domain name is associated, in RFC3339 format.
+
+## Import
+
+The resource can be imported using `environment_id` and `name`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_cae_domain.test <environment_id>/<name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1424,6 +1424,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cae_component":                cae.ResourceComponent(),
 			"huaweicloud_cae_component_configurations": cae.ResourceComponentConfigurations(),
 			"huaweicloud_cae_component_deployment":     cae.ResourceComponentDeployment(),
+			"huaweicloud_cae_domain":                   cae.ResourceDomain(),
 			"huaweicloud_cae_environment":              cae.ResourceEnvironment(),
 			"huaweicloud_cae_notification_rule":        cae.ResourceNotificationRule(),
 			"huaweicloud_cae_vpc_egress":               cae.ResourceVpcEgress(),

--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_domain_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_domain_test.go
@@ -1,0 +1,106 @@
+package cae
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cae"
+)
+
+func getResourceDomainFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("cae", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CAE client: %s", err)
+	}
+
+	return cae.GetDomainById(client, state.Primary.Attributes["environment_id"], state.Primary.ID)
+}
+
+func TestAccResourceDomain_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		domainName = fmt.Sprintf("%s.com", acceptance.RandomAccResourceNameWithDash())
+
+		rName = "huaweicloud_cae_domain.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getResourceDomainFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCaeEnvironment(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceDomain_basic(domainName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "environment_id", acceptance.HW_CAE_ENVIRONMENT_ID),
+					resource.TestCheckResourceAttr(rName, "name", domainName),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config:      testAccResourceDomain_existed(domainName),
+				ExpectError: regexp.MustCompile(`the domain has already existed`),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccDomainImportFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccResourceDomain_basic(domainName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cae_domain" "test" {
+  environment_id = "%[1]s"
+  name           = "%[2]s"
+}
+`, acceptance.HW_CAE_ENVIRONMENT_ID, domainName)
+}
+
+func testAccResourceDomain_existed(domainName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cae_domain" "test2" {
+  environment_id = "%[2]s"
+  name           = "%[3]s"
+}
+`, testAccResourceDomain_basic(domainName), acceptance.HW_CAE_ENVIRONMENT_ID, domainName)
+}
+
+func testAccDomainImportFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		var (
+			environmentId = rs.Primary.Attributes["environment_id"]
+			domainName    = rs.Primary.Attributes["name"]
+		)
+		if environmentId == "" || domainName == "" {
+			return "", fmt.Errorf("some import IDs are missing, want '<environment_id>/<name>', but got '%s/%s'",
+				environmentId, domainName)
+		}
+
+		return fmt.Sprintf("%s/%s", environmentId, domainName), nil
+	}
+}

--- a/huaweicloud/services/cae/resource_huaweicloud_cae_domain.go
+++ b/huaweicloud/services/cae/resource_huaweicloud_cae_domain.go
@@ -1,0 +1,238 @@
+package cae
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CAE POST /v1/{project_id}/cae/domains
+// @API CAE GET /v1/{project_id}/cae/domains
+// @API CAE DELETE /v1/{project_id}/cae/domains/{domain_id}
+func ResourceDomain() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDomainCreate,
+		ReadContext:   resourceDomainRead,
+		DeleteContext: resourceDomainDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDomainImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+			},
+			"environment_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the CAE environment.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The domain name to be associated with the CAE environment.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the domain name is associated, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func buildCreateDomainBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"api_version": "v1",
+		"kind":        "Domain",
+		"metadata": map[string]interface{}{
+			"name": d.Get("name"),
+		},
+	}
+}
+
+func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		httpUrl       = "v1/{project_id}/cae/domains"
+		environmentId = d.Get("environment_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("cae", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"X-Environment-ID": environmentId,
+		},
+		JSONBody: buildCreateDomainBodyParams(d),
+	}
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("unable to associate domain name for specified environment (%s): %s", environmentId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	domainId := utils.PathSearch("items[0].metadata.id", respBody, "").(string)
+	if domainId == "" {
+		return diag.Errorf("unable to find the domain name ID from the API response")
+	}
+
+	d.SetId(domainId)
+
+	return resourceDomainRead(ctx, d, meta)
+}
+
+func resourceDomainRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("cae", region)
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	domainInfo, err := GetDomainById(client, d.Get("environment_id").(string), d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error retrieving domain name (%s)", d.Get("name").(string)))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", domainInfo, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("created_at",
+			domainInfo, "").(string))/1000, false)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func GetDomainById(client *golangsdk.ServiceClient, environmentId, domainId string) (interface{}, error) {
+	domains, err := getDomains(client, environmentId)
+	if err != nil {
+		return nil, common.ConvertExpected400ErrInto404Err(err, "error_code", envResourceNotFoundCodes...)
+	}
+
+	domainInfo := utils.PathSearch(fmt.Sprintf("items[?metadata.id=='%s']|[0].metadata", domainId), domains, nil)
+	if domainInfo == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return domainInfo, nil
+}
+
+func resourceDomainDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v1/{project_id}/cae/domains/{domain_id}"
+	)
+
+	client, err := cfg.NewServiceClient("cae", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{domain_id}", d.Id())
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"X-Environment-ID": d.Get("environment_id").(string),
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		// CAE.01500005: The environment or resource not found.
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", "CAE.01500005"),
+			fmt.Sprintf("error deleting associated domain name (%s)", d.Get("name").(string)))
+	}
+	return nil
+}
+
+func getDomains(client *golangsdk.ServiceClient, environmentId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/cae/domains"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"X-Environment-ID": environmentId,
+		},
+	}
+	resp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+// Since the ID cannot be found on the console, so we need to import by the domain name.
+func resourceDomainImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	var (
+		cfg        = meta.(*config.Config)
+		importedId = d.Id()
+		parts      = strings.Split(importedId, "/")
+	)
+
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<environment_id>/<name>', but got '%s'",
+			importedId)
+	}
+
+	var (
+		environmentId = parts[0]
+		domainName    = parts[1]
+	)
+	mErr := multierror.Append(nil,
+		d.Set("environment_id", environmentId),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return nil, mErr
+	}
+
+	client, err := cfg.NewServiceClient("cae", cfg.GetRegion(d))
+	if err != nil {
+		return nil, fmt.Errorf("error creating CAE client: %s", err)
+	}
+
+	domains, err := getDomains(client, environmentId)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving domains: %s", err)
+	}
+
+	domainId := utils.PathSearch(fmt.Sprintf("items[?metadata.name=='%s']|[0].metadata.id", domainName), domains, "").(string)
+	if domainId == "" {
+		return nil, fmt.Errorf("unable to find ID of the domain name (%s) from API response : %s", domainName, err)
+	}
+
+	d.SetId(domainId)
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource (**huaweicloud_cae_domain**) to bind domain for CAE environment.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cae -f TestAccResourceDomain_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccResourceDomain_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceDomain_basic
=== PAUSE TestAccResourceDomain_basic
=== CONT  TestAccResourceDomain_basic
--- PASS: TestAccResourceDomain_basic (20.07s)
PASS
coverage: 12.6% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       20.143s coverage: 12.6% of statements in ./huaweicloud/services/cae
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/6285ca70-78da-4420-a037-4f4032004c51)

     ab. Related resources (parent resources) not found
The environment not found.
![image](https://github.com/user-attachments/assets/d7eb6118-57bf-4887-a322-c1283e421bdd)

   
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found  
![image](https://github.com/user-attachments/assets/6bafcb96-4e23-4805-a4c0-980d2cd3aa1d)

     bb. Related resources (parent resources) not found
  The environment not found.
![image](https://github.com/user-attachments/assets/48bdd620-d446-4ca3-a0bc-71cfde881d20)

