### PR TITLE
refactor(dew): refactor kps keypair datasource by automatically genate style

### DIFF
--- a/docs/data-sources/kps_keypairs.md
+++ b/docs/data-sources/kps_keypairs.md
@@ -2,7 +2,8 @@
 subcategory: "Data Encryption Workshop (DEW)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_kps_keypairs"
-description: ""
+description: |-
+  Use this data source to get a list of keypairs.
 ---
 
 # huaweicloud_kps_keypairs
@@ -23,8 +24,8 @@ data "huaweicloud_kps_keypairs" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) The region in which to obtain the keypairs. If omitted, the provider-level region will
-  be used.
+* `region` - (Optional, String) Specifies the region in which to obtain the keypairs. If omitted, the provider-level
+  region will be used.
 
 * `name` - (Optional, String) Specifies the name of the keypair.
 
@@ -32,24 +33,25 @@ The following arguments are supported:
 
 * `fingerprint` - (Optional, String) Specifies the fingerprint of the keypair.
 
-* `is_managed` - (Optional, Bool) Specifies whether the private key is managed by HuaweiCloud.
-
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Indicates a data source ID.
+* `id` - The data source ID in UUID format.
 
-* `keypairs` - Indicates a list of all keypairs found. Structure is documented below.
+* `keypairs` - The KPS keypairs list.
 
-The `keypairs` block contains:
+  The [keypairs](#kps-keypairs) structure is documented below.
+
+<a name="kps-keypairs"></a>
+The `keypairs` block supports:
 
 * `name` - Indicates the name of the keypair.
 
-* `scope` - Indicates the scope of key pair. The value can be **account**or **user**.
+* `scope` - Indicates the scope of keypair. The value can be **account**or **user**.
 
 * `public_key` - Indicates the imported OpenSSH-formatted public key.
 
-* `fingerprint` - Indicates the fingerprint information about an key pair.
+* `fingerprint` - Indicates the fingerprint information about a keypair.
 
 * `is_managed` - Indicates whether the private key is managed by HuaweiCloud.

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_kps_keypairs_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_kps_keypairs_test.go
@@ -11,11 +11,22 @@ import (
 )
 
 func TestAccDataKpsKeypairs_basic(t *testing.T) {
-	rName := acceptance.RandomAccResourceName()
-	resourceName := "data.huaweicloud_kps_keypairs.test"
-	publicKey, _, _ := acctest.RandSSHKeyPair("Generated-by-AccTest")
+	var (
+		rName           = acceptance.RandomAccResourceName()
+		publicKey, _, _ = acctest.RandSSHKeyPair("Generated-by-AccTest")
 
-	dc := acceptance.InitDataSourceCheck(resourceName)
+		resourceName = "data.huaweicloud_kps_keypairs.test"
+		dc           = acceptance.InitDataSourceCheck(resourceName)
+
+		byName   = "data.huaweicloud_kps_keypairs.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byPublicKey   = "data.huaweicloud_kps_keypairs.filter_by_public_key"
+		dcByPublicKey = acceptance.InitDataSourceCheck(byPublicKey)
+
+		byFingerprint   = "data.huaweicloud_kps_keypairs.filter_by_fingerprint"
+		dcByFingerprint = acceptance.InitDataSourceCheck(byFingerprint)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -25,18 +36,33 @@ func TestAccDataKpsKeypairs_basic(t *testing.T) {
 				Config: testAccDataKpsKeypairs_basic(rName, publicKey),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "keypairs.0.name", rName),
-					resource.TestCheckResourceAttr(resourceName, "keypairs.0.public_key", publicKey),
-					resource.TestCheckResourceAttrPair(resourceName, "keypairs.0.scope",
-						"huaweicloud_kps_keypair.test", "scope"),
-					resource.TestCheckResourceAttrPair(resourceName, "keypairs.0.fingerprint",
-						"huaweicloud_kps_keypair.test", "fingerprint"),
-					resource.TestCheckResourceAttrPair(resourceName, "keypairs.0.is_managed",
-						"huaweicloud_kps_keypair.test", "is_managed"),
+					resource.TestCheckResourceAttrSet(resourceName, "keypairs.0.name"),
+					resource.TestCheckResourceAttrSet(resourceName, "keypairs.0.public_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "keypairs.0.scope"),
+					resource.TestCheckResourceAttrSet(resourceName, "keypairs.0.fingerprint"),
+					resource.TestCheckResourceAttrSet(resourceName, "keypairs.0.is_managed"),
+
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+
+					dcByPublicKey.CheckResourceExists(),
+					resource.TestCheckOutput("is_public_key_filter_useful", "true"),
+
+					dcByFingerprint.CheckResourceExists(),
+					resource.TestCheckOutput("is_fingerprint_filter_useful", "true"),
 				),
 			},
 		},
 	})
