### PR TITLE
refactor(GaussDB): fix gaussdb opengauss api comments

### DIFF
--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance_node_startup.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance_node_startup.go
@@ -16,7 +16,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API GaussDB POST /v3/{project_id}/instances/{instance_id}/restart
+// @API GaussDB POST /v3/{project_id}/instances/{instance_id}/db-startup
 // @API GaussDB GET /v3/{project_id}/instances
 // @API GaussDB GET /v3/{project_id}/jobs
 func ResourceOpenGaussInstanceNodeStartup() *schema.Resource {

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance_node_stop.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance_node_stop.go
@@ -16,7 +16,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API GaussDB POST /v3/{project_id}/instances/{instance_id}/restart
+// @API GaussDB POST /v3/{project_id}/instances/{instance_id}/db-stop
 // @API GaussDB GET /v3/{project_id}/instances
 // @API GaussDB GET /v3/{project_id}/jobs
 func ResourceOpenGaussInstanceNodeStop() *schema.Resource {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix gaussdb opengauss api comments
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix gaussdb opengauss api comments
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
