### PR TITLE
feat(vpc): add new resource subnet private IP

### DIFF
--- a/docs/resources/vpc_subnet_private_ip.md
+++ b/docs/resources/vpc_subnet_private_ip.md
@@ -1,0 +1,54 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_vpc_subnet_private_ip"
+description: |-
+  Manages a VPC subnet private IP resource within HuaweiCloud.
+---
+
+# huaweicloud_vpc_subnet_private_ip
+
+Manages a VPC subnet private IP resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "subnet_id" {}
+variable "ip_address" {}
+
+resource "huaweicloud_vpc_subnet_private_ip" "test" {
+  subnet_id  = var.subnet_id
+  ip_address = var.ip_address
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `subnet_id` - (Required, String, NonUpdatable) Specifies the ID of the subnet to which the private IP belongs.
+
+* `ip_address` - (Optional, String, NonUpdatable) Specifies the IP address. The value must be an unused address
+  within the subnet cidr. If it is not specified, the system automatically assigns an IP address.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - The status of the private IP address. Possible values are **ACTIVE** and **DOWN**.
+
+* `device_owner` - The resource using the private IP address. The parameter is left blank if it is not used.
+
+## Import
+
+The private IP can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_vpc_subnet_private_ip.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2200,6 +2200,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_route":                       vpc.ResourceVPCRouteTableRoute(),
 			"huaweicloud_vpc":                             vpc.ResourceVirtualPrivateCloudV1(),
 			"huaweicloud_vpc_subnet":                      vpc.ResourceVpcSubnetV1(),
+			"huaweicloud_vpc_subnet_private_ip":           vpc.ResourceSubnetPrivateIP(),
 			"huaweicloud_vpc_address_group":               vpc.ResourceVpcAddressGroup(),
 			"huaweicloud_vpc_flow_log":                    vpc.ResourceVpcFlowLog(),
 			"huaweicloud_vpc_network_interface":           vpc.ResourceNetworkInterface(),

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_subnet_private_ip_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_subnet_private_ip_test.go
@@ -1,0 +1,87 @@
+package vpc
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getSubnetPrivateIPResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("vpc", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating VPC v1 client: %s", err)
+	}
+
+	getSubnetPrivateIPHttpUrl := "v1/{project_id}/privateips/{privateip_id}"
+	getSubnetPrivateIPPath := client.Endpoint + getSubnetPrivateIPHttpUrl
+	getSubnetPrivateIPPath = strings.ReplaceAll(getSubnetPrivateIPPath, "{project_id}", client.ProjectID)
+	getSubnetPrivateIPPath = strings.ReplaceAll(getSubnetPrivateIPPath, "{privateip_id}", state.Primary.ID)
+	getSubnetPrivateIPOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getSubnetPrivateIPResp, err := client.Request("GET", getSubnetPrivateIPPath, &getSubnetPrivateIPOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving VPC subnet private IP: %s", err)
+	}
+
+	return utils.FlattenResponse(getSubnetPrivateIPResp)
+}
+
+func TestAccSubnetPrivateIP_basic(t *testing.T) {
+	var (
+		privateIP    interface{}
+		name         = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_vpc_subnet_private_ip.test"
+
+		rc = acceptance.InitResourceCheck(
+			resourceName,
+			&privateIP,
+			getSubnetPrivateIPResourceFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSubnetPrivateIP_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "ip_address", "192.168.0.111"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_id",
+						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "status", "DOWN"),
+					resource.TestCheckResourceAttr(resourceName, "device_owner", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSubnetPrivateIP_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_vpc_subnet_private_ip" "test" {
+  subnet_id  = huaweicloud_vpc_subnet.test.id
+  ip_address = "192.168.0.111"
+}
+`, testAccVpcSubnetV1_basic(name))
+}

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet_private_ip.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet_private_ip.go
@@ -1,0 +1,167 @@
+package vpc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API VPC POST /v1/{project_id}/privateips
+// @API VPC GET /v1/{project_id}/privateips/{privateip_id}
+// @API VPC DELETE /v1/{project_id}/privateips/{privateip_id}
+func ResourceSubnetPrivateIP() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSubnetPrivateIPCreate,
+		ReadContext:   resourceSubnetPrivateIPRead,
+		UpdateContext: resourceSubnetPrivateIPUpdate,
+		DeleteContext: resourceSubnetPrivateIPDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"device_owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildSubnetPrivateIPBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"privateips": []map[string]interface{}{
+			{
+				"subnet_id":  d.Get("subnet_id"),
+				"ip_address": utils.ValueIgnoreEmpty(d.Get("ip_address")),
+			},
+		},
+	}
+	return bodyParams
+}
+
+func resourceSubnetPrivateIPCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vpc", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC v1 client: %s", err)
+	}
+
+	ctreateSubnetPrivateIPHttpUrl := "v1/{project_id}/privateips"
+	ctreateSubnetPrivateIPPath := client.Endpoint + ctreateSubnetPrivateIPHttpUrl
+	ctreateSubnetPrivateIPPath = strings.ReplaceAll(ctreateSubnetPrivateIPPath, "{project_id}", client.ProjectID)
+	createSubnetPrivateIPOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createSubnetPrivateIPOpt.JSONBody = utils.RemoveNil(buildSubnetPrivateIPBodyParams(d))
+	createSubnetPrivateIPResp, err := client.Request("POST", ctreateSubnetPrivateIPPath, &createSubnetPrivateIPOpt)
+	if err != nil {
+		return diag.Errorf("error creating VPC subnet private IP: %s", err)
+	}
+
+	createSubnetPrivateIPRespBody, err := utils.FlattenResponse(createSubnetPrivateIPResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("privateips[0].id", createSubnetPrivateIPRespBody, "").(string)
+	if id == "" {
+		return diag.Errorf("error creating VPC subnet private IP: ID is not found in API response")
+	}
+	d.SetId(id)
+
+	return resourceSubnetPrivateIPRead(ctx, d, meta)
+}
+
+func resourceSubnetPrivateIPRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vpc", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC v1 client: %s", err)
+	}
+
+	getSubnetPrivateIPHttpUrl := "v1/{project_id}/privateips/{privateip_id}"
+	getSubnetPrivateIPPath := client.Endpoint + getSubnetPrivateIPHttpUrl
+	getSubnetPrivateIPPath = strings.ReplaceAll(getSubnetPrivateIPPath, "{project_id}", client.ProjectID)
+	getSubnetPrivateIPPath = strings.ReplaceAll(getSubnetPrivateIPPath, "{privateip_id}", d.Id())
+	getSubnetPrivateIPOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getSubnetPrivateIPResp, err := client.Request("GET", getSubnetPrivateIPPath, &getSubnetPrivateIPOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "VPC subnet private IP")
+	}
+
+	getSubnetPrivateIPRespBody, err := utils.FlattenResponse(getSubnetPrivateIPResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr := multierror.Append(
+		nil,
+		d.Set("region", region),
+		d.Set("subnet_id", utils.PathSearch("privateip.subnet_id", getSubnetPrivateIPRespBody, nil)),
+		d.Set("ip_address", utils.PathSearch("privateip.ip_address", getSubnetPrivateIPRespBody, nil)),
+		d.Set("status", utils.PathSearch("privateip.status", getSubnetPrivateIPRespBody, nil)),
+		d.Set("device_owner", utils.PathSearch("privateip.device_owner", getSubnetPrivateIPRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceSubnetPrivateIPUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceSubnetPrivateIPDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vpc", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC v1 client: %s", err)
+	}
+
+	deleteSubnetPrivateIPHttpUrl := "v1/{project_id}/privateips/{privateip_id}"
+	deleteSubnetPrivateIPPath := client.Endpoint + deleteSubnetPrivateIPHttpUrl
+	deleteSubnetPrivateIPPath = strings.ReplaceAll(deleteSubnetPrivateIPPath, "{project_id}", client.ProjectID)
+	deleteSubnetPrivateIPPath = strings.ReplaceAll(deleteSubnetPrivateIPPath, "{privateip_id}", d.Id())
+	deleteSubnetPrivateIPOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	_, err = client.Request("DELETE", deleteSubnetPrivateIPPath, &deleteSubnetPrivateIPOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "VPC subnet private IP")
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccSubnetPrivateIP_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccSubnetPrivateIP_basic -timeout 360m -parallel 4
=== RUN   TestAccSubnetPrivateIP_basic
=== PAUSE TestAccSubnetPrivateIP_basic
=== CONT  TestAccSubnetPrivateIP_basic
--- PASS: TestAccSubnetPrivateIP_basic (89.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       89.206s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/d97a4548-f626-4843-8aa1-fdab1eb6a47d)


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/b17fad14-c3c2-41c8-ad2b-28bed2bc36d0)


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
