### PR TITLE
refactor(vpc): remove sdk-go-v3 in vpc resource

### DIFF
--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc.go
@@ -152,7 +152,7 @@ func dataSourceVpcV1Read(_ context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	// save VirtualPrivateCloudV3 extend_cidr
-	v3Client, err := cfg.HcVpcV3Client(region)
+	v3Client, err := cfg.NewServiceClient("vpcv3", region)
 	if err != nil {
 		return diag.Errorf("error creating VPC v3 client: %s", err)
 	}
@@ -161,7 +161,7 @@ func dataSourceVpcV1Read(_ context.Context, d *schema.ResourceData, meta interfa
 	if err != nil {
 		diag.Errorf("error retrieving VPC (%s) v3 detail: %s", d.Id(), err)
 	}
-	d.Set("secondary_cidrs", res.Vpc.ExtendCidrs)
+	d.Set("secondary_cidrs", utils.PathSearch("vpc.extend_cidrs", res, nil))
 
 	return nil
 }

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpcs.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpcs.go
@@ -113,7 +113,7 @@ func dataSourceVpcsRead(_ context.Context, d *schema.ResourceData, meta interfac
 		return diag.Errorf("error creating VPC V2 client: %s", err)
 	}
 
-	v3Client, err := cfg.HcVpcV3Client(region)
+	v3Client, err := cfg.NewServiceClient("vpcv3", region)
 	if err != nil {
 		return diag.Errorf("error creating VPC v3 client: %s", err)
 	}
@@ -167,7 +167,7 @@ func dataSourceVpcsRead(_ context.Context, d *schema.ResourceData, meta interfac
 		if err != nil {
 			diag.Errorf("error retrieving VPC (%s) v3 detail: %s", vpcResource.ID, err)
 		}
-		vpc["secondary_cidrs"] = res.Vpc.ExtendCidrs
+		vpc["secondary_cidrs"] = utils.PathSearch("vpc.extend_cidrs", res, nil)
 
 		vpcs = append(vpcs, vpc)
 		ids = append(ids, vpcResource.ID)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcV1_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcV1_ -timeout 360m -parallel 4
=== RUN   TestAccVpcV1_basic
=== PAUSE TestAccVpcV1_basic
=== RUN   TestAccVpcV1_secondaryCIDR
=== PAUSE TestAccVpcV1_secondaryCIDR
=== RUN   TestAccVpcV1_secondaryCIDRs
=== PAUSE TestAccVpcV1_secondaryCIDRs
=== RUN   TestAccVpcV1_WithEpsId
=== PAUSE TestAccVpcV1_WithEpsId
=== RUN   TestAccVpcV1_WithEnhancedLocalRoute
=== PAUSE TestAccVpcV1_WithEnhancedLocalRoute
=== RUN   TestAccVpcV1_WithCustomRegion
=== PAUSE TestAccVpcV1_WithCustomRegion
=== CONT  TestAccVpcV1_basic
=== CONT  TestAccVpcV1_WithEpsId
=== CONT  TestAccVpcV1_secondaryCIDRs
=== CONT  TestAccVpcV1_WithCustomRegion
=== NAME  TestAccVpcV1_WithEpsId
    acceptance.go:744: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccVpcV1_WithEpsId (0.00s)
=== CONT  TestAccVpcV1_WithEnhancedLocalRoute
=== NAME  TestAccVpcV1_WithCustomRegion
    acceptance.go:718: HW_CUSTOM_REGION_NAME must be set for acceptance tests
--- SKIP: TestAccVpcV1_WithCustomRegion (0.00s)
=== CONT  TestAccVpcV1_secondaryCIDR
=== NAME  TestAccVpcV1_WithEnhancedLocalRoute
    acceptance.go:2763: HW_VPC_ENHANCED_LOCAL_ROUTE must be set for the acceptance test
--- SKIP: TestAccVpcV1_WithEnhancedLocalRoute (0.02s)
--- PASS: TestAccVpcV1_basic (61.59s)
--- PASS: TestAccVpcV1_secondaryCIDR (77.33s)
--- PASS: TestAccVpcV1_secondaryCIDRs (86.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       86.333s

make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcsDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcsDataSource_ -timeout 360m -parallel 4
=== RUN   TestAccVpcsDataSource_basic
=== PAUSE TestAccVpcsDataSource_basic
=== RUN   TestAccVpcsDataSource_byCidr
=== PAUSE TestAccVpcsDataSource_byCidr
=== RUN   TestAccVpcsDataSource_byName
=== PAUSE TestAccVpcsDataSource_byName
=== RUN   TestAccVpcsDataSource_byAll
=== PAUSE TestAccVpcsDataSource_byAll
=== RUN   TestAccVpcsDataSource_tags
=== PAUSE TestAccVpcsDataSource_tags
=== CONT  TestAccVpcsDataSource_basic
=== CONT  TestAccVpcsDataSource_byAll
=== CONT  TestAccVpcsDataSource_byName
=== CONT  TestAccVpcsDataSource_tags
=== NAME  TestAccVpcsDataSource_byAll
    acceptance.go:744: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccVpcsDataSource_byAll (0.00s)
=== CONT  TestAccVpcsDataSource_byCidr
--- PASS: TestAccVpcsDataSource_basic (54.66s)
--- PASS: TestAccVpcsDataSource_byCidr (58.27s)
--- PASS: TestAccVpcsDataSource_byName (58.46s)
--- PASS: TestAccVpcsDataSource_tags (60.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       60.660s

make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcDataSource_ -timeout 360m -parallel 4
=== RUN   TestAccVpcDataSource_basic
=== PAUSE TestAccVpcDataSource_basic
=== RUN   TestAccVpcDataSource_byCidr
=== PAUSE TestAccVpcDataSource_byCidr
=== RUN   TestAccVpcDataSource_byName
=== PAUSE TestAccVpcDataSource_byName
=== CONT  TestAccVpcDataSource_basic
=== CONT  TestAccVpcDataSource_byName
=== CONT  TestAccVpcDataSource_byCidr
--- PASS: TestAccVpcDataSource_byCidr (52.32s)
--- PASS: TestAccVpcDataSource_byName (54.68s)
--- PASS: TestAccVpcDataSource_basic (54.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       54.792s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
