### PR TITLE
feat(fgs/function): add new resource for function topping

### DIFF
--- a/docs/resources/fgs_function_topping.md
+++ b/docs/resources/fgs_function_topping.md
@@ -1,0 +1,37 @@
+---
+subcategory: "FunctionGraph"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_fgs_function_topping"
+description: |-
+  Using this function to top function within HuaweiCloud.
+---
+
+# huaweicloud_fgs_function_topping
+
+Using this function to top function within HuaweiCloud.
+
+## Example Usage
+
+### Topping function
+
+```hcl
+variable "function_urn" {}
+
+resource "huaweicloud_fgs_function_topping" "test" {
+  function_urn = var.function_urn
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the function is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `function_urn` - (Required, String, ForceNew) Specifies the URN of the function to be topped.  
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1804,6 +1804,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_dependency_version":         fgs.ResourceDependencyVersion(),
 			"huaweicloud_fgs_function":                   fgs.ResourceFgsFunctionV2(),
 			"huaweicloud_fgs_function_event":             fgs.ResourceFunctionEvent(),
+			"huaweicloud_fgs_function_topping":           fgs.ResourceFunctionTopping(),
 			"huaweicloud_fgs_function_trigger":           fgs.ResourceFunctionTrigger(),
 
 			"huaweicloud_ga_accelerator":    ga.ResourceAccelerator(),

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_topping_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_topping_test.go
@@ -1,0 +1,72 @@
+package fgs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// lintignore:AT001
+func TestAccFunctionTopping_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckFgsAgency(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionTopping_basic(),
+			},
+		},
+	})
+}
+
+func testAccFunctionTopping_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+variable "js_script_content" {
+  default = <<EOT
+exports.handler = async (event, context) => {
+    const result =
+    {
+        'repsonse_code': 200,
+        'headers':
+        {
+            'Content-Type': 'application/json'
+        },
+        'isBase64Encoded': false,
+        'body': JSON.stringify(event)
+    }
+    return result
+}
+EOT
+}
+
+resource "huaweicloud_fgs_function" "test" {
+  count = 3
+
+  name        = format("%[1]s_%%d", count.index) 
+  app         = "default"
+  agency      = "%[2]s"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  code_type   = "inline"
+  runtime     = "Node.js12.13"
+  func_code   = base64encode(jsonencode(var.js_script_content))
+}
+
+resource "huaweicloud_fgs_function_topping" "test" {
+  depends_on = [huaweicloud_fgs_function.test]
+
+  count = 3
+
+  function_urn = huaweicloud_fgs_function.test[count.index].urn
+}
+`, name, acceptance.HW_FGS_AGENCY_NAME)
+}

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_topping.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_topping.go
@@ -1,0 +1,113 @@
+package fgs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+type ToppingStatus string
+
+var (
+	ToppingStatusEnable  ToppingStatus = "true"
+	ToppingStatusDisable ToppingStatus = "false"
+)
+
+// @API FunctionGraph PUT /v2/{project_id}/fgs/functions/{func_urn}/collect/{state}
+func ResourceFunctionTopping() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceFunctionToppingCreate,
+		ReadContext:   resourceFunctionToppingRead,
+		DeleteContext: resourceFunctionToppingDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the function is located.`,
+			},
+			"function_urn": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The URN of the function to be topped.`,
+			},
+		},
+	}
+}
+
+func updateFunctionToppingStatus(client *golangsdk.ServiceClient, functionUrn, status string) error {
+	httpUrl := "v2/{project_id}/fgs/functions/{func_urn}/collect/{state}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{func_urn}", functionUrn)
+	updatePath = strings.ReplaceAll(updatePath, "{state}", status)
+
+	updateOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	_, err := client.Request("PUT", updatePath, &updateOpts)
+	if err != nil {
+		return fmt.Errorf("error updating function topping status (target is: %s): %s", status, err)
+	}
+	return nil
+}
+
+func resourceFunctionToppingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		functionUrn = d.Get("function_urn").(string)
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	err = updateFunctionToppingStatus(client, functionUrn, string(ToppingStatusEnable))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// In the same script, a function can only be topped once.
+	d.SetId(functionUrn)
+
+	return resourceFunctionToppingRead(ctx, d, meta)
+}
+
+func resourceFunctionToppingRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceFunctionToppingDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		functionUrn = d.Get("function_urn").(string)
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	err = updateFunctionToppingStatus(client, functionUrn, string(ToppingStatusDisable))
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "FunctionGraph function topping")
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new resource to top the function, there is no limit for function topping currently.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource for function topping
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFunctionTopping_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunctionTopping_basic -timeout 360m -parallel 10
=== RUN   TestAccFunctionTopping_basic
=== PAUSE TestAccFunctionTopping_basic
=== CONT  TestAccFunctionTopping_basic
--- PASS: TestAccFunctionTopping_basic (15.28s)
PASS
coverage: 12.8% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       15.328s coverage: 12.8% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![image](https://github.com/user-attachments/assets/e8f36d1e-237c-45a9-9665-3952f465fe37)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
