### PR TITLE
feat(dns): support new parameter to query custom line

### DIFF
--- a/docs/data-sources/dns_custom_lines.md
+++ b/docs/data-sources/dns_custom_lines.md
@@ -27,6 +27,8 @@ The following arguments are supported:
 
 * `name` - (Optional, String) Specified the name of the custom line. Fuzzy search is supported.
 
+* `ip` - (Optional, String) Specifies the IP address used to query custom line which is in the IP address range.
+
 * `status` - (Optional, String) Specifies the status of the custom line.  
   The valid values are as follows:
   + **ACTIVE**

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_custom_lines.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_custom_lines.go
@@ -11,7 +11,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/filters"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/httphelper"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/schemas"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -136,6 +135,7 @@ func (w *CustomLinesDSWrapper) ListCustomLine() (*gjson.Result, error) {
 	params := map[string]any{
 		"line_id": w.Get("line_id"),
 		"name":    w.Get("name"),
+		"status":  w.Get("status"),
 	}
 	params = utils.RemoveNil(params)
 	return httphelper.New(client).
@@ -143,10 +143,6 @@ func (w *CustomLinesDSWrapper) ListCustomLine() (*gjson.Result, error) {
 		URI(uri).
 		Query(params).
 		OffsetPager("lines", "offset", "limit", 0).
-		Filter(
-			filters.New().From("lines").
-				Where("status", "=", w.Get("status")),
-		).
 		Request().
 		Result()
 }

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_custom_lines.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_custom_lines.go
@@ -37,6 +37,11 @@ func DataSourceDNSCustomLines() *schema.Resource {
 				Optional:    true,
 				Description: `Specified the name of the custom line. Fuzzy search is supported.`,
 			},
+			"ip": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the IP address used to query custom line which is in the IP address range.`,
+			},
 			"status": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -136,6 +141,7 @@ func (w *CustomLinesDSWrapper) ListCustomLine() (*gjson.Result, error) {
 		"line_id": w.Get("line_id"),
 		"name":    w.Get("name"),
 		"status":  w.Get("status"),
+		"ip":      w.Get("ip"),
 	}
 	params = utils.RemoveNil(params)
 	return httphelper.New(client).


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Support using IP to query custom lines.
2. For the `status` parameter, use the API's own capabilities instead of manual filtering.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new paramster.
2. use api capabilities instead of manual filtering.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccDataSourceCustomLines_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDataSourceCustomLines_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCustomLines_basic
=== PAUSE TestAccDataSourceCustomLines_basic
=== CONT  TestAccDataSourceCustomLines_basic
--- PASS: TestAccDataSourceCustomLines_basic (84.33s)
PASS
coverage: 7.9% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       84.389s coverage: 7.9% of statements in ./huaweicloud/services/dns
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
