### PR TITLE
fix(fgs/function): adjust the parameter encrypted_user_data and depend_list

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -505,7 +505,7 @@ $ terraform import huaweicloud_fgs_function.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to the attribute missing from the
-API response. The missing attributes are: `app`, `func_code`, `tags`.
+API response. The missing attributes are: `app`, `func_code`, `encrypted_user_data`, `tags`.
 It is generally recommended running `terraform plan` after importing a function.
 You can then decide if changes should be applied to the function, or the resource definition should be updated to align
 with the function. Also you can ignore changes as below.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20250207083604-9eb3506329cf
+	github.com/chnsz/golangsdk v0.0.0-20250217034539-d16a3d7dc780
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
@@ -17,6 +17,9 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/thedevsaddam/gojsonq v2.3.0+incompatible
 	github.com/tidwall/gjson v1.17.1
+	github.com/tjfoc/gmsm v1.4.1
+	go.mongodb.org/mongo-driver v1.12.0
+	golang.org/x/crypto v0.21.0
 )
 
 require (
@@ -57,13 +60,10 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
-	github.com/tjfoc/gmsm v1.4.1 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/zclconf/go-cty v1.11.0 // indirect
-	go.mongodb.org/mongo-driver v1.12.0 // indirect
-	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20250207083604-9eb3506329cf h1:TLRIbEinizoM7AL8JJJMFBzv2B295Q8B7uHKSkAwxFI=
-github.com/chnsz/golangsdk v0.0.0-20250207083604-9eb3506329cf/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20250217034539-d16a3d7dc780 h1:diWEvRNeM/FktUT+HWiv6z9LLpG3smWeKCNpAyGq5m0=
+github.com/chnsz/golangsdk v0.0.0-20250217034539-d16a3d7dc780/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -984,7 +984,6 @@ func resourceFgsFunctionRead(_ context.Context, d *schema.ResourceData, meta int
 		d.Set("runtime", f.Runtime),
 		d.Set("timeout", f.Timeout),
 		d.Set("user_data", f.UserData),
-		d.Set("encrypted_user_data", f.EncryptedUserData),
 		d.Set("version", f.Version),
 		d.Set("urn", functionUrn),
 		d.Set("app_agency", f.AppXrole),

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -1423,7 +1423,7 @@ func resourceFgsFunctionCodeUpdate(fgsClient *golangsdk.ServiceClient, urn strin
 		for _, depend := range dependListRaw.List() {
 			dependList = append(dependList, depend.(string))
 		}
-		updateCodeOpts.DependList = dependList
+		updateCodeOpts.DependVersionList = dependList
 	}
 
 	if v, ok := d.GetOk("func_code"); ok {

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/requests.go
@@ -140,11 +140,13 @@ type UpdateOptsBuilder interface {
 
 // Function struct for update
 type UpdateCodeOpts struct {
-	CodeType     string           `json:"code_type" required:"true"`
-	CodeUrl      string           `json:"code_url,omitempty"`
-	DependList   []string         `json:"depend_list,omitempty"`
-	CodeFileName string           `json:"code_filename,omitempty"`
-	FuncCode     FunctionCodeOpts `json:"func_code,omitempty"`
+	CodeType          string           `json:"code_type" required:"true"`
+	CodeUrl           string           `json:"code_url,omitempty"`
+	DependVersionList []string         `json:"depend_version_list,omitempty"`
+	CodeFileName      string           `json:"code_filename,omitempty"`
+	FuncCode          FunctionCodeOpts `json:"func_code,omitempty"`
+	// Deprecated parameter.
+	DependList []string `json:"depend_list,omitempty"`
 }
 
 func (opts UpdateCodeOpts) ToUpdateMap() (map[string]interface{}, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20250207083604-9eb3506329cf
+# github.com/chnsz/golangsdk v0.0.0-20250217034539-d16a3d7dc780
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth
@@ -187,7 +187,6 @@ github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes
 github.com/chnsz/golangsdk/openstack/evs/v2/snapshots
 github.com/chnsz/golangsdk/openstack/evs/v5/cloudvolumes
 github.com/chnsz/golangsdk/openstack/fgs/v2/aliases
-github.com/chnsz/golangsdk/openstack/fgs/v2/application
 github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies
 github.com/chnsz/golangsdk/openstack/fgs/v2/function
 github.com/chnsz/golangsdk/openstack/fgs/v2/trigger
@@ -360,7 +359,6 @@ github.com/chnsz/golangsdk/openstack/waf_hw/v1/whiteblackip_rules
 github.com/chnsz/golangsdk/openstack/workspace/v2/accesspolicies
 github.com/chnsz/golangsdk/openstack/workspace/v2/desktops
 github.com/chnsz/golangsdk/openstack/workspace/v2/groups
-github.com/chnsz/golangsdk/openstack/workspace/v2/jobs
 github.com/chnsz/golangsdk/openstack/workspace/v2/policygroups
 github.com/chnsz/golangsdk/openstack/workspace/v2/services
 github.com/chnsz/golangsdk/openstack/workspace/v2/terminals


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The response value of the encrypted user data key/value pairs does not have the values because of the value is the sentisive if the user data is encrypted.
![image](https://github.com/user-attachments/assets/e6a40545-9a97-42ff-b41a-ade2bcc72a0d)
If the script have the configuration of the function encrypted user data, the lifecycle.ignore_changes must be configured.
If not, the terraform will trigger a change, seems an example as follows:
```
  encrypted_user_data = "{\"owner\":\"\"}" -> "{\"owner\":\"terraform\"}"
```

The depend version list of the function is recommand, and the depend list (without version) is deprecated.
![image](https://github.com/user-attachments/assets/f2aa5899-bb59-4a6d-8d31-52efeb300f7d)
For now, the response values and the corresponding request parameters are matched as follows:
- depend_list <--> depend_list
- depend_version_list <--> depend_version_list

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. the value of the encrypted user data not returned
2. deprecate depend list and supports version list
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFgsV2Function_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFgsV2Function_basic -timeout 360m -parallel 10
=== RUN   TestAccFgsV2Function_basic
=== PAUSE TestAccFgsV2Function_basic
=== CONT  TestAccFgsV2Function_basic
--- PASS: TestAccFgsV2Function_basic (76.51s)
PASS
coverage: 16.7% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       76.575s coverage: 16.7% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
