### PR TITLE
feat(VPC): vpc support new param enhanced_local_route

### DIFF
--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -52,6 +52,9 @@ The following arguments are supported:
 * `description` - (Optional, String) Specifies supplementary information about the VPC. The value is a string of
   no more than 255 characters and cannot contain angle brackets (< or >).
 
+* `enhanced_local_route` - (Optional, String) Specifies whether to enable local route enhancement function. It can not be
+  closed if it has been open. Value options: **true** or **false**. Defaults to **true**.
+
 * `secondary_cidrs` - (Optional, List) Specifies the secondary CIDR blocks of the VPC.
   Each VPC can have 5 secondary CIDR blocks.
 
@@ -86,7 +89,7 @@ $ terraform import huaweicloud_vpc.vpc_v1 7117d38e-4c8f-4624-a505-bd96b97d024c
 ```
 
 Note that the imported state may not be identical to your resource definition when `secondary_cidr` was set.
-You you can ignore changes as below.
+You can ignore changes as below.
 
 ```hcl
 resource "huaweicloud_vpc" "vpc_v1" {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20241226031404-57791d6b2637
+	github.com/chnsz/golangsdk v0.0.0-20250114114204-a56a2c74f332
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20241226031404-57791d6b2637 h1:AMk/Wr0ScKV9OO7rCsNLvFvkQTKibV3bznMhoB6El18=
-github.com/chnsz/golangsdk v0.0.0-20241226031404-57791d6b2637/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20250114114204-a56a2c74f332 h1:Ot5Nx+RRIq6B8bdsreletGCSBom2D3tOJSeEZ4x83a8=
+github.com/chnsz/golangsdk v0.0.0-20250114114204-a56a2c74f332/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -42,6 +42,7 @@ var (
 	HW_IMAGE_NAME                    = os.Getenv("HW_IMAGE_NAME")
 	HW_IMS_DATA_DISK_IMAGE_ID        = os.Getenv("HW_IMS_DATA_DISK_IMAGE_ID")
 	HW_VPC_ID                        = os.Getenv("HW_VPC_ID")
+	HW_VPC_ENHANCED_LOCAL_ROUTE      = os.Getenv("HW_VPC_ENHANCED_LOCAL_ROUTE")
 	HW_VPN_P2C_GATEWAY_ID            = os.Getenv("HW_VPN_P2C_GATEWAY_ID")
 	HW_VPN_P2C_SERVER                = os.Getenv("HW_VPN_P2C_SERVER")
 	HW_VPN_P2C_CLIENT_CA_CERTIFICATE = os.Getenv("HW_VPN_P2C_CLIENT_CA_CERTIFICATE")
@@ -2726,6 +2727,13 @@ func TestAccPreCheckAsDataDiskImageId(t *testing.T) {
 func TestAccPreCheckVpcId(t *testing.T) {
 	if HW_VPC_ID == "" {
 		t.Skip("HW_VPC_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckVpcEnhancedLocalRoute(t *testing.T) {
+	if HW_VPC_ENHANCED_LOCAL_ROUTE == "" {
+		t.Skip("HW_VPC_ENHANCED_LOCAL_ROUTE must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_test.go
@@ -210,6 +210,42 @@ func TestAccVpcV1_WithEpsId(t *testing.T) {
 	})
 }
 
+func TestAccVpcV1_WithEnhancedLocalRoute(t *testing.T) {
+	var vpc vpcs.Vpc
+
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_vpc.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckVpcEnhancedLocalRoute(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckVpcV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcV1_enhancedLocalRoute(rName, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcV1Exists(resourceName, &vpc),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "cidr", "192.168.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "enhanced_local_route", "false"),
+				),
+			},
+			{
+				Config: testAccVpcV1_enhancedLocalRoute(rName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcV1Exists(resourceName, &vpc),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "cidr", "192.168.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "enhanced_local_route", "true"),
+				),
+			},
+		},
+	})
+}
+
 // TestAccVpcV1_WithCustomRegion this case will run a test for resource-level region. Before run this case,
 // you shoule set `HW_CUSTOM_REGION_NAME` in your system and it should be different from `HW_REGION_NAME`.
 func TestAccVpcV1_WithCustomRegion(t *testing.T) {
@@ -440,6 +476,16 @@ resource "huaweicloud_vpc" "test" {
   enterprise_project_id = "%[2]s"
 }
 `, rName, epsId)
+}
+
+func testAccVpcV1_enhancedLocalRoute(rName, enhancedLocalRoute string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name                 = "%[1]s"
+  cidr                 = "192.168.0.0/16"
+  enhanced_local_route = "%[2]s"
+}
+`, rName, enhancedLocalRoute)
 }
 
 func testAccVpcV1_WithCustomRegion(name1, name2, region string) string {

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/vpcs/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/vpcs/requests.go
@@ -146,6 +146,7 @@ type CreateOpts struct {
 	Name                string `json:"name,omitempty"`
 	CIDR                string `json:"cidr,omitempty"`
 	Description         string `json:"description,omitempty"`
+	EnhancedLocalRoute  *bool  `json:"enhanced_local_route,omitempty"`
 	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
 }
 
@@ -187,10 +188,11 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts contains the values used when updating a vpc.
 type UpdateOpts struct {
-	Name             string  `json:"name,omitempty"`
-	CIDR             string  `json:"cidr,omitempty"`
-	Description      *string `json:"description,omitempty"`
-	EnableSharedSnat *bool   `json:"enable_shared_snat,omitempty"`
+	Name               string  `json:"name,omitempty"`
+	CIDR               string  `json:"cidr,omitempty"`
+	Description        *string `json:"description,omitempty"`
+	EnhancedLocalRoute *bool   `json:"enhanced_local_route,omitempty"`
+	EnableSharedSnat   *bool   `json:"enable_shared_snat,omitempty"`
 }
 
 // ToVpcUpdateMap builds an update body based on UpdateOpts.

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/vpcs/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/vpcs/results.go
@@ -33,6 +33,9 @@ type Vpc struct {
 	//Specifies the range of available subnets in the VPC.
 	CIDR string `json:"cidr"`
 
+	// Whether enable local route enhance
+	EnhancedLocalRoute bool `json:"enhanced_local_route"`
+
 	//Enterprise Project ID.
 	EnterpriseProjectID string `json:"enterprise_project_id"`
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20241226031404-57791d6b2637
+# github.com/chnsz/golangsdk v0.0.0-20250114114204-a56a2c74f332
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  vpc support new param enhanced_local_route
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  vpc support new param enhanced_local_route
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/vpc/ TESTARGS='-run estAccVpcV1_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/ -v -run estAccVpcV1_ -timeout 360m -parallel 4
=== RUN   TestAccVpcV1_basic
=== PAUSE TestAccVpcV1_basic
=== RUN   TestAccVpcV1_secondaryCIDR
=== PAUSE TestAccVpcV1_secondaryCIDR
=== RUN   TestAccVpcV1_secondaryCIDRs
=== PAUSE TestAccVpcV1_secondaryCIDRs
=== RUN   TestAccVpcV1_WithEpsId
=== PAUSE TestAccVpcV1_WithEpsId
=== RUN   TestAccVpcV1_WithEnhancedLocalRoute
=== PAUSE TestAccVpcV1_WithEnhancedLocalRoute
=== RUN   TestAccVpcV1_WithCustomRegion
=== PAUSE TestAccVpcV1_WithCustomRegion
=== CONT  TestAccVpcV1_basic
=== CONT  TestAccVpcV1_WithEpsId
=== CONT  TestAccVpcV1_WithCustomRegion
=== CONT  TestAccVpcV1_WithEnhancedLocalRoute
=== CONT  TestAccVpcV1_WithCustomRegion
    acceptance.go:713: HW_CUSTOM_REGION_NAME must be set for acceptance tests
--- SKIP: TestAccVpcV1_WithCustomRegion (0.00s)
=== CONT  TestAccVpcV1_secondaryCIDRs
=== CONT  TestAccVpcV1_WithEpsId
    acceptance.go:746: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccVpcV1_WithEpsId (0.01s)
=== CONT  TestAccVpcV1_secondaryCIDR
=== CONT  TestAccVpcV1_WithEnhancedLocalRoute
    acceptance.go:2736: HW_VPC_ENHANCED_LOCAL_ROUTE must be set for the acceptance test
--- SKIP: TestAccVpcV1_WithEnhancedLocalRoute (0.02s)
--- PASS: TestAccVpcV1_basic (154.00s)
--- PASS: TestAccVpcV1_secondaryCIDR (169.54s)
--- PASS: TestAccVpcV1_secondaryCIDRs (194.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       194.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
