### PR TITLE
chore(cae): rename component action resource

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1455,11 +1455,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_bms_instance": bms.ResourceBmsInstance(),
 			"huaweicloud_bcs_instance": bcs.ResourceInstance(),
 
+			"huaweicloud_cae_component_action":         cae.ResourceComponentAction(),
 			"huaweicloud_cae_application":              cae.ResourceApplication(),
 			"huaweicloud_cae_certificate":              cae.ResourceCertificate(),
 			"huaweicloud_cae_component":                cae.ResourceComponent(),
 			"huaweicloud_cae_component_configurations": cae.ResourceComponentConfigurations(),
-			"huaweicloud_cae_component_deployment":     cae.ResourceComponentDeployment(),
 			"huaweicloud_cae_domain":                   cae.ResourceDomain(),
 			"huaweicloud_cae_environment":              cae.ResourceEnvironment(),
 			"huaweicloud_cae_notification_rule":        cae.ResourceNotificationRule(),
@@ -2458,6 +2458,7 @@ func Provider() *schema.Provider {
 			// Deprecated
 			"huaweicloud_apig_vpc_channel":               deprecated.ResourceApigVpcChannelV2(),
 			"huaweicloud_blockstorage_volume_v2":         deprecated.ResourceBlockStorageVolumeV2(),
+			"huaweicloud_cae_component_deployment":       cae.ResourceComponentAction(),
 			"huaweicloud_cfw_protection_rule":            deprecated.ResourceProtectionRule(),
 			"huaweicloud_csbs_backup":                    deprecated.ResourceCSBSBackupV1(),
 			"huaweicloud_csbs_backup_policy":             deprecated.ResourceCSBSBackupPolicyV1(),

--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_action_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_action_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccComponentDeployment_basic(t *testing.T) {
+func TestAccComponentAction_basic(t *testing.T) {
 	baseConfig := testAccComponentConfiguration_base()
 	// Avoid CheckDestroy because this resource is a one-time action resource and there is nothing in the destroy
 	// method.
@@ -24,22 +24,22 @@ func TestAccComponentDeployment_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// One-time action resource do not need to be checked and no processing is performed in the Read method.
-				Config: testAccComponentDeployment_basic_step1(baseConfig),
+				Config: testAccComponentAction_basic_step1(baseConfig),
 			},
 			{
-				Config: testAccComponentDeployment_basic_step2(baseConfig),
+				Config: testAccComponentAction_basic_step2(baseConfig),
 			},
 			{
-				Config: testAccComponentDeployment_basic_step3(baseConfig),
+				Config: testAccComponentAction_basic_step3(baseConfig),
 			},
 			{
-				Config: testAccComponentDeployment_basic_step4(baseConfig),
+				Config: testAccComponentAction_basic_step4(baseConfig),
 			},
 		},
 	})
 }
 
