### PR TITLE
feat(GaussDB): add gaussdb opengauss sync sql throttling task resource

### DIFF
--- a/docs/resources/gaussdb_opengauss_sync_sql_throttling_task.md
+++ b/docs/resources/gaussdb_opengauss_sync_sql_throttling_task.md
@@ -1,0 +1,42 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_opengauss_sync_sql_throttling_task"
+description: |-
+  Manages a GaussDB OpenGauss sync SQL throttling task resource within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_opengauss_sync_sql_throttling_task
+
+Manages a GaussDB OpenGauss sync SQL throttling task resource within HuaweiCloud.
+
+-> This resource is only a one-time action resource for operating the API.
+Deleting this resource will not clear the corresponding request record,
+but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_gaussdb_opengauss_sync_sql_throttling_task" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the GaussDB OpenGauss instance.
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. The value is `instance_id`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1866,6 +1866,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_opengauss_parameter_template_reset":   gaussdb.ResourceOpenGaussParameterTemplateReset(),
 			"huaweicloud_gaussdb_opengauss_recycling_policy":           gaussdb.ResourceOpenGaussRecyclingPolicy(),
 			"huaweicloud_gaussdb_opengauss_task_delete":                gaussdb.ResourceOpenGaussTaskDelete(),
+			"huaweicloud_gaussdb_opengauss_sync_sql_throttling_task":   gaussdb.ResourceOpenGaussSyncSqlThrottlingTask(),
 			"huaweicloud_gaussdb_opengauss_quota":                      gaussdb.ResourceOpenGaussQuota(),
 
 			"huaweicloud_ges_graph":    ges.ResourceGesGraph(),

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_opengauss_sync_sql_throttling_task_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_opengauss_sync_sql_throttling_task_test.go
@@ -1,0 +1,100 @@
+package gaussdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccOpenGaussSyncSqlThrottlingTask_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+			acceptance.TestAccPreCheckHighCostAllow(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenGaussSyncSqlThrottlingTask_basic(name),
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
+func testAccOpenGaussSyncSqlThrottlingTask_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_gaussdb_opengauss_flavors" "test" {
+  version = "8.201"
+  ha_mode = "centralization_standard"
+}
+
+resource "huaweicloud_networking_secgroup_rule" "in_v4_tcp_opengauss" {
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  ethertype         = "IPv4"
+  direction         = "ingress"
+  protocol          = "tcp"
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+
+resource "huaweicloud_networking_secgroup_rule" "in_v4_tcp_opengauss_egress" {
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  ethertype         = "IPv4"
+  direction         = "egress"
+  protocol          = "tcp"
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+
+resource "huaweicloud_gaussdb_opengauss_instance" "test" {
+  depends_on = [
+    huaweicloud_networking_secgroup_rule.in_v4_tcp_opengauss,
+    huaweicloud_networking_secgroup_rule.in_v4_tcp_opengauss_egress
+  ]
+
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  flavor                = data.huaweicloud_gaussdb_opengauss_flavors.test.flavors[0].spec_code
+  name                  = "%[2]s"
+  password              = "Huangwei!120521"
+  enterprise_project_id = "%[3]s"
+
+  availability_zone = join(",", [data.huaweicloud_availability_zones.test.names[0], 
+                      data.huaweicloud_availability_zones.test.names[1], 
+                      data.huaweicloud_availability_zones.test.names[2]])
+
+  ha {
+    mode             = "centralization_standard"
+    replication_mode = "sync"
+    consistency      = "eventual"
+    instance_mode    = "basic"
+  }
+
+  volume {
+    type = "ULTRAHIGH"
+    size = 40
+  }
+}
+`, common.TestBaseNetwork(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccOpenGaussSyncSqlThrottlingTask_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_gaussdb_opengauss_sync_sql_throttling_task" "test" {
+  instance_id = huaweicloud_gaussdb_opengauss_instance.test.id
+}`, testAccOpenGaussSyncSqlThrottlingTask_base(name))
+}

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_sync_sql_throttling_task.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_sync_sql_throttling_task.go
@@ -1,0 +1,83 @@
+package gaussdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API GaussDB POST /v3/{project_id}/instances/{instance_id}/sync-limit-task
+func ResourceOpenGaussSyncSqlThrottlingTask() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceOpenGaussSyncSqlThrottlingTaskCreate,
+		ReadContext:   resourceOpenGaussSyncSqlThrottlingTaskRead,
+		DeleteContext: resourceOpenGaussSyncSqlThrottlingTaskDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceOpenGaussSyncSqlThrottlingTaskCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/sync-limit-task"
+		product = "opengauss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB OpenGauss(%s) sync SQL throttling task: %s", instanceId, err)
+	}
+
+	d.SetId(instanceId)
+
+	return nil
+}
+
+func resourceOpenGaussSyncSqlThrottlingTaskRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceOpenGaussSyncSqlThrottlingTaskDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting GaussDB OpenGauss sync SQL throttling task resource is not supported. The GaussDB OpenGauss" +
+		" sync SQL throttling task resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb opengauss sync sql throttling task resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb opengauss sync sql throttling task resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccOpenGaussSyncSqlThrottlingTask_basic' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccOpenGaussSyncSqlThrottlingTask_basic -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussSyncSqlThrottlingTask_basic
=== PAUSE TestAccOpenGaussSyncSqlThrottlingTask_basic
=== CONT  TestAccOpenGaussSyncSqlThrottlingTask_basic
--- PASS: TestAccOpenGaussSyncSqlThrottlingTask_basic (2065.70s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   2065.790s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
