### PR TITLE
refactor(fgs/dependency): using auto-gen style to replace old coding

### DIFF
--- a/docs/resources/fgs_dependency_version.md
+++ b/docs/resources/fgs_dependency_version.md
@@ -2,7 +2,8 @@
 subcategory: "FunctionGraph"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_fgs_dependency_version"
-description: ""
+description: |-
+  Manages a custom dependency version within HuaweiCloud.
 ---
 
 # huaweicloud_fgs_dependency_version
@@ -14,11 +15,11 @@ packages. You can migrate smoothly because the parameter behavior of the two res
 
 ## Example Usage
 
-### Create a custom dependency version using a OBS bucket path where the ZIP file is located
+### Create a custom dependency version using an OBS bucket path where the ZIP file is located
 
 ```hcl
-variable "dependency_name"
-variable "custom_dependency_location"
+variable "dependency_name" {}
+variable "custom_dependency_location" {}
 
 resource "huaweicloud_fgs_dependency_version" "test" {
   name    = var.dependency_name
@@ -55,19 +56,20 @@ resource "huaweicloud_fgs_dependency_version" "test" {
 
   Changing this will create a new resource.
 
-* `name` - (Required, String, ForceNew) Specifies the name of the custom dependency package to which the version belongs.
-  The name can contain a maximum of `96` characters and must start with a letter and end with a letter or digit.
+* `name` - (Required, String, ForceNew) Specifies the name of the custom dependency package to which the version
+  belongs.  
+  The name can contain a maximum of `96` characters and must start with a letter and end with a letter or digit.  
   Only letters, digits, underscores (_), periods (.), and hyphens (-) are allowed.  
   Changing this will create a new resource.
 
-* `link` - (Required, String, ForceNew) Specifies the OBS bucket path where the dependency package is located.
+* `link` - (Required, String, ForceNew) Specifies the OBS bucket path where the dependency package is located.  
   The OBS object URL must be in ZIP format, such as
-  `https://obs-terraform.obs.cn-north-4.myhuaweicloud.com/huaweicloudsdkcore.zip`.
+  `https://obs-terraform.obs.cn-north-4.myhuaweicloud.com/huaweicloudsdkcore.zip`.  
   Changing this will create a new resource.
 
   -> A link can only be used to create at most one dependency package.
 
-* `description` - (Optional, String, ForceNew) Specifies the description of the custom dependency version.
+* `description` - (Optional, String, ForceNew) Specifies the description of the custom dependency version.  
   The description can contain a maximum of `512` characters.  
   Changing this will create a new resource.
 
@@ -75,19 +77,20 @@ resource "huaweicloud_fgs_dependency_version" "test" {
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The resource ID, consists of dependency ID and version number, separated by a slash.
+* `id` - The resource ID, consists of dependency ID and version number, separated by a slash (/).  
+  The format is `<name>/<version>`.
 
 * `version` - The dependency package version.
 
 * `version_id` - The ID of the dependency package version.
 
-* `owner` - The dependency owner, public indicates a public dependency.
+* `owner` - The dependency owner, **public** indicates a public dependency.
 
 * `etag` - The unique ID of the dependency.
 
 * `size` - The dependency size, in bytes.
 
-* `dependency_id` - The ID of the dependency package.
+* `dependency_id` - The ID of the dependency package corresponding to the version.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_dependency_version_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_dependency_version_test.go
@@ -14,17 +14,13 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
 )
 
-func getDependencyVersionFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.FgsV2Client(acceptance.HW_REGION_NAME)
+func getDependencyVersionFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("fgs", acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating FunctionGraph v2 client: %s", err)
+		return nil, fmt.Errorf("error creating FunctionGraph client: %s", err)
 	}
 
-	dependId, version, err := fgs.ParseDependVersionResourceId(state.Primary.ID)
-	if err != nil {
-		return nil, err
-	}
-	return dependencies.GetVersion(client, dependId, version)
+	return fgs.GetDependencyVersionById(client, state.Primary.ID)
 }
 
 func TestAccDependencyVersion_basic(t *testing.T) {

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency_version.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency_version.go
@@ -3,6 +3,7 @@ package fgs
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -10,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -38,100 +38,128 @@ func ResourceDependencyVersion() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				ForceNew:    true,
-				Description: "The region where the custom dependency version is located.",
+				Description: `The region where the custom dependency version is located.`,
 			},
 			"runtime": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The runtime of the custom dependency package version.",
+				Description: `The runtime of the custom dependency package version.`,
 			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The name of the custom dependency package to which the version belongs.",
+				Description: `The name of the custom dependency package to which the version belongs.`,
 			},
 			"link": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The OBS bucket path where the dependency package is located.",