-func testAccComponentDeployment_basic_step1(baseConfig string) string {
+func testAccComponentAction_basic_step1(baseConfig string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -68,7 +68,7 @@ resource "huaweicloud_cae_component_configurations" "test" {
   }
 }
 
-resource "huaweicloud_cae_component_deployment" "test" {
+resource "huaweicloud_cae_component_action" "test" {
   environment_id = "%[2]s"
   application_id = "%[3]s"
   component_id   = huaweicloud_cae_component.test.id
@@ -86,7 +86,7 @@ resource "huaweicloud_cae_component_deployment" "test" {
 `, baseConfig, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID)
 }
 
-func testAccComponentDeployment_basic_step2(baseConfig string) string {
+func testAccComponentAction_basic_step2(baseConfig string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -126,7 +126,7 @@ resource "huaweicloud_cae_component_configurations" "test" {
   }
 }
 
-resource "huaweicloud_cae_component_deployment" "test" {
+resource "huaweicloud_cae_component_action" "test" {
   environment_id = "%[2]s"
   application_id = "%[3]s"
   component_id   = huaweicloud_cae_component.test.id
@@ -144,7 +144,7 @@ resource "huaweicloud_cae_component_deployment" "test" {
 `, baseConfig, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID)
 }
 
-func testAccComponentDeployment_basic_step3(baseConfig string) string {
+func testAccComponentAction_basic_step3(baseConfig string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -184,7 +184,7 @@ resource "huaweicloud_cae_component_configurations" "test" {
   }
 }
 
-resource "huaweicloud_cae_component_deployment" "test" {
+resource "huaweicloud_cae_component_action" "test" {
   environment_id = "%[2]s"
   application_id = "%[3]s"
   component_id   = huaweicloud_cae_component.test.id
@@ -202,7 +202,7 @@ resource "huaweicloud_cae_component_deployment" "test" {
 `, baseConfig, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID)
 }
 
-func testAccComponentDeployment_basic_step4(baseConfig string) string {
+func testAccComponentAction_basic_step4(baseConfig string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -242,7 +242,7 @@ resource "huaweicloud_cae_component_configurations" "test" {
   }
 }
 
-resource "huaweicloud_cae_component_deployment" "test" {
+resource "huaweicloud_cae_component_action" "test" {
   environment_id = "%[2]s"
   application_id = "%[3]s"
   component_id   = huaweicloud_cae_component.test.id

--- a/huaweicloud/services/cae/resource_huaweicloud_cae_component_action.go
+++ b/huaweicloud/services/cae/resource_huaweicloud_cae_component_action.go
@@ -19,13 +19,13 @@ import (
 
 // @API CAE POST /v1/{project_id}/cae/applications/{application_id}/components/{component_id}/action
 // @API CAE GET /v1/{project_id}/cae/jobs/{job_id}
-// ResourceComponentDeployment is a definition of the one-time action resource that used to manage component deployment.
-func ResourceComponentDeployment() *schema.Resource {
+// ResourceComponentAction is a definition of the one-time action resource that used to manage component deployment.
+func ResourceComponentAction() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceComponentDeploymentCreate,
-		ReadContext:   resourceComponentDeploymentRead,
-		UpdateContext: resourceComponentDeploymentUpdate,
-		DeleteContext: resourceComponentDeploymentDelete,
+		CreateContext: resourceComponentActionCreate,
+		ReadContext:   resourceComponentActionRead,
+		UpdateContext: resourceComponentActionUpdate,
+		DeleteContext: resourceComponentActionDelete,
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
@@ -89,7 +89,7 @@ func ResourceComponentDeployment() *schema.Resource {
 	}
 }
 
-func buildCreateComponentDeploymentBodyParams(d *schema.ResourceData) map[string]interface{} {
+func buildCreateComponentActionBodyParams(d *schema.ResourceData) map[string]interface{} {
 	return map[string]interface{}{
 		"api_version": "v1",
 		"kind":        "Action",
@@ -119,7 +119,7 @@ func deployComponent(ctx context.Context, client *golangsdk.ServiceClient, d *sc
 		MoreHeaders: map[string]string{
 			"X-Environment-ID": environmentId,
 		},
-		JSONBody: utils.RemoveNil(buildCreateComponentDeploymentBodyParams(d)),
+		JSONBody: utils.RemoveNil(buildCreateComponentActionBodyParams(d)),
 	}
 	requestResp, err := client.Request("POST", modifyPath, &opts)
 	if err != nil {
@@ -192,7 +192,7 @@ func deployJobRefreshFunc(client *golangsdk.ServiceClient, environmentId, jobId 
 	}
 }
 
-func resourceComponentDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceComponentActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg         = meta.(*config.Config)
 		region      = cfg.GetRegion(d)
@@ -209,15 +209,15 @@ func resourceComponentDeploymentCreate(ctx context.Context, d *schema.ResourceDa
 	}
 	d.SetId(componentId)
 
-	return resourceComponentDeploymentRead(ctx, d, meta)
+	return resourceComponentActionRead(ctx, d, meta)
 }
 
-func resourceComponentDeploymentRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourceComponentActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
 	return nil
 }
 
-func resourceComponentDeploymentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceComponentActionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg    = meta.(*config.Config)
 		region = cfg.GetRegion(d)
@@ -232,10 +232,10 @@ func resourceComponentDeploymentUpdate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	return resourceComponentDeploymentRead(ctx, d, meta)
+	return resourceComponentActionRead(ctx, d, meta)
 }
 
-func resourceComponentDeploymentDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourceComponentActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	// No processing is performed in the 'Delete()' method because the resource is a one-time action resource.
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 Rename the component action resource to **huaweicloud_cae_component_action**.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
rename the resource to **huaweicloud_cae_component_action**.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cae -f TestAccComponentAction
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccComponentAction -timeout 360m -parallel 10
=== RUN   TestAccComponentAction_basic
=== PAUSE TestAccComponentAction_basic
=== CONT  TestAccComponentAction_basic
--- PASS: TestAccComponentAction_basic (747.09s)
PASS
coverage: 21.0% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       747.213s        coverage: 21.0% of statements in ./huaweicloud/services/cae
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
