### PR TITLE
refactor(iotda/device_message): refactor resource code style

### DIFF
--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_messages.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_messages.go
@@ -183,60 +183,13 @@ func flattenDeviceMessages(messagesResp []interface{}) []interface{} {
 			"encoding":       utils.PathSearch("encoding", v, nil),
 			"payload_format": utils.PathSearch("payload_format", v, nil),
 			"topic":          utils.PathSearch("topic", v, nil),
-			"properties":     flattenDataSourceDeviceMessageProperties(utils.PathSearch("properties", v, nil)),
+			"properties":     flattenDeviceMessageProperties(utils.PathSearch("properties", v, nil)),
 			"status":         utils.PathSearch("status", v, nil),
-			"error_info":     flattenDataSourceDeviceMessageErrorInfo(utils.PathSearch("error_info", v, nil)),
+			"error_info":     flattenDeviceMessageErrorInfo(utils.PathSearch("error_info", v, nil)),
 			"created_time":   utils.PathSearch("created_time", v, nil),
 			"finished_time":  utils.PathSearch("finished_time", v, nil),
 		})
 	}
 
 	return rst
-}
-
-// When refactoring resource, move this method directly to the resource for reuse.
-func flattenDataSourceDeviceMessageProperties(propertiesResp interface{}) []interface{} {
-	if propertiesResp == nil {
-		return nil
-	}
-
-	propertiesMap := map[string]interface{}{
-		"correlation_data": utils.PathSearch("correlation_data", propertiesResp, nil),
-		"response_topic":   utils.PathSearch("response_topic", propertiesResp, nil),
-		"user_properties":  flattenDataSourceDeviceMessageUserProperties(utils.PathSearch("user_properties", propertiesResp, nil)),
-	}
-
-	return []interface{}{propertiesMap}
-}
-
-// When refactoring resource, move this method directly to the resource for reuse.
-func flattenDataSourceDeviceMessageUserProperties(userPropertiesResp interface{}) []interface{} {
-	if userPropertiesResp == nil {
-		return nil
-	}
-
-	userPropertiesRespList := userPropertiesResp.([]interface{})
-	result := make([]interface{}, len(userPropertiesRespList))
-	for i, v := range userPropertiesRespList {
-		result[i] = map[string]interface{}{
-			"prop_key":   utils.PathSearch("prop_key", v, nil),
-			"prop_value": utils.PathSearch("prop_value", v, nil),
-		}
-	}
-
-	return result
-}
-
-// When refactoring resource, move this method directly to the resource for reuse.
-func flattenDataSourceDeviceMessageErrorInfo(errorInfoResp interface{}) []interface{} {
-	if errorInfoResp == nil {
-		return nil
-	}
-
-	errorInfoMap := map[string]interface{}{
-		"error_code": utils.PathSearch("error_code", errorInfoResp, nil),
-		"error_msg":  utils.PathSearch("error_msg", errorInfoResp, nil),
-	}
-
-	return []interface{}{errorInfoMap}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

refactor `device_message` resource code style

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Create a resource using the old code package
![image](https://github.com/user-attachments/assets/964053d2-59e7-41b4-a506-a974afc8867f)

- Execute terraform plan using new code package
![image](https://github.com/user-attachments/assets/93fa5d5f-68ee-4c27-a60e-02f513e7b831)

- In summary, it can be considered that this reconstruction will have no impact on existing users.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

refactor `device_message` resource code style

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

#### Resource Test
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDeviceMessage_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceMessage_basic -timeout 360m -parallel 4
=== RUN   TestAccDeviceMessage_basic
--- PASS: TestAccDeviceMessage_basic (9.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     9.123s

```
![image](https://github.com/user-attachments/assets/11b1f501-dcf0-43fe-89f2-48f68d8238e7)


#### DataSource Test
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceMessages_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceMessages_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceMessages_basic
=== PAUSE TestAccDataSourceDeviceMessages_basic
=== CONT  TestAccDataSourceDeviceMessages_basic
--- PASS: TestAccDataSourceDeviceMessages_basic (9.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     9.415s

```
![image](https://github.com/user-attachments/assets/3388937f-13d3-4f94-a6be-4bdb6963ebc7)


* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    ab. Related resources (parent resources) not found
![image](https://github.com/user-attachments/assets/8f08ee65-6940-429a-85d7-2f96f520f41c)


  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
