### PR TITLE
fix(CodeArts/Deploy): fix error and add acc test

### DIFF
--- a/docs/resources/codearts_deploy_group_permission.md
+++ b/docs/resources/codearts_deploy_group_permission.md
@@ -56,6 +56,13 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+
 ## Import
 
 The CodeArts deploy group permission resource can be imported using the `project_id`, `group_id`, `role_id` and

--- a/huaweicloud/services/acceptance/codeartsdeploy/resource_huaweicloud_codearts_deploy_application_permission_test.go
+++ b/huaweicloud/services/acceptance/codeartsdeploy/resource_huaweicloud_codearts_deploy_application_permission_test.go
@@ -47,3 +47,41 @@ resource "huaweicloud_codearts_deploy_application_permission" "test" {
   }
 }`, testDeployApplication_basic(rName), value)
 }
+
+func TestAccDeployApplicationPermissionModify_conflict(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeployApplicationPermissionModify_conflict(rName),
+			},
+		},
+	})
+}
+
+func testAccDeployApplicationPermissionModify_conflict(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_codearts_deploy_application_permission" "test" {
+  count = 2 
+
+  project_id      = huaweicloud_codearts_deploy_application.test.project_id
+  application_ids = [huaweicloud_codearts_deploy_application.test.id]
+
+  roles {
+    role_id        = try(huaweicloud_codearts_deploy_application.test.permission_matrix[2].role_id, "")
+    can_modify     = false
+    can_disable    = true
+    can_delete     = true
+    can_view       = true
+    can_execute    = true
+    can_copy       = true
+    can_manage     = true
+    can_create_env = true
+  }
+}`, testDeployApplication_basic(rName))
+}

--- a/huaweicloud/services/codeartsdeploy/resource_huaweicloud_codearts_deploy_group.go
+++ b/huaweicloud/services/codeartsdeploy/resource_huaweicloud_codearts_deploy_group.go
@@ -359,7 +359,6 @@ func getDeployGroupPermissionMatrix(client *golangsdk.ServiceClient, id string) 
 func flattenDeployGroupCreatedBy(resp interface{}) []interface{} {
 	curJson := utils.PathSearch("created_by", resp, nil)
 	if curJson == nil {
-		log.Printf("[ERROR] error flatten created_by, cause this field is not found in API response")
 		return nil
 	}
 
@@ -374,7 +373,6 @@ func flattenDeployGroupCreatedBy(resp interface{}) []interface{} {
 func flattenDeployGroupPermission(resp interface{}) []interface{} {
 	curJson := utils.PathSearch("permission", resp, nil)
 	if curJson == nil {
-		log.Printf("[ERROR] error flatten permission, cause this field is not found in API response")
 		return nil
 	}
 
@@ -489,8 +487,9 @@ func resourceDeployGroupImportState(_ context.Context, d *schema.ResourceData,
 	}
 
 	d.SetId(parts[1])
-	if err := d.Set("project_id", parts[0]); err != nil {
-		return nil, fmt.Errorf("error saving project ID: %s", err)
-	}
-	return []*schema.ResourceData{d}, nil
+	mErr := multierror.Append(nil,
+		d.Set("project_id", parts[0]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 fix error and add acc test
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
./scripts/acc-test.sh 

run acceptance tests of huaweicloud/services/acceptance/codeartsdeploy/resource_huaweicloud_codearts_deploy_application_test.go:
=== RUN   TestAccDeployApplication_basic
=== PAUSE TestAccDeployApplication_basic
=== RUN   TestAccDeployApplication_resourcePoolId
=== PAUSE TestAccDeployApplication_resourcePoolId
=== RUN   TestAccDeployApplication_errorCheckInvalidArgument
=== PAUSE TestAccDeployApplication_errorCheckInvalidArgument
=== RUN   TestAccDeployApplication_conflict
=== PAUSE TestAccDeployApplication_conflict
=== CONT  TestAccDeployApplication_basic
=== CONT  TestAccDeployApplication_errorCheckInvalidArgument
=== CONT  TestAccDeployApplication_resourcePoolId
=== CONT  TestAccDeployApplication_conflict
=== CONT  TestAccDeployApplication_resourcePoolId
    acceptance.go:1924: HW_CODEARTS_RESOURCE_POOL_ID must be set for this acceptance test
--- SKIP: TestAccDeployApplication_resourcePoolId (0.00s)
--- PASS: TestAccDeployApplication_errorCheckInvalidArgument (3.27s)
--- PASS: TestAccDeployApplication_conflict (55.57s)
--- PASS: TestAccDeployApplication_basic (56.18s)
PASS
coverage: 20.8% of statements in ./huaweicloud/services/codeartsdeploy
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codeartsdeploy    56.238s coverage: 20.8% of statements in ./huaweicloud/services/codeartsdeploy

run acceptance tests of huaweicloud/services/acceptance/codeartsdeploy/resource_huaweicloud_codearts_deploy_application_permission_test.go:
=== RUN   TestAccDeployApplicationPermissionModify_basic
=== PAUSE TestAccDeployApplicationPermissionModify_basic
=== RUN   TestAccDeployApplicationPermissionModify_conflict
=== PAUSE TestAccDeployApplicationPermissionModify_conflict
=== CONT  TestAccDeployApplicationPermissionModify_basic
=== CONT  TestAccDeployApplicationPermissionModify_conflict
--- PASS: TestAccDeployApplicationPermissionModify_conflict (52.14s)
--- PASS: TestAccDeployApplicationPermissionModify_basic (67.35s)
PASS
coverage: 15.2% of statements in ./huaweicloud/services/codeartsdeploy
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codeartsdeploy    67.420s coverage: 15.2% of statements in ./huaweicloud/services/codeartsdeploy

run acceptance tests of huaweicloud/services/acceptance/codeartsdeploy/resource_huaweicloud_codearts_deploy_group_test.go:
=== RUN   TestAccDeployGroup_basic
=== PAUSE TestAccDeployGroup_basic
=== RUN   TestAccDeployGroup_resourcePoolId
=== PAUSE TestAccDeployGroup_resourcePoolId
=== CONT  TestAccDeployGroup_basic
=== CONT  TestAccDeployGroup_resourcePoolId
    acceptance.go:1924: HW_CODEARTS_RESOURCE_POOL_ID must be set for this acceptance test
--- SKIP: TestAccDeployGroup_resourcePoolId (0.00s)
--- PASS: TestAccDeployGroup_basic (37.90s)
PASS
coverage: 9.5% of statements in ./huaweicloud/services/codeartsdeploy
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codeartsdeploy    37.953s coverage: 9.5% of statements in ./huaweicloud/services/codeartsdeploy

### coverage of files in huaweicloud/services:

- github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/codeartsdeploy/resource_huaweicloud_codearts_deploy_application.go (80.6%)
- github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/codeartsdeploy/resource_huaweicloud_codearts_deploy_application_permission.go (86.4%)
- github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/codeartsdeploy/resource_huaweicloud_codearts_deploy_group.go (80.6%)

### [summary] 0 failed in 3 resource acceptance tests
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
