### PR TITLE
feat(workspace): add new resource to amanage ou

### DIFF
--- a/docs/resources/workspace_ou.md
+++ b/docs/resources/workspace_ou.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_ou"
+description: |-
+  Manages an OU resource of Workspace within HuaweiCloud.
+---
+# huaweicloud_workspace_ou
+
+Manages an OU resource of Workspace within HuaweiCloud.
+
+-> Before creating an OU, you need to create OUs on the AD server and register the Workspace service
+   to connect to the AD domain.
+
+## Example Usage
+
+```hcl
+variable "ou_name" {}
+variable "ad_domain_name" {}
+
+resource "huaweicloud_workspace_ou" "test" {
+  name   = var.ou_name
+  domain = var.ad_domain_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `name` - (Required, String) Specifies the name of the OU.  
+  The name only allows Chinese and English characters, digits, spaces and special characters (-_$!@*?.).
+  Multiple levels of OUs are separated by slashes (/) and no space is allowed before or after the slashes (/),
+  a maximum of five layers of OUs are supported. e.g. `ab/cd/ef`.
+
+* `domain` - (Required, String, ForceNew) Specifies the AD domain name to which the OU belongs.
+
+* `description` - (Optional, String) Specifies the description of the OU.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also OU ID.
+
+## Import
+
+The OU resource can be imported using `name`, e.g.
+
+```bash
+$ terraform import huaweicloud_workspace_ou.test <name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2291,11 +2291,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_access_policy":           workspace.ResourceAccessPolicy(),
 			"huaweicloud_workspace_desktop_name_rule":       workspace.ResourceDesktopNameRule(),
 			"huaweicloud_workspace_desktop":                 workspace.ResourceDesktop(),
+			"huaweicloud_workspace_eip_associate":           workspace.ResourceEipAssociate(),
+			"huaweicloud_workspace_ou":                      workspace.ResourceOu(),
 			"huaweicloud_workspace_policy_group":            workspace.ResourcePolicyGroup(),
 			"huaweicloud_workspace_service":                 workspace.ResourceService(),
 			"huaweicloud_workspace_terminal_binding":        workspace.ResourceTerminalBinding(),
 			"huaweicloud_workspace_user":                    workspace.ResourceUser(),
