### PR TITLE
refactor(iotda): refactor amqp resource code style

### DIFF
--- a/docs/resources/iotda_amqp.md
+++ b/docs/resources/iotda_amqp.md
@@ -52,6 +52,12 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID in UUID format.
 
+* `created_at` - The creation time of the AMQP queue.
+  The format is **yyyyMMdd'T'HHmmss'Z'**. e.g. **20151212T121212Z**.
+
+* `updated_at` - The latest update time of the AMQP queue.
+  The format is **yyyyMMdd'T'HHmmss'Z'**. e.g. **20151212T121212Z**.
+
 ## Import
 
 The AMQP queue can be imported using the `id`, e.g.

--- a/docs/resources/iotda_amqp.md
+++ b/docs/resources/iotda_amqp.md
@@ -2,19 +2,20 @@
 subcategory: "IoT Device Access (IoTDA)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_iotda_amqp"
-description: ""
+description: |-
+  Manages an IoTDA AMQP queue resource within HuaweiCloud.
 ---
 
 # huaweicloud_iotda_amqp
 
-Manages an IoTDA AMQP queue within HuaweiCloud.
+Manages an IoTDA AMQP queue resource within HuaweiCloud.
 
 -> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
-endpoint in `provider` block.
-You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
-to view the HTTPS application access address. An example of the access address might be
-**9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
-`provider` block as follows:
+  endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  **9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+  `provider` block as follows:
 
   ```hcl
   provider "huaweicloud" {
@@ -27,8 +28,10 @@ to view the HTTPS application access address. An example of the access address m
 ## Example Usage
 
 ```hcl
-resource "huaweicloud_iotda_amqp" "queue" {
-  name = "queue_name"
+variable "queue_name" {}
+
+resource "huaweicloud_iotda_amqp" "test" {
+  name = var.queue_name
 }
 ```
 
@@ -51,8 +54,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-AMQP queues can be imported using the `id`, e.g.
+The AMQP queue can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_iotda_amqp.test 10022532f4f94f26b01daa1e424853e1
+$ terraform import huaweicloud_iotda_amqp.test <id>
 ```

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_amqp_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_amqp_test.go
@@ -7,32 +7,33 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iotda"
 )
 
-func getAmqpResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, WithDerivedAuth())
+func getAmqpResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region    = acceptance.HW_REGION_NAME
+		isDerived = iotda.WithDerivedAuth(cfg, region)
+		product   = "iotda"
+		queueId   = state.Primary.ID
+	)
+
+	client, err := cfg.NewServiceClientWithDerivedAuth(product, region, isDerived)
 	if err != nil {
-		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
+		return nil, fmt.Errorf("error creating IoTDA client: %s", err)
 	}
 
-	detail, err := client.ShowQueue(&model.ShowQueueRequest{QueueId: state.Primary.ID})
-	// When the queue does not exist, it still returns an empty struct
-	if detail == nil || detail.QueueId == nil {
-		return nil, fmt.Errorf("error retrieving IoTDA AMQP queue")
-	}
-
-	return detail, err
+	return iotda.ReadAmqpById(client, queueId)
 }
 
 func TestAccAmqp_basic(t *testing.T) {
-	var obj model.ShowQueueResponse
-
-	name := acceptance.RandomAccResourceName()
-	rName := "huaweicloud_iotda_amqp.test"
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_iotda_amqp.test"
+	)
 
 	rc := acceptance.InitResourceCheck(
 		rName,

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_amqp_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_amqp_test.go
@@ -54,6 +54,8 @@ func TestAccAmqp_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
 				),
 			},
 			{

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_amqp.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_amqp.go
@@ -2,7 +2,8 @@ package iotda
 
 import (
 	"context"
-	"log"
+	"fmt"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -10,10 +11,9 @@ import (
 
 	"github.com/chnsz/golangsdk"
 
-	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API IoTDA DELETE /v5/iot/{project_id}/amqp-queues/{queue_id}
@@ -45,77 +45,132 @@ func ResourceAmqp() *schema.Resource {
 	}
 }
 
+func buildCreateAmqpBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"queue_name": d.Get("name").(string),
+	}
+}
+
 func resourceAmqpCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	isDerived := WithDerivedAuth(c, region)
-	client, err := c.HcIoTdaV5Client(region, isDerived)
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+		product   = "iotda"
+	)
+
+	client, err := cfg.NewServiceClientWithDerivedAuth(product, region, isDerived)
 	if err != nil {
-		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+		return diag.Errorf("error creating IoTDA client: %s", err)
 	}
 
-	createOpts := model.AddQueueRequest{
-		Body: &model.QueueInfo{
-			QueueName: d.Get("name").(string),
-		},
+	createPath := client.Endpoint + "v5/iot/{project_id}/amqp-queues"
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildCreateAmqpBodyParams(d),
 	}