+}
+
+func testAccDataKpsKeypairs_base(rName, key string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kps_keypair" "test" {
+  name       = "%s"
+  public_key = "%s"
+}
+`, rName, key)
 }
 
 func testAccDataKpsKeypairs_basic(rName, key string) string {
@@ -44,9 +70,70 @@ func testAccDataKpsKeypairs_basic(rName, key string) string {
 %s
 
 data "huaweicloud_kps_keypairs" "test" {
-  name = huaweicloud_kps_keypair.test.name
-
   depends_on = [huaweicloud_kps_keypair.test]
 }
-`, testKeypair_publicKey(rName, key))
+
+# Filter by name
+locals {
+  name = data.huaweicloud_kps_keypairs.test.keypairs.0.name
+}
+
+data "huaweicloud_kps_keypairs" "filter_by_name" {
+  depends_on = [huaweicloud_kps_keypair.test]
+
+  name = local.name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_kps_keypairs.filter_by_name.keypairs[*].name : v == local.name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by public_key
+locals {
+  public_key = data.huaweicloud_kps_keypairs.test.keypairs.0.public_key
+}
+
+data "huaweicloud_kps_keypairs" "filter_by_public_key" {
+  depends_on = [huaweicloud_kps_keypair.test]
+
+  public_key = local.public_key
+}
+
+locals {
+  public_key_filter_result = [
+    for v in data.huaweicloud_kps_keypairs.filter_by_public_key.keypairs[*].public_key : v == local.public_key
+  ]
+}
+
+output "is_public_key_filter_useful" {
+  value = length(local.public_key_filter_result) > 0 && alltrue(local.public_key_filter_result)
+}
+
+# Filter by fingerprint
+locals {
+  fingerprint = data.huaweicloud_kps_keypairs.test.keypairs.0.fingerprint
+}
+
+data "huaweicloud_kps_keypairs" "filter_by_fingerprint" {
+  depends_on = [huaweicloud_kps_keypair.test]
+
+  fingerprint = local.fingerprint
+}
+
+locals {
+  fingerprint_filter_result = [
+    for v in data.huaweicloud_kps_keypairs.filter_by_fingerprint.keypairs[*].fingerprint : v == local.fingerprint
+  ]
+}
+
+output "is_fingerprint_filter_useful" {
+  value = length(local.fingerprint_filter_result) > 0 && alltrue(local.fingerprint_filter_result)
+}
+`, testAccDataKpsKeypairs_base(rName, key))
 }

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_keypair_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_keypair_test.go
@@ -423,12 +423,3 @@ resource "huaweicloud_kps_keypair" "test" {
 }
 `, testAccKeypair_import_base(name), name)
 }
-
-func testKeypair_publicKey(rName, key string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_kps_keypair" "test" {
-  name       = "%s"
-  public_key = "%s"
-}
-`, rName, key)
-}

--- a/huaweicloud/services/dew/resource_huaweicloud_kps_keypair.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kps_keypair.go
@@ -1,9 +1,7 @@
 package dew
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -526,18 +524,4 @@ func resourceKeypairDelete(_ context.Context, d *schema.ResourceData, meta inter
 	}
 
 	return nil
-}
-
-func parseEncodeValue(b []byte, err error) (string, error) {
-	if err != nil {
-		return "", err
-	}
-
-	var rst *string
-	err = json.NewDecoder(bytes.NewReader(b)).Decode(&rst)
-	if err != nil {
-		return "", err
-	}
-
-	return *rst, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

refactor kps keypair datasource by automatically genate style.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
go test -v -coverprofile=coverage_1736753855005_TestAccDataKpsKeypairs_basic.cov -coverpkg=./huaweicloud/services/dew ./huaweicloud/services/acceptance/dew -run TestAccDataKpsKeypairs_basic -timeout 360m -parallel 4
=== RUN   TestAccDataKpsKeypairs_basic
=== PAUSE TestAccDataKpsKeypairs_basic
=== CONT  TestAccDataKpsKeypairs_basic
--- PASS: TestAccDataKpsKeypairs_basic (8.96s)
PASS
coverage: 9.7% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       9.024s  coverage: 9.7% of statements in ./huaweicloud/services/dew
```

![image](https://github.com/user-attachments/assets/f2434930-eb27-4768-a67b-4ad57ead80af)


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
