### PR TITLE
feat(accessanalyzer): add options of type and add new argument configuration

### DIFF
--- a/docs/resources/access_analyzer.md
+++ b/docs/resources/access_analyzer.md
@@ -32,9 +32,24 @@ The following arguments are supported:
 * `name` - (Required, String, NonUpdatable) Specifies the name of the analyzer.
 
 * `type` - (Required, String, NonUpdatable) Specifies the type of the analyzer.
-  The value can be: **account**.
+  The value can be: **account**, **organization**, **account_unused_access** and **organization_unused_access**.
+
+* `configuration` - (Optional, List, NonUpdatable) Specifies the configuration of the analyzer.
+  The [configuration](#configuration) structure is documented below.
 
 * `tags` - (Optional, Map) Specifies the tags of the analyzer.
+
+<a name="configuration"></a>
+The `configuration` block supports:
+
+* `unused_access` - (Optional, List, NonUpdatable) Specifies the unused access.
+  The [unused_access](#unused_access) structure is documented below.
+
+<a name="unused_access"></a>
+The `unused_access` block supports:
+
+* `unused_access_age` - (Optional, Int, NonUpdatable) Specifies the unused access age in days.
+  When the `type` is **account_unused_access** or **organization_unused_access**, the default value is 90.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/accessanalyzer/huaweicloud_access_analyzer_test.go
+++ b/huaweicloud/services/acceptance/accessanalyzer/huaweicloud_access_analyzer_test.go
@@ -112,3 +112,67 @@ resource "huaweicloud_access_analyzer" "test" {
 }
 `, rName)
 }
+
+func TestAccAnalyzer_unused(t *testing.T) {
+	var object interface{}
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_access_analyzer.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&object,
+		getAnalyzerResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnalyzer_unused(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "account_unused_access"),
+					resource.TestCheckResourceAttr(resourceName,
+						"configuration.0.unused_access.0.unused_access_age", "30"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "urn"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_analyzed_resource", "last_resource_analyzed_at"},
+			},
+		},
+	})
+}
+
+func testAccAnalyzer_unused(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_access_analyzer" "test" {
+  name = "%s"
+  type = "account_unused_access"
+
+  configuration {
+    unused_access {
+      unused_access_age = 30
+    }
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, rName)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/accessanalyzer' TESTARGS='-run TestAccAnalyzer_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/accessanalyzer -v -run TestAccAnalyzer_basic -timeout 360m -parallel 4
=== RUN   TestAccAnalyzer_basic
=== PAUSE TestAccAnalyzer_basic
=== CONT  TestAccAnalyzer_basic
--- PASS: TestAccAnalyzer_basic (36.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/accessanalyzer    36.923s

make testacc TEST='./huaweicloud/services/acceptance/accessanalyzer' TESTARGS='-run TestAccAnalyzer_unused'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/accessanalyzer -v -run TestAccAnalyzer_unused -timeout 360m -parallel 4
=== RUN   TestAccAnalyzer_unused
=== PAUSE TestAccAnalyzer_unused
=== CONT  TestAccAnalyzer_unused
--- PASS: TestAccAnalyzer_unused (20.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/accessanalyzer    20.690s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
