### PR TITLE
feat(GaussDB): add gaussdb opengauss sql throtting task resource

### DIFF
--- a/docs/resources/gaussdb_opengauss_sql_throttling_task.md
+++ b/docs/resources/gaussdb_opengauss_sql_throttling_task.md
@@ -1,0 +1,203 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_opengauss_sql_throttling_task"
+description: |-
+  Manages a GaussDB OpenGauss SQL throttling task resource within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_opengauss_sql_throttling_task
+
+Manages a GaussDB OpenGauss SQL throttling task resource within HuaweiCloud.
+
+## Example Usage
+
+### Create by SQL_ID
+
+```hcl
+variable "instance_id"{}
+variable "node_id"{}
+variable "sql_id"{}
+
+resource "huaweicloud_gaussdb_opengauss_sql_throttling_task" "source" {
+  instance_id      = var.instance_id
+  task_scope       = "SQL"
+  limit_type       = "SQL_ID"
+  limit_type_value = var.sql_id
+  task_name        = "test_task_name"
+  parallel_size    = 4
+  start_time       = "2025-02-12T11:47:20+0800"
+  end_time         = "2025-02-13T11:47:20+0800"
+  sql_model        = "select name, setting from pg_settings where name in (1...n)"
+
+  node_infos {
+    node_id = var.node_id
+    sql_id  = var.sql_id
+  }
+}
+```
+
+### Create by SQL_TYPE
+
+```hcl
+variable "instance_id"{}
+
+resource "huaweicloud_gaussdb_opengauss_sql_throttling_task" "test" {
+  instance_id      = var.instance_id
+  task_scope       = "SQL"
+  limit_type       = "SQL_TYPE"
+  limit_type_value = "update"
+  task_name        = "test_task_name"
+  parallel_size    = 4
+  start_time       = "2025-02-12T11:47:20+0800"
+  end_time         = "2025-02-13T11:47:20+0800"
+  key_words        = "aaa,bbb,ccc"
+  databases        = "test_db_111"
+}
+```
+
+### Create by SESSION
+
+```hcl
+variable "instance_id"{}
+
+resource "huaweicloud_gaussdb_opengauss_sql_throttling_task" "test" {
+  instance_id        = var.instance_id
+  task_scope         = "SESSION"
+  limit_type         = "SESSION_ACTIVE_MAX_COUNT"
+  limit_type_value   = "CPU_OR_MEMORY"
+  task_name          = "test_task_name"
+  parallel_size      = 4
+  cpu_utilization    = 20
+  memory_utilization = 40
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the GaussDB OpenGauss instance.
+
+  Changing this parameter will create a new resource.
+
+* `task_scope` - (Required, String, ForceNew) Specifies the task scope. Currently, **SQL** and **SESSION** are supported.
+
+  Changing this parameter will create a new resource.
+
+* `limit_type` - (Required, String, ForceNew) Specifies the throttling type.
+  + When `task_scope` is set to **SQL**, the value can be **SQL_ID** or **SQL_TYPE**.
+  + When `task_scope` is set to **SESSION**, the value can be **SESSION_ACTIVE_MAX_COUNT**.
+
+  Changing this parameter will create a new resource.
+
+* `limit_type_value` - (Required, String, ForceNew) Specifies the throttling type value.
+  + When `limit_type` is set to **SQL_ID**, the value of this parameter is the SQL ID of the selected template.
+  + When `limit_type` is set to **SQL_TYPE**, the value of this parameter can be **select**, **update**, **insert**,
+    **delete**, or **merge**.
+  + When `limit_type` is set to **SESSION_ACTIVE_MAX_COUNT**, the value of this parameter can only be **CPU_OR_MEMORY**.
+
+  Changing this parameter will create a new resource.
+
+* `task_name` - (Required, String, ForceNew) Specifies the name of the SQL throttling task. The value can contain up to
+  **100** characters. Only uppercase letters, lowercase letters, underscores (_), digits, and dollar signs ($) are allowed.
+
+* `parallel_size` - (Required, Int) Specifies the maximum concurrency. The value can be **0** or a positive integer.
+  Value range: **0** to **2147483647**.
+
+* `start_time` - (Optional, String) Specifies the task start time. It is mandatory when `task_scope` is set to **SQL**.
+  Value range: two minutes later than or equal to the current time (UTC time). The format must be **yyyy-mm-ddThh:mm:ss+0000**.
+
+* `end_time` - (Optional, String) Specifies the task end time. It is mandatory when `task_scope` is set to **SQL**.
+  Value range: later than the task start time. The format must be **yyyy-mm-ddThh:mm:ss+0000**.
+
+* `key_words` - (Optional, String) Specifies the keyword. It is mandatory when `limit_type` is set to **SQL_TYPE**. You
+  can enter **2** to **100** keywords and separate multiple keywords by commas (,). Each keyword can contain **2** to
+  **64** characters and cannot start and end with a space. The specifical characters ("\{}) and null are not allowed.
+
+* `sql_model` - (Optional, String, ForceNew) Specifies the SQL template. It is mandatory when `limit_type` is set to
+  **SQL_ID**.
+
+  Changing this parameter will create a new resource.
+
+* `cpu_utilization` - (Optional, Int) Specifies the CPU usage threshold. The value is an integer ranging from **0** to
+  **100**. It is mandatory when `limit_type` is set to **SESSION_ACTIVE_MAX_COUNT**. This parameter and `memory_utilization`
+  cannot be both set to **0**. If you only need one of them for throttling, set the other threshold to **0**.
+
+* `memory_utilization` - (Optional, Int) Specifies the Memory usage threshold. The value is an integer ranging from **0**
+  to **100**. It is mandatory when `limit_type` is set to **SESSION_ACTIVE_MAX_COUNT**. This parameter and
+  `cpu_utilization` cannot be both set to **0**. If you only need one of them for throttling, set the other threshold to
+  **0**.
+
+* `databases` - (Optional, String) Specifies the databases of the instance. Databases are separated by commas (,). It is
+  mandatory when `limit_type` is set to **SQL_TYPE**.
+
+* `node_infos` - (Optional, List, ForceNew) Specifies the CN information. It is mandatory when `limit_type` is set to
+  **SQL_ID**. The [node_infos](#node_infos_struct) structure is documented below.
+
+  Changing this parameter will create a new resource.
+
+<a name="node_infos_struct"></a>
+The `node_infos` block supports:
+
+* `node_id` - (Required, String, ForceNew) Specifies the node ID.
+
+  Changing this parameter will create a new resource.
+
+* `sql_id` - (Required, String, ForceNew) Specifies the ID of the SQL statement executed on the node. If `limit_type` is
+  set to **SQL_ID**, the value of this parameter must be the same as that of `limit_type_value`.
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `created_at` - Indicates the creation time in the format of **yyyy-mm-ddThh:mm:ssZ**.
+
+* `updated_at` - Indicates the update time in the format of **yyyy-mm-ddThh:mm:ssZ**.
+
+* `creator` - Indicates the creator.
+
+* `modifier` - Indicates the modifier.
+
+* `rule_name` - Indicates the rule name.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 90 minutes.
+* `update` - Default is 90 minutes.
+* `delete` - Default is 90 minutes.
+
+## Import
+
+The GaussDB OpenGauss SQL throttling task can be imported using `instance_id` and `id` separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_gaussdb_opengauss_sql_throttling_task.test <instance_id>/<id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to the attribute missing from the
+API response. The missing attribute is: `start_time` `end_time`. It is generally recommended running `terraform plan`
+after importing a GaussDB OpenGauss SQL throttling task. You can then decide if changes should be applied to the GaussDB
+OpenGauss SQL throttling task, or the resource definition should be updated to align with the GaussDB OpenGauss SQL
+throttling task. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_gaussdb_opengauss_sql_throttling_task" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      start_time, end_time,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1876,6 +1876,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_opengauss_task_delete":                gaussdb.ResourceOpenGaussTaskDelete(),
 			"huaweicloud_gaussdb_opengauss_sync_sql_throttling_task":   gaussdb.ResourceOpenGaussSyncSqlThrottlingTask(),
 			"huaweicloud_gaussdb_opengauss_quota":                      gaussdb.ResourceOpenGaussQuota(),
+			"huaweicloud_gaussdb_opengauss_sql_throttling_task":        gaussdb.ResourceOpenGaussSqlThrottlingTask(),
 
 			"huaweicloud_ges_graph":    ges.ResourceGesGraph(),
 			"huaweicloud_ges_metadata": ges.ResourceGesMetadata(),

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_opengauss_sql_throttling_task_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_opengauss_sql_throttling_task_test.go
@@ -1,0 +1,419 @@
+package gaussdb
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getOpenGaussSqlThrottlingTaskResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/limit-task-list"
+		product = "opengauss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	listBasePath := client.Endpoint + httpUrl
+	listBasePath = strings.ReplaceAll(listBasePath, "{project_id}", client.ProjectID)
+	listBasePath = strings.ReplaceAll(listBasePath, "{instance_id}", state.Primary.Attributes["instance_id"])
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	var sqlThrottlingTask interface{}
+	offset := 0
+	for {
+		listPath := listBasePath + buildPageQueryParam(100, offset)
+		requestResp, err := client.Request("GET", listPath, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		sqlThrottlingTasks := utils.PathSearch("limit_task_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(sqlThrottlingTasks) == 0 {
+			break
+		}
+		searchExpression := fmt.Sprintf("[?task_id=='%s']|[0]", state.Primary.ID)
+		sqlThrottlingTask = utils.PathSearch(searchExpression, sqlThrottlingTasks, nil)
+		if sqlThrottlingTask != nil {
+			break
+		}
+
+		offset += 100
+		totalCount := utils.PathSearch("total_count", respBody, float64(0)).(float64)
+		if int(totalCount) <= offset {
+			break
+		}
+	}
+	if sqlThrottlingTask == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return sqlThrottlingTask, nil
+}
+
+func buildPageQueryParam(limit, offset int) string {
+	return fmt.Sprintf("?limit=%d&offset=%d", limit, offset)
+}
+
+func TestAccOpenGaussSqlThrottlingTask_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	updateName := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_gaussdb_opengauss_sql_throttling_task.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getOpenGaussSqlThrottlingTaskResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGaussDBOpenGaussInstanceId(t)
+			acceptance.TestAccPreCheckGaussDBOpenGaussTimeRange(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testOpenGaussSqlThrottlingTask_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "instance_id", acceptance.HW_GAUSSDB_OPENGAUSS_INSTANCE_ID),
+					resource.TestCheckResourceAttr(rName, "task_scope", "SQL"),
+					resource.TestCheckResourceAttr(rName, "limit_type", "SQL_ID"),
+					resource.TestCheckResourceAttrPair(rName, "limit_type_value",
+						"data.huaweicloud_gaussdb_opengauss_sql_templates.test",
+						"node_limit_sql_model_list.1.sql_id"),
+					resource.TestCheckResourceAttr(rName, "task_name", name),
+					resource.TestCheckResourceAttr(rName, "parallel_size", "4"),
+					resource.TestCheckResourceAttrPair(rName, "sql_model",
+						"data.huaweicloud_gaussdb_opengauss_sql_templates.test",
+						"node_limit_sql_model_list.1.sql_model"),
+					resource.TestCheckResourceAttrPair(rName, "node_infos.0.sql_id",
+						"data.huaweicloud_gaussdb_opengauss_sql_templates.test",
+						"node_limit_sql_model_list.1.sql_id"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "creator"),
+					resource.TestCheckResourceAttrSet(rName, "rule_name"),
+				),
+			},
+			{
+				Config: testOpenGaussSqlThrottlingTask_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "task_name", updateName),
+					resource.TestCheckResourceAttr(rName, "parallel_size", "10"),
+					resource.TestCheckResourceAttrSet(rName, "modifier"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"start_time", "end_time"},
+				ImportStateIdFunc:       testOpenGaussSqlThrottlingTaskImportState(rName),
+			},
+		},
+	})
+}
+
+func TestAccOpenGaussSqlThrottlingTask_sql_type(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	updateName := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_gaussdb_opengauss_sql_throttling_task.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getOpenGaussSqlThrottlingTaskResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGaussDBOpenGaussInstanceId(t)
+			acceptance.TestAccPreCheckGaussDBOpenGaussTimeRange(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testOpenGaussSqlThrottlingTask_sql_type(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "instance_id", acceptance.HW_GAUSSDB_OPENGAUSS_INSTANCE_ID),
+					resource.TestCheckResourceAttr(rName, "task_scope", "SQL"),
+					resource.TestCheckResourceAttr(rName, "limit_type", "SQL_TYPE"),
+					resource.TestCheckResourceAttr(rName, "limit_type_value", "update"),
+					resource.TestCheckResourceAttr(rName, "task_name", name),
+					resource.TestCheckResourceAttr(rName, "parallel_size", "4"),
+					resource.TestCheckResourceAttr(rName, "key_words", "aaa,bbb,ccc"),
+					resource.TestCheckResourceAttrPair(rName, "databases",
+						"data.huaweicloud_gaussdb_opengauss_databases.test", "databases.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "creator"),
+					resource.TestCheckResourceAttrSet(rName, "rule_name"),
+				),
+			},
+			{
+				Config: testOpenGaussSqlThrottlingTask_sql_type_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "task_name", updateName),
+					resource.TestCheckResourceAttr(rName, "parallel_size", "10"),
+					resource.TestCheckResourceAttr(rName, "key_words", "aaa,fff,ggg,kkk"),
+					resource.TestCheckResourceAttrPair(rName, "databases",
+						"data.huaweicloud_gaussdb_opengauss_databases.test", "databases.1.name"),
+					resource.TestCheckResourceAttrSet(rName, "modifier"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"start_time", "end_time"},
+				ImportStateIdFunc:       testOpenGaussSqlThrottlingTaskImportState(rName),
+			},
+		},
+	})
+}
+
+func TestAccOpenGaussSqlThrottlingTask_session(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	updateName := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_gaussdb_opengauss_sql_throttling_task.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getOpenGaussSqlThrottlingTaskResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGaussDBOpenGaussInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testOpenGaussSqlThrottlingTask_session(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "instance_id", acceptance.HW_GAUSSDB_OPENGAUSS_INSTANCE_ID),
+					resource.TestCheckResourceAttr(rName, "task_scope", "SESSION"),
+					resource.TestCheckResourceAttr(rName, "limit_type", "SESSION_ACTIVE_MAX_COUNT"),
+					resource.TestCheckResourceAttr(rName, "limit_type_value", "CPU_OR_MEMORY"),
+					resource.TestCheckResourceAttr(rName, "task_name", name),
+					resource.TestCheckResourceAttr(rName, "parallel_size", "4"),
+					resource.TestCheckResourceAttr(rName, "cpu_utilization", "20"),
+					resource.TestCheckResourceAttr(rName, "memory_utilization", "40"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "creator"),
+					resource.TestCheckResourceAttrSet(rName, "rule_name"),
+				),
+			},
+			{
+				Config: testOpenGaussSqlThrottlingTask_session_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "task_name", updateName),
+					resource.TestCheckResourceAttr(rName, "parallel_size", "10"),
+					resource.TestCheckResourceAttr(rName, "cpu_utilization", "50"),
+					resource.TestCheckResourceAttr(rName, "memory_utilization", "80"),
+					resource.TestCheckResourceAttrSet(rName, "modifier"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"start_time", "end_time"},
+				ImportStateIdFunc:       testOpenGaussSqlThrottlingTaskImportState(rName),
+			},
+		},
+	})
+}
+
+func testOpenGaussSqlThrottlingTask_basic(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_opengauss_instances" "test" {}
+
+locals {
+  instance       = [for v in  data.huaweicloud_gaussdb_opengauss_instances.test.instances : v if v.id == "%[1]s"][0]
+  master_node_id = [for v in local.instance.nodes : v if v.role == "master"][0].id
+}
+
+data "huaweicloud_gaussdb_opengauss_sql_templates" "test" {
+  instance_id = "%[1]s"
+  node_id     = local.master_node_id
+}
+
+resource "huaweicloud_gaussdb_opengauss_sql_throttling_task" "test" {
+  instance_id      = "%[1]s"
+  task_scope       = "SQL"
+  limit_type       = "SQL_ID"
+  limit_type_value = data.huaweicloud_gaussdb_opengauss_sql_templates.test.node_limit_sql_model_list[1].sql_id
+  task_name        = "%[2]s"
+  parallel_size    = 4
+  start_time       = "%[3]s"
+  end_time         = "%[4]s"
+  sql_model        = data.huaweicloud_gaussdb_opengauss_sql_templates.test.node_limit_sql_model_list[1].sql_model
+
+  node_infos {
+    node_id = local.master_node_id
+    sql_id  = data.huaweicloud_gaussdb_opengauss_sql_templates.test.node_limit_sql_model_list[1].sql_id
+  }
+}
+`, acceptance.HW_GAUSSDB_OPENGAUSS_INSTANCE_ID, name, acceptance.HW_GAUSSDB_OPENGAUSS_START_TIME,
+		acceptance.HW_GAUSSDB_OPENGAUSS_END_TIME)
+}
+
+func testOpenGaussSqlThrottlingTask_update(updateName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_opengauss_instances" "test" {}
+
+locals {
+  instance       = [for v in  data.huaweicloud_gaussdb_opengauss_instances.test.instances : v if v.id == "%[1]s"][0]
+  master_node_id = [for v in local.instance.nodes : v if v.role == "master"][0].id
+}
+
+data "huaweicloud_gaussdb_opengauss_sql_templates" "test" {
+  instance_id = "%[1]s"
+  node_id     = local.master_node_id
+}
+
+resource "huaweicloud_gaussdb_opengauss_sql_throttling_task" "test" {
+  instance_id      = "%[1]s"
+  task_scope       = "SQL"
+  limit_type       = "SQL_ID"
+  limit_type_value = data.huaweicloud_gaussdb_opengauss_sql_templates.test.node_limit_sql_model_list[1].sql_id
+  task_name        = "%[2]s"
+  parallel_size    = 10
+  start_time       = "%[3]s"
+  end_time         = "%[4]s"
+  sql_model        = data.huaweicloud_gaussdb_opengauss_sql_templates.test.node_limit_sql_model_list[1].sql_model
+
+  node_infos {
+    node_id = local.master_node_id
+    sql_id  = data.huaweicloud_gaussdb_opengauss_sql_templates.test.node_limit_sql_model_list[1].sql_id
+  }
+}
+`, acceptance.HW_GAUSSDB_OPENGAUSS_INSTANCE_ID, updateName, acceptance.HW_GAUSSDB_OPENGAUSS_START_TIME,
+		acceptance.HW_GAUSSDB_OPENGAUSS_END_TIME)
+}
+
+func testOpenGaussSqlThrottlingTask_sql_type(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_opengauss_databases" "test" {
+  instance_id = "%[1]s"
+}
+
+resource "huaweicloud_gaussdb_opengauss_sql_throttling_task" "test" {
+  instance_id      = "%[1]s"
+  task_scope       = "SQL"
+  limit_type       = "SQL_TYPE"
+  limit_type_value = "update"
+  task_name        = "%[2]s"
+  parallel_size    = 4
+  start_time       = "%[3]s"
+  end_time         = "%[4]s"
+  key_words        = "aaa,bbb,ccc"
+  databases        = data.huaweicloud_gaussdb_opengauss_databases.test.databases[0].name
+}
+`, acceptance.HW_GAUSSDB_OPENGAUSS_INSTANCE_ID, name, acceptance.HW_GAUSSDB_OPENGAUSS_START_TIME,
+		acceptance.HW_GAUSSDB_OPENGAUSS_END_TIME)
+}
+
+func testOpenGaussSqlThrottlingTask_sql_type_update(updateName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_opengauss_databases" "test" {
+  instance_id = "%[1]s"
+}
+resource "huaweicloud_gaussdb_opengauss_sql_throttling_task" "test" {
+  instance_id      = "%[1]s"
+  task_scope       = "SQL"
+  limit_type       = "SQL_TYPE"
+  limit_type_value = "update"
+  task_name        = "%[2]s"
+  parallel_size    = 10
+  start_time       = "%[3]s"
+  end_time         = "%[4]s"
+  key_words        = "aaa,fff,ggg,kkk"
+  databases        = data.huaweicloud_gaussdb_opengauss_databases.test.databases[1].name
+}
+`, acceptance.HW_GAUSSDB_OPENGAUSS_INSTANCE_ID, updateName, acceptance.HW_GAUSSDB_OPENGAUSS_START_TIME,
+		acceptance.HW_GAUSSDB_OPENGAUSS_END_TIME)
+}
+
+func testOpenGaussSqlThrottlingTask_session(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_gaussdb_opengauss_sql_throttling_task" "test" {
+  instance_id        = "%[1]s"
+  task_scope         = "SESSION"
+  limit_type         = "SESSION_ACTIVE_MAX_COUNT"
+  limit_type_value   = "CPU_OR_MEMORY"
+  task_name          = "%[2]s"
+  parallel_size      = 4
+  cpu_utilization    = 20
+  memory_utilization = 40
+}
+`, acceptance.HW_GAUSSDB_OPENGAUSS_INSTANCE_ID, name)
+}
+
+func testOpenGaussSqlThrottlingTask_session_update(updateName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_gaussdb_opengauss_sql_throttling_task" "test" {
+  instance_id        = "%[1]s"
+  task_scope         = "SESSION"
+  limit_type         = "SESSION_ACTIVE_MAX_COUNT"
+  limit_type_value   = "CPU_OR_MEMORY"
+  task_name          = "%[2]s"
+  parallel_size      = 10
+  cpu_utilization    = 50
+  memory_utilization = 80
+}
+`, acceptance.HW_GAUSSDB_OPENGAUSS_INSTANCE_ID, updateName)
+}
+
+func testOpenGaussSqlThrottlingTaskImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("the resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.Attributes["instance_id"] == "" {
+			return "", fmt.Errorf("attribute (instance_id) of Resource (%s) not found: %s", name, rs)
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.ID), nil
+	}
+}

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_sql_throttling_task.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_sql_throttling_task.go
@@ -1,0 +1,481 @@
+package gaussdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDB POST /v3/{project_id}/instances/{instance_id}/limit-task
+// @API GaussDB POST /v3/{project_id}/instances/{instance_id}/limit-task/{task_id}
+// @API GaussDB GET /v3/{project_id}/instances/{instance_id}/limit-task-list
+// @API GaussDB DELETE /v3/{project_id}/instances/{instance_id}/limit-task/{task_id}
+func ResourceOpenGaussSqlThrottlingTask() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceOpenGaussSqlThrottlingTaskCreate,
+		UpdateContext: resourceOpenGaussSqlThrottlingTaskUpdate,
+		ReadContext:   resourceOpenGaussSqlThrottlingTaskRead,
+		DeleteContext: resourceOpenGaussSqlThrottlingTaskDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceOpenGaussSqlThrottlingTaskImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(90 * time.Minute),
+			Update: schema.DefaultTimeout(90 * time.Minute),
+			Delete: schema.DefaultTimeout(90 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"task_scope": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"limit_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"limit_type_value": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"task_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"parallel_size": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"key_words": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"sql_model": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"cpu_utilization": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"memory_utilization": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"databases": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"node_infos": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     sqlThrottlingTaskNodeInfosSchema(),
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"creator": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"modifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"rule_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func sqlThrottlingTaskNodeInfosSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"node_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"sql_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceOpenGaussSqlThrottlingTaskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/limit-task"
+		product = "opengauss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", d.Get("instance_id").(string))
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createOpt.JSONBody = utils.RemoveNil(buildCreateOpenGaussSqlThrottlingTaskBodyParams(d))
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB OpenGauss SQL throttling task: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	taskId := utils.PathSearch("task_id", createRespBody, "").(string)
+	if taskId == "" {
+		return diag.Errorf("error creating GaussDB OpenGauss SQL throttling task: task_id is not found in API response")
+	}
+	d.SetId(taskId)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"CREATING"},
+		Target:       []string{"WAIT_EXCUTE", "EXCUTING"},
+		Refresh:      sqlThrottlingTaskStateRefreshFunc(client, d),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		PollInterval: 2 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for SQL throttling task(%s) to completed: %s", d.Id(), err)
+	}
+	return resourceOpenGaussSqlThrottlingTaskRead(ctx, d, meta)
+}
+
+func buildCreateOpenGaussSqlThrottlingTaskBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"task_scope":         d.Get("task_scope"),
+		"limit_type":         d.Get("limit_type"),
+		"limit_type_value":   d.Get("limit_type_value"),
+		"task_name":          d.Get("task_name"),
+		"parallel_size":      d.Get("parallel_size"),
+		"start_time":         utils.ValueIgnoreEmpty(d.Get("start_time")),
+		"end_time":           utils.ValueIgnoreEmpty(d.Get("end_time")),
+		"key_words":          utils.ValueIgnoreEmpty(d.Get("key_words")),
+		"sql_model":          utils.ValueIgnoreEmpty(d.Get("sql_model")),
+		"cpu_utilization":    utils.ValueIgnoreEmpty(d.Get("cpu_utilization")),
+		"memory_utilization": utils.ValueIgnoreEmpty(d.Get("memory_utilization")),
+		"databases":          utils.ValueIgnoreEmpty(d.Get("databases")),
+		"node_infos":         buildCreateSqlThrottlingTaskBodyParam(d),
+	}
+	return bodyParams
+}
+
+func buildCreateSqlThrottlingTaskBodyParam(d *schema.ResourceData) []interface{} {
+	nodeInfos := d.Get("node_infos").(*schema.Set)
+	if nodeInfos.Len() == 0 {
+		return nil
+	}
+	rst := make([]interface{}, 0, nodeInfos.Len())
+	for _, v := range nodeInfos.List() {
+		if raw, ok := v.(map[string]interface{}); ok {
+			rst = append(rst, map[string]interface{}{
+				"node_id": raw["node_id"].(string),
+				"sql_id":  raw["sql_id"].(string),
+			})
+		}
+	}
+	return rst
+}
+
+func resourceOpenGaussSqlThrottlingTaskUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/limit-task/{task_id}"
+		product = "opengauss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
+	updatePath = strings.ReplaceAll(updatePath, "{task_id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	updateOpt.JSONBody = utils.RemoveNil(buildUpdateOpenGaussSqlThrottlingTaskBodyParams(d))
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating GaussDB OpenGauss SQL throttling task: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"UPDATING"},
+		Target:       []string{"WAIT_EXCUTE", "EXCUTING"},
+		Refresh:      sqlThrottlingTaskStateRefreshFunc(client, d),
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		PollInterval: 2 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for SQL throttling task(%s) to completed: %s", d.Id(), err)
+	}
+
+	return resourceOpenGaussSqlThrottlingTaskRead(ctx, d, meta)
+}
+
+func buildUpdateOpenGaussSqlThrottlingTaskBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"start_time":         utils.ValueIgnoreEmpty(d.Get("start_time")),
+		"end_time":           utils.ValueIgnoreEmpty(d.Get("end_time")),
+		"key_words":          utils.ValueIgnoreEmpty(d.Get("key_words")),
+		"task_name":          utils.ValueIgnoreEmpty(d.Get("task_name")),
+		"parallel_size":      utils.ValueIgnoreEmpty(d.Get("parallel_size")),
+		"cpu_utilization":    utils.ValueIgnoreEmpty(d.Get("cpu_utilization")),
+		"memory_utilization": utils.ValueIgnoreEmpty(d.Get("memory_utilization")),
+		"databases":          utils.ValueIgnoreEmpty(d.Get("databases")),
+	}
+	return bodyParams
+}
+
+func resourceOpenGaussSqlThrottlingTaskRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		product = "opengauss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	sqlThrottlingTask, err := getSqlThrottlingTask(client, d)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving GaussDB OpenGauss SQL throttling task")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("instance_id", utils.PathSearch("instance_id", sqlThrottlingTask, nil)),
+		d.Set("task_scope", utils.PathSearch("task_scope", sqlThrottlingTask, nil)),
+		d.Set("limit_type", utils.PathSearch("limit_type", sqlThrottlingTask, nil)),
+		d.Set("limit_type_value", utils.PathSearch("limit_type_value", sqlThrottlingTask, nil)),
+		d.Set("task_name", utils.PathSearch("task_name", sqlThrottlingTask, nil)),
+		d.Set("parallel_size", utils.PathSearch("parallel_size", sqlThrottlingTask, nil)),
+		d.Set("key_words", utils.PathSearch("key_words", sqlThrottlingTask, nil)),
+		d.Set("sql_model", utils.PathSearch("sql_model", sqlThrottlingTask, nil)),
+		d.Set("cpu_utilization", utils.PathSearch("cpu_utilization", sqlThrottlingTask, nil)),
+		d.Set("memory_utilization", utils.PathSearch("memory_utilization", sqlThrottlingTask, nil)),
+		d.Set("databases", utils.PathSearch("databases", sqlThrottlingTask, nil)),
+		d.Set("node_infos", flattenSqlThrottlingTaskResponseBodyNodeInfos(sqlThrottlingTask)),
+		d.Set("created_at", utils.PathSearch("created", sqlThrottlingTask, nil)),
+		d.Set("updated_at", utils.PathSearch("updated", sqlThrottlingTask, nil)),
+		d.Set("creator", utils.PathSearch("creator", sqlThrottlingTask, nil)),
+		d.Set("modifier", utils.PathSearch("modifier", sqlThrottlingTask, nil)),
+		d.Set("rule_name", utils.PathSearch("rule_name", sqlThrottlingTask, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSqlThrottlingTaskResponseBodyNodeInfos(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("node_infos", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"node_id": utils.PathSearch("node_id", v, nil),
+			"sql_id":  utils.PathSearch("sql_id", v, nil),
+		})
+	}
+	return rst
+}
+
+func getSqlThrottlingTask(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/limit-task-list"
+	)
+
+	listBasePath := client.Endpoint + httpUrl
+	listBasePath = strings.ReplaceAll(listBasePath, "{project_id}", client.ProjectID)
+	listBasePath = strings.ReplaceAll(listBasePath, "{instance_id}", d.Get("instance_id").(string))
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	var sqlThrottlingTask interface{}
+	offset := 0
+	for {
+		listPath := listBasePath + buildPageQueryParam(100, offset)
+		requestResp, err := client.Request("GET", listPath, &listOpt)
+		if err != nil {
+			return nil, common.ConvertUndefinedErrInto404Err(err, 500, "errCode", "DBS.280005")
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		sqlThrottlingTasks := utils.PathSearch("limit_task_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(sqlThrottlingTasks) == 0 {
+			break
+		}
+		searchExpression := fmt.Sprintf("[?task_id=='%s']|[0]", d.Id())
+		sqlThrottlingTask = utils.PathSearch(searchExpression, sqlThrottlingTasks, nil)
+		if sqlThrottlingTask != nil {
+			break
+		}
+
+		offset += 100
+		totalCount := utils.PathSearch("total_count", respBody, float64(0)).(float64)
+		if int(totalCount) <= offset {
+			break
+		}
+	}
+	if sqlThrottlingTask == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return sqlThrottlingTask, nil
+}
+
+func buildPageQueryParam(limit, offset int) string {
+	return fmt.Sprintf("?limit=%d&offset=%d", limit, offset)
+}
+
+func sqlThrottlingTaskStateRefreshFunc(client *golangsdk.ServiceClient, d *schema.ResourceData) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		res, err := getSqlThrottlingTask(client, d)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return "", "DELETED", nil
+			}
+			return nil, "", err
+		}
+		status := utils.PathSearch("status", res, "").(string)
+		return res, status, nil
+	}
+}
+
+func resourceOpenGaussSqlThrottlingTaskDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/limit-task/{task_id}"
+		product = "opengauss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", d.Get("instance_id").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{task_id}", d.Id())
+
+	deleteGOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	_, err = client.Request("DELETE", deletePath, &deleteGOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "errCode", "DBS.06010013"),
+			"error deleting GaussDB OpenGauss SQL throttling task")
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"DELETING"},
+		Target:       []string{"DELETED"},
+		Refresh:      sqlThrottlingTaskStateRefreshFunc(client, d),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		PollInterval: 2 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for SQL throttling task(%s) to completed: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceOpenGaussSqlThrottlingTaskImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, errors.New("invalid format specified for import id, must be <instance_id>/<id>")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("instance_id", parts[0]),
+	)
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb opengauss sql throtting task resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb opengauss sql throtting task resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccOpenGaussSqlThrottlingTask_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccOpenGaussSqlThrottlingTask_ -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussSqlThrottlingTask_basic
=== PAUSE TestAccOpenGaussSqlThrottlingTask_basic
=== RUN   TestAccOpenGaussSqlThrottlingTask_sql_type
=== PAUSE TestAccOpenGaussSqlThrottlingTask_sql_type
=== RUN   TestAccOpenGaussSqlThrottlingTask_session
=== PAUSE TestAccOpenGaussSqlThrottlingTask_session
=== CONT  TestAccOpenGaussSqlThrottlingTask_basic
=== CONT  TestAccOpenGaussSqlThrottlingTask_session
=== CONT  TestAccOpenGaussSqlThrottlingTask_sql_type
--- PASS: TestAccOpenGaussSqlThrottlingTask_session (42.63s)
--- PASS: TestAccOpenGaussSqlThrottlingTask_sql_type (67.34s)
--- PASS: TestAccOpenGaussSqlThrottlingTask_basic (115.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   115.599s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![删除后查询](https://github.com/user-attachments/assets/61db746a-76d0-41a0-9bb2-4b1492a85566).
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![删除后删除](https://github.com/user-attachments/assets/88a02f71-4e3e-4d87-bbef-78efdec31099).
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
