### PR TITLE
refactor(cpts): refactor cpts task resource to general code style

### DIFF
--- a/huaweicloud/services/acceptance/cpts/resource_huaweicloud_cpts_project_test.go
+++ b/huaweicloud/services/acceptance/cpts/resource_huaweicloud_cpts_project_test.go
@@ -54,19 +54,19 @@ func TestAccProject_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testProject_basic(rName, "created by acc test"),
+				Config: testProject_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "description", "created by acc test"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
 				),
 			},
 			{
-				Config: testProject_basic(rName, ""),
+				Config: testProject_basic_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s-update", rName)),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
@@ -81,11 +81,20 @@ func TestAccProject_basic(t *testing.T) {
 	})
 }
 
-func testProject_basic(rName, desc string) string {
+func testProject_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_cpts_project" "test" {
   name        = "%s"
-  description = "%s"
+  description = "test description"
 }
-`, rName, desc)
+`, rName)
+}
+
+func testProject_basic_update(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cpts_project" "test" {
+  name        = "%s-update"
+  description = ""
+}
+`, rName)
 }

--- a/huaweicloud/services/cpts/resource_huaweicloud_cpts_task.go
+++ b/huaweicloud/services/cpts/resource_huaweicloud_cpts_task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -12,18 +13,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	cpts "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cpts/v1"
-	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cpts/v1/model"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 const (
 	clusterTypeShare   = "shared-cluster-internet"
 	clusterTypePrivate = "private-cluster"
 
-	runStatusRunning   = 0
 	runStatusFinished  = 2
 	runStatusToRunning = 9
 
@@ -94,195 +94,231 @@ func ResourceTask() *schema.Resource {
 	}
 }
 
+func buildCreateTaskBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":             d.Get("name"),
+		"project_id":       d.Get("project_id"),
+		"bench_concurrent": d.Get("benchmark_concurrency"),
+	}
+}
+
 func resourceTaskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	client, err := c.HcCptsV1Client(region)
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/tasks"
+		product = "cpts"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating CPTS v1 client: %s", err)
+		return diag.Errorf("error creating CPTS client: %s", err)
 	}
 
-	projectId := int32(d.Get("project_id").(int))
-	benchConcurrent := int32(d.Get("benchmark_concurrency").(int))
-	createOpts := &model.CreateTaskRequest{
-		Body: &model.CreateTaskRequestBody{
-			Name:            d.Get("name").(string),
-			ProjectId:       projectId,
-			BenchConcurrent: &benchConcurrent,
-		},
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildCreateTaskBodyParams(d),
 	}
 
-	response, err := client.CreateTask(createOpts)
+	resp, err := client.Request("POST", requestPath, &requestOpt)
 	if err != nil {
 		return diag.Errorf("error creating CPTS task: %s", err)
 	}
 
-	if response.TaskId == nil {
-		return diag.Errorf("error creating CPTS task: id not found in api response")
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
-	d.SetId(strconv.Itoa(int(*response.TaskId)))
+	taskID := utils.PathSearch("task_id", respBody, nil)
+	if taskID == nil {
+		return diag.Errorf("error creating CPTS task: ID is not found in API response")
+	}
+
+	// The `task_id` field is a numeric type.
+	d.SetId(strconv.Itoa(int(taskID.(float64))))
 	return resourceTaskRead(ctx, d, meta)
 }
 
 func resourceTaskRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	client, err := c.HcCptsV1Client(region)
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cpts"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating CPTS v1 client: %s", err)
+		return diag.Errorf("error creating CPTS client: %s", err)
 	}
 
-	id, err := strconv.ParseInt(d.Id(), 10, 32)
+	respBody, err := GetTaskDetail(client, d.Id())
 	if err != nil {
-		return diag.Errorf("the task ID must be integer: %s", err)
-	}
-
-	response, err := client.ShowTask(&model.ShowTaskRequest{
-		TaskId: int32(id),
-	})
-	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving CPTS task")
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected403ErrInto404Err(err, "code", "SVCSTG.CPTS.4032002"),
+			"error retrieving CPTS task")
 	}
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("name", response.TaskInfo.Name),
-		d.Set("project_id", response.TaskInfo.ProjectId),
-		d.Set("benchmark_concurrency", response.TaskInfo.BenchConcurrent),
-		d.Set("status", response.TaskInfo.RunStatus),
+		d.Set("name", utils.PathSearch("taskInfo.name", respBody, nil)),
+		d.Set("project_id", utils.PathSearch("taskInfo.project_id", respBody, nil)),
+		d.Set("benchmark_concurrency", utils.PathSearch("taskInfo.bench_concurrent", respBody, nil)),
+		d.Set("status", utils.PathSearch("taskInfo.run_status", respBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceTaskUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	client, err := c.HcCptsV1Client(region)
-	if err != nil {
-		return diag.Errorf("error creating CPTS v1 client: %s", err)
+func buildUpdateTaskBodyParams(d *schema.ResourceData, idInt64 int64) map[string]interface{} {
+	return map[string]interface{}{
+		"id":               idInt64,
+		"name":             d.Get("name"),
+		"project_id":       d.Get("project_id"),
+		"bench_concurrent": d.Get("benchmark_concurrency"),
 	}
-
-	id, err := strconv.ParseInt(d.Id(), 10, 32)
-	if err != nil {
-		return diag.Errorf("the task ID must be integer: %s", err)
-	}
-
-	projectId := int32(d.Get("project_id").(int))
-
-	if d.HasChanges("benchmark_concurrency", "name") {
-		benchConcurrent := int32(d.Get("benchmark_concurrency").(int))
-		_, err = client.UpdateTask(&model.UpdateTaskRequest{
-			TaskId: int32(id),
-			Body: &model.UpdateTaskRequestBody{
-				Id:              int32(id),
-				Name:            d.Get("name").(string),
-				ProjectId:       projectId,
-				BenchConcurrent: &benchConcurrent,
-			},
-		})
-
-		if err != nil {
-			return diag.Errorf("error updating the task %q: %s", id, err)
-		}
-	}
-
-	// Enable or stop task
-	if d.HasChange("operation") {
-		op := d.Get("operation").(string)
-		// Enable task
-		if op == operationEnable {
-			updateStatusRequest := model.UpdateTaskStatusRequest{
-				TestSuiteId: projectId,
-				TaskId:      int32(id),
-			}
-			clusterId := int32(d.Get("cluster_id").(int))
-			if clusterId > 0 {
-				updateStatusRequest.Body = &model.UpdateTaskStatusRequestBody{
-					ClusterType: clusterTypePrivate,
-					ClusterId:   clusterId,
-					Status:      runStatusToRunning,
-					NetworkInfo: &model.NetworkInfo{},
-				}
-			} else {
-				updateStatusRequest.Body = &model.UpdateTaskStatusRequestBody{
-					ClusterType: clusterTypeShare,
-					ClusterId:   0,
-					Status:      runStatusToRunning,
-					NetworkInfo: &model.NetworkInfo{
-						NetworkType: "internet",
-					},
-				}
-			}
-			_, err := client.UpdateTaskStatus(&updateStatusRequest)
-			if err != nil {
-				return diag.Errorf("error starting the task %q: %s", id, err)
-			}
-		}
-
-		// stop task
-		if op == operationStop {
-			_, err := client.UpdateTaskStatus(&model.UpdateTaskStatusRequest{
-				TestSuiteId: projectId,
-				TaskId:      int32(id),
-				Body: &model.UpdateTaskStatusRequestBody{
-					ClusterType: clusterTypeShare,
-					ClusterId:   -1,
-					Status:      runStatusFinished,
-					NetworkInfo: &model.NetworkInfo{},
-				},
-			})
-			if err != nil {
-				return diag.Errorf("error stopping the task %q: %s", id, err)
-			}
-		}
-
-		err = waitingforTaskFinished(ctx, client, id, d.Timeout(schema.TimeoutUpdate))
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	return resourceTaskRead(ctx, d, meta)
 }
 
-func resourceTaskDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	client, err := c.HcCptsV1Client(region)
+func updateTask(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	idInt64, err := strconv.ParseInt(d.Id(), 10, 32)
 	if err != nil {
-		return diag.Errorf("error creating CPTS v1 client: %s", err)
+		return fmt.Errorf("the task ID must be integer: %s", err)
 	}
 
-	id, err := strconv.ParseInt(d.Id(), 10, 32)
-	if err != nil {
-		return diag.Errorf("the task ID must be integer: %s", err)
+	requestPath := client.Endpoint + "v1/{project_id}/tasks/{task_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{task_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildUpdateTaskBodyParams(d, idInt64),
 	}
 
-	deleteOpts := &model.DeleteTaskRequest{
-		TaskId: int32(id),
-	}
-
-	_, err = client.DeleteTask(deleteOpts)
+	_, err = client.Request("PUT", requestPath, &requestOpt)
 	if err != nil {
-		return diag.Errorf("error deleting CPTS task %q: %s", id, err)
+		return fmt.Errorf("error updating CPTS task: %s", err)
 	}
 
 	return nil
 }
 
-func waitingforTaskFinished(ctx context.Context, client *cpts.CptsClient, id int64, timeout time.Duration) error {
+func buildEnableTaskClusterType(d *schema.ResourceData) string {
+	clusterId := d.Get("cluster_id").(int)
+	if clusterId > 0 {
+		return clusterTypePrivate
+	}
+
+	return clusterTypeShare
+}
+
+func buildEnableTaskClusterID(d *schema.ResourceData) int {
+	clusterId := d.Get("cluster_id").(int)
+	if clusterId > 0 {
+		return clusterId
+	}
+
+	return 0
+}
+
+func buildEnableTaskNetworkInfo(d *schema.ResourceData) map[string]interface{} {
+	clusterId := d.Get("cluster_id").(int)
+	if clusterId > 0 {
+		return make(map[string]interface{})
+	}
+
+	return map[string]interface{}{
+		"network_type": "internet",
+	}
+}
+
+func buildEnableTaskBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"cluster_type": buildEnableTaskClusterType(d),
+		"cluster_id":   buildEnableTaskClusterID(d),
+		"status":       runStatusToRunning,
+		"network_info": buildEnableTaskNetworkInfo(d),
+	}
+}
+
+func enableTask(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v1/{project_id}/test-suites/{test_suite_id}/tasks/{task_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{test_suite_id}", fmt.Sprintf("%d", d.Get("project_id")))
+	requestPath = strings.ReplaceAll(requestPath, "{task_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildEnableTaskBodyParams(d),
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return fmt.Errorf("error enabling CPTS task: %s", err)
+	}
+
+	return nil
+}
+
+func buildDisableTaskBodyParams() map[string]interface{} {
+	return map[string]interface{}{
+		"cluster_type": clusterTypeShare,
+		"cluster_id":   -1,
+		"status":       runStatusFinished,
+		"network_info": make(map[string]interface{}),
+	}
+}
+
+func disableTask(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v1/{project_id}/test-suites/{test_suite_id}/tasks/{task_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{test_suite_id}", fmt.Sprintf("%d", d.Get("project_id")))
+	requestPath = strings.ReplaceAll(requestPath, "{task_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildDisableTaskBodyParams(),
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return fmt.Errorf("error disabling CPTS task: %s", err)
+	}
+
+	return nil
+}
+
+func GetTaskDetail(client *golangsdk.ServiceClient, taskID string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/tasks/{task_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{task_id}", taskID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func waitingForTaskFinished(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{fmt.Sprint(runStatusRunning), fmt.Sprint(runStatusToRunning)},
-		Target:  []string{fmt.Sprint(runStatusFinished)},
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			resp, err := client.ShowTask(&model.ShowTaskRequest{TaskId: int32(id)})
+			respBody, err := GetTaskDetail(client, d.Id())
 			if err != nil {
-				return nil, "", err
+				return nil, "ERROR", err
 			}
-			status := resp.TaskInfo.RunStatus
-			return resp, fmt.Sprintf("%d", status), nil
+
+			runStatus := utils.PathSearch("taskInfo.run_status", respBody, "").(int)
+			if runStatus == runStatusFinished {
+				return respBody, "COMPLETED", nil
+			}
+
+			return respBody, "PENDING", nil
 		},
 		Timeout:      timeout,
 		Delay:        10 * time.Second,
@@ -291,7 +327,77 @@ func waitingforTaskFinished(ctx context.Context, client *cpts.CptsClient, id int
 
 	_, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmt.Errorf("error waiting for CPTS task (%d) to be finished: %s", id, err)
+		return fmt.Errorf("error waiting for CPTS task (%s) to be finished: %s", d.Id(), err)
 	}
+	return nil
+}
+
+func resourceTaskUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cpts"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CPTS client: %s", err)
+	}
+
+	if d.HasChanges("benchmark_concurrency", "name") {
+		if err := updateTask(client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// Enable or stop task
+	if d.HasChange("operation") {
+		var err error
+		switch d.Get("operation").(string) {
+		case operationEnable:
+			err = enableTask(client, d)
+		case operationStop:
+			err = disableTask(client, d)
+		}
+
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		if err := waitingForTaskFinished(ctx, client, d, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceTaskRead(ctx, d, meta)
+}
+
+func resourceTaskDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/tasks/{task_id}"
+		product = "cpts"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CPTS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{task_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected403ErrInto404Err(err, "code", "SVCSTG.CPTS.4032002"),
+			"error deleting CPTS task")
+	}
+
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

refactor cpts task resource to general code style.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

This PR is only for the huaweicloud-sdk-go-v3 package.
Because the original resources have functional defects, the `operation` function cannot be tested. This problem will be modified in other PRs.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
go test -v -coverprofile=coverage_1737440909509_TestAccTask_basic.cov -coverpkg=./huaweicloud/services/cpts ./huaweicloud/services/acceptance/cpts -run TestAccTask_basic -timeout 360m -parallel 4
=== RUN   TestAccTask_basic
--- PASS: TestAccTask_basic (15.15s)
PASS
coverage: 52.7% of statements in ./huaweicloud/services/cpts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cpts      15.231s coverage: 52.7% of statements in ./huaweicloud/services/cpts
```

![image](https://github.com/user-attachments/assets/d70e8ba4-cdfc-4ba7-9d9e-eb7071d124ba)


* [ ] Documentation updated.
* [ ] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/cc8cc5b6-e895-4852-92fe-7f580e506ffc)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![image](https://github.com/user-attachments/assets/69ca45ba-e61a-462b-832f-0a19cf7e5940)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
