### PR TITLE
chore(cae): deploy component job missing failed status

### DIFF
--- a/huaweicloud/services/cae/resource_huaweicloud_cae_component_deployment.go
+++ b/huaweicloud/services/cae/resource_huaweicloud_cae_component_deployment.go
@@ -176,10 +176,18 @@ func deployJobRefreshFunc(client *golangsdk.ServiceClient, environmentId, jobId 
 		}
 
 		status := utils.PathSearch("spec.status", resp, "null").(string)
-
 		if utils.StrSliceContains(targets, status) {
 			return resp, "COMPLETED", nil
 		}
+
+		if status == "failed" {
+			task := utils.PathSearch("spec.tasks[?status=='failed']|[0]", resp, nil)
+
+			return resp, "ERROR",
+				fmt.Errorf("the job (%s) execution failed: (%s)", utils.PathSearch("name", task, "").(string),
+					utils.PathSearch("detail", task, "").(string))
+		}
+
 		return resp, "PENDING", nil
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Missing **failed** status restriction in Deployment Component Job Refresh method.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
