### PR TITLE
chore(dns/zone): set value ​​for router parameter in ReadContext

### DIFF
--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_test.go
@@ -114,9 +114,15 @@ func TestAccDNSZone_private(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", nameWithDotSuffix),
-					resource.TestCheckOutput("valid_route_id", "true"),
 					resource.TestCheckResourceAttr(resourceName, "router.#", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "router.0.router_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "router.0.router_region"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -143,6 +149,11 @@ func TestAccDNSZone_readTTL(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestMatchResourceAttr(resourceName, "ttl", regexp.MustCompile("^[0-9]+$")),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -172,6 +183,11 @@ func TestAccDNSZone_withEpsId(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "zone_type", "private"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -276,14 +292,6 @@ resource "huaweicloud_dns_zone" "test" {
     zone_type = "private"
     owner     = "terraform"
   }
-}
-
-locals {
-  router_ids = huaweicloud_dns_zone.test.router[*].router_id
-}
-
-output "valid_route_id" {
-  value = contains(local.router_ids, huaweicloud_vpc.test[1].id) && contains(local.router_ids, huaweicloud_vpc.test[2].id)
 }
 `, baseConfig, name)
 }

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_zone.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_zone.go
@@ -97,6 +97,7 @@ func ResourceDNSZone() *schema.Resource {
 						"router_region": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},
@@ -304,12 +305,14 @@ func resourceDNSZoneRead(_ context.Context, d *schema.ResourceData, meta interfa
 		d.Set("email", zoneInfo.Email),
 		d.Set("description", zoneInfo.Description),
 		d.Set("ttl", zoneInfo.TTL),
-		d.Set("masters", zoneInfo.Masters),
 		d.Set("region", region),
 		d.Set("zone_type", zoneInfo.ZoneType),
+		d.Set("router", flattenPrivateZoneRouters(zoneInfo.Routers)),
 		d.Set("enterprise_project_id", zoneInfo.EnterpriseProjectID),
 		// The private zone also returns the "status" attribute.
 		d.Set("status", parseZoneStatus(zoneInfo.Status)),
+		// Attributes
+		d.Set("masters", zoneInfo.Masters),
 	)
 
 	// save tags
@@ -328,6 +331,21 @@ func resourceDNSZoneRead(_ context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	return nil
+}
+
+func flattenPrivateZoneRouters(routers []zones.RouterResult) []map[string]interface{} {
+	if len(routers) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(routers))
+	for i, router := range routers {
+		result[i] = map[string]interface{}{
+			"router_id":     router.RouterID,
+			"router_region": router.RouterRegion,
+		}
+	}
+	return result
 }
 
 func parseZoneStatus(status string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Set value ​​for router parameter in ReadContext method.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o dns -f TestAccDNSZone_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDNSZone_ -timeout 360m -parallel 10
=== RUN   TestAccDNSZone_basic
=== PAUSE TestAccDNSZone_basic
=== RUN   TestAccDNSZone_private
=== PAUSE TestAccDNSZone_private
=== RUN   TestAccDNSZone_readTTL
=== PAUSE TestAccDNSZone_readTTL
=== RUN   TestAccDNSZone_withEpsId
=== PAUSE TestAccDNSZone_withEpsId
=== CONT  TestAccDNSZone_basic
=== CONT  TestAccDNSZone_readTTL
=== CONT  TestAccDNSZone_withEpsId
=== CONT  TestAccDNSZone_private
--- PASS: TestAccDNSZone_readTTL (48.24s)
--- PASS: TestAccDNSZone_withEpsId (70.64s)
--- PASS: TestAccDNSZone_basic (77.71s)
--- PASS: TestAccDNSZone_private (132.78s)
PASS
coverage: 14.9% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       132.915s        coverage: 14.9% of statements in ./huaweicloud/services/dns
```

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
