### PR TITLE
feat(cae/component): add new data source to query components

### DIFF
--- a/docs/data-sources/cae_components.md
+++ b/docs/data-sources/cae_components.md
@@ -1,0 +1,80 @@
+---
+subcategory: "Cloud Application Engine (CAE)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cae_components"
+description: |-
+  Use this data source to get the list of CAE components within HuaweiCloud.
+---
+
+# huaweicloud_cae_components
+
+Use this data source to get the list of CAE components within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "environment_id" {}
+variable "application_id" {}
+
+data "huaweicloud_cae_components" "test" {
+  environment_id = var.environment_id
+  application_id = var.application_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the components are located.  
+  If omitted, the provider-level region will be used.
+
+* `environment_id` - (Required, String) Specifies the ID of the environment to which the components belong.
+
+* `application_id` - (Required, String) Specifies the ID of the application to which the components belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `components` - All queried components.  
+  The [components](#cae_components) structure is documented below.
+
+<a name="cae_components"></a>
+The `components` block supports:
+
+* `id` - The ID of the component.
+
+* `name` - The name of the component.
+
+* `annotations` - The parameters of key/value pairs related to the component.
+
+* `spec` - The configuration information of the component.  
+  The [spec](#cae_components_spec) structure is documented below.
+
+* `created_at` - The creation time of the component, in RFC3339 format.
+
+* `updated_at` - The latest update time of the component, in RFC3339 format.
+
+<a name="cae_components_spec"></a>
+The `spec` block supports:
+
+* `runtime` - The component runtime.
+
+* `environment_id` - The ID of the environment to which the component belongs.
+
+* `replica` - The instance number of the component.
+
+* `available_replica` - The available instance number of the component.
+
+* `source` - The code source configuration information corresponding to the component.
+
+* `build` - The build information of the code source corresponding to the component.
+
+* `resource_limit` - The instance specification corresponding to the component.
+
+* `image_url` - The image URL that component used.
+
+* `status` - The status of the component.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -482,6 +482,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_bms_instances": bms.DataSourceBmsInstances(),
 
 			"huaweicloud_cae_applications":       cae.DataSourceApplications(),
+			"huaweicloud_cae_components":         cae.DataSourceComponents(),
 			"huaweicloud_cae_environments":       cae.DataSourceEnvironments(),
 			"huaweicloud_cae_notification_rules": cae.DataSourceCaeNotificationRules(),
 

--- a/huaweicloud/services/acceptance/cae/data_source_huaweicloud_cae_components_test.go
+++ b/huaweicloud/services/acceptance/cae/data_source_huaweicloud_cae_components_test.go
@@ -1,0 +1,142 @@
+package cae
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceComponents_basic(t *testing.T) {
+	all := "data.huaweicloud_cae_components.test"
+	dc := acceptance.InitDataSourceCheck(all)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCaeEnvironment(t)
+			acceptance.TestAccPreCheckCaeApplication(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceComponents_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_component_id_set_and_valid", "true"),
+					resource.TestCheckOutput("is_component_name_set_and_valid", "true"),
+					resource.TestCheckOutput("is_component_annotations_set_and_valid", "true"),
+					resource.TestCheckOutput("is_component_spec_set_and_valid", "true"),
+					resource.TestCheckOutput("is_component_created_at_set_and_valid", "true"),
+					resource.TestCheckOutput("is_component_updated_at_set_and_valid", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceComponents_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_swr_repositories" "test" {}
+
+locals {
+  swr_repositories = [for v in data.huaweicloud_swr_repositories.test.repositories : v if length(v.tags) > 0][0]
+}
+
+resource "huaweicloud_cae_component" "test" {
+  environment_id = "%[1]s"
+  application_id = "%[2]s"
+
+  metadata {
+    name = "%[3]s"
+
+    annotations = {
+      version = "1.0.0"
+    }
+  }
+
+  spec {
+    replica = 1
+    runtime = "Docker"
+
+    source {
+      type = "image"
+      url  = format("%%s:%%s", local.swr_repositories.path, local.swr_repositories.tags[0])
+    }
+
+    resource_limit {
+      cpu    = "500m"
+      memory = "1Gi"
+    }
+  }
+}
+`, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID, name)
+}
+
+func testAccDataSourceComponents_basic() string {
+	name := acceptance.RandomAccResourceNameWithDash()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_cae_components" "test" {
+  depends_on = [
+    huaweicloud_cae_component.test
+  ]
+
+  environment_id = "%[2]s"
+  application_id = "%[3]s"
+}
+
+locals {
+  component_id            = huaweicloud_cae_component.test.id
+  component_filter_result = try([
+    for v in data.huaweicloud_cae_components.test.components : v if v.id == local.component_id
+  ][0], null)
+}
+
+output "is_component_id_set_and_valid" {
+  value = local.component_filter_result != null
+}
+
+output "is_component_name_set_and_valid" {
+  value = try(local.component_filter_result.name == huaweicloud_cae_component.test.metadata[0].name, false)
+}
+
+output "is_component_annotations_set_and_valid" {
+  value = try(alltrue([
+    length(local.component_filter_result.annotations) > 0,
+    local.component_filter_result.annotations["version"] == huaweicloud_cae_component.test.metadata[0].annotations["version"]
+  ]), false)
+}
+
+output "is_component_spec_set_and_valid" {
+  value = try(alltrue([
+    length(local.component_filter_result.spec) > 0,
+    local.component_filter_result.spec[0].runtime != "",
+    local.component_filter_result.spec[0].environment_id != "",
+    local.component_filter_result.spec[0].replica != 0,
+    local.component_filter_result.spec[0].available_replica >= 0,
+    local.component_filter_result.spec[0].source != "",
+    local.component_filter_result.spec[0].build != "",
+    local.component_filter_result.spec[0].resource_limit != "",
+    local.component_filter_result.spec[0].image_url != "",
+    local.component_filter_result.spec[0].status != "",
+  ]), false)
+}
+
+output "is_component_created_at_set_and_valid" {
+  value = try(length(regexall("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
+    local.component_filter_result.created_at)) > 0, false)
+}
+
+output "is_component_updated_at_set_and_valid" {
+  value = try(length(regexall("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
+    local.component_filter_result.updated_at)) > 0, false)
+}
+`, testAccDataSourceComponents_base(name),
+		acceptance.HW_CAE_ENVIRONMENT_ID,
+		acceptance.HW_CAE_APPLICATION_ID)
+}

--- a/huaweicloud/services/cae/data_source_huaweicloud_cae_components.go
+++ b/huaweicloud/services/cae/data_source_huaweicloud_cae_components.go
@@ -1,0 +1,258 @@
+package cae
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CAE GET /v1/{project_id}/cae/applications/{application_id}/components
+func DataSourceComponents() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceComponentsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the components are located.`,
+			},
+			"environment_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the environment to which the components belong.`,
+			},
+			"application_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the application to which the components belong.`,
+			},
+			"components": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The component ID.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the component.`,
+						},
+						"annotations": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The parameters of key/value pairs related to the component.`,
+						},
+						"spec": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"runtime": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The component runtime.`,
+									},
+									"environment_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the environment to which the component belongs.`,
+									},
+									"replica": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The instance number of the component.`,
+									},
+									"available_replica": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The available instance number of the component.`,
+									},
+									"source": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The code source configuration information corresponding to the component.`,
+									},
+									"build": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The build information of the code source corresponding to the component.`,
+									},
+									"resource_limit": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The instance specification corresponding to the component.`,
+									},
+									"image_url": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The image URL that component used.`,
+									},
+									"status": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The status of the component.`,
+									},
+								},
+							},
+							Description: "The configuration information of the component.",
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the component, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the component, in RFC3339 format.`,
+						},
+					},
+				},
+				Description: `All queried components.`,
+			},
+		},
+	}
+}
+
+func queryComponents(client *golangsdk.ServiceClient, environmentId, appId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/cae/applications/{application_id}/components?limit=100"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{application_id}", appId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type":     "application/json",
+			"X-Environment-ID": environmentId,
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		components := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		if len(components) < 1 {
+			break
+		}
+		result = append(result, components...)
+		offset += len(components)
+	}
+
+	return result, nil
+}
+
+func flattenComponentAnnotations(annotations map[string]interface{}) map[string]interface{} {
+	if len(annotations) < 1 {
+		return nil
+	}
+
+	result := make(map[string]interface{})
+	// All values convert to the string values.
+	for key, value := range annotations {
+		result[key] = fmt.Sprint(value)
+	}
+	return result
+}
+
+func flattenComponentSpec(spec interface{}) []map[string]interface{} {
+	if spec == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"runtime":           utils.PathSearch("runtime", spec, nil),
+			"environment_id":    utils.PathSearch("env_id", spec, nil),
+			"replica":           utils.PathSearch("replica", spec, nil),
+			"available_replica": utils.PathSearch("available_replica", spec, nil),
+			"source":            utils.JsonToString(utils.PathSearch("source", spec, nil)),
+			"build":             utils.JsonToString(utils.PathSearch("build", spec, nil)),
+			"resource_limit":    utils.JsonToString(utils.PathSearch("resource_limit", spec, nil)),
+			"image_url":         utils.PathSearch("image_url", spec, nil),
+			"status":            utils.PathSearch("status", spec, nil),
+		},
+	}
+}
+
+func flattenComponents(components []interface{}) []map[string]interface{} {
+	if len(components) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(components))
+	for _, component := range components {
+		result = append(result, map[string]interface{}{
+			"id":   utils.PathSearch("id", component, nil),
+			"name": utils.PathSearch("name", component, nil),
+			"annotations": flattenComponentAnnotations(utils.PathSearch("annotations",
+				component, make(map[string]interface{})).(map[string]interface{})),
+			"spec": flattenComponentSpec(utils.PathSearch("spec", component, make(map[string]interface{})).(map[string]interface{})),
+			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("created_at",
+				component, "").(string))/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("updated_at",
+				component, "").(string))/1000, false),
+		})
+	}
+
+	return result
+}
+
+func dataSourceComponentsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		envId  = d.Get("environment_id").(string)
+		appId  = d.Get("application_id").(string)
+	)
+	client, err := cfg.NewServiceClient("cae", region)
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	components, err := queryComponents(client, envId, appId)
+	if err != nil {
+		return diag.Errorf("error getting components: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("components", flattenComponents(components)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new data source that used to query components.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports a new data source that used to query components.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cae -f TestAccDataSourceComponents_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccDataSourceComponents_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceComponents_basic
=== PAUSE TestAccDataSourceComponents_basic
=== CONT  TestAccDataSourceComponents_basic
--- PASS: TestAccDataSourceComponents_basic (23.90s)
PASS
coverage: 17.2% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       23.954s coverage: 17.2% of statements in ./huaweicloud/services/cae
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
