### PR TITLE
refactor(fgs/async): using auto-gen style to replace old coding

### DIFF
--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_async_invoke_configuration_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_async_invoke_configuration_test.go
@@ -8,18 +8,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/fgs/v2/function"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
 )
 
-func getAsyncInvokeConfigFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	c, err := conf.FgsV2Client(acceptance.HW_REGION_NAME)
+func getAsyncInvokeConfigFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("fgs", acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating FunctionGraph v2 client: %s", err)
+		return nil, fmt.Errorf("error creating FunctionGraph client: %s", err)
 	}
-	return function.GetAsyncInvokeConfig(c, state.Primary.ID)
+	return fgs.GetAsyncIncokeConfigurations(client, state.Primary.ID)
 }
 
 func TestAccAsyncInvokeConfig_basic(t *testing.T) {

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_async_invoke_configuration.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_async_invoke_configuration.go
@@ -2,14 +2,13 @@ package fgs
 
 import (
 	"context"
-	"fmt"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/fgs/v2/function"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -36,54 +35,53 @@ func ResourceAsyncInvokeConfiguration() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				ForceNew:    true,
-				Description: "The region in which to configure the asynchronous invocation.",
+				Description: `The region in which to configure the asynchronous invocation.`,
 			},
 			"function_urn": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The function URN to which the asynchronous invocation belongs.",
+				Description: `The function URN to which the asynchronous invocation belongs.`,
 			},
 			"max_async_event_age_in_seconds": {
 				Type:        schema.TypeInt,
 				Required:    true,
-				Description: "The maximum validity period of a message.",
+				Description: `The maximum validity period of a message.`,
 			},
 			"max_async_retry_attempts": {
-				Type:     schema.TypeInt,
-				Required: true,
-				Description: "The maximum number of retry attempts to be made if asynchronous invocation " +
-					"fails.",
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The maximum number of retry attempts to be made if asynchronous invocation fails.`,
 			},
 			"on_success": {
 				Type:        schema.TypeList,
 				Optional:    true,
 				MaxItems:    1,
 				Elem:        destinationConfigSchemaResource(),
-				Description: "The target to be invoked when a function is successfully executed.",
+				Description: `The target to be invoked when a function is successfully executed.`,
 			},
 			"on_failure": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
 				Elem:     destinationConfigSchemaResource(),
-				Description: "The target to be invoked when a function fails to be executed due to a " +
-					"system error or an internal error.",
+				Description: `The target to be invoked when a function fails to be executed due to a system error or an
+internal error.`,
 			},
 			"enable_async_status_log": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Whether to enable asynchronous invocation status persistence.",
+				Description: `Whether to enable asynchronous invocation status persistence.`,
 			},
 			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The creation time of the asynchronous invocation.",
+				Description: `The creation time of the asynchronous invocation.`,
 			},
 			"updated_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The latest update time of the asynchronous invocation.",
+				Description: `The latest update time of the asynchronous invocation.`,
 			},
 		},
 	}
@@ -95,60 +93,75 @@ func destinationConfigSchemaResource() *schema.Resource {
 			"destination": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The object type.",
+				Description: `The object type.`,
 			},
 			"param": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The parameters (in JSON format) corresponding to the target service.",
+				Description: `The parameters (in JSON format) corresponding to the target service.`,
 			},
 		},
+	}
+}
+
+func buildAsyncInvokeConfigurationDestinationConfig(destinationConfigs []interface{}) map[string]interface{} {
+	if len(destinationConfigs) < 1 {
+		return nil
+	}
+
+	destinationConfig := destinationConfigs[0]
+	return map[string]interface{}{
+		// Required parameters.
+		"destination": utils.PathSearch("destination", destinationConfig, ""),
+		"param":       utils.PathSearch("param", destinationConfig, ""),
+	}
+}
+
+func buildCreateAsyncInvokeConfigurationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		// Required parameters.
+		"max_async_event_age_in_seconds": d.Get("max_async_event_age_in_seconds").(int),
+		"max_async_retry_attempts":       d.Get("max_async_retry_attempts").(int),
+		// Optional parameters.
+		"enable_async_status_log": d.Get("enable_async_status_log").(bool),
+		// Empty structure will send if the map is not parsing destination configurations via RemoveNil function.
+		"destination_config": utils.RemoveNil(map[string]interface{}{
+			"on_success": buildAsyncInvokeConfigurationDestinationConfig(d.Get("on_success").([]interface{})),
+			"on_failure": buildAsyncInvokeConfigurationDestinationConfig(d.Get("on_failure").([]interface{})),
+		}),
 	}
 }
 
 func modifyAsyncInvokeConfiguration(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
 	var (
 		functionUrn = d.Get("function_urn").(string)
-		opts        = function.AsyncInvokeConfigOpts{
-			MaxAsyncEventAgeInSeconds: d.Get("max_async_event_age_in_seconds").(int),
-			MaxAsyncRetryAttempts:     utils.Int(d.Get("max_async_retry_attempts").(int)),
-			EnableAsyncStatusLog:      utils.Bool(d.Get("enable_async_status_log").(bool)),
-		}
-		destinationConfig = function.DestinationConfig{}
+		httpUrl     = "v2/{project_id}/fgs/functions/{function_urn}/async-invoke-config"
 	)
 
-	if successConfigs, ok := d.GetOk("on_success"); ok {
-		raws := successConfigs.([]interface{})
-		cfgDetails := raws[0].(map[string]interface{})
-		destinationConfig.OnSuccess = function.DestinationConfigDetails{
-			Destination: cfgDetails["destination"].(string),
-			Param:       cfgDetails["param"].(string),
-		}
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{function_urn}", functionUrn)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildCreateAsyncInvokeConfigurationBodyParams(d)),
 	}
-	if failureConfigs, ok := d.GetOk("on_failure"); ok {
-		raws := failureConfigs.([]interface{})
-		cfgDetails := raws[0].(map[string]interface{})
-		destinationConfig.OnFailure = function.DestinationConfigDetails{
-			Destination: cfgDetails["destination"].(string),
-			Param:       cfgDetails["param"].(string),
-		}
-	}
-	if destinationConfig != (function.DestinationConfig{}) {
-		opts.DestinationConfig = destinationConfig
-	}
-	_, err := function.UpdateAsyncInvokeConfig(client, functionUrn, opts)
-	if err != nil {
-		return fmt.Errorf("error modifying the async invoke configuration: %s", err)
-	}
-	return nil
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
 }
 
-func resourceAsyncInvokeConfigurationCreate(ctx context.Context, d *schema.ResourceData,
-	meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	client, err := cfg.FgsV2Client(cfg.GetRegion(d))
+func resourceAsyncInvokeConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
 	if err != nil {
-		return diag.Errorf("error creating FunctionGraph V2 client: %s", err)
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
 	}
 
 	err = modifyAsyncInvokeConfiguration(client, d)
@@ -160,51 +173,86 @@ func resourceAsyncInvokeConfigurationCreate(ctx context.Context, d *schema.Resou
 	return resourceAsyncInvokeConfigurationRead(ctx, d, meta)
 }
 
-func flattenDestinationConfig(destConfig function.DestinationConfigDetails) []map[string]interface{} {
-	return []map[string]interface{}{
-		{
-			"destination": destConfig.Destination,
-			"param":       destConfig.Param,
+func GetAsyncIncokeConfigurations(client *golangsdk.ServiceClient, functionUrn string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/fgs/functions/{function_urn}/async-invoke-config"
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{function_urn}", functionUrn)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
 		},
 	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
 }
 
-func resourceAsyncInvokeConfigurationRead(_ context.Context, d *schema.ResourceData,
-	meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.FgsV2Client(region)
-	if err != nil {
-		return diag.Errorf("error creating FunctionGraph V2 client: %s", err)
+func flattenDestinationConfig(destConfig map[string]interface{}) []interface{} {
+	if len(destConfig) < 1 {
+		return nil
 	}
 
-	resp, err := function.GetAsyncInvokeConfig(client, d.Id())
+	parsedConfig := utils.RemoveNil(map[string]interface{}{
+		"destination": utils.ValueIgnoreEmpty(utils.PathSearch("destination", destConfig, nil)),
+		"param":       utils.ValueIgnoreEmpty(utils.PathSearch("param", destConfig, nil)),
+	})
+
+	result := make([]interface{}, 0, 1)
+	if len(parsedConfig) > 0 {
+		result = append(result, parsedConfig)
+	}
+	return result
+}
+
+func resourceAsyncInvokeConfigurationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		functionUrn = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	resp, err := GetAsyncIncokeConfigurations(client, functionUrn)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "asynchronous invocation configuration")
 	}
 	mErr := multierror.Append(
 		d.Set("region", region),
-		d.Set("max_async_event_age_in_seconds", resp.MaxAsyncEventAgeInSeconds),
-		d.Set("max_async_retry_attempts", resp.MaxAsyncRetryAttempts),
-		d.Set("on_success", flattenDestinationConfig(resp.DestinationConfig.OnSuccess)),
-		d.Set("on_failure", flattenDestinationConfig(resp.DestinationConfig.OnFailure)),
-		d.Set("enable_async_status_log", resp.EnableAsyncStatusLog),
-		d.Set("created_at", resp.CreatedAt),
-		d.Set("updated_at", resp.UpdatedAt),
+		d.Set("max_async_event_age_in_seconds", utils.PathSearch("max_async_event_age_in_seconds", resp, nil)),
+		d.Set("max_async_retry_attempts", utils.PathSearch("max_async_retry_attempts", resp, nil)),
+		d.Set("on_success", flattenDestinationConfig(utils.PathSearch("destination_config.on_success",
+			resp, make(map[string]interface{})).(map[string]interface{}))),
+		d.Set("on_failure", flattenDestinationConfig(utils.PathSearch("destination_config.on_failure",
+			resp, make(map[string]interface{})).(map[string]interface{}))),
+		d.Set("enable_async_status_log", utils.PathSearch("enable_async_status_log", resp, nil)),
+		d.Set("created_at", utils.PathSearch("created_time", resp, nil)),
+		d.Set("updated_at", utils.PathSearch("last_modified", resp, nil)),
 	)
 	if mErr.ErrorOrNil() != nil {
 		return diag.Errorf("error saving asynchronous invocation configuration fields: %s", mErr)
 	}
-
 	return nil
 }
 
-func resourceAsyncInvokeConfigurationUpdate(ctx context.Context, d *schema.ResourceData,
-	meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	client, err := cfg.FgsV2Client(cfg.GetRegion(d))
+func resourceAsyncInvokeConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
 	if err != nil {
-		return diag.Errorf("error creating FunctionGraph V2 client: %s", err)
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
 	}
 
 	err = modifyAsyncInvokeConfiguration(client, d)
@@ -215,22 +263,36 @@ func resourceAsyncInvokeConfigurationUpdate(ctx context.Context, d *schema.Resou
 	return resourceAsyncInvokeConfigurationRead(ctx, d, meta)
 }
 
-func resourceAsyncInvokeConfigurationDelete(_ context.Context, d *schema.ResourceData,
-	meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	client, err := cfg.FgsV2Client(cfg.GetRegion(d))
+func resourceAsyncInvokeConfigurationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v2/{project_id}/fgs/functions/{function_urn}/async-invoke-config"
+		functionUrn = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
 	if err != nil {
-		return diag.Errorf("error creating FunctionGraph V2 client: %s", err)
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
 	}
 
-	err = function.DeleteAsyncInvokeConfig(client, d.Id())
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{function_urn}", functionUrn)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "error deleting the configuration of the asynchronous invocation")
 	}
 	return nil
 }
 
-func resourceAsyncInvokeConfigImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
-	error) {
+func resourceAsyncInvokeConfigImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
 	return []*schema.ResourceData{d}, d.Set("function_urn", d.Id())
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New acceptance to coverage the destination configuration structure when it is empty.
Refactor the async configuration resource and using auto-generate style to replace the old coding.
![image](https://github.com/user-attachments/assets/7856c6bf-243a-467e-b1bb-de36501ce0ef)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. new acceptance to coverage the destination configuration structure when it is empty.
2. using auto-gen style to replace old coding.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccAsyncInvokeConfig
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccAsyncInvokeConfig -timeout 360m -parallel 10
=== RUN   TestAccAsyncInvokeConfig_basic
=== PAUSE TestAccAsyncInvokeConfig_basic
=== RUN   TestAccAsyncInvokeConfig_withoutDestConfigs
=== PAUSE TestAccAsyncInvokeConfig_withoutDestConfigs
=== CONT  TestAccAsyncInvokeConfig_basic
=== CONT  TestAccAsyncInvokeConfig_withoutDestConfigs
--- PASS: TestAccAsyncInvokeConfig_withoutDestConfigs (21.66s)
--- PASS: TestAccAsyncInvokeConfig_basic (28.94s)
PASS
coverage: 14.6% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       29.003s coverage: 14.6% of statements in ./huaweicloud/services/fgs
```

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