+				Description: `The OBS bucket path where the dependency package is located.`,
 			},
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
 				ForceNew:    true,
-				Description: "The description of the custom dependency version.",
+				Description: `The description of the custom dependency version.`,
 			},
 			"version": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "The dependency package version.",
+				Description: `The dependency package version.`,
 			},
 			"version_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The ID of the dependency package version.",
+				Description: `The ID of the dependency package version.`,
 			},
 			"owner": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The dependency owner, public indicates a public dependency.",
+				Description: `The dependency owner, public indicates a public dependency.`,
 			},
 			"etag": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The unique ID of the dependency.",
+				Description: `The unique ID of the dependency.`,
 			},
 			"size": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "The dependency size, in bytes.",
+				Description: `The dependency size, in bytes.`,
 			},
 			"dependency_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The ID of the dependency package corresponding to the version.",
+				Description: `The ID of the dependency package corresponding to the version.`,
 			},
 		},
 	}
 }
 
-func buildDependencyVersionOpts(d *schema.ResourceData) dependencies.DependVersionOpts {
+func buildCreateDependencyVersionBodyParams(d *schema.ResourceData) map[string]interface{} {
 	// Since the ZIP file upload is limited in size and requires encoding, only the OBS type is supported.
 	// The ZIP file uploading can also be achieved by uploading OBS objects and is more secure.
-	return dependencies.DependVersionOpts{
-		Name:        d.Get("name").(string),
-		Runtime:     d.Get("runtime").(string),
-		Description: utils.String(d.Get("description").(string)),
-		Type:        "obs",
-		Link:        d.Get("link").(string),
+	return map[string]interface{}{
+		// Required parameters.
+		"name":        d.Get("name").(string),
+		"runtime":     d.Get("runtime").(string),
+		"depend_type": "obs",
+		"depend_link": d.Get("link").(string),
+		// Optional parameters.
+		"description": d.Get("description").(string),
 	}
 }
 
 func resourceDependencyVersionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	client, err := cfg.FgsV2Client(cfg.GetRegion(d))
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/fgs/dependencies/version"
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
 	if err != nil {
-		return diag.Errorf("error creating FunctionGraph v2 client: %s", err)
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
 	}
 
-	resp, err := dependencies.CreateVersion(client, buildDependencyVersionOpts(d))
-	if err != nil {
-		return diag.Errorf("error creating custom dependency version: %s", err)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildCreateDependencyVersionBodyParams(d)),
 	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating dependency package version: %s", err)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dependId := utils.PathSearch("dep_id", respBody, "").(string)
+	dependVersion := utils.PathSearch("version", respBody, float64(0)).(float64)
+	if dependId == "" || dependVersion == 0 {
+		return diag.Errorf("unable to find the dependency package version ID or version from the API response")
+	}
+
 	// Using depend ID and version number as the resource ID.
-	d.SetId(fmt.Sprintf("%s/%d", resp.DepId, resp.Version))
+	d.SetId(fmt.Sprintf("%s/%v", dependId, dependVersion))
 
 	return resourceDependencyVersionRead(ctx, d, meta)
 }
 
-func ParseDependVersionResourceId(resourceId string) (dependId, versionInfo string, err error) {
+func parseDependVersionResourceId(resourceId string) (dependId, versionInfo string) {
 	parts := strings.Split(resourceId, "/")
 	if len(parts) < 2 {
-		err = fmt.Errorf("invalid ID format for dependency version resource, it must contain two parts: "+
+		log.Printf("[ERROR] invalid ID format for dependency package version resource, it must contain two parts: "+
 			"dependency package information and version information, e.g. '<dependency name>/<version number>'. "+
 			"but the ID that you provided does not meet this requirement '%s'", resourceId)
 		return
@@ -141,20 +169,45 @@ func ParseDependVersionResourceId(resourceId string) (dependId, versionInfo stri
 	return
 }
 
-func resourceDependencyVersionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	client, err := cfg.FgsV2Client(cfg.GetRegion(d))
-	if err != nil {
-		return diag.Errorf("error creating FunctionGraph v2 client: %s", err)
+func GetDependencyVersionById(client *golangsdk.ServiceClient, resourceId string) (interface{}, error) {
+	var (
+		httpUrl                 = "v2/{project_id}/fgs/dependencies/{depend_id}/version/{version}"
+		dependId, dependVersion = parseDependVersionResourceId(resourceId)
+	)
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{depend_id}", dependId)
+	getPath = strings.ReplaceAll(getPath, "{version}", dependVersion)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
-	dependId, version, err := ParseDependVersionResourceId(d.Id())
+	requestResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return diag.FromErr(err)
+		return nil, fmt.Errorf("error querying dependency package version (%s): %s", dependVersion, err)
 	}
-	resp, err := dependencies.GetVersion(client, dependId, version)
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceDependencyVersionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		resourceId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "FunctionGraph dependency version")
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	respBody, err := GetDependencyVersionById(client, resourceId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "FunctionGraph dependency package version")
 	}
 
 	// FunctionGraph will store the compressed package content pointed to by the link into the new storage bucket that
@@ -162,39 +215,130 @@ func resourceDependencyVersionRead(_ context.Context, d *schema.ResourceData, me
 	// If the ReadContext is set this value according to the query result, ForceNew behavior will be triggered the next
 	// time it is applied.
 	mErr := multierror.Append(
-		d.Set("runtime", resp.Runtime),
-		d.Set("name", resp.Name),
-		d.Set("description", resp.Description),
-		d.Set("etag", resp.Etag),
-		d.Set("size", resp.Size),
-		d.Set("owner", resp.Owner),
-		d.Set("version", resp.Version),
-		d.Set("version_id", resp.ID),
-		d.Set("dependency_id", resp.DepId),
+		d.Set("region", region),
+		d.Set("runtime", utils.PathSearch("runtime", respBody, nil)),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("etag", utils.PathSearch("etag", respBody, nil)),
+		d.Set("size", utils.PathSearch("size", respBody, nil)),
+		d.Set("owner", utils.PathSearch("owner", respBody, nil)),
+		d.Set("version", utils.PathSearch("version", respBody, nil)),
+		d.Set("version_id", utils.PathSearch("id", respBody, nil)),
+		d.Set("dependency_id", utils.PathSearch("dep_id", respBody, nil)),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error setting resource fields of custom dependency version (%s): %s", d.Id(), err)
+		return diag.Errorf("error setting resource fields of custom dependency package version (%s): %s",
+			resourceId, err)
 	}
 
 	return nil
 }
 
 func resourceDependencyVersionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	client, err := cfg.FgsV2Client(cfg.GetRegion(d))
+	var (
+		cfg                     = meta.(*config.Config)
+		region                  = cfg.GetRegion(d)
+		httpUrl                 = "v2/{project_id}/fgs/dependencies/{depend_id}/version/{version}"
+		resourceId              = d.Id()
+		dependId, dependVersion = parseDependVersionResourceId(resourceId)
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
 	if err != nil {
-		return diag.Errorf("error creating FunctionGraph v2 client: %s", err)
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
 	}
 
-	dependId, version, err := ParseDependVersionResourceId(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{depend_id}", dependId)
+	deletePath = strings.ReplaceAll(deletePath, "{version}", dependVersion)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
-	err = dependencies.DeleteVersion(client, dependId, version)
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error deleting custom dependency version")
+		return common.CheckDeletedDiag(d, err, "error deleting custom dependency package version")
 	}
 	return nil
+}
+
+func getDependencies(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/fgs/dependencies?maxitems=100"
+		marker  = 0
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	result := make([]interface{}, 0)
+	for {
+		listPathWithMarker := fmt.Sprintf("%s&&marker=%v", listPath, marker)
+		requestResp, err := client.Request("GET", listPathWithMarker, &listOpt)
+		if err != nil {
+			return nil, fmt.Errorf("error querying dependency packages: %s", err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		dependencies := utils.PathSearch("dependencies", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dependencies) < 1 {
+			break
+		}
+		result = append(result, dependencies...)
+		marker += len(dependencies)
+	}
+
+	return result, nil
+}
+
+func getDependencyVersions(client *golangsdk.ServiceClient, dependId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/fgs/dependencies/{depend_id}/version?maxitems=100"
+		marker  = 0
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{depend_id}", dependId)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	result := make([]interface{}, 0)
+	for {
+		listPathWithMarker := fmt.Sprintf("%s&&marker=%v", listPath, marker)
+		requestResp, err := client.Request("GET", listPathWithMarker, &listOpt)
+		if err != nil {
+			return nil, fmt.Errorf("error querying dependency package versions: %s", err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		dependencies := utils.PathSearch("dependencies", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dependencies) < 1 {
+			break
+		}
+		result = append(result, dependencies...)
+		marker += len(dependencies)
+	}
+
+	return result, nil
 }
 
 // getSpecifiedDependencyVersion is a method that queries the corresponding dependency version based on the entered ID.
@@ -203,71 +347,64 @@ func resourceDependencyVersionDelete(_ context.Context, d *schema.ResourceData, 
 // + <depend_id>/<version_id>
 // + <depend_name>/<version> (All information that can be found through the console)
 // + <depend_name>/<version_id>
-func getSpecifiedDependencyVersion(client *golangsdk.ServiceClient, resourceId string) (*dependencies.DependencyVersion, error) {
-	dependInfo, versionInfo, err := ParseDependVersionResourceId(resourceId)
-	if err != nil {
-		return nil, err
-	}
+func refreshSpecifiedDependencyVersion(client *golangsdk.ServiceClient, resourceId string) (dependId, dependVersion string, err error) {
+	dependId, dependVersion = parseDependVersionResourceId(resourceId)
 
+	var result []interface{}
 	// If the input dependency package information part is not in UUID format, perform a query to obtain the
 	// corresponding ID.
-	if !utils.IsUUID(dependInfo) {
-		opts := dependencies.ListOpts{
-			Name: dependInfo,
-		}
-		allPages, err := dependencies.List(client, opts).AllPages()
+	if !utils.IsUUID(dependId) {
+		result, err = getDependencies(client)
 		if err != nil {
-			return nil, err
+			return dependId, dependVersion, err
 		}
-		listResp, _ := dependencies.ExtractDependencies(allPages)
-		if len(listResp.Dependencies) < 1 {
-			return nil, golangsdk.ErrDefault404{
+		dependId = utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0].id", dependId), result, "").(string)
+		if dependId == "" {
+			return dependId, dependVersion, golangsdk.ErrDefault404{
 				ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-					Body: []byte(fmt.Sprintf("unable to find the dependency package using its name: %s", dependInfo)),
+					Body: []byte(fmt.Sprintf("unable to find the dependency package using its name: %s", dependId)),
 				},
 			}
 		}
-		// Make sure the dependInfo content is the dependency ID.
-		dependInfo = listResp.Dependencies[0].ID
 	}
 
 	// If the input dependency version information part is in UUID format, perform a query to obtain the specified
 	// version using its ID.
-	if utils.IsUUID(versionInfo) {
-		opts := dependencies.ListVersionsOpts{
-			DependId: dependInfo,
-		}
-		listResp, err := dependencies.ListVersions(client, opts)
+	if utils.IsUUID(dependVersion) {
+		result, err := getDependencyVersions(client, dependId)
 		if err != nil {
-			return nil, err
+			return dependId, dependVersion, err
 		}
-		for _, dependVersion := range listResp {
-			if dependVersion.ID == versionInfo {
-				return &dependVersion, nil
+		dependVersion = fmt.Sprint(utils.PathSearch(fmt.Sprintf("[?id=='%s']|[0].version", dependVersion),
+			result, float64(0)).(float64))
+		if dependVersion == "" {
+			return dependId, dependVersion, golangsdk.ErrDefault404{
+				ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+					Body: []byte(fmt.Sprintf("unable to find the dependency package version using its ID: %s", dependVersion)),
+				},
 			}
 		}
-		return nil, golangsdk.ErrDefault404{
-			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("unable to find the dependency package using its ID: %s", versionInfo)),
-			},
-		}
 	}
-	return dependencies.GetVersion(client, dependInfo, versionInfo)
+
+	return dependId, dependVersion, nil
 }
 
 func resourceDependencyVersionImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	cfg := meta.(*config.Config)
-	client, err := cfg.FgsV2Client(cfg.GetRegion(d))
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("fgs", region)
 	if err != nil {
-		return []*schema.ResourceData{d}, fmt.Errorf("error creating FunctionGraph v2 client: %s", err)
+		return []*schema.ResourceData{d}, fmt.Errorf("error creating FunctionGraph client: %s", err)
 	}
 
 	// Query the corresponding dependency version based on the user's import ID.
-	resp, err := getSpecifiedDependencyVersion(client, d.Id())
+	dependId, dependVersion, err := refreshSpecifiedDependencyVersion(client, d.Id())
 	if err != nil {
 		return []*schema.ResourceData{d}, err
 	}
-	d.SetId(fmt.Sprintf("%s/%d", resp.DepId, resp.Version))
+	d.SetId(fmt.Sprintf("%s/%s", dependId, dependVersion))
 
 	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Using auto-generate style to replace the old resource coding.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. using auto-gen style to replace old coding.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccDependencyVersion_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDependencyVersion_basic -timeout 360m -parallel 10
=== RUN   TestAccDependencyVersion_basic
=== PAUSE TestAccDependencyVersion_basic
=== CONT  TestAccDependencyVersion_basic
--- PASS: TestAccDependencyVersion_basic (38.98s)
PASS
coverage: 10.4% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       39.030s coverage: 10.4% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