-			"huaweicloud_workspace_eip_associate":           workspace.ResourceEipAssociate(),
 
 			"huaweicloud_cpts_project": cpts.ResourceProject(),
 			"huaweicloud_cpts_task":    cpts.ResourceTask(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -234,6 +234,7 @@ var (
 	HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID")
 	HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_SPEC_CODE  = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_SPEC_CODE")
 	HW_WORKSPACE_OU_NAME                           = os.Getenv("HW_WORKSPACE_OU_NAME")
+	HW_WORKSPACE_OU_UPDATE_NAME                    = os.Getenv("HW_WORKSPACE_OU_UPDATE_NAME")
 	HW_WORKSPACE_APP_FILE_NAME                     = os.Getenv("HW_WORKSPACE_APP_FILE_NAME")
 	HW_WORKSPACE_USER_NAMES                        = os.Getenv("HW_WORKSPACE_USER_NAMES")
 
@@ -1619,6 +1620,13 @@ func TestAccPrecheckWorkspaceUserNames(t *testing.T) {
 func TestAccPreCheckWorkspaceOUName(t *testing.T) {
 	if HW_WORKSPACE_OU_NAME == "" {
 		t.Skip("HW_WORKSPACE_OU_NAME must be set for Workspace service acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckWorkspaceOUUpdateName(t *testing.T) {
+	if HW_WORKSPACE_OU_UPDATE_NAME == "" {
+		t.Skip("HW_WORKSPACE_OU_UPDATE_NAME must be set for Workspace service acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_ou_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_ou_test.go
@@ -1,0 +1,138 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/workspace"
+)
+
+func getOuFun(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("workspace", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Workspace client: %s", err)
+	}
+
+	return workspace.GetOuByName(client, state.Primary.Attributes["name"])
+}
+
+func TestAccOu_basic(t *testing.T) {
+	var (
+		ouObj        interface{}
+		resourceName = "huaweicloud_workspace_ou.test"
+		rc           = acceptance.InitResourceCheck(
+			resourceName,
+			&ouObj,
+			getOuFun,
+		)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAD(t)
+			acceptance.TestAccPreCheckWorkspaceOUName(t)
+			acceptance.TestAccPreCheckWorkspaceOUUpdateName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOu_step1(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", acceptance.HW_WORKSPACE_OU_NAME),
+					resource.TestCheckResourceAttrPair(resourceName, "domain",
+						"huaweicloud_workspace_service.test", "ad_domain.0.name"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
+				),
+			},
+			{
+				Config: testAccOu_step2(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", acceptance.HW_WORKSPACE_OU_UPDATE_NAME),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccOuImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccOu_base() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_service" "test" {
+  ad_domain {
+    name                   = try(element(regexall("\\w+\\.(.*)", element(split(",", "%[1]s"), 0))[0], 0), "")
+    active_domain_name     = element(split(",", "%[1]s"), 0)
+    active_domain_ip       = element(split(",", "%[2]s"), 0)
+    active_dns_ip          = element(split(",", "%[2]s"), 0)
+    admin_account          = "%[3]s"
+    password               = "%[4]s"
+    delete_computer_object = true
+  }
+
+  auth_type   = "LOCAL_AD"
+  access_mode = "INTERNET"
+  vpc_id      = "%[5]s"
+  network_ids = ["%[6]s"]
+}
+`, acceptance.HW_WORKSPACE_AD_DOMAIN_NAMES,
+		acceptance.HW_WORKSPACE_AD_DOMAIN_IPS,
+		acceptance.HW_WORKSPACE_AD_SERVER_ACCOUNT,
+		acceptance.HW_WORKSPACE_AD_SERVER_PWD,
+		acceptance.HW_WORKSPACE_AD_VPC_ID,
+		acceptance.HW_WORKSPACE_AD_NETWORK_ID)
+}
+
+func testAccOu_step1() string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_ou" "test" {
+  depends_on = [huaweicloud_workspace_service.test]
+
+  name        = "%[2]s"
+  domain      = huaweicloud_workspace_service.test.ad_domain[0].name
+  description = "Created by terraform script"
+}
+`, testAccOu_base(), acceptance.HW_WORKSPACE_OU_NAME)
+}
+
+func testAccOu_step2() string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_ou" "test" {
+  depends_on = [huaweicloud_workspace_service.test]
+
+  name   = "%[2]s"
+  domain = huaweicloud_workspace_service.test.ad_domain[0].name
+}
+`, testAccOu_base(), acceptance.HW_WORKSPACE_OU_UPDATE_NAME)
+}
+
+func testAccOuImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+		ouName := rs.Primary.Attributes["name"]
+		if ouName == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<name>', but got '%s'", ouName)
+		}
+		return ouName, nil
+	}
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_ou.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_ou.go
@@ -1,0 +1,259 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace POST /v2/{project_id}/ous
+// @API Workspace GET /v2/{project_id}/ous
+// @API Workspace PUT /v2/{project_id}/ous/{ou_id}
+// @API Workspace DELETE /v2/{project_id}/ous/{ou_id}
+func ResourceOu() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceOuCreate,
+		ReadContext:   resourceOuRead,
+		UpdateContext: resourceOuUpdate,
+		DeleteContext: resourceOuDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceOuImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the OU.`,
+			},
+			"domain": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The domain name to which the OU belongs.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the OU.`,
+			},
+		},
+	}
+}
+
+func buildCreateOuBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"ou_name":     d.Get("name"),
+		"domain":      d.Get("domain"),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+}
+
+func resourceOuCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v2/{project_id}/ous"
+	)
+
+	client, err := cfg.NewServiceClient("workspace", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateOuBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating OU: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	ouId := utils.PathSearch("id", respBody, "").(string)
+	if ouId == "" {
+		return diag.Errorf("unable to find OU ID from API response")
+	}
+
+	d.SetId(ouId)
+	return resourceOuRead(ctx, d, meta)
+}
+
+func GetOuByName(client *golangsdk.ServiceClient, ouName string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/ous"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = fmt.Sprintf("%s?ou_name=%s", listPath, ouName)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	resp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		// WKS.0202: The resource not found.
+		// WKS.00010099: The Workspace service is disabled.
+		return nil, common.ConvertExpected500ErrInto404Err(
+			common.ConvertExpected403ErrInto404Err(err, "error_code", "WKS.00010099"),
+			"error_code", "WKS.0202")
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	ous := utils.PathSearch("ous", respBody, make([]interface{}, 0)).([]interface{})
+	if len(ous) == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return ous[0], nil
+}
+
+func resourceOuRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	respBody, err := GetOuByName(client, d.Get("name").(string))
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving Workspace OU")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("ou_name", respBody, nil)),
+		d.Set("domain", utils.PathSearch("domain", respBody, nil)),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdateOuBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"ou_name":     d.Get("name"),
+		"description": d.Get("description"),
+	}
+}
+
+func resourceOuUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v2/{project_id}/ous/{ou_id}"
+	)
+
+	client, err := cfg.NewServiceClient("workspace", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{ou_id}", d.Id())
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildUpdateOuBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating OU (%s): %s", d.Get("name").(string), err)
+	}
+
+	return resourceOuRead(ctx, d, meta)
+}
+
+func resourceOuDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v2/{project_id}/ous/{ou_id}"
+	)
+
+	client, err := cfg.NewServiceClient("workspace", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{ou_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		// WKS.0915: The resource not found.
+		// WKS.00010099: The Workspace service is disabled.
+		return common.CheckDeletedDiag(d, common.ConvertExpected500ErrInto404Err(
+			common.ConvertExpected403ErrInto404Err(err, "error_code", "WKS.00010099"),
+			"error_code", "WKS.0915"),
+			"error deleting Workspace OU")
+	}
+
+	return nil
+}
+
+func resourceOuImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	importId := d.Id()
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Workspace client: %s", err)
+	}
+
+	ouInfo, err := GetOuByName(client, importId)
+	if err != nil {
+		return nil, err
+	}
+
+	ouId := utils.PathSearch("id", ouInfo, "").(string)
+	if ouId == "" {
+		return nil, fmt.Errorf("unable to find the OU ID using its name (%s): %s", importId, err)
+	}
+
+	d.SetId(ouId)
+	mErr := multierror.Append(nil,
+		d.Set("name", importId),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource to amage OU.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDesktop_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDesktop_ -timeout 360m -parallel 10
=== RUN   TestAccDesktop_basic
--- PASS: TestAccDesktop_basic (2167.89s)
=== RUN   TestAccDesktop_UpdateWithEpsId
--- PASS: TestAccDesktop_UpdateWithEpsId (1287.56s)
=== RUN   TestAccDesktop_powerAction
--- PASS: TestAccDesktop_powerAction (1638.78s)
PASS
coverage: 15.4% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 5094.304s       coverage: 15.4% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found    
![image](https://github.com/user-attachments/assets/dc6b6ed6-14ab-4e30-921a-07131de8d104)

    ab. Related resources (parent resources) not found
   The Workspace service is disabled.
![image](https://github.com/user-attachments/assets/b6fe01aa-a812-4eea-b5c5-3e512d6c5ac7)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found 
![image](https://github.com/user-attachments/assets/f3a703fd-da39-4c95-a575-f775b8cebcce)

    bb. Related resources (parent resources) not found
   The Workspace service is disabled.
   ![image](https://github.com/user-attachments/assets/60e7a69e-ec83-490e-bde3-32223650c9ca)

