### PR TITLE
refactor(fgs/dependency): do not query versions by default

### DIFF
--- a/docs/data-sources/fgs_dependencies.md
+++ b/docs/data-sources/fgs_dependencies.md
@@ -9,6 +9,10 @@ description: ""
 
 Use this data source to filter dependent packages of FGS from HuaweiCloud.
 
+~> Between `1.64.2` and `1.72.1`., the version list of each dependent package is queried by default.
+   <br>This will cause the query to take up a lot of time and may trigger flow control.
+   <br>There are not recommended to use.
+
 ## Example Usage
 
 ### Obtain all public dependent packages
@@ -47,6 +51,9 @@ data "huaweicloud_fgs_dependencies" "test" {
   **Go1.x**, **C#(.NET Core 2.0)**, **C#(.NET Core 2.1)**, **C#(.NET Core 3.1)** and **PHP7.3**.
 
 * `name` - (Optional, String) Specifies the dependent package runtime to match.
+
+* `is_versions_query_allowed` - (Optional, Bool) Specifies whether to query the versions of each dependent package.
+  Defaults to **false**.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For the dependent package data source, the querys of the package versions will cost much time because of the FunctionGraph flow control.
Disable it by default is the best way to reduce the time costs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. do not query versions by default
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
