### PR TITLE
feat: add new utils function to unmarshal json array string

### DIFF
--- a/huaweicloud/utils/type_convert.go
+++ b/huaweicloud/utils/type_convert.go
@@ -136,6 +136,21 @@ func StringToJson(jsonStrObj string) interface{} {
 	return jsonMap
 }
 
+// Try to parse the string value as the JSON array format, if the operation failed, returns an empty list result.
+func StringToJsonArray(jsonStrArray string) []map[string]interface{} {
+	if jsonStrArray == "" {
+		return nil
+	}
+
+	var jsonArray []map[string]interface{}
+	err := json.Unmarshal([]byte(jsonStrArray), &jsonArray)
+	if err != nil {
+		log.Printf("[ERROR] Unable to convert the JSON string to the JSON array: %s", err)
+		return make([]map[string]interface{}, 0)
+	}
+	return jsonArray
+}
+
 // Try to convert the JSON object to the string value, if the operation failed, returns an empty string.
 func JsonToString(jsonObj interface{}) string {
 	if jsonObj == nil {

--- a/huaweicloud/utils/type_convert_test.go
+++ b/huaweicloud/utils/type_convert_test.go
@@ -42,6 +42,43 @@ func TestTypeConvertFunc_StringToJson(t *testing.T) {
 	t.Logf("All processing results of the JsonToString method meets expectation")
 }
 
+func TestTypeConvertFunc_StringToJsonArray(t *testing.T) {
+	var (
+		emptyInput           = "[]"
+		correctInput         = "[{\"key1\":\"value1\"},{\"key2\":\"value2\"}]"
+		incorrectInput       = "{\"foo\":\"bar\"}"
+		emptyInputExpected   = make([]map[string]interface{}, 0)
+		correctInputExpected = []map[string]interface{}{
+			{
+				"key1": "value1",
+			},
+			{
+				"key2": "value2",
+			},
+		}
+	)
+
+	testOutput := utils.StringToJsonArray(emptyInput)
+	if !reflect.DeepEqual(testOutput, emptyInputExpected) {
+		t.Fatalf("The processing result of the StringToJsonArray method is not as expected, want %s, but got %s",
+			utils.Green(emptyInputExpected), utils.Yellow(testOutput))
+	}
+
+	testOutput = utils.StringToJsonArray(correctInput)
+	if !reflect.DeepEqual(testOutput, correctInputExpected) {
+		t.Fatalf("The processing result of the StringToJsonArray method is not as expected, want %s, but got %s",
+			utils.Green(correctInputExpected), utils.Yellow(testOutput))
+	}
+
+	testOutput = utils.StringToJsonArray(incorrectInput)
+	if !reflect.DeepEqual(testOutput, make([]map[string]interface{}, 0)) {
+		t.Fatalf("The processing result of the StringToJsonArray method is not as expected, want \"\", but got %s",
+			utils.Yellow(testOutput))
+	}
+
+	t.Logf("All processing results of the StringToJsonArray method meets expectation")
+}
+
 func TestTypeConvertFunc_JsonToString(t *testing.T) {
 	type Test struct {
 		Foo string `json:"foo,omitempty"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add new utils function to unmarshal json array string.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
go test -v ./huaweicloud/utils/ -run TestTypeConvertFunc_StringToJsonArray
=== RUN   TestTypeConvertFunc_StringToJsonArray
2025/02/11 11:41:48 [ERROR] Unable to convert the JSON string to the JSON array: json: cannot unmarshal object into Go value of type []map[string]interface {}
    type_convert_test.go:79: All processing results of the StringToJsonArray method meets expectation
--- PASS: TestTypeConvertFunc_StringToJsonArray (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils (cached)
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
