### PR TITLE
refactor(AccessAnalyzer): add region in access analyzer resources

### DIFF
--- a/docs/resources/access_analyzer.md
+++ b/docs/resources/access_analyzer.md
@@ -29,6 +29,9 @@ resource "huaweicloud_access_analyzer" "test" {
 
 The following arguments are supported:
 
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
 * `name` - (Required, String, NonUpdatable) Specifies the name of the analyzer.
 
 * `type` - (Required, String, NonUpdatable) Specifies the type of the analyzer.

--- a/docs/resources/access_analyzer_achive_rule.md
+++ b/docs/resources/access_analyzer_achive_rule.md
@@ -40,6 +40,9 @@ resource "huaweicloud_access_analyzer_archive_rule" "test" {
 
 The following arguments are supported:
 
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
 * `analyzer_id` - (Required, String, NonUpdatable) Specifies the ID of the analyzer to which the archice rule belongs.
 
 * `name` - (Required, String, NonUpdatable) Specifies the name of the archice rule.

--- a/huaweicloud/services/accessanalyzer/resource_huaweicloud_access_analyzer.go
+++ b/huaweicloud/services/accessanalyzer/resource_huaweicloud_access_analyzer.go
@@ -39,6 +39,12 @@ func ResourceAccessAnalyzer() *schema.Resource {
 		CustomizeDiff: config.FlexibleForceNew(nonUpdatableParams),
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -198,6 +204,7 @@ func resourceAccessAnalyzerRead(_ context.Context, d *schema.ResourceData, meta 
 	}
 
 	mErr := multierror.Append(nil,
+		d.Set("region", region),
 		d.Set("name", utils.PathSearch("name", analyzer, nil)),
 		d.Set("type", utils.PathSearch("type", analyzer, nil)),
 		d.Set("configuration", flattenConfiguration(utils.PathSearch("configuration", analyzer, nil))),

--- a/huaweicloud/services/accessanalyzer/resource_huaweicloud_access_analyzer_archive_rule.go
+++ b/huaweicloud/services/accessanalyzer/resource_huaweicloud_access_analyzer_archive_rule.go
@@ -38,6 +38,12 @@ func ResourceArchiveRule() *schema.Resource {
 		CustomizeDiff: config.FlexibleForceNew(nonUpdatableParamsArchiveRule),
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"analyzer_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -229,6 +235,7 @@ func resourceArchiveRuleRead(_ context.Context, d *schema.ResourceData, meta int
 	}
 
 	mErr := multierror.Append(nil,
+		d.Set("region", region),
 		d.Set("name", utils.PathSearch("name", archiveRule, nil)),
 		d.Set("urn", utils.PathSearch("urn", archiveRule, nil)),
 		d.Set("created_at", utils.PathSearch("created_at", archiveRule, nil)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/accessanalyzer' TESTARGS='-run TestAccAnalyzer_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/accessanalyzer -v -run TestAccAnalyzer_basic -timeout 360m -parallel 4
=== RUN   TestAccAnalyzer_basic
=== PAUSE TestAccAnalyzer_basic
=== CONT  TestAccAnalyzer_basic
--- PASS: TestAccAnalyzer_basic (35.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/accessanalyzer    35.312s

make testacc TEST='./huaweicloud/services/acceptance/accessanalyzer' TESTARGS='-run TestAccArchiveRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/accessanalyzer -v -run TestAccArchiveRule_basic -timeout 360m -parallel 4
=== RUN   TestAccArchiveRule_basic
=== PAUSE TestAccArchiveRule_basic
=== CONT  TestAccArchiveRule_basic
--- PASS: TestAccArchiveRule_basic (51.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/accessanalyzer    51.580s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
