### PR TITLE
feat(cse): add new data source to query microservice instances

### DIFF
--- a/docs/data-sources/cse_microservice_instances.md
+++ b/docs/data-sources/cse_microservice_instances.md
@@ -1,0 +1,117 @@
+---
+subcategory: "Cloud Service Engine (CSE)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cse_microservice_instances"
+description: |-
+  Use this data source to get the list of the instances under dedicated microservice within HuaweiCloud.
+---
+
+# huaweicloud_cse_microservice_instances
+
+Use this data source to get the list of the instances under dedicated microservice within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "microservice_engine_id" {} // Ensure EIP access is enabled.
+variable "admin_user" {}
+variable "admin_password" {}
+variable "microservice_id" {}
+
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  filter_engines = [for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == var.microservice_engine_id]
+}
+
+data "huaweicloud_cse_microservice_instances" "test" {
+  auth_address    = local.filter_engines[0].service_registry_addresses[0].public
+  connect_address = local.filter_engines[0].service_registry_addresses[0].public
+  admin_user      = var.admin_user
+  admin_pass      = var.admin_password
+
+  microservice_id = var.microservice_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `auth_address` - (Required, String) Specifies the address that used to request the access token.
+
+* `connect_address` - (Required, String) Specifies the address that used to send requests and manage configuration.
+
+-> We are only support IPv4 addresses yet (for `auth_address` and `connect_address`).
+
+* `admin_pass` - (Optional, String) Specifies the user password that used to pass the **RBAC** control.
+
+* `admin_user` - (Optional, String) Specifies the user name that used to pass the **RBAC** control.
+  The password format must meet the following conditions:
+  + Must be `8` to `32` characters long.
+  + A password must contain at least one digit, one uppercase letter, one lowercase letter, and one special character
+    (-~!@#%^*_=+?$&()|<>{}[]).
+  + Cannot be the account name or account name spelled backwards.
+  + The password can only start with a letter.
+
+-> Both `admin_user` and `admin_pass` are required if **RBAC** is enabled for the microservice engine.
+
+* `microservice_id` - (Required, String) Specifies the ID of the dedicated microservice to which the instances belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `instances` - The list of the microservice instances.
+  The [instances](#microservice_instances) structure is documented below.
+
+<a name="microservice_instances"></a>
+The `instances` block supports:
+
+* `id` - The ID of the microservice instance.
+
+* `host_name` - The host name of the microservice instance.
+
+* `endpoints` - The list of the access addresses of the microservice instance.
+
+* `version` - The version of the microservice instance.
+
+* `properties` - The extended attributes of the microservice instance, in key/value format.
+
+* `health_check` - The health check configuration of the microservice instance.
+  The [health_check](#microservice_instances_health_check) structure is documented below.
+
+* `data_center` - The data center configuration of the microservice instance.
+  The [data_center](#microservice_instances_data_center) structure is documented below.
+
+* `status` - The current status of the microservice instance.
+  + **UP**
+  + **DOWN**
+  + **STARTING**
+  + **OUTOFSERVICE**
+
+* `created_at` - The creation time of the microservice instance, in RFC3339 format.
+
+* `updated_at` - The latest update time of the microservice instance, in RFC3339 format.
+
+<a name="microservice_instances_data_center"></a>
+The `data_center` block supports:
+
+* `region` - The custom region name of the data center.
+
+* `name` - The name of the data center.
+
+* `availability_zone` - The custom availability zone of the data center.
+
+<a name="microservice_instances_health_check"></a>
+The `health_check` block supports:
+
+* `mode` - The heartbeat mode of the health check.
+
+* `interval` - The heartbeat interval of the health check, in seconds.
+
+* `max_retries` - The maximum retry number of the health check.
+
+* `port` - The port of the health check.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -621,6 +621,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cse_microservice_engine_configurations": cse.DataSourceMicroserviceEngineConfigurations(),
 			"huaweicloud_cse_microservice_engine_flavors":        cse.DataSourceMicroserviceEngineFlavors(),
 			"huaweicloud_cse_microservice_engines":               cse.DataSourceMicroserviceEngines(),
+			"huaweicloud_cse_microservice_instances":             cse.DataSourceMicroserviceInstances(),
 			"huaweicloud_cse_nacos_namespaces":                   cse.DataSourceNacosNamespaces(),
 
 			"huaweicloud_csms_events":                   dew.DataSourceDewCsmsEvents(),

--- a/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservice_instances_test.go
+++ b/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservice_instances_test.go
@@ -1,0 +1,167 @@
+package cse
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataMicroserviceInstances_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		dataSource = "data.huaweicloud_cse_microservice_instances.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCSEMicroserviceEngineID(t)
+			acceptance.TestAccPreCheckCSEMicroserviceEngineAdminPassword(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataMicroserviceInstances_expectErr(),
+				ExpectError: regexp.MustCompile(`Micro-service does not exist`),
+			},
+			{
+				Config: testAccDataMicroserviceInstances_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "instances.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckOutput("is_host_name_set", "true"),
+					resource.TestCheckOutput("is_endpoints_set", "true"),
+					resource.TestCheckOutput("is_version_set", "true"),
+					resource.TestCheckOutput("is_properties_set", "true"),
+					resource.TestCheckOutput("is_health_check_set", "true"),
+					resource.TestCheckOutput("is_data_center_set", "true"),
+					resource.TestCheckOutput("is_created_at_set_and_valid", "true"),
+					resource.TestCheckOutput("is_updated_at_set_and_valid", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataMicroserviceInstances_expectErr() string {
+	randUUID, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  id_filter_result = [for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[1]s"]
+}
+
+data "huaweicloud_cse_microservice_instances" "test" {
+  auth_address    = local.id_filter_result[0].service_registry_addresses[0].public
+  connect_address = local.id_filter_result[0].service_registry_addresses[0].public
+  admin_user      = "root"
+  admin_pass      = "%[2]s"
+
+  microservice_id = "%[3]s"
+}
+`, acceptance.HW_CSE_MICROSERVICE_ENGINE_ID, acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD, randUUID)
+}
+
+func testAccDataMicroserviceInstances_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cse_microservice_instance" "test" {
+  auth_address    = local.id_filter_result[0].service_registry_addresses[0].public
+  connect_address = local.id_filter_result[0].service_registry_addresses[0].public
+  microservice_id = huaweicloud_cse_microservice.test.id
+  host_name       = "localhost_with_auth_address"
+  endpoints       = ["grpc://127.0.1.132:9980", "rest://127.0.0.111:8081"]
+  version         = "1.0.1"
+
+  properties = {
+    "nodeIP" = "127.0.0.1"
+  }
+
+  health_check {
+    mode        = "push"
+    interval    = 30
+    max_retries = 3
+    port        = 8080
+  }
+
+  data_center {
+    region            = "%[2]s"
+    name              = "dc1"
+    availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  }
+
+  admin_user = "root"
+  admin_pass = "%[3]s"
+}
+
+data "huaweicloud_cse_microservice_instances" "test" {
+  depends_on = [huaweicloud_cse_microservice_instance.test]
+
+  auth_address    = local.id_filter_result[0].service_registry_addresses[0].public
+  connect_address = local.id_filter_result[0].service_registry_addresses[0].public
+  admin_user      = "root"
+  admin_pass      = "%[3]s"
+
+  microservice_id = huaweicloud_cse_microservice.test.id
+}
+
+locals {
+  filter_result = try([
+  for v in data.huaweicloud_cse_microservice_instances.test.instances : v if v.id == huaweicloud_cse_microservice_instance.test.id][0], null)
+}
+
+output "is_host_name_set" {
+  value = try(local.filter_result.host_name == huaweicloud_cse_microservice_instance.test.host_name, false)
+}
+
+output "is_endpoints_set" {
+  value = try(length(local.filter_result.endpoints) == length(huaweicloud_cse_microservice_instance.test.endpoints), false)
+}
+
+output "is_version_set" {
+  value = try(local.filter_result.version == huaweicloud_cse_microservice_instance.test.version, false)
+}
+
+output "is_properties_set" {
+  value = try(length(local.filter_result.properties) > 0, false)
+}
+
+output "is_health_check_set" {
+  value = try(alltrue([
+    length(local.filter_result.health_check) > 0,
+    local.filter_result.health_check[0].interval == huaweicloud_cse_microservice_instance.test.health_check[0].interval,
+    local.filter_result.health_check[0].max_retries == huaweicloud_cse_microservice_instance.test.health_check[0].max_retries,
+    local.filter_result.health_check[0].mode == huaweicloud_cse_microservice_instance.test.health_check[0].mode,
+    local.filter_result.health_check[0].port == huaweicloud_cse_microservice_instance.test.health_check[0].port,
+  ]), false)
+}
+
+output "is_data_center_set" {
+  value = try(alltrue([
+    length(local.filter_result.data_center) > 0,
+    local.filter_result.data_center[0].name == huaweicloud_cse_microservice_instance.test.data_center[0].name,
+    local.filter_result.data_center[0].region == huaweicloud_cse_microservice_instance.test.data_center[0].region,
+    local.filter_result.data_center[0].availability_zone == huaweicloud_cse_microservice_instance.test.data_center[0].availability_zone,
+  ]), false)
+}
+
+output "is_created_at_set_and_valid" {
+  value = try(length(regexall("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
+  local.filter_result.created_at)) > 0, false)
+}
+
+output "is_updated_at_set_and_valid" {
+  value = try(length(regexall("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
+  local.filter_result.updated_at)) > 0, false)
+}
+`, testAccMicroserviceInstance_base(name), acceptance.HW_REGION_NAME, acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD)
+}

--- a/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_instances.go
+++ b/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_instances.go
@@ -1,0 +1,276 @@
+package cse
+
+import (
+	"context"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CSE GET /v4/{project_id}/registry/microservices/{service_id}/instances
+func DataSourceMicroserviceInstances() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceMicroserviceInstancesRead,
+
+		Schema: map[string]*schema.Schema{
+			"auth_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The address that used to request the access token.`,
+			},
+			"connect_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The address that used to send requests and manage configuration.`,
+			},
+			"admin_user": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"admin_pass"},
+				Description:  `The user name that used to pass the RBAC control.`,
+			},
+			"admin_pass": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				RequiredWith: []string{"admin_user"},
+				Description:  `The user password that used to pass the RBAC control.`,
+			},
+			"microservice_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated microservice to which the instances belong.`,
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the microservice instance.`,
+						},
+						"host_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The host name ID of the microservice instance.`,
+						},
+						"endpoints": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The list of the access addresses of the microservice instance.`,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The version of the microservice instance.`,
+						},
+						"properties": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The extended attributes of the microservice instance, in key/value format.`,
+						},
+						"health_check": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"mode": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The heartbeat mode of the health check.`,
+									},
+									"interval": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The heartbeat interval of the health check, in seconds.`,
+									},
+									"max_retries": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The maximum retry number of the health check.`,
+									},
+									"port": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The port of the health check.`,
+									},
+								},
+							},
+							Description: `The health check configuration of the microservice instance.`,
+						},
+						"data_center": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"region": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The custom region name of the data center.`,
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the data center.`,
+									},
+									"availability_zone": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The custom availability zone of the data center.`,
+									},
+								},
+							},
+							Description: `The data center configuration of the microservice instance.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The current status of the microservice instance.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the microservice instance, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the microservice instance, in RFC3339 format.`,
+						},
+					},
+				},
+				Description: `The list of the microservice instances.`,
+			},
+		},
+	}
+}
+
+func queryMicroserviceInstances(client *golangsdk.ServiceClient, token, microserviceId string) ([]interface{}, error) {
+	var (
+		httpUrl = "registry/microservices/{service_id}/instances"
+		listOpt = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+	)
+
+	if token != "" {
+		listOpt.MoreHeaders = map[string]string{
+			"Authorization": token,
+		}
+	}
+
+	listPath := client.ResourceBase + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{service_id}", microserviceId)
+
+	requestResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+	return utils.PathSearch("instances", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenMicroserviceInstances(instances []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(instances))
+
+	for _, instance := range instances {
+		result = append(result, map[string]interface{}{
+			"id":           utils.PathSearch("instanceId", instance, nil),
+			"host_name":    utils.PathSearch("hostName", instance, nil),
+			"endpoints":    utils.PathSearch("endpoints", instance, nil),
+			"version":      utils.PathSearch("version", instance, nil),
+			"properties":   utils.PathSearch("properties", instance, nil),
+			"health_check": flattenMicroserviceInstancesHealthCheck(utils.PathSearch("healthCheck", instance, nil)),
+			"data_center":  flattenMicroserviceInstancesDataCenter(utils.PathSearch("dataCenterInfo", instance, nil)),
+			"status":       utils.PathSearch("status", instance, nil),
+			"created_at":   parseMicroserviceInstancesTime(utils.PathSearch("timestamp", instance, "").(string)),
+			"updated_at":   parseMicroserviceInstancesTime(utils.PathSearch("modTimestamp", instance, "").(string)),
+		})
+	}
+
+	return result
+}
+
+func flattenMicroserviceInstancesHealthCheck(healthCheck interface{}) []map[string]interface{} {
+	if healthCheck == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"mode":        utils.PathSearch("mode", healthCheck, nil),
+			"interval":    utils.PathSearch("interval", healthCheck, nil),
+			"max_retries": utils.PathSearch("times", healthCheck, nil),
+			"port":        utils.PathSearch("port", healthCheck, nil),
+		},
+	}
+}
+
+func flattenMicroserviceInstancesDataCenter(dataCenter interface{}) []map[string]interface{} {
+	if dataCenter == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"region":            utils.PathSearch("region", dataCenter, nil),
+			"name":              utils.PathSearch("name", dataCenter, nil),
+			"availability_zone": utils.PathSearch("availableZone", dataCenter, nil),
+		},
+	}
+}
+
+func parseMicroserviceInstancesTime(timeStampStr string) string {
+	r, err := strconv.Atoi(timeStampStr)
+	if err != nil {
+		log.Printf("[ERROR] unable to convert the string (%s) to int", timeStampStr)
+		return ""
+	}
+
+	return utils.FormatTimeStampRFC3339(int64(r), false)
+}
+
+func dataSourceMicroserviceInstancesRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	token, err := GetAuthorizationToken(d.Get("auth_address").(string), d.Get("admin_user").(string),
+		d.Get("admin_pass").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
+	instances, err := queryMicroserviceInstances(client, token, d.Get("microservice_id").(string))
+	if err != nil {
+		return diag.Errorf("error querying CSE microservice instances: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("instances", flattenMicroserviceInstances(instances)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new data source to query instances under specified dedicated microservice.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cse -f TestAccDataMicroserviceInstances_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccDataMicroserviceInstances_basic -timeout 360m -parallel 10
=== RUN   TestAccDataMicroserviceInstances_basic
=== PAUSE TestAccDataMicroserviceInstances_basic
=== CONT  TestAccDataMicroserviceInstances_basic
--- PASS: TestAccDataMicroserviceInstances_basic (113.32s)
PASS
coverage: 26.0% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       113.514s        coverage: 26.0% of statements in ./huaweicloud/services/cse
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
