### PR TITLE
fix(hss/host_protection): fix host_protection checkDeleted judgment logic

### DIFF
--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_host_protection_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_host_protection_test.go
@@ -46,8 +46,8 @@ func getHostProtectionResourceFunc(cfg *config.Config, state *terraform.Resource
 	}
 
 	hostResp := utils.PathSearch("data_list[0]", getRespBody, nil)
-	agentStatus := utils.PathSearch("agent_status", hostResp, "").(string)
-	if hostResp == nil || agentStatus == string(hss.ProtectStatusClosed) {
+	protectStatus := utils.PathSearch("protect_status", hostResp, "").(string)
+	if hostResp == nil || protectStatus == string(hss.ProtectStatusClosed) {
 		return nil, golangsdk.ErrDefault404{}
 	}
 

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_host_protection.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_host_protection.go
@@ -349,8 +349,8 @@ func resourceHostProtectionRead(_ context.Context, d *schema.ResourceData, meta 
 	}
 
 	hostResp := utils.PathSearch("data_list[0]", getRespBody, nil)
-	agentStatus := utils.PathSearch("agent_status", hostResp, "").(string)
-	if hostResp == nil || agentStatus == string(ProtectStatusClosed) {
+	protectStatus := utils.PathSearch("protect_status", hostResp, "").(string)
+	if hostResp == nil || protectStatus == string(ProtectStatusClosed) {
 		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "HSS host protection")
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix host_protection checkDeleted judgment logic

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- After successfully creating resources, execute the `terraform plan`
![image](https://github.com/user-attachments/assets/93ac3d69-213b-4047-bf24-f8ca76df8522)


- Manually close the protection and execute the `terraform plan`
![image](https://github.com/user-attachments/assets/704ffc4b-1abb-4d7d-bfb0-6feb68ce3296)


- Manually delete the host and execute the `terraform plan`
![image](https://github.com/user-attachments/assets/0b54f409-10d5-4e11-8f4c-0c4e52b212cd)



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

fix host_protection checkDeleted judgment logic

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccHostProtection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccHostProtection_basic -timeout 360m -parallel 4
=== RUN   TestAccHostProtection_basic
=== PAUSE TestAccHostProtection_basic
=== CONT  TestAccHostProtection_basic
--- PASS: TestAccHostProtection_basic (102.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       102.302s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
