### PR TITLE
refactor(RDS): remove rds storage types validation

### DIFF
--- a/docs/data-sources/rds_storage_types.md
+++ b/docs/data-sources/rds_storage_types.md
@@ -2,7 +2,8 @@
 subcategory: "Relational Database Service (RDS)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_rds_storage_types"
-description: ""
+description: |-
+  Use this data source to get the list of RDS storage types.
 ---
 
 # huaweicloud_rds_storage_types

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_storage_types.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_storage_types.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -34,31 +33,21 @@ func DataSourceStoragetype() *schema.Resource {
 				Computed: true,
 			},
 			"db_type": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: `DB engine. The valid values are **MySQL**, **PostgreSQL**, **SQLServer**.`,
-				ValidateFunc: validation.StringInSlice([]string{
-					"MySQL", "PostgreSQL", "SQLServer",
-				}, false),
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"db_version": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: `DB version number.`,
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"instance_mode": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: `HA mode. The valid values are **single**, **ha**, **replica**.`,
-				ValidateFunc: validation.StringInSlice([]string{
-					"single", "ha", "replica",
-				}, false),
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"storage_types": {
-				Type:        schema.TypeList,
-				Elem:        StoragetypeStorageTypeSchema(),
-				Computed:    true,
-				Description: `Storage_type list. For details, see Data structure of the storageType field.`,
+				Type:     schema.TypeList,
+				Elem:     StoragetypeStorageTypeSchema(),
+				Computed: true,
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  remove rds storage types validation
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  remove rds storage types validation
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
