### PR TITLE
refactor(fgs/dependency): adjust resource function and acceptance test coding

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1780,7 +1780,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_fgs_application":                fgs.ResourceApplication(),
 			"huaweicloud_fgs_async_invoke_configuration": fgs.ResourceAsyncInvokeConfiguration(),
-			"huaweicloud_fgs_dependency":                 fgs.ResourceFgsDependency(),
+			"huaweicloud_fgs_dependency":                 fgs.ResourceDependency(),
 			"huaweicloud_fgs_dependency_version":         fgs.ResourceDependencyVersion(),
 			"huaweicloud_fgs_function":                   fgs.ResourceFgsFunctionV2(),
 			"huaweicloud_fgs_function_event":             fgs.ResourceFunctionEvent(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -73,7 +73,6 @@ var (
 	HW_CNAD_ENABLE_FLAG       = os.Getenv("HW_CNAD_ENABLE_FLAG")
 	HW_CNAD_PROJECT_OBJECT_ID = os.Getenv("HW_CNAD_PROJECT_OBJECT_ID")
 
-	HW_OBS_BUCKET_NAME        = os.Getenv("HW_OBS_BUCKET_NAME")
 	HW_OBS_DESTINATION_BUCKET = os.Getenv("HW_OBS_DESTINATION_BUCKET")
 	HW_OBS_USER_DOMAIN_NAME1  = os.Getenv("HW_OBS_USER_DOMAIN_NAME1")
 	HW_OBS_USER_DOMAIN_NAME2  = os.Getenv("HW_OBS_USER_DOMAIN_NAME2")
@@ -999,13 +998,6 @@ func TestAccPreCheckProject(t *testing.T) {
 func TestAccPreCheckOBS(t *testing.T) {
 	if HW_ACCESS_KEY == "" || HW_SECRET_KEY == "" {
 		t.Skip("HW_ACCESS_KEY and HW_SECRET_KEY must be set for OBS acceptance tests")
-	}
-}
-
-// lintignore:AT003
-func TestAccPreCheckOBSBucket(t *testing.T) {
-	if HW_OBS_BUCKET_NAME == "" {
-		t.Skip("HW_OBS_BUCKET_NAME must be set for OBS object acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependency_versions_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependency_versions_test.go
@@ -107,5 +107,5 @@ output "is_runtime_filter_useful" {
     [for v in data.huaweicloud_fgs_dependency_versions.filter_by_runtime.versions[*].runtime : v == local.runtime]
   )
 }
-`, testAccDependencyVersion_basic(name, acceptance.HW_FGS_DEPENDENCY_OBS_LINK))
+`, testAccDependencyVersion_basic(name))
 }

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_dependency_version_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_dependency_version_test.go
@@ -34,27 +34,24 @@ func TestAccDependencyVersion_basic(t *testing.T) {
 		rName        = acceptance.RandomAccResourceName()
 		resourceName = "huaweicloud_fgs_dependency_version.test"
 		rc           = acceptance.InitResourceCheck(resourceName, &obj, getDependencyVersionFunc)
-
-		pkgLocation = fmt.Sprintf("https://%s.obs.cn-north-4.myhuaweicloud.com/FunctionGraph/dependencies/huaweicloudsdkcore.zip",
-			acceptance.HW_OBS_BUCKET_NAME)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckOBSBucket(t)
+			acceptance.TestAccPreCheckFgsDependencyLink(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDependencyVersion_basic(rName, pkgLocation),
+				Config: testAccDependencyVersion_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
 					resource.TestCheckResourceAttr(resourceName, "runtime", "Python2.7"),
-					resource.TestCheckResourceAttr(resourceName, "link", pkgLocation),
+					resource.TestCheckResourceAttr(resourceName, "link", acceptance.HW_FGS_DEPENDENCY_OBS_LINK),
 					resource.TestCheckResourceAttrSet(resourceName, "dependency_id"),
 				),
 			},
@@ -126,7 +123,7 @@ func testAccDependencyVersionImportStateFunc_withVersionId(rName string) resourc
 	}
 }
 
-func testAccDependencyVersion_basic(rName, pkgLocation string) string {
+func testAccDependencyVersion_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_fgs_dependency_version" "test" {
   name        = "%s"
@@ -134,5 +131,5 @@ resource "huaweicloud_fgs_dependency_version" "test" {
   runtime     = "Python2.7"
   link        = "%s"
 }
-`, rName, pkgLocation)
+`, rName, acceptance.HW_FGS_DEPENDENCY_OBS_LINK)
 }

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency.go
@@ -2,162 +2,254 @@ package fgs
 
 import (
 	"context"
-	"log"
+	"fmt"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API FunctionGraph POST /v2/{project_id}/fgs/dependencies
 // @API FunctionGraph GET /v2/{project_id}/fgs/dependencies/{depend_id}
 // @API FunctionGraph PUT /v2/{project_id}/fgs/dependencies/{depend_id}
 // @API FunctionGraph DELETE /v2/{project_id}/fgs/dependencies/{depend_id}
-func ResourceFgsDependency() *schema.Resource {
+func ResourceDependency() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceFgsDependencyCreate,
-		ReadContext:   resourceFgsDependencyRead,
-		UpdateContext: resourceFgsDependencyUpdate,
-		DeleteContext: resourceFgsDependencyDelete,
+		CreateContext: resourceDependencyCreate,
+		ReadContext:   resourceDependencyRead,
+		UpdateContext: resourceDependencyUpdate,
+		DeleteContext: resourceDependencyDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the dependency package is located.`,
 			},
 			"runtime": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The runtime of the dependency package.`,
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the dependency package.`,
 			},
 			"link": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The OBS storage URL of the dependency package.`,
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The description of the dependency package.`,
 			},
 			"etag": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The etag of the dependency package.`,
 			},
 			"owner": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The owner name of the dependency package.`,
 			},
 			"size": {
-				Type:     schema.TypeInt,
-				Computed: true,
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The capacity of the dependency package.`,
 			},
 			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The version of the dependency package.`,
 			},
 		},
 	}
 }
 
-func buildFgsDependencyOpts(d *schema.ResourceData) dependencies.DependOpts {
-	desc := d.Get("description").(string)
-	// Since the zip file upload is limited in size and requires encoding, only the OBS type is supported.
-	// The zip file uploading can also be achieved by uploading OBS objects and is more secure.
-	return dependencies.DependOpts{
-		Name:        d.Get("name").(string),
-		Runtime:     d.Get("runtime").(string),
-		Description: &desc,
-		Type:        "obs",
-		Link:        d.Get("link").(string),
+func buildCreateDependencyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name").(string),
+		"runtime":     d.Get("runtime").(string),
+		"description": d.Get("description").(string),
+		"depend_type": "obs",
+		"depend_link": d.Get("link").(string),
 	}
 }
 
-func resourceFgsDependencyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	client, err := cfg.FgsV2Client(cfg.GetRegion(d))
+func resourceDependencyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/fgs/dependencies"
+	)
+	client, err := cfg.NewServiceClient("fgs", region)
 	if err != nil {
-		return diag.Errorf("error creating FunctionGraph v2 client: %s", err)
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
 	}
 
-	opts := buildFgsDependencyOpts(d)
-	resp, err := dependencies.Create(client, opts)
-	if err != nil {
-		return diag.Errorf("error creating custom dependency: %s", err)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateDependencyBodyParams(d)),
 	}
-	d.SetId(resp.ID)
 
-	return resourceFgsDependencyRead(ctx, d, meta)
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph custom dependency: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dependencyId := utils.PathSearch("id", respBody, "").(string)
+	if dependencyId == "" {
+		return diag.Errorf("unable to find the dependency ID from the API response")
+	}
+	d.SetId(dependencyId)
+
+	return resourceDependencyRead(ctx, d, meta)
 }
 
-func resourceFgsDependencyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	client, err := cfg.FgsV2Client(cfg.GetRegion(d))
-	if err != nil {
-		return diag.Errorf("error creating FunctionGraph v2 client: %s", err)
+func GetDependencyById(client *golangsdk.ServiceClient, dependencyId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/fgs/dependencies/{depend_id}"
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{depend_id}", dependencyId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
-	resp, err := dependencies.Get(client, d.Id())
+	requestResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "FunctionGraph dependency")
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceDependencyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		dependencyId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
 	}
 
-	log.Printf("[DEBUG] Retrieved custom dependency %s: %+v", d.Id(), resp)
+	respBody, err := GetDependencyById(client, dependencyId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error querying custom dependency (%s)", dependencyId))
+	}
+
 	mErr := multierror.Append(
-		d.Set("runtime", resp.Runtime),
-		d.Set("name", resp.Name),
-		d.Set("description", resp.Description),
-		d.Set("link", resp.Link),
-		d.Set("etag", resp.Etag),
-		d.Set("size", resp.Size),
-		d.Set("owner", resp.Owner),
-		d.Set("version", resp.Version),
+		d.Set("runtime", utils.PathSearch("runtime", respBody, nil)),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("link", utils.PathSearch("link", respBody, nil)),
+		d.Set("etag", utils.PathSearch("etag", respBody, nil)),
+		d.Set("size", utils.PathSearch("size", respBody, nil)),
+		d.Set("owner", utils.PathSearch("owner", respBody, nil)),
+		d.Set("version", utils.PathSearch("version", respBody, nil)),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
 		return diag.Errorf("error setting resource fields of custom dependency (%s): %s", d.Id(), err)
 	}
-
 	return nil
 }
 
-func resourceFgsDependencyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	client, err := cfg.FgsV2Client(cfg.GetRegion(d))
+func buildUpdateDependencyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name").(string),
+		"runtime":     d.Get("runtime").(string),
+		"description": d.Get("description").(string),
+		"depend_type": "obs",
+		"depend_link": d.Get("link").(string),
+	}
+}
+
+func resourceDependencyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		httpUrl      = "v2/{project_id}/fgs/dependencies/{depend_id}"
+		dependencyId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
 	if err != nil {
-		return diag.Errorf("error creating FunctionGraph v2 client: %s", err)
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
 	}
 
-	opts := buildFgsDependencyOpts(d)
-	_, err = dependencies.Update(client, d.Id(), opts)
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{depend_id}", dependencyId)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildUpdateDependencyBodyParams(d)),
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
 	if err != nil {
 		return diag.Errorf("error updating custom dependency: %s", err)
 	}
-
-	return resourceFgsDependencyRead(ctx, d, meta)
+	return resourceDependencyRead(ctx, d, meta)
 }
 
-func resourceFgsDependencyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	fgsClient, err := cfg.FgsV2Client(cfg.GetRegion(d))
+func resourceDependencyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		httpUrl      = "v2/{project_id}/fgs/dependencies/{depend_id}"
+		dependencyId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
 	if err != nil {
-		return diag.Errorf("error creating FunctionGraph v2 client: %s", err)
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
 	}
 
-	err = dependencies.Delete(fgsClient, d.Id()).ExtractErr()
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{depend_id}", dependencyId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error deleting custom dependency")
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting custom dependency (%s)", dependencyId))
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For the dependency resource, adjust the function and corresponding acceptance test coding.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. adjust function and test coding.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccDependency_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDependency_basic -timeout 360m -parallel 10
=== RUN   TestAccDependency_basic
=== PAUSE TestAccDependency_basic
=== CONT  TestAccDependency_basic
--- PASS: TestAccDependency_basic (18.82s)
PASS
coverage: 6.4% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       18.884s coverage: 6.4% of statements in ./huaweicloud/services/fgs
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
