### PR TITLE
fix(lts/steam): ignore eps input if its not set

### DIFF
--- a/huaweicloud/services/lts/resource_huaweicloud_lts_stream.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_stream.go
@@ -134,7 +134,7 @@ func buildCreateStreamBodyParams(cfg *config.Config, d *schema.ResourceData) map
 	userNoPermission := []string{"EPS.0004"}
 	epsId := cfg.GetEnterpriseProjectID(d)
 	if epsId == "" {
-		epsId = "0"
+		return bodyParams
 	}
 	epsInfo, err := getEnterpriseProjectById(cfg, cfg.GetRegion(d), epsId)
 	// If we catch error 403, it means that the user does not have EPS permissions, return immediately.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Ignore JSON body input if the enterprise_project_id not set.
Using default value of the enterprise project "default" if corresponding region supports eps service and the script have related inputs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. ignore eps input if its not set.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lts -f TestAccLtsStream_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccLtsStream_basic -timeout 360m -parallel 10
=== RUN   TestAccLtsStream_basic
=== PAUSE TestAccLtsStream_basic
=== CONT  TestAccLtsStream_basic
--- PASS: TestAccLtsStream_basic (22.32s)
PASS
coverage: 8.9% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       22.389s coverage: 8.9% of statements in ./huaweicloud/services/lts
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
