### PR TITLE
feat(cae): add new resource to manage timer rule

### DIFF
--- a/docs/resources/cae_timer_rule.md
+++ b/docs/resources/cae_timer_rule.md
@@ -1,0 +1,139 @@
+---
+subcategory: "Cloud Application Engine (CAE)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cae_timer_rule"
+description: |-
+  Use this resource to manage a timer rule for starting and stopping components within HuaweiCloud.
+---
+
+# huaweicloud_cae_timer_rule
+
+Use this resource to manage a timer rule for starting and stopping components within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "environment_id" {}
+variable "rule_name" {}
+variable "cron" {}
+variable "component_configurations" {
+  type = list(object({
+    id   = string
+    name = string
+  }))
+}
+
+resource "huaweicloud_cae_timer_rule" "test" {
+  environment_id   = var.environment_id
+  name             = var.rule_name
+  type             = "start"
+  status           = "on"
+  effective_range  = "component"
+  effective_policy = "onetime"
+  cron             =  var.cron
+
+  dynamic "components" {
+    for_each = var.component_configurations
+    content {
+      id   = components.value["id"]
+      name = components.value["name"]
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `environment_id` - (Required, String, ForceNew) Specifies the ID of the CAE environment.
+  Changing this creates a new resource.
+
+* `name` - (Required, String) Specifies the name of the timer rule.  
+  The maximum length of the name is `64` characters, only letters, digits, underscores (_) and hyphens (-)
+  are allowed.  
+  The name must start and end with a letter or a digit.
+
+* `type` - (Required, String) Specifies the type of the timer rule.  
+  The valid values are as follows:
+  + **stop**: The components will be started in batches. The components that have been started are not affected.
+  + **start**: The components will be stopped in batches. The components that have been stopped are not affected.
+
+* `status` - (Required, String) Specifies the status of the timer rule.  
+  The valid values are as follows:
+  + **on**
+  + **off**
+
+* `effective_range` - (Required, String) Specifies the effective range of the timer rule.  
+  The valid values are as follows:
+  + **environment**: The rule takes effect for all components in the environment.
+  + **application**: The rule takes effect for all components in the application.
+  + **component**: The rule takes effect for the specified components.
+
+* `effective_policy` - (Required, String) Specifies the effective policy of the timer rule.  
+  The valid values are as follows:
+  + **onetime**: The rule is executed only once.
+  + **periodic**: The rule is executed periodically.
+
+* `cron` - (Required, String) Specifies the cron expression of the timer rule.  
+  The triggered time of the rule must be at least two minutes later than the current time.  
+  When `effective_policy` is set to **periodic**, the rule can only be executed by week of day.
+
+* `applications` - (Optional, List) Specifies the list of the applications in which the timer rule takes effect.  
+  The [applications](#timer_rule_applications) structure is documented below.  
+  This parameter is required and available only when the `effective_range` parameter is set to **application**.
+
+* `components` - (Optional, List) Specifies the list of the components in which the timer rule takes effect.  
+  The [components](#timer_rule_components) structure is documented below.  
+  This parameter is required and available only when the `effective_range` parameter is set to **component**.
+
+<a name="timer_rule_applications"></a>
+The `applications` block supports:
+
+* `id` - (Required, String) Specifies the ID of the application.
+
+* `name` - (Optional, String) Specifies the name of the application.
+
+<a name="timer_rule_components"></a>
+The `components` block supports:
+
+* `id` - (Required, String) Specifies the ID of the component.
+
+* `name` - (Optional, String) Specifies the name of the component.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The resource can be imported using `environment_id` and `name`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_cae_timer_rule.test <environment_id>/<name>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes include: `status`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_cae_timer_rule" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      status,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1426,6 +1426,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cae_component_deployment":     cae.ResourceComponentDeployment(),
 			"huaweicloud_cae_environment":              cae.ResourceEnvironment(),
 			"huaweicloud_cae_notification_rule":        cae.ResourceNotificationRule(),
+			"huaweicloud_cae_timer_rule":               cae.ResourceTimerRule(),
 			"huaweicloud_cae_vpc_egress":               cae.ResourceVpcEgress(),
 
 			"huaweicloud_cbr_backup_share_accepter": cbr.ResourceBackupShareAccepter(),

--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_timer_rule_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_timer_rule_test.go
@@ -1,0 +1,325 @@
+package cae
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cae"
+)
+
+func getTimerRuleFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("cae", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CAE client: %s", err)
+	}
+
+	return cae.GetTimerRuleById(client, state.Primary.Attributes["environment_id"], state.Primary.ID)
+}
+
+func getCronPrefix(isOneTime bool) string {
+	currentTime := time.Now()
+	// The triggered time of the rule must be at least two minutes later than the current time.
+	nextTime := currentTime.AddDate(0, 0, 1)
+	parsedTime := fmt.Sprintf("%d %d %d", nextTime.Second(), nextTime.Minute(), nextTime.Hour())
+	if isOneTime {
+		parsedTime = fmt.Sprintf("%s %d %d ? %d", parsedTime, nextTime.Day(), nextTime.Month(), nextTime.Year())
+	}
+
+	return parsedTime
+}
+
+func TestAccTimerRule_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		name       = acceptance.RandomAccResourceNameWithDash()
+		updateName = acceptance.RandomAccResourceNameWithDash()
+
+		withEnv   = "huaweicloud_cae_timer_rule.env"
+		withApp   = "huaweicloud_cae_timer_rule.app"
+		withCom   = "huaweicloud_cae_timer_rule.com"
+		withEnvRc = acceptance.InitResourceCheck(withEnv, &obj, getTimerRuleFunc)
+		withAppRc = acceptance.InitResourceCheck(withApp, &obj, getTimerRuleFunc)
+		withComRc = acceptance.InitResourceCheck(withCom, &obj, getTimerRuleFunc)
+
+		oneTimeCron  = getCronPrefix(true)
+		withDayCron  = fmt.Sprintf("%s ? * * *", getCronPrefix(false))
+		withWeekCron = fmt.Sprintf("%s ? * 0,1,2,3,4,5,6 *", getCronPrefix(false))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCaeEnvironment(t)
+			acceptance.TestAccPreCheckCaeApplication(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			withEnvRc.CheckResourceDestroy(),
+			withAppRc.CheckResourceDestroy(),
+			withComRc.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTimerRule_step1(name, oneTimeCron, withDayCron, withWeekCron),
+				Check: resource.ComposeTestCheckFunc(
+					// For all components in the environment.
+					withEnvRc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withEnv, "environment_id", acceptance.HW_CAE_ENVIRONMENT_ID),
+					resource.TestCheckResourceAttr(withEnv, "name", name+"_env"),
+					resource.TestCheckResourceAttr(withEnv, "type", "start"),
+					resource.TestCheckResourceAttr(withEnv, "effective_range", "environment"),
+					resource.TestCheckResourceAttr(withEnv, "effective_policy", "onetime"),
+					resource.TestCheckResourceAttr(withEnv, "cron", oneTimeCron),
+					resource.TestCheckResourceAttr(withEnv, "applications.#", "0"),
+					resource.TestCheckResourceAttr(withEnv, "components.#", "0"),
+					// For all components in the application.
+					withAppRc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withApp, "name", name+"_app"),
+					resource.TestCheckResourceAttr(withApp, "type", "stop"),
+					resource.TestCheckResourceAttr(withApp, "effective_range", "application"),
+					resource.TestCheckResourceAttr(withApp, "effective_policy", "periodic"),
+					resource.TestCheckResourceAttr(withApp, "cron", withDayCron),
+					resource.TestCheckResourceAttr(withApp, "applications.#", "1"),
+					resource.TestCheckResourceAttrPair(withApp, "applications.0.id", "data.huaweicloud_cae_applications.test",
+						"applications.0.id"),
+					resource.TestCheckResourceAttrPair(withApp, "applications.0.name", "data.huaweicloud_cae_applications.test",
+						"applications.0.name"),
+					resource.TestCheckResourceAttr(withApp, "components.#", "0"),
+					// For specified components.
+					withComRc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withCom, "name", name+"_com"),
+					resource.TestCheckResourceAttr(withCom, "type", "start"),
+					resource.TestCheckResourceAttr(withCom, "effective_range", "component"),
+					resource.TestCheckResourceAttr(withCom, "effective_policy", "periodic"),
+					resource.TestCheckResourceAttr(withCom, "cron", withWeekCron),
+					resource.TestCheckResourceAttr(withCom, "applications.#", "0"),
+					resource.TestCheckResourceAttr(withCom, "components.#", "2"),
+					resource.TestCheckResourceAttrSet(withCom, "components.0.id"),
+					resource.TestCheckResourceAttrSet(withCom, "components.0.name"),
+				),
+			},
+			{
+				Config: testAccTimerRule_step2(name, updateName, oneTimeCron, withDayCron, withWeekCron),
+				Check: resource.ComposeTestCheckFunc(
+					// Update from all components in the environment to all components in the application.
+					withEnvRc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withEnv, "name", updateName+"_app"),
+					resource.TestCheckResourceAttr(withEnv, "type", "stop"),
+					resource.TestCheckResourceAttr(withEnv, "effective_range", "application"),
+					resource.TestCheckResourceAttr(withEnv, "effective_policy", "periodic"),
+					resource.TestCheckResourceAttr(withEnv, "cron", withWeekCron),
+					resource.TestCheckResourceAttr(withEnv, "applications.#", "1"),
+					resource.TestCheckResourceAttrPair(withEnv, "applications.0.id", "data.huaweicloud_cae_applications.test",
+						"applications.0.id"),
+					resource.TestCheckResourceAttr(withEnv, "applications.0.name", ""),
+					resource.TestCheckResourceAttr(withEnv, "components.#", "0"),
+					// Update from all components in the application to specified components.
+					withAppRc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withApp, "name", updateName+"_com"),
+					resource.TestCheckResourceAttr(withApp, "type", "stop"),
+					resource.TestCheckResourceAttr(withApp, "effective_range", "component"),
+					resource.TestCheckResourceAttr(withApp, "effective_policy", "onetime"),
+					resource.TestCheckResourceAttr(withApp, "cron", oneTimeCron),
+					resource.TestCheckResourceAttr(withApp, "components.#", "1"),
+					resource.TestCheckResourceAttrPair(withApp, "components.0.id", "huaweicloud_cae_component.test.0", "id"),
+					resource.TestCheckResourceAttr(withApp, "components.0.name", ""),
+					resource.TestCheckResourceAttr(withApp, "applications.#", "0"),
+					// Update from specified components to all components in the environment.
+					withComRc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withCom, "name", updateName+"_env"),
+					resource.TestCheckResourceAttr(withCom, "type", "stop"),
+					resource.TestCheckResourceAttr(withCom, "effective_range", "environment"),
+					resource.TestCheckResourceAttr(withCom, "effective_policy", "periodic"),
+					resource.TestCheckResourceAttr(withCom, "cron", withDayCron),
+					resource.TestCheckResourceAttr(withCom, "components.#", "0"),
+					resource.TestCheckResourceAttr(withCom, "applications.#", "0"),
+				),
+			},
+			{
+				ResourceName:            withEnv,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       testAccTimerRuleImportStateFunc(withEnv),
+				ImportStateVerifyIgnore: []string{"status"},
+			},
+			{
+				ResourceName:            withApp,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       testAccTimerRuleImportStateFunc(withApp),
+				ImportStateVerifyIgnore: []string{"status"},
+			},
+			{
+				ResourceName:            withCom,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       testAccTimerRuleImportStateFunc(withCom),
+				ImportStateVerifyIgnore: []string{"status"},
+			},
+		},
+	})
+}
+
+func testAccResourceTimerRule_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_swr_repositories" "test" {}
+
+locals {
+  swr_repositories = [for v in data.huaweicloud_swr_repositories.test.repositories : v if length(v.tags) > 0][0]
+}
+
+resource "huaweicloud_cae_component" "test" {
+  count          = 2
+  environment_id = "%[1]s"
+  application_id = "%[2]s"
+
+  metadata {
+    name = "%[3]s${count.index}"
+
+    annotations = {
+      version = "1.0.0"
+    }
+  }
+
+  spec {
+    replica = 1
+    runtime = "Docker"
+
+    source {
+      type = "image"
+      url  = format("%%s:%%s", local.swr_repositories.path, local.swr_repositories.tags[0])
+    }
+
+    resource_limit {
+      cpu    = "1000m"
+      memory = "4Gi"
+    }
+  }
+}
+
+data "huaweicloud_cae_applications" "test" {
+  environment_id = "%[1]s"
+  application_id = "%[2]s"
+}
+`, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID, name)
+}
+
+func testAccTimerRule_step1(name, oneTimeCron, withDayCron, withWeekCron string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cae_timer_rule" "env" {
+  environment_id   = "%[2]s"
+  name             = "%[3]s_env"
+  type             = "start"
+  status           = "on"
+  effective_range  = "environment"
+  effective_policy = "onetime"
+  cron             = "%[4]s"
+}
+
+resource "huaweicloud_cae_timer_rule" "app" {
+  environment_id   = "%[2]s"
+  name             = "%[3]s_app"
+  type             = "stop"
+  status           = "off"
+  effective_range  = "application"
+  effective_policy = "periodic"
+  cron             = "%[5]s"
+
+  applications {
+    id   = data.huaweicloud_cae_applications.test.applications[0].id
+    name = data.huaweicloud_cae_applications.test.applications[0].name
+  }
+}
+
+resource "huaweicloud_cae_timer_rule" "com" {
+  environment_id   = "%[2]s"
+  name             = "%[3]s_com"
+  type             = "start"
+  status           = "off"
+  effective_range  = "component"
+  effective_policy = "periodic"
+  cron             = "%[6]s"
+
+  dynamic "components" {
+    for_each = huaweicloud_cae_component.test[*]
+    content {
+      id   = components.value.id
+      name = components.value.metadata[0].name
+    }
+  }
+}
+`, testAccResourceTimerRule_base(name), acceptance.HW_CAE_ENVIRONMENT_ID, name, oneTimeCron, withDayCron, withWeekCron)
+}
+
+func testAccTimerRule_step2(name, updateName, oneTimeCron, withDayCron, withWeekCron string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cae_timer_rule" "env" {
+  environment_id   = "%[2]s"
+  name             = "%[3]s_app"
+  type             = "stop"
+  status           = "off"
+  effective_range  = "application"
+  effective_policy = "periodic"
+  cron             = "%[6]s"
+
+  applications {
+    id   = data.huaweicloud_cae_applications.test.applications[0].id
+  }
+}
+
+resource "huaweicloud_cae_timer_rule" "app" {
+  environment_id   = "%[2]s"
+  name             = "%[3]s_com"
+  type             = "stop"
+  status           = "on"
+  effective_range  = "component"
+  effective_policy = "onetime"
+  cron             = "%[4]s"
+
+  components {
+    id   = huaweicloud_cae_component.test[0].id
+  }
+}
+
+resource "huaweicloud_cae_timer_rule" "com" {
+  environment_id   = "%[2]s"
+  name             = "%[3]s_env"
+  type             = "stop"
+  status           = "on"
+  effective_range  = "environment"
+  effective_policy = "periodic"
+  cron             = "%[5]s"
+}
+`, testAccResourceTimerRule_base(name), acceptance.HW_CAE_ENVIRONMENT_ID, updateName, oneTimeCron, withDayCron, withWeekCron)
+}
+
+func testAccTimerRuleImportStateFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		var (
+			environmentId = rs.Primary.Attributes["environment_id"]
+			timerRuleName = rs.Primary.Attributes["name"]
+		)
+		if environmentId == "" || timerRuleName == "" {
+			return "", fmt.Errorf("some import IDs are missing, want '<environment_id>/<name>', but got '%s/%s'",
+				environmentId, timerRuleName)
+		}
+
+		return fmt.Sprintf("%s/%s", environmentId, timerRuleName), nil
+	}
+}

--- a/huaweicloud/services/cae/resource_huaweicloud_cae_timer_rule.go
+++ b/huaweicloud/services/cae/resource_huaweicloud_cae_timer_rule.go
@@ -1,0 +1,399 @@
+package cae
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CAE POST /v1/{project_id}/cae/timer-rules
+// @API CAE GET /v1/{project_id}/cae/timer-rules
+// @API CAE PUT /v1/{project_id}/cae/timer-rules/{timer_rule_id}
+// @API CAE DELETE /v1/{project_id}/cae/timer-rules/{timer_rule_id}
+func ResourceTimerRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTimerRuleCreate,
+		ReadContext:   resourceTimerRuleRead,
+		UpdateContext: resourceTimerRuleUpdate,
+		DeleteContext: resourceTimerRuleDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceTimerRuleImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+			},
+			"environment_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the CAE environment.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the timer rule.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the timer rule.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The status of the timer rule.`,
+			},
+			"effective_range": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The effective range of the timer rule.`,
+			},
+			"effective_policy": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The effective policy of the timer rule.`,
+			},
+			"cron": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The cron expression of the timer rule.`,
+			},
+			"applications": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The ID of the application.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The name of the application.`,
+						},
+					},
+				},
+				Description: `The list of the applications in which the timer rule takes effect.`,
+			},
+			"components": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The ID of the component.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The name of the component.`,
+						},
+					},
+				},
+				Description: `The list of the components in which the timer rule takes effect.`,
+			},
+		},
+	}
+}
+
+func buildTimerRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"api_version": "v1",
+		"kind":        "TimerRule",
+		"spec": map[string]interface{}{
+			"name":             d.Get("name"),
+			"type":             d.Get("type"),
+			"status":           d.Get("status"),
+			"effective_range":  d.Get("effective_range"),
+			"effective_policy": d.Get("effective_policy"),
+			"cron":             d.Get("cron"),
+			"apps":             utils.ValueIgnoreEmpty(buildTimerRuleApplications(d.Get("applications").(*schema.Set))),
+			"components":       utils.ValueIgnoreEmpty(buildTimerRuleComponents(d.Get("components").(*schema.Set))),
+		},
+	}
+}
+
+func buildTimerRuleApplications(applications *schema.Set) []map[string]interface{} {
+	if applications.Len() == 0 {
+		return nil
+	}
+
+	rest := make([]map[string]interface{}, applications.Len())
+	for i, v := range applications.List() {
+		rest[i] = map[string]interface{}{
+			"app_id":   utils.PathSearch("id", v, nil),
+			"app_name": utils.ValueIgnoreEmpty(utils.PathSearch("name", v, nil)),
+		}
+	}
+	return rest
+}
+
+func buildTimerRuleComponents(components *schema.Set) []map[string]interface{} {
+	if components.Len() == 0 {
+		return nil
+	}
+
+	rest := make([]map[string]interface{}, components.Len())
+	for i, v := range components.List() {
+		rest[i] = map[string]interface{}{
+			"component_id":   utils.PathSearch("id", v, nil),
+			"component_name": utils.ValueIgnoreEmpty(utils.PathSearch("name", v, nil)),
+		}
+	}
+	return rest
+}
+
+func resourceTimerRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v1/{project_id}/cae/timer-rules"
+	)
+
+	client, err := cfg.NewServiceClient("cae", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"X-Environment-Id": d.Get("environment_id").(string),
+		},
+		JSONBody: utils.RemoveNil(buildTimerRuleBodyParams(d)),
+	}
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating the timer rule: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	timerRuleId := utils.PathSearch("items[0].id", respBody, "").(string)
+	if timerRuleId == "" {
+		return diag.Errorf("unable to find the timer rule ID from the API response")
+	}
+
+	d.SetId(timerRuleId)
+
+	return resourceTimerRuleRead(ctx, d, meta)
+}
+
+func GetTimerRuleById(client *golangsdk.ServiceClient, environmentId, timerRuleId string) (interface{}, error) {
+	timerRules, err := getTimerRules(client, environmentId)
+	if err != nil {
+		return nil, common.ConvertExpected400ErrInto404Err(err, "error_code", envResourceNotFoundCodes...)
+	}
+
+	timerRule := utils.PathSearch(fmt.Sprintf("items[?id=='%s']|[0]", timerRuleId), timerRules, nil)
+	if timerRule == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return timerRule, nil
+}
+
+func getTimerRules(client *golangsdk.ServiceClient, environmentId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/cae/timer-rules"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	getListOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"X-Environment-Id": environmentId,
+		},
+	}
+	resp, err := client.Request("GET", listPath, &getListOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceTimerRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("cae", region)
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	timerRule, err := GetTimerRuleById(client, d.Get("environment_id").(string), d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error retrieving the timer rule (%s)", d.Get("name").(string)))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", timerRule, nil)),
+		d.Set("type", utils.PathSearch("type", timerRule, nil)),
+		d.Set("effective_range", utils.PathSearch("effective_range", timerRule, nil)),
+		d.Set("effective_policy", utils.PathSearch("effective_policy", timerRule, nil)),
+		d.Set("cron", utils.PathSearch("cron", timerRule, nil)),
+		d.Set("components", flattenTimerRuleComponents(utils.PathSearch("components", timerRule, make([]interface{}, 0)).([]interface{}))),
+		d.Set("applications", flattenTimerRuleApplications(utils.PathSearch("apps", timerRule, make([]interface{}, 0)).([]interface{}))),
+		// After the rule is executed, the value of the `status` parameter will be changed to `off`, so in order to prevent the resource
+		// from changing. The `status` parameter is not set.
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenTimerRuleComponents(components []interface{}) []map[string]interface{} {
+	if len(components) == 0 {
+		return nil
+	}
+
+	rest := make([]map[string]interface{}, len(components))
+	for i, v := range components {
+		rest[i] = map[string]interface{}{
+			"id":   utils.PathSearch("component_id", v, nil),
+			"name": utils.PathSearch("component_name", v, nil),
+		}
+	}
+	return rest
+}
+
+func flattenTimerRuleApplications(applications []interface{}) []map[string]interface{} {
+	if len(applications) == 0 {
+		return nil
+	}
+
+	rest := make([]map[string]interface{}, len(applications))
+	for i, v := range applications {
+		rest[i] = map[string]interface{}{
+			"id":   utils.PathSearch("app_id", v, nil),
+			"name": utils.PathSearch("app_name", v, nil),
+		}
+	}
+	return rest
+}
+
+func resourceTimerRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v1/{project_id}/cae/timer-rules/{timer_rule_id}"
+	)
+
+	client, err := cfg.NewServiceClient("cae", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{timer_rule_id}", d.Id())
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"X-Environment-Id": d.Get("environment_id").(string),
+		},
+		JSONBody: utils.RemoveNil(buildTimerRuleBodyParams(d)),
+		OkCodes:  []int{204},
+	}
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating the timer rule (%s): %s", d.Get("name").(string), err)
+	}
+
+	return resourceTimerRuleRead(ctx, d, meta)
+}
+
+func resourceTimerRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v1/{project_id}/cae/timer-rules/{timer_rule_id}"
+	)
+
+	client, err := cfg.NewServiceClient("cae", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{timer_rule_id}", d.Id())
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"X-Environment-Id": d.Get("environment_id").(string),
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", envResourceNotFoundCodes...),
+			fmt.Sprintf("error deleting the timer rule (%s)", d.Get("name").(string)))
+	}
+	return nil
+}
+
+// Since the ID cannot be found on the console, so we need to import by the timer rule name.
+func resourceTimerRuleImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	var (
+		cfg        = meta.(*config.Config)
+		importedId = d.Id()
+		parts      = strings.Split(importedId, "/")
+	)
+
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<environment_id>/<name>', but got '%s'",
+			importedId)
+	}
+
+	var (
+		environmentId = parts[0]
+		timerRuleName = parts[1]
+	)
+	mErr := multierror.Append(nil,
+		d.Set("environment_id", environmentId),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return nil, mErr
+	}
+
+	client, err := cfg.NewServiceClient("cae", cfg.GetRegion(d))
+	if err != nil {
+		return nil, fmt.Errorf("error creating CAE client: %s", err)
+	}
+
+	timerRules, err := getTimerRules(client, environmentId)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving the timer rules: %s", err)
+	}
+
+	timerRuleId := utils.PathSearch(fmt.Sprintf("items[?name=='%s']|[0].id", timerRuleName), timerRules, "").(string)
+	if timerRuleId == "" {
+		return []*schema.ResourceData{d},
+			fmt.Errorf("unable to find the ID of the timer rule (%s) from API response : %s", timerRuleName, err)
+	}
+
+	d.SetId(timerRuleId)
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource （**huaweicloud_cae_timer_rule**） to manage a timer rule for starting and stopping components.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cae -f TestAccTimerRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccTimerRule_basic -timeout 360m -parallel 10
=== RUN   TestAccTimerRule_basic
=== PAUSE TestAccTimerRule_basic
=== CONT  TestAccTimerRule_basic
--- PASS: TestAccTimerRule_basic (117.39s)
PASS
coverage: 36.2% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       117.458s        coverage: 36.2% of statements in ./huaweicloud/services/cae
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found   
![image](https://github.com/user-attachments/assets/de55cd0e-9ced-4a06-a84f-0bd141f65ae1)

    ab. Related resources (parent resources) not found  
![image](https://github.com/user-attachments/assets/865054f7-4505-4f13-911b-99117f1c5b7a)

   - **b. During delete/disassociate/unbind operation (Delete Context)**  
![image](https://github.com/user-attachments/assets/7f9c063f-6728-4bdc-8514-cc7b717477ba)
  
     bb. Related resources (parent resources) not found
   ![image](https://github.com/user-attachments/assets/2afab8a4-d201-4b41-aee0-8cf9bf04ec98)
