### PR TITLE
refactor(fgs/function): using auto-gen style to replace old coding

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1818,7 +1818,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_async_invoke_configuration": fgs.ResourceAsyncInvokeConfiguration(),
 			"huaweicloud_fgs_dependency":                 fgs.ResourceDependency(),
 			"huaweicloud_fgs_dependency_version":         fgs.ResourceDependencyVersion(),
-			"huaweicloud_fgs_function":                   fgs.ResourceFgsFunctionV2(),
+			"huaweicloud_fgs_function":                   fgs.ResourceFgsFunction(),
 			"huaweicloud_fgs_function_event":             fgs.ResourceFunctionEvent(),
 			"huaweicloud_fgs_function_topping":           fgs.ResourceFunctionTopping(),
 			"huaweicloud_fgs_function_trigger":           fgs.ResourceFunctionTrigger(),
@@ -2468,7 +2468,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dli_queue_v1":                dli.ResourceDliQueue(),
 			"huaweicloud_networking_vip_v2":           vpc.ResourceNetworkingVip(),
 			"huaweicloud_networking_vip_associate_v2": vpc.ResourceNetworkingVIPAssociateV2(),
-			"huaweicloud_fgs_function_v2":             fgs.ResourceFgsFunctionV2(),
+			"huaweicloud_fgs_function_v2":             fgs.ResourceFgsFunction(),
 			"huaweicloud_cdn_domain_v1":               cdn.ResourceCdnDomain(),
 			"huaweicloud_scm_certificate":             ccm.ResourceCertificateImport(),
 

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -8,19 +8,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/fgs/v2/function"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
 )
 
-func getFunction(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	c, err := conf.FgsV2Client(acceptance.HW_REGION_NAME)
+func getFunction(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("fgs", acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating HuaweiCloud FunctionGraph client: %s", err)
+		return nil, fmt.Errorf("error creating FunctionGraph client: %s", err)
 	}
-	return function.GetMetadata(c, state.Primary.ID).Extract()
+
+	return fgs.GetFunctionMetadata(client, state.Primary.ID)
 }
 
 func TestAccFunction_basic(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Using auto-gen style to replace old coding.
![image](https://github.com/user-attachments/assets/0f7286a3-8d78-4e79-ba4e-ece49565399c)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. using auto-gen style to replace old coding.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFunction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_basic -timeout 360m -parallel 10
=== RUN   TestAccFunction_basic
=== PAUSE TestAccFunction_basic
=== CONT  TestAccFunction_basic
--- PASS: TestAccFunction_basic (86.75s)
PASS
coverage: 21.1% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       86.823s coverage: 21.1% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_withEpsId
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_withEpsId -timeout 360m -parallel 10
=== RUN   TestAccFunction_withEpsId
=== PAUSE TestAccFunction_withEpsId
=== CONT  TestAccFunction_withEpsId
--- PASS: TestAccFunction_withEpsId (16.09s)
PASS
coverage: 11.4% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       16.141s coverage: 11.4% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_logConfig
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_logConfig -timeout 360m -parallel 10
=== RUN   TestAccFunction_logConfig
=== PAUSE TestAccFunction_logConfig
=== CONT  TestAccFunction_logConfig
--- PASS: TestAccFunction_logConfig (27.31s)
PASS
coverage: 13.8% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       27.443s coverage: 13.8% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_strategy
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_strategy -timeout 360m -parallel 10
=== RUN   TestAccFunction_strategy
=== PAUSE TestAccFunction_strategy
=== CONT  TestAccFunction_strategy
--- PASS: TestAccFunction_strategy (46.86s)
PASS
coverage: 12.9% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       46.932s coverage: 12.9% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_versions
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_versions -timeout 360m -parallel 10
=== RUN   TestAccFunction_versions
=== PAUSE TestAccFunction_versions
=== CONT  TestAccFunction_versions
--- PASS: TestAccFunction_versions (36.97s)
PASS
coverage: 15.4% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       37.037s coverage: 15.4% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_domain
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_domain -timeout 360m -parallel 10
=== RUN   TestAccFunction_domain
=== PAUSE TestAccFunction_domain
=== CONT  TestAccFunction_domain
--- PASS: TestAccFunction_domain (67.54s)
PASS
coverage: 13.9% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       67.591s coverage: 13.9% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_reservedInstance
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_reservedInstance -timeout 360m -parallel 10
=== RUN   TestAccFunction_reservedInstance
=== PAUSE TestAccFunction_reservedInstance
=== CONT  TestAccFunction_reservedInstance
--- PASS: TestAccFunction_reservedInstance (38.25s)
PASS
coverage: 22.0% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       38.359s coverage: 22.0% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_gpuMemory
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_gpuMemory -timeout 360m -parallel 10
=== RUN   TestAccFunction_gpuMemory
=== PAUSE TestAccFunction_gpuMemory
=== CONT  TestAccFunction_gpuMemory
--- PASS: TestAccFunction_gpuMemory (34.61s)
PASS
coverage: 13.8% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       34.666s coverage: 13.8% of statements in ./huaweicloud/services/fgs
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/3b904fe4-1a50-46a9-ae9c-513428c08836)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![image](https://github.com/user-attachments/assets/05ca90c4-8d84-479d-9271-83b77b2266fe)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
