### PR TITLE
feat(GaussDB): add gaussdb opengauss parameter template reset resource

### DIFF
--- a/docs/resources/gaussdb_opengauss_parameter_template_reset.md
+++ b/docs/resources/gaussdb_opengauss_parameter_template_reset.md
@@ -1,0 +1,37 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_opengauss_parameter_template_reset"
+description: |-
+  Manages a GaussDB OpenGauss parameter template reset resource within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_opengauss_parameter_template_reset
+
+Manages a GaussDB OpenGauss parameter template reset resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "config_id" {}
+
+resource "huaweicloud_gaussdb_opengauss_parameter_template_reset" "test" {
+  config_id = var.config_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `config_id` - (Required, String, ForceNew) Specifies the ID of the source parameter template to be reset. Changing
+  this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which equals `config_id`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1812,6 +1812,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_opengauss_parameter_template":         gaussdb.ResourceOpenGaussParameterTemplate(),
 			"huaweicloud_gaussdb_opengauss_parameter_template_apply":   gaussdb.ResourceOpenGaussParameterTemplateApply(),
 			"huaweicloud_gaussdb_opengauss_parameter_template_compare": gaussdb.ResourceOpenGaussParameterTemplateCompare(),
+			"huaweicloud_gaussdb_opengauss_parameter_template_reset":   gaussdb.ResourceOpenGaussParameterTemplateReset(),
 			"huaweicloud_gaussdb_opengauss_recycling_policy":           gaussdb.ResourceOpenGaussRecyclingPolicy(),
 
 			"huaweicloud_ges_graph":    ges.ResourceGesGraph(),

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_opengauss_parameter_template_reset_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_opengauss_parameter_template_reset_test.go
@@ -1,0 +1,48 @@
+package gaussdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccOpenGaussParameterTemplateReset_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testOpenGaussParameterrTemplateReset_basic(name),
+			},
+		},
+	})
+}
+
+func testOpenGaussParameterrTemplateReset_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_gaussdb_opengauss_parameter_template" "test" {
+  name           = "%[1]s_source"
+  engine_version = "8.201"
+  instance_mode  = "independent"
+
+  parameters {
+    name  = "cn:auto_explain_log_min_duration"
+    value = "1000"
+  }
+
+  lifecycle {
+    ignore_changes = [parameters]
+  }
+}
+
+resource "huaweicloud_gaussdb_opengauss_parameter_template_reset" "test" {
+  config_id = huaweicloud_gaussdb_opengauss_parameter_template.test.id
+}
+`, name)
+}

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_parameter_template_reset.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_parameter_template_reset.go
@@ -1,0 +1,83 @@
+package gaussdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API GaussDB POST /v3/{project_id}/configurations/{config_id}/reset
+func ResourceOpenGaussParameterTemplateReset() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceOpenGaussParameterTemplateResetCreate,
+		ReadContext:   resourceOpenGaussParameterTemplateResetRead,
+		DeleteContext: resourceOpenGaussParameterTemplateResetDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"config_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceOpenGaussParameterTemplateResetCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/configurations/{config_id}/reset"
+		product = "opengauss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	configId := d.Get("config_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{config_id}", configId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB OpenGauss parameter template reset: %s", err)
+	}
+
+	d.SetId(configId)
+
+	return nil
+}
+
+func resourceOpenGaussParameterTemplateResetRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceOpenGaussParameterTemplateResetDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting parameter template reset resource is not supported. The resource is only removed from the" +
+		"state, the GaussDB OpenGauss parameter template remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb opengauss parameter template reset resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb opengauss parameter template reset resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccOpenGaussParameterTemplateReset_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccOpenGaussParameterTemplateReset_basic -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussParameterTemplateReset_basic
=== PAUSE TestAccOpenGaussParameterTemplateReset_basic
=== CONT  TestAccOpenGaussParameterTemplateReset_basic
--- PASS: TestAccOpenGaussParameterTemplateReset_basic (23.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   23.286s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