-	log.Printf("[DEBUG] Create IoTDA AMQP queue params: %#v", createOpts)
 
-	resp, err := client.AddQueue(&createOpts)
+	createResp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA AMQP queue: %s", err)
 	}
 
-	if resp.QueueId == nil {
-		return diag.Errorf("error creating IoTDA AMQP queue: id is not found in API response")
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
-	d.SetId(*resp.QueueId)
+	queueId := utils.PathSearch("queue_id", createRespBody, "").(string)
+	if queueId == "" {
+		return diag.Errorf("error creating IoTDA AMQP queue: ID is not found in API response")
+	}
+
+	d.SetId(queueId)
+
 	return resourceAmqpRead(ctx, d, meta)
 }
 
-func resourceAmqpRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	isDerived := WithDerivedAuth(c, region)
-	client, err := c.HcIoTdaV5Client(region, isDerived)
-	if err != nil {
-		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+func ReadAmqpById(client *golangsdk.ServiceClient, queueId string) (interface{}, error) {
+	getPath := client.Endpoint + "v5/iot/{project_id}/amqp-queues/{queue_id}"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{queue_id}", queueId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
 
-	detail, err := client.ShowQueue(&model.ShowQueueRequest{QueueId: d.Id()})
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving IoTDA AMQP queue: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	// When the resource does not exist, the query API returns a `200` status code and `queue_id` returns null.
+	// For this situation, a `404` status code needs to be returned for subsequent checkDeleted logic processing.
+	queueIdResp := utils.PathSearch("queue_id", getRespBody, "").(string)
+	if queueIdResp == "" {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return getRespBody, nil
+}
+
+func resourceAmqpRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+		product   = "iotda"
+		queueId   = d.Id()
+	)
+
+	client, err := cfg.NewServiceClientWithDerivedAuth(product, region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA client: %s", err)
+	}
+
+	queueResp, err := ReadAmqpById(client, queueId)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "error retrieving IoTDA AMQP queue")
 	}
 
-	// When the queue does not exist, it still returns a empty struct
-	if detail == nil || detail.QueueId == nil {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving IoTDA AMQP queue")
-	}
-
 	mErr := multierror.Append(
 		d.Set("region", region),
-		d.Set("name", detail.QueueName),
+		d.Set("name", utils.PathSearch("queue_name", queueResp, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func resourceAmqpDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	isDerived := WithDerivedAuth(c, region)
-	client, err := c.HcIoTdaV5Client(region, isDerived)
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+		product   = "iotda"
+		queueId   = d.Id()
+	)
+
+	client, err := cfg.NewServiceClientWithDerivedAuth(product, region, isDerived)
 	if err != nil {
-		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+		return diag.Errorf("error creating IoTDA client: %s", err)
 	}
 
-	deleteOpts := &model.DeleteQueueRequest{
-		QueueId: d.Id(),
+	deletePath := client.Endpoint + "v5/iot/{project_id}/amqp-queues/{queue_id}"
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{queue_id}", queueId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
-	_, err = client.DeleteQueue(deleteOpts)
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	// When deleting non-existent resource, the API returns a `404` status code.
 	if err != nil {
-		return diag.Errorf("error deleting IoTDA AMQP queue: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting IoTDA AMQP queue")
 	}
 
 	return nil

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_amqp.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_amqp.go
@@ -41,6 +41,14 @@ func ResourceAmqp() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -141,6 +149,8 @@ func resourceAmqpRead(_ context.Context, d *schema.ResourceData, meta interface{
 	mErr := multierror.Append(
 		d.Set("region", region),
 		d.Set("name", utils.PathSearch("queue_name", queueResp, nil)),
+		d.Set("created_at", utils.PathSearch("create_time", queueResp, nil)),
+		d.Set("updated_at", utils.PathSearch("last_modify_time", queueResp, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

commit1: refactor `amqp` resource code style
commit2: `amqp` resource support new attribute fields

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

refactor `amqp` resource code style

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ export HW_IOTDA_ACCESS_ADDRESS=xxxxxxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccAmqp_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccAmqp_basic -timeout 360m -parallel 4
=== RUN   TestAccAmqp_basic
=== PAUSE TestAccAmqp_basic
=== CONT  TestAccAmqp_basic
--- PASS: TestAccAmqp_basic (12.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     12.112s

```
![image](https://github.com/user-attachments/assets/b46b37a6-aed0-444d-bede-1a97c179517b)



* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/cbaa6467-0221-48a2-b2a7-62523da5f57f)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/user-attachments/assets/b8c870b2-8291-4e81-9efe-07fb25ac0aab)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
