### PR TITLE
refactor(fgs/function): adjust the acceptance tests

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -238,6 +238,7 @@ var (
 	HW_WORKSPACE_USER_NAMES                        = os.Getenv("HW_WORKSPACE_USER_NAMES")
 
 	HW_FGS_AGENCY_NAME         = os.Getenv("HW_FGS_AGENCY_NAME")
+	HW_FGS_APP_AGENCY_NAME     = os.Getenv("HW_FGS_APP_AGENCY_NAME")
 	HW_FGS_GPU_TYPE            = os.Getenv("HW_FGS_GPU_TYPE")
 	HW_FGS_DEPENDENCY_OBS_LINK = os.Getenv("HW_FGS_DEPENDENCY_OBS_LINK")
 
@@ -804,8 +805,16 @@ func TestAccPreCheckFgsAgency(t *testing.T) {
 	// + SMN Administrator
 	// For the acceptance tests of the function trigger and the application:
 	// + LTS Administrator
+	// + SWR Administrator
 	if HW_FGS_AGENCY_NAME == "" {
 		t.Skip("HW_FGS_AGENCY_NAME must be set for FGS acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckFgsAppAgency(t *testing.T) {
+	if HW_FGS_APP_AGENCY_NAME == "" {
+		t.Skip("HW_FGS_APP_AGENCY_NAME must be set for FGS acceptance tests")
 	}
 }
 
@@ -1295,16 +1304,16 @@ func TestAccPreCheckComponent(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckComponentDeployment(t *testing.T) {
+func TestAccPreCheckImageUrl(t *testing.T) {
 	if HW_BUILD_IMAGE_URL == "" {
-		t.Skip("SWR image URL configuration is not completed for acceptance test of component deployment.")
+		t.Skip("HW_BUILD_IMAGE_URL must be set for acceptance test.")
 	}
 }
 
 // lintignore:AT003
 func TestAccPreCheckImageUrlUpdated(t *testing.T) {
 	if HW_BUILD_IMAGE_URL_UPDATED == "" {
-		t.Skip("SWR image update URL configuration is not completed for acceptance test of component deployment.")
+		t.Skip("HW_BUILD_IMAGE_URL_UPDATED must be set for acceptance test.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func getResourceObj(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getFunction(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	c, err := conf.FgsV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating HuaweiCloud FunctionGraph client: %s", err)
@@ -23,287 +23,307 @@ func getResourceObj(conf *config.Config, state *terraform.ResourceState) (interf
 	return function.GetMetadata(c, state.Primary.ID).Extract()
 }
 
-func TestAccFgsV2Function_basic(t *testing.T) {
+func TestAccFunction_basic(t *testing.T) {
 	var (
-		f              function.Function
-		randName       = acceptance.RandomAccResourceName()
-		obsOjectConfig = zipFileUploadResourcesConfig()
-		resourceName   = "huaweicloud_fgs_function.test"
-	)
+		obj interface{}
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&f,
-		getResourceObj,
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		withBase64Code   = "huaweicloud_fgs_function.with_base64_code"
+		rcWithBase64Code = acceptance.InitResourceCheck(withBase64Code, &obj, getFunction)
+
+		withTextCode   = "huaweicloud_fgs_function.with_text_code"
+		rcWithTextCode = acceptance.InitResourceCheck(withTextCode, &obj, getFunction)
+
+		withObsStorage   = "huaweicloud_fgs_function.with_obs_storage"
+		rcWithObsStorage = acceptance.InitResourceCheck(withObsStorage, &obj, getFunction)
+
+		withCustomImage   = "huaweicloud_fgs_function.with_custom_image"
+		rcWithCustomImage = acceptance.InitResourceCheck(withCustomImage, &obj, getFunction)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckFgsAgency(t)
+			acceptance.TestAccPreCheckFgsAppAgency(t)
+			acceptance.TestAccPreCheckImageUrl(t)
+			acceptance.TestAccPreCheckImageUrlUpdated(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcWithBase64Code.CheckResourceDestroy(),
+			rcWithTextCode.CheckResourceDestroy(),
+			rcWithObsStorage.CheckResourceDestroy(),
+		),
+
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFgsV2Function_basic_step1(randName),
+				Config: testAccFunction_basic_step1(name, "Python2.7"),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					// Default value is v2. Some regions support only v1, the default value is v1
-					resource.TestMatchResourceAttr(resourceName, "functiongraph_version", regexp.MustCompile(`v1|v2`)),
-					resource.TestCheckResourceAttr(resourceName, "description", "function test"),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
-					resource.TestCheckResourceAttrSet(resourceName, "urn"),
-					resource.TestCheckResourceAttrSet(resourceName, "version"),
-					resource.TestCheckResourceAttr(resourceName, "code_type", "inline"),
+					// Check the function which the code context is base64 encoded.
+					rcWithBase64Code.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withBase64Code, "name", name+"-base64-code"),
+					resource.TestCheckResourceAttr(withBase64Code, "memory_size", "128"),
+					resource.TestCheckResourceAttr(withBase64Code, "runtime", "Python2.7"),
+					resource.TestCheckResourceAttr(withBase64Code, "timeout", "3"),
+					resource.TestCheckResourceAttr(withBase64Code, "app", "default"),
+					resource.TestCheckResourceAttr(withBase64Code, "handler", "index.handler"),
+					resource.TestCheckResourceAttr(withBase64Code, "code_type", "inline"),
+					resource.TestCheckResourceAttr(withBase64Code, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(withBase64Code, "concurrency_num", "1"),
+					resource.TestCheckResourceAttr(withBase64Code, "depend_list.#", "1"),
+					resource.TestCheckResourceAttrPair(withBase64Code, "depend_list.0",
+						"huaweicloud_fgs_dependency_version.test", "version_id"),
+					resource.TestCheckResourceAttr(withBase64Code, "user_data", "{\"owner\":\"terraform\"}"),
+					resource.TestCheckResourceAttr(withBase64Code, "encrypted_user_data", "{\"owner\":\"terraform\"}"),
+					resource.TestCheckResourceAttr(withBase64Code, "tags.%", "2"),
+					resource.TestCheckResourceAttr(withBase64Code, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(withBase64Code, "tags.key", "value"),
+					resource.TestCheckResourceAttr(withObsStorage, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttrSet(withBase64Code, "urn"),
+					resource.TestCheckResourceAttrSet(withBase64Code, "version"),
+					// Check the function which the code context is not base64 encoded.
+					rcWithTextCode.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withTextCode, "name", name+"-text-code"),
+					resource.TestCheckResourceAttr(withTextCode, "memory_size", "128"),
+					resource.TestCheckResourceAttr(withTextCode, "runtime", "Python2.7"),
+					resource.TestCheckResourceAttr(withTextCode, "timeout", "3"),
+					resource.TestCheckResourceAttr(withTextCode, "app", "default"),
+					resource.TestCheckResourceAttr(withTextCode, "handler", "index.handler"),
+					resource.TestCheckResourceAttr(withTextCode, "code_type", "inline"),
+					resource.TestCheckResourceAttr(withTextCode, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(withTextCode, "concurrency_num", "1"),
+					resource.TestCheckResourceAttr(withTextCode, "depend_list.#", "1"),
+					resource.TestCheckResourceAttrPair(withTextCode, "depend_list.0",
+						"huaweicloud_fgs_dependency_version.test", "version_id"),
+					resource.TestCheckResourceAttr(withTextCode, "user_data", "{\"owner\":\"terraform\"}"),
+					resource.TestCheckResourceAttr(withTextCode, "encrypted_user_data", "{\"owner\":\"terraform\"}"),
+					resource.TestCheckResourceAttr(withTextCode, "tags.%", "2"),
+					resource.TestCheckResourceAttr(withTextCode, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(withTextCode, "tags.key", "value"),
+					resource.TestCheckResourceAttr(withObsStorage, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttrSet(withTextCode, "urn"),
+					resource.TestCheckResourceAttrSet(withTextCode, "version"),
+					// Check the function which the code file is storaged in the OBS bucket.
+					rcWithObsStorage.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withObsStorage, "name", name+"-obs-storage"),
+					resource.TestCheckResourceAttr(withObsStorage, "memory_size", "128"),
+					resource.TestCheckResourceAttr(withObsStorage, "runtime", "Python2.7"),
+					resource.TestCheckResourceAttr(withObsStorage, "timeout", "3"),
+					resource.TestCheckResourceAttr(withObsStorage, "app", "default"),
+					resource.TestCheckResourceAttr(withObsStorage, "handler", "index.handler"),
+					resource.TestCheckResourceAttr(withObsStorage, "code_type", "obs"),
+					resource.TestCheckResourceAttr(withObsStorage, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(withObsStorage, "concurrency_num", "1"),
+					resource.TestCheckResourceAttr(withObsStorage, "depend_list.#", "1"),
+					resource.TestCheckResourceAttrPair(withObsStorage, "depend_list.0",
+						"huaweicloud_fgs_dependency_version.test", "version_id"),
+					resource.TestCheckResourceAttr(withObsStorage, "user_data", "{\"owner\":\"terraform\"}"),
+					resource.TestCheckResourceAttr(withObsStorage, "encrypted_user_data", "{\"owner\":\"terraform\"}"),
+					resource.TestCheckResourceAttr(withObsStorage, "tags.%", "2"),
+					resource.TestCheckResourceAttr(withObsStorage, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(withObsStorage, "tags.key", "value"),
+					resource.TestCheckResourceAttr(withObsStorage, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttrSet(withObsStorage, "urn"),
+					resource.TestCheckResourceAttrSet(withObsStorage, "version"),
+					// Check the function which is build via an SWR image.
+					rcWithCustomImage.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withCustomImage, "name", name+"-custom-image"),
+					resource.TestCheckResourceAttr(withCustomImage, "memory_size", "128"),
+					resource.TestCheckResourceAttr(withCustomImage, "runtime", "Custom Image"),
+					resource.TestCheckResourceAttr(withCustomImage, "timeout", "3"),
+					resource.TestCheckResourceAttr(withCustomImage, "app", "default"),
+					resource.TestCheckResourceAttr(withCustomImage, "handler", "-"),
+					resource.TestCheckResourceAttr(withCustomImage, "code_type", "Custom-Image-Swr"),
+					resource.TestCheckResourceAttr(withCustomImage, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttrPair(withCustomImage, "vpc_id", "huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(withCustomImage, "network_id", "huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttr(withCustomImage, "concurrency_num", "1"),
+					resource.TestCheckResourceAttr(withCustomImage, "custom_image.#", "1"),
+					resource.TestCheckResourceAttr(withCustomImage, "custom_image.0.url", acceptance.HW_BUILD_IMAGE_URL),
+					resource.TestCheckResourceAttr(withCustomImage, "custom_image.0.command", ""),
+					resource.TestCheckResourceAttr(withCustomImage, "custom_image.0.args", ""),
+					resource.TestCheckResourceAttr(withCustomImage, "custom_image.0.working_dir", "/"),
+					resource.TestCheckResourceAttr(withObsStorage, "user_data", "{\"owner\":\"terraform\"}"),
+					resource.TestCheckResourceAttr(withObsStorage, "encrypted_user_data", "{\"owner\":\"terraform\"}"),
+					resource.TestCheckResourceAttr(withObsStorage, "tags.%", "2"),
+					resource.TestCheckResourceAttr(withObsStorage, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(withObsStorage, "tags.key", "value"),
+					resource.TestCheckResourceAttr(withObsStorage, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttrSet(withObsStorage, "urn"),
+					resource.TestCheckResourceAttrSet(withObsStorage, "version"),
 				),
 			},
 			{
-				Config: testAccFgsV2Function_basic_step2(randName),
+				Config: testAccFunction_basic_step2(name, "Python3.6"),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "description", "function test update"),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "baar"),
-					resource.TestCheckResourceAttr(resourceName, "tags.newkey", "value"),
-					resource.TestCheckResourceAttrSet(resourceName, "urn"),
-					resource.TestCheckResourceAttrSet(resourceName, "version"),
-					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "huaweicloud_vpc.test", "id"),
-					resource.TestCheckResourceAttrPair(resourceName, "network_id", "huaweicloud_vpc_subnet.test", "id"),
-					resource.TestCheckResourceAttr(resourceName, "depend_list.#", "1"),
+					// Check the function which the code context is base64 encoded.
+					rcWithBase64Code.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withBase64Code, "memory_size", "256"),
+					resource.TestCheckResourceAttr(withBase64Code, "runtime", "Python3.6"),
+					resource.TestCheckResourceAttr(withBase64Code, "timeout", "5"),
+					resource.TestCheckResourceAttr(withBase64Code, "app", "default"),
+					resource.TestCheckResourceAttr(withBase64Code, "handler", "index.handler"),
+					resource.TestCheckResourceAttr(withBase64Code, "code_type", "inline"),
+					resource.TestCheckResourceAttr(withBase64Code, "description", "Updated by terraform script"),
+					resource.TestCheckResourceAttr(withBase64Code, "concurrency_num", "500"),
+					resource.TestCheckResourceAttr(withBase64Code, "depend_list.#", "1"),
+					resource.TestCheckResourceAttrPair(withBase64Code, "depend_list.0",
+						"huaweicloud_fgs_dependency_version.test", "version_id"),
+					resource.TestCheckResourceAttr(withBase64Code, "user_data", "{\"owner\":\"terraform\",\"usage\":\"acceptance test\"}"),
+					resource.TestCheckResourceAttr(withBase64Code, "encrypted_user_data", "{\"owner\":\"terraform\",\"usage\":\"acceptance test\"}"),
+					resource.TestCheckResourceAttr(withBase64Code, "tags.%", "2"),
+					resource.TestCheckResourceAttr(withBase64Code, "tags.foo", "baar"),
+					resource.TestCheckResourceAttr(withBase64Code, "tags.new_key", "value"),
+					resource.TestCheckResourceAttr(withObsStorage, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttrSet(withBase64Code, "urn"),
+					resource.TestCheckResourceAttrSet(withBase64Code, "version"),
+					// Check the function which the code context is not base64 encoded.
+					rcWithTextCode.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withTextCode, "memory_size", "256"),
+					resource.TestCheckResourceAttr(withTextCode, "runtime", "Python3.6"),
+					resource.TestCheckResourceAttr(withTextCode, "timeout", "5"),
+					resource.TestCheckResourceAttr(withTextCode, "app", "default"),
+					resource.TestCheckResourceAttr(withTextCode, "handler", "index.handler"),
+					resource.TestCheckResourceAttr(withTextCode, "code_type", "inline"),
+					resource.TestCheckResourceAttr(withTextCode, "description", "Updated by terraform script"),
+					resource.TestCheckResourceAttr(withTextCode, "concurrency_num", "500"),
+					resource.TestCheckResourceAttr(withTextCode, "depend_list.#", "1"),
+					resource.TestCheckResourceAttrPair(withTextCode, "depend_list.0",
+						"huaweicloud_fgs_dependency_version.test", "version_id"),
+					resource.TestCheckResourceAttr(withTextCode, "user_data", "{\"owner\":\"terraform\",\"usage\":\"acceptance test\"}"),
+					resource.TestCheckResourceAttr(withTextCode, "encrypted_user_data", "{\"owner\":\"terraform\",\"usage\":\"acceptance test\"}"),
+					resource.TestCheckResourceAttr(withTextCode, "tags.%", "2"),
+					resource.TestCheckResourceAttr(withTextCode, "tags.foo", "baar"),
+					resource.TestCheckResourceAttr(withTextCode, "tags.new_key", "value"),
+					resource.TestCheckResourceAttr(withObsStorage, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttrSet(withTextCode, "urn"),
+					resource.TestCheckResourceAttrSet(withTextCode, "version"),
+					// Check the function which the code file is storaged in the OBS bucket.
+					rcWithObsStorage.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withObsStorage, "memory_size", "256"),
+					resource.TestCheckResourceAttr(withObsStorage, "runtime", "Python3.6"),
+					resource.TestCheckResourceAttr(withObsStorage, "timeout", "5"),
+					resource.TestCheckResourceAttr(withObsStorage, "app", "default"),
+					resource.TestCheckResourceAttr(withObsStorage, "handler", "index.handler"),
+					resource.TestCheckResourceAttr(withObsStorage, "code_type", "obs"),
+					resource.TestCheckResourceAttr(withObsStorage, "description", "Updated by terraform script"),
+					resource.TestCheckResourceAttr(withObsStorage, "concurrency_num", "500"),
+					resource.TestCheckResourceAttr(withObsStorage, "depend_list.#", "1"),
+					resource.TestCheckResourceAttrPair(withObsStorage, "depend_list.0",
+						"huaweicloud_fgs_dependency_version.test", "version_id"),
+					resource.TestCheckResourceAttr(withObsStorage, "user_data", "{\"owner\":\"terraform\",\"usage\":\"acceptance test\"}"),
+					resource.TestCheckResourceAttr(withObsStorage, "encrypted_user_data", "{\"owner\":\"terraform\",\"usage\":\"acceptance test\"}"),
+					resource.TestCheckResourceAttr(withObsStorage, "tags.%", "2"),
+					resource.TestCheckResourceAttr(withObsStorage, "tags.foo", "baar"),
+					resource.TestCheckResourceAttr(withObsStorage, "tags.new_key", "value"),
+					resource.TestCheckResourceAttr(withObsStorage, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttrSet(withObsStorage, "urn"),
+					resource.TestCheckResourceAttrSet(withObsStorage, "version"),
+					// Check the function which is build via an SWR image.
+					rcWithCustomImage.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withCustomImage, "memory_size", "256"),
+					resource.TestCheckResourceAttr(withCustomImage, "runtime", "Custom Image"),
+					resource.TestCheckResourceAttr(withCustomImage, "timeout", "5"),
+					resource.TestCheckResourceAttr(withCustomImage, "app", "default"),
+					resource.TestCheckResourceAttr(withCustomImage, "app_agency", acceptance.HW_FGS_APP_AGENCY_NAME),
+					resource.TestCheckResourceAttr(withCustomImage, "handler", "-"),
+					resource.TestCheckResourceAttr(withCustomImage, "description", "Updated by terraform script"),
+					resource.TestCheckResourceAttrPair(withCustomImage, "vpc_id", "huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(withCustomImage, "network_id", "huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttr(withObsStorage, "concurrency_num", "500"),
+					resource.TestCheckResourceAttr(withCustomImage, "custom_image.#", "1"),
+					resource.TestCheckResourceAttr(withCustomImage, "custom_image.0.url", acceptance.HW_BUILD_IMAGE_URL_UPDATED),
+					resource.TestCheckResourceAttr(withCustomImage, "custom_image.0.command", "/bin/sh"),
+					resource.TestCheckResourceAttr(withCustomImage, "custom_image.0.args", "-args,value"),
+					resource.TestCheckResourceAttr(withCustomImage, "custom_image.0.working_dir", "/"),
+					resource.TestCheckResourceAttr(withObsStorage, "user_data", "{\"owner\":\"terraform\",\"usage\":\"acceptance test\"}"),
+					resource.TestCheckResourceAttr(withObsStorage, "encrypted_user_data", "{\"owner\":\"terraform\",\"usage\":\"acceptance test\"}"),
+					resource.TestCheckResourceAttr(withObsStorage, "tags.%", "2"),
+					resource.TestCheckResourceAttr(withObsStorage, "tags.foo", "baar"),
+					resource.TestCheckResourceAttr(withObsStorage, "tags.new_key", "value"),
+					resource.TestCheckResourceAttr(withObsStorage, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttrSet(withObsStorage, "urn"),
+					resource.TestCheckResourceAttrSet(withObsStorage, "version"),
 				),
 			},
 			{
-				Config: testAccFgsV2Function_basic_step3(randName, obsOjectConfig),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "depend_list.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "code_type", "obs"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
+				ResourceName:      withBase64Code,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"func_code",
 					"tags",
+					"encrypted_user_data",
 				},
 			},
-		},
-	})
-}
-
-func TestAccFgsV2Function_withEpsId(t *testing.T) {
-	var f function.Function
-	randName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_fgs_function.test"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&f,
-		getResourceObj,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
 			{
-				Config: testAccFgsV2Function_withEpsId(randName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id",
-						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
-				),
-			},
-			{
-				ResourceName:      resourceName,
+				ResourceName:      withTextCode,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"func_code",
+					"tags",
+					"encrypted_user_data",
 				},
 			},
-		},
-	})
-}
-
-func TestAccFgsV2Function_text(t *testing.T) {
-	var f function.Function
-	randName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_fgs_function.test"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&f,
-		getResourceObj,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
 			{
-				Config: testAccFgsV2Function_text(randName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-				),
-			},
-			{
-				ResourceName:      resourceName,
+				ResourceName:      withObsStorage,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"func_code",
+					"tags",
+					"encrypted_user_data",
+				},
+			},
+			{
+				ResourceName:      withCustomImage,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"func_code",
+					"tags",
+					"encrypted_user_data",
 				},
 			},
 		},
 	})
 }
 
-func TestAccFgsV2Function_createByImage(t *testing.T) {
-	var f function.Function
-	randName := acceptance.RandomAccResourceName()
-	rName1 := "huaweicloud_fgs_function.create_with_vpc_access"
-	rName2 := "huaweicloud_fgs_function.create_without_vpc_access"
-
-	rc1 := acceptance.InitResourceCheck(
-		rName1,
-		&f,
-		getResourceObj,
-	)
-
-	rc2 := acceptance.InitResourceCheck(
-		rName2,
-		&f,
-		getResourceObj,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckComponentDeployment(t)
-			acceptance.TestAccPreCheckImageUrlUpdated(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc1.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFgsV2Function_createByImage_step_1(randName),
-				Check: resource.ComposeTestCheckFunc(
-					rc1.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName1, "name", randName+"_1"),
-					resource.TestCheckResourceAttr(rName1, "agency", "functiongraph_swr_trust"),
-					resource.TestCheckResourceAttr(rName1, "runtime", "Custom Image"),
-					resource.TestCheckResourceAttr(rName1, "handler", "-"),
-					resource.TestCheckResourceAttr(rName1, "custom_image.0.url", acceptance.HW_BUILD_IMAGE_URL),
-					resource.TestCheckResourceAttrPair(rName1, "vpc_id", "huaweicloud_vpc.test", "id"),
-					resource.TestCheckResourceAttrPair(rName1, "network_id", "huaweicloud_vpc_subnet.test", "id"),
-					resource.TestCheckResourceAttr(rName1, "custom_image.0.command", "/bin/sh"),
-					resource.TestCheckResourceAttr(rName1, "custom_image.0.args", "-args,value"),
-					resource.TestCheckResourceAttr(rName1, "custom_image.0.working_dir", "/"),
-					resource.TestCheckResourceAttr(rName1, "concurrency_num", "1"),
-					rc2.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName2, "name", randName+"_2"),
-					resource.TestCheckResourceAttr(rName2, "agency", "functiongraph_swr_trust"),
-					resource.TestCheckResourceAttr(rName2, "runtime", "Custom Image"),
-					resource.TestCheckResourceAttr(rName2, "handler", "-"),
-					resource.TestCheckResourceAttr(rName2, "custom_image.0.url", acceptance.HW_BUILD_IMAGE_URL),
-					resource.TestCheckResourceAttr(rName2, "vpc_id", ""),
-					resource.TestCheckResourceAttr(rName2, "network_id", ""),
-				),
-			},
-			{
-				Config: testAccFgsV2Function_createByImage_step_2(randName),
-				Check: resource.ComposeTestCheckFunc(
-					rc1.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName1, "handler", "-"),
-					resource.TestCheckResourceAttr(rName1, "vpc_id", ""),
-					resource.TestCheckResourceAttr(rName1, "network_id", ""),
-					resource.TestCheckResourceAttr(rName1, "custom_image.0.url", acceptance.HW_BUILD_IMAGE_URL_UPDATED),
-					resource.TestCheckResourceAttr(rName1, "custom_image.0.command", ""),
-					resource.TestCheckResourceAttr(rName1, "custom_image.0.args", ""),
-					resource.TestCheckResourceAttr(rName1, "custom_image.0.working_dir", "/"),
-					resource.TestCheckResourceAttr(rName1, "concurrency_num", "1000"),
-					rc2.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName2, "handler", "-"),
-					resource.TestCheckResourceAttrPair(rName2, "vpc_id", "huaweicloud_vpc.test", "id"),
-					resource.TestCheckResourceAttrPair(rName2, "network_id", "huaweicloud_vpc_subnet.test", "id"),
-					resource.TestCheckResourceAttr(rName2, "custom_image.0.url", acceptance.HW_BUILD_IMAGE_URL_UPDATED),
-				),
-			},
-			{
-				ResourceName:      rName1,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				ResourceName:      rName2,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccFgsV2Function_logConfig(t *testing.T) {
-	var f function.Function
-	randName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_fgs_function.test"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&f,
-		getResourceObj,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFgsV2Function_logConfig(randName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "functiongraph_version", "v1"),
-					resource.TestCheckResourceAttrSet(resourceName, "log_group_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "log_stream_id"),
-				),
-			},
-			{
-				Config: testAccFgsV2Function_logConfigUpdate(randName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "functiongraph_version", "v1"),
-					resource.TestCheckResourceAttrSet(resourceName, "log_group_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "log_stream_id"),
-				),
-			},
-		},
-	})
-}
-
-func zipFileUploadResourcesConfig() string {
-	randName := acceptance.RandomAccResourceNameWithDash()
-
-	return fmt.Sprintf(`
+const functionScriptVariableDefinition = `
 variable "script_content" {
   type    = string
   default = <<EOT
-def main():  
-    print("Hello, World!")  
+def main():
+    print("Hello, World!")
 
-if __name__ == "__main__":  
+if __name__ == "__main__":
     main()
 EOT
 }
+`
+
+func zipFileUploadResourcesConfig(name, runtime string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[2]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id = huaweicloud_vpc.test.id
+
+  name       = "%[2]s"
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 0)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 0), 1)
+}
 
 resource "huaweicloud_obs_bucket" "test" {
-  bucket = "%[1]s"
+  bucket = "%[2]s"
   acl    = "private"
 
   provisioner "local-exec" {
@@ -319,241 +339,354 @@ resource "huaweicloud_obs_bucket_object" "test" {
   bucket = huaweicloud_obs_bucket.test.bucket
   key    = "test.zip"
   source = abspath("./test.zip")
-}`, randName)
 }
 
-func testAccFgsV2Function_basic_step1(rName string) string {
-	//nolint:revive
+resource "huaweicloud_fgs_dependency_version" "test" {
+  name    = "%[2]s"
+  runtime = "%[3]s"
+  link    = "%[4]s"
+}
+`, functionScriptVariableDefinition, name, runtime,
+		acceptance.HW_FGS_DEPENDENCY_OBS_LINK)
+}
+
+func testAccFunction_basic_step1(name, runtime string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_fgs_function" "test" {
-  name        = "%s"
-  app         = "default"
-  description = "function test"
-  handler     = "index.handler"
-  memory_size = 128
-  timeout     = 3
-  runtime     = "Python2.7"
-  code_type   = "inline"
-  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGV2ZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+%[1]s
+
+resource "huaweicloud_fgs_function" "with_base64_code" {
+  name                  = "%[2]s-base64-code"
+  memory_size           = 128
+  runtime               = "%[3]s"
+  timeout               = 3
+  app                   = "default"
+  handler               = "index.handler"
+  code_type             = "inline"
+  func_code             = base64encode(var.script_content)
+  description           = "Created by terraform script"
+  functiongraph_version = "v2"
+
+  user_data = jsonencode({
+    "owner": "terraform"
+  })
+  encrypted_user_data = jsonencode({
+    "owner": "terraform"
+  })
+
+  # Update the runtime value will trigger the dependency version change.
+  depend_list = [huaweicloud_fgs_dependency_version.test.version_id]
+  
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+resource "huaweicloud_fgs_function" "with_text_code" {
+  name                  = "%[2]s-text-code"
+  memory_size           = 128
+  runtime               = "%[3]s"
+  timeout               = 3
+  app                   = "default"
+  handler               = "index.handler"
+  code_type             = "inline"
+  func_code             = var.script_content
+  description           = "Created by terraform script"
+  functiongraph_version = "v2"
+
+  user_data = jsonencode({
+    "owner": "terraform"
+  })
+  encrypted_user_data = jsonencode({
+    "owner": "terraform"
+  })
+
+  # Update the runtime value will trigger the dependency version change.
+  depend_list = [huaweicloud_fgs_dependency_version.test.version_id]
 
   tags = {
     foo = "bar"
     key = "value"
   }
 }
-`, rName)
-}
 
-func testAccFgsV2Function_basic_step2(rName string) string {
-	//nolint:revive
-	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_fgs_dependencies" "test" {
-  type    = "public"
-  runtime = "Python2.7"
-}
-
-resource "huaweicloud_fgs_function" "test" {
-  name        = "%[2]s"
-  app         = "default"
-  description = "function test update"
-  handler     = "index.handler"
-  memory_size = 128
-  timeout     = 3
-  runtime     = "Python2.7"
-  code_type   = "inline"
-  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGV2ZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
-  agency      = "function_vpc_trust"
-  vpc_id      = huaweicloud_vpc.test.id
-  network_id  = huaweicloud_vpc_subnet.test.id
-  depend_list = try(slice(data.huaweicloud_fgs_dependencies.test.packages[*].id, 0, 1), [])
-
-  tags = {
-    foo    = "baar"
-    newkey = "value"
-  }
-}
-`, common.TestVpc(rName), rName)
-}
-
-func testAccFgsV2Function_basic_step3(rName, obsConfig string) string {
-	//nolint:revive
-	return fmt.Sprintf(`
-%[1]s
-
-%[2]s
-
-data "huaweicloud_fgs_dependencies" "test" {
-  type    = "public"
-  runtime = "Python2.7"
-}
-
-resource "huaweicloud_fgs_function" "test" {
-  name        = "%[3]s"
-  app         = "default"
-  description = "fuction test update"
-  handler     = "index.handler"
-  memory_size = 128
-  timeout     = 3
-  runtime     = "Python2.7"
-  code_type   = "obs"
-  code_url    = format("https://%%s/%%s", huaweicloud_obs_bucket.test.bucket_domain_name, huaweicloud_obs_bucket_object.test.key)
-  agency      = "function_vpc_trust"
-  vpc_id      = huaweicloud_vpc.test.id
-  network_id  = huaweicloud_vpc_subnet.test.id
-  depend_list = try(slice(data.huaweicloud_fgs_dependencies.test.packages[*].id, 0, 2), [])
-
-  tags = {
-    foo    = "baar"
-    newkey = "value"
-  }
-}
-`, common.TestVpc(rName), obsConfig, rName)
-}
-
-func testAccFgsV2Function_text(rName string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_fgs_function" "test" {
-  name        = "%s"
-  app         = "default"
-  description = "fuction test"
-  handler     = "index.handler"
-  memory_size = 128
-  timeout     = 3
-  runtime     = "Python2.7"
-  code_type   = "inline"
-
-  func_code = <<EOF
-# -*- coding:utf-8 -*-
-import json
-def handler (event, context):
-    return {
-        "statusCode": 200,
-        "isBase64Encoded": False,
-        "body": json.dumps(event),
-        "headers": {
-            "Content-Type": "application/json"
-        }
-    }
-EOF
-}
-`, rName)
-}
-
-func testAccFgsV2Function_withEpsId(rName string) string {
-	//nolint:revive
-	return fmt.Sprintf(`
-resource "huaweicloud_fgs_function" "test" {
-  name                  = "%s"
-  app                   = "default"
-  description           = "fuction test"
-  handler               = "index.handler"
+resource "huaweicloud_fgs_function" "with_obs_storage" {
+  name                  = "%[2]s-obs-storage"
   memory_size           = 128
+  runtime               = "%[3]s"
   timeout               = 3
-  runtime               = "Python2.7"
-  code_type             = "inline"
-  enterprise_project_id = "%s"
-  func_code             = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGV2ZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
-}
-`, rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
-}
-
-func testAccFgsV2Function_createByImage_step_1(rName string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_fgs_function" "create_with_vpc_access" {
-  name                  = "%[2]s_1"
   app                   = "default"
-  handler               = "-"
+  handler               = "index.handler"
+  code_type             = "obs"
+  code_url              = format("https://%%s/%%s", huaweicloud_obs_bucket.test.bucket_domain_name, huaweicloud_obs_bucket_object.test.key)
+  agency                = "%[4]s"
+  description           = "Created by terraform script"
   functiongraph_version = "v2"
+
+  user_data = jsonencode({
+    "owner": "terraform"
+  })
+  encrypted_user_data = jsonencode({
+    "owner": "terraform"
+  })
+
+  # Update the runtime value will trigger the dependency version change.
+  depend_list = [huaweicloud_fgs_dependency_version.test.version_id]
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+# The dependencies are already packaged in the custom image, do not specifies the depend_list parameter.
+resource "huaweicloud_fgs_function" "with_custom_image" {
+  name                  = "%[2]s-custom-image"
   memory_size           = 128
   runtime               = "Custom Image"
   timeout               = 3
-  agency                = "functiongraph_swr_trust"
+  app                   = "default"
+  handler               = "-"
+  agency                = "%[4]s"
+  description           = "Created by terraform script"
+  functiongraph_version = "v2"
+  vpc_id                = huaweicloud_vpc.test.id
+  network_id            = huaweicloud_vpc_subnet.test.id
 
   custom_image {
-    url         = "%[3]s"
+    url = "%[5]s"
+  }
+
+  user_data = jsonencode({
+    "owner": "terraform"
+  })
+  encrypted_user_data = jsonencode({
+    "owner": "terraform"
+  })
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, zipFileUploadResourcesConfig(name, runtime), name, runtime,
+		acceptance.HW_FGS_AGENCY_NAME,
+		acceptance.HW_BUILD_IMAGE_URL)
+}
+
+func testAccFunction_basic_step2(name, runtime string) string {
+	//nolint:revive
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_fgs_function" "with_base64_code" {
+  name                  = "%[2]s-base64-code"
+  memory_size           = 256
+  runtime               = "%[3]s"
+  timeout               = 5
+  app                   = "default"
+  handler               = "index.handler"
+  code_type             = "inline"
+  func_code             = base64encode(var.script_content)
+  description           = "Updated by terraform script"
+  functiongraph_version = "v2"
+  concurrency_num       = 500
+
+  user_data = jsonencode({
+    "owner": "terraform",
+    "usage": "acceptance test"
+  })
+  encrypted_user_data = jsonencode({
+    "owner": "terraform",
+    "usage": "acceptance test"
+  })
+
+  # Update the runtime value will trigger the dependency version change.
+  depend_list = [huaweicloud_fgs_dependency_version.test.version_id]
+  
+  tags = {
+    foo     = "baar"
+    new_key = "value"
+  }
+}
+
+resource "huaweicloud_fgs_function" "with_text_code" {
+  name                  = "%[2]s-text-code"
+  memory_size           = 256
+  runtime               = "%[3]s"
+  timeout               = 5
+  app                   = "default"
+  handler               = "index.handler"
+  code_type             = "inline"
+  func_code             = var.script_content
+  description           = "Updated by terraform script"
+  functiongraph_version = "v2"
+  concurrency_num       = 500
+
+  user_data = jsonencode({
+    "owner": "terraform",
+    "usage": "acceptance test"
+  })
+  encrypted_user_data = jsonencode({
+    "owner": "terraform",
+    "usage": "acceptance test"
+  })
+
+  # Update the runtime value will trigger the dependency version change.
+  depend_list = [huaweicloud_fgs_dependency_version.test.version_id]
+
+  tags = {
+    foo     = "baar"
+    new_key = "value"
+  }
+}
+
+resource "huaweicloud_fgs_function" "with_obs_storage" {
+  name                  = "%[2]s-obs-storage"
+  memory_size           = 256
+  runtime               = "%[3]s"
+  timeout               = 5
+  app                   = "default"
+  handler               = "index.handler"
+  code_type             = "obs"
+  code_url              = format("https://%%s/%%s", huaweicloud_obs_bucket.test.bucket_domain_name, huaweicloud_obs_bucket_object.test.key)
+  agency                = "%[4]s"
+  vpc_id                = huaweicloud_vpc.test.id
+  network_id            = huaweicloud_vpc_subnet.test.id
+  description           = "Updated by terraform script"
+  functiongraph_version = "v2"
+  concurrency_num       = 500
+
+  user_data = jsonencode({
+    "owner": "terraform",
+    "usage": "acceptance test"
+  })
+  encrypted_user_data = jsonencode({
+    "owner": "terraform",
+    "usage": "acceptance test"
+  })
+
+  # Update the runtime value will trigger the dependency version change.
+  depend_list = [huaweicloud_fgs_dependency_version.test.version_id]
+
+  tags = {
+    foo     = "baar"
+    new_key = "value"
+  }
+}
+
+# The dependencies are already packaged in the custom image, do not specifies the depend_list parameter.
+resource "huaweicloud_fgs_function" "with_custom_image" {
+  name                  = "%[2]s-custom-image"
+  memory_size           = 256
+  runtime               = "Custom Image"
+  timeout               = 5
+  app                   = "default"
+  handler               = "-"
+  agency                = "%[4]s"
+  app_agency            = "%[5]s"
+  description           = "Updated by terraform script"
+  functiongraph_version = "v2"
+  concurrency_num       = 500
+  vpc_id                = huaweicloud_vpc.test.id
+  network_id            = huaweicloud_vpc_subnet.test.id
+
+  custom_image {
+    url         = "%[6]s"
     command     = "/bin/sh"
     args        = "-args,value"
     working_dir = "/"
   }
 
-  vpc_id     = huaweicloud_vpc.test.id
-  network_id = huaweicloud_vpc_subnet.test.id
-}
+  user_data = jsonencode({
+    "owner": "terraform",
+    "usage": "acceptance test"
+  })
+  encrypted_user_data = jsonencode({
+    "owner": "terraform",
+    "usage": "acceptance test"
+  })
 
-resource "huaweicloud_fgs_function" "create_without_vpc_access" {
-  name        = "%[2]s_2"
-  app         = "default"
-  handler     = "-"
-  memory_size = 128
-  runtime     = "Custom Image"
-  timeout     = 3
-  agency      = "functiongraph_swr_trust"
-
-  custom_image {
-    url = "%[3]s"
+  tags = {
+    foo     = "baar"
+    new_key = "value"
   }
 }
-`, common.TestVpc(rName), rName, acceptance.HW_BUILD_IMAGE_URL)
+`, zipFileUploadResourcesConfig(name, runtime), name, runtime,
+		acceptance.HW_FGS_AGENCY_NAME,
+		acceptance.HW_FGS_APP_AGENCY_NAME,
+		acceptance.HW_BUILD_IMAGE_URL_UPDATED)
 }
 
-func testAccFgsV2Function_createByImage_step_2(rName string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-# Closs the VPC access
-resource "huaweicloud_fgs_function" "create_with_vpc_access" {
-  name                  = "%[2]s_1"
-  app                   = "default"
-  handler               = "-"
-  functiongraph_version = "v2"
-  memory_size           = 128
-  runtime               = "Custom Image"
-  timeout               = 3
-  agency                = "functiongraph_swr_trust"
-
-  custom_image {
-    url = "%[3]s"
-  }
-
-  concurrency_num = 1000
-}
-
-# Open the VPC access
-resource "huaweicloud_fgs_function" "create_without_vpc_access" {
-  name        = "%[2]s_2"
-  app         = "default"
-  handler     = "-"
-  memory_size = 128
-  runtime     = "Custom Image"
-  timeout     = 3
-  agency      = "functiongraph_swr_trust"
-
-  custom_image {
-    url = "%[3]s"
-  }
-
-  vpc_id     = huaweicloud_vpc.test.id
-  network_id = huaweicloud_vpc_subnet.test.id
-}
-`, common.TestVpc(rName), rName, acceptance.HW_BUILD_IMAGE_URL_UPDATED)
-}
-
-func TestAccFgsV2Function_strategy(t *testing.T) {
+func TestAccFunction_withEpsId(t *testing.T) {
 	var (
-		f function.Function
+		obj interface{}
 
 		name         = acceptance.RandomAccResourceName()
 		resourceName = "huaweicloud_fgs_function.test"
+
+		rc = acceptance.InitResourceCheck(resourceName, &obj, getFunction)
 	)
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&f,
-		getResourceObj,
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunction_withEpsId(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id",
+						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					// Default value is v2. Some regions support only v1, the default value is v1.
+					resource.TestMatchResourceAttr(resourceName, "functiongraph_version", regexp.MustCompile(`v1|v2`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"func_code",
+				},
+			},
+		},
+	})
+}
+
+func testAccFunction_withEpsId(name string) string {
+	//nolint:revive
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_fgs_function" "test" {
+  name                  = "%[2]s"
+  memory_size           = 128
+  runtime               = "Python2.7"
+  timeout               = 3
+  app                   = "default"
+  handler               = "index.handler"
+  code_type             = "inline"
+  func_code             = base64encode(var.script_content)
+  enterprise_project_id = "%[3]s"
+  description           = "Created by terraform script"
+}
+`, functionScriptVariableDefinition,
+		name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func TestAccFunction_logConfig(t *testing.T) {
+	var (
+		obj interface{}
+
+		name         = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_fgs_function.test"
+
+		rc = acceptance.InitResourceCheck(resourceName, &obj, getFunction)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -562,7 +695,112 @@ func TestAccFgsV2Function_strategy(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFunction_strategy_default(name),
+				Config: testAccFunction_logConfig_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "functiongraph_version", "v1"),
+					resource.TestCheckResourceAttrSet(resourceName, "log_group_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "log_stream_id"),
+				),
+			},
+			{
+				Config: testAccFunction_logConfig_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "functiongraph_version", "v1"),
+					resource.TestCheckResourceAttrSet(resourceName, "log_group_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "log_stream_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccFunction_logConfig_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_lts_group" "test" {
+  count = 2
+
+  group_name  = format("%[2]s_%%d", count.index)
+  ttl_in_days = 30
+}
+
+resource "huaweicloud_lts_stream" "test" {
+  count = 2
+
+  group_id    = huaweicloud_lts_group.test[count.index].id
+  stream_name = format("%[2]s_%%d", count.index)
+}
+`, functionScriptVariableDefinition, name)
+}
+
+func testAccFunction_logConfig_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_fgs_function" "test" {
+  name                  = "%[2]s"
+  memory_size           = 128
+  runtime               = "Python2.7"
+  timeout               = 3
+  app                   = "default"
+  handler               = "index.handler"
+  code_type             = "inline"
+  func_code             = base64encode(var.script_content)
+  description           = "Created by terraform script"
+  functiongraph_version = "v1"
+
+  log_group_id    = huaweicloud_lts_group.test[0].id
+  log_stream_id   = huaweicloud_lts_stream.test[0].id
+  log_group_name  = huaweicloud_lts_group.test[0].group_name
+  log_stream_name = huaweicloud_lts_stream.test[0].stream_name
+}
+`, testAccFunction_logConfig_base(name), name)
+}
+
+func testAccFunction_logConfig_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_fgs_function" "test" {
+  name                  = "%[2]s"
+  memory_size           = 128
+  runtime               = "Python2.7"
+  timeout               = 3
+  app                   = "default"
+  handler               = "index.handler"
+  code_type             = "inline"
+  func_code             = base64encode(var.script_content)
+  description           = "Created by terraform script"
+  functiongraph_version = "v1"
+
+  log_group_id    = huaweicloud_lts_group.test[1].id
+  log_stream_id   = huaweicloud_lts_stream.test[1].id
+  log_group_name  = huaweicloud_lts_group.test[1].group_name
+  log_stream_name = huaweicloud_lts_stream.test[1].stream_name
+}
+`, testAccFunction_logConfig_base(name), name)
+}
+
+func TestAccFunction_strategy(t *testing.T) {
+	var (
+		obj interface{}
+
+		name         = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_fgs_function.test"
+
+		rc = acceptance.InitResourceCheck(resourceName, &obj, getFunction)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunction_strategy_undefined(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "max_instance_num", "400"),
@@ -590,7 +828,7 @@ func TestAccFgsV2Function_strategy(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccFunction_strategy_default(name),
+				Config: testAccFunction_strategy_undefined(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "max_instance_num", "-1"),
@@ -608,51 +846,55 @@ func TestAccFgsV2Function_strategy(t *testing.T) {
 	})
 }
 
-func testAccFunction_strategy_default(name string) string {
+func testAccFunction_strategy_undefined(name string) string {
 	return fmt.Sprintf(`
+%[1]s
+
+# max_instance_num can only be configured in the ver.2 function.
 resource "huaweicloud_fgs_function" "test" {
-  functiongraph_version = "v2"
-  name                  = "%[1]s"
+  name                  = "%[2]s"
+  memory_size           = 128
+  runtime               = "Python2.7"
+  timeout               = 3
   app                   = "default"
   handler               = "index.handler"
-  memory_size           = 128
-  timeout               = 3
-  runtime               = "Python2.7"
   code_type             = "inline"
-  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+  func_code             = base64encode(var.script_content)
+  description           = "Created by terraform script"
+  functiongraph_version = "v2"
 }
-`, name)
+`, functionScriptVariableDefinition, name)
 }
 
 func testAccFunction_strategy_defined(name string, maxInstanceNum int) string {
 	return fmt.Sprintf(`
+%[1]s
+
+# max_instance_num can only be configured in the ver.2 function.
 resource "huaweicloud_fgs_function" "test" {
-  functiongraph_version = "v2"
-  name                  = "%[1]s"
+  name                  = "%[2]s"
+  memory_size           = 128
+  runtime               = "Python2.7"
+  timeout               = 3
   app                   = "default"
   handler               = "index.handler"
-  memory_size           = 128
-  timeout               = 3
-  runtime               = "Python2.7"
   code_type             = "inline"
-  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
-  max_instance_num      = %[2]d
+  func_code             = base64encode(var.script_content)
+  description           = "Created by terraform script"
+  functiongraph_version = "v2"
+  max_instance_num      = %[3]d
 }
-`, name, maxInstanceNum)
+`, functionScriptVariableDefinition, name, maxInstanceNum)
 }
 
-func TestAccFgsV2Function_versions(t *testing.T) {
+func TestAccFunction_versions(t *testing.T) {
 	var (
-		f function.Function
+		obj interface{}
 
 		name         = acceptance.RandomAccResourceName()
 		resourceName = "huaweicloud_fgs_function.test"
-	)
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&f,
-		getResourceObj,
+		rc = acceptance.InitResourceCheck(resourceName, &obj, getFunction)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -695,35 +937,41 @@ func TestAccFgsV2Function_versions(t *testing.T) {
 
 func testAccFunction_versions_step1(name string) string {
 	return fmt.Sprintf(`
+%[1]s
+
 resource "huaweicloud_fgs_function" "test" {
-  functiongraph_version = "v2"
-  name                  = "%[1]s"
+  name                  = "%[2]s"
+  memory_size           = 128
+  runtime               = "Python2.7"
+  timeout               = 3
   app                   = "default"
   handler               = "index.handler"
-  memory_size           = 128
-  timeout               = 3
-  runtime               = "Python2.7"
   code_type             = "inline"
-  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+  func_code             = base64encode(var.script_content)
+  description           = "Created by terraform script"
+  functiongraph_version = "v2"
 }
-`, name)
+`, functionScriptVariableDefinition, name)
 }
 
 func testAccFunction_versions_step2(name string) string {
 	return fmt.Sprintf(`
+%[1]s
+
 resource "huaweicloud_fgs_function" "test" {
-  functiongraph_version = "v2"
-  name                  = "%[1]s"
+  name                  = "%[2]s"
+  memory_size           = 128
+  runtime               = "Python2.7"
+  timeout               = 3
   app                   = "default"
   handler               = "index.handler"
-  memory_size           = 128
-  timeout               = 3
-  runtime               = "Python2.7"
   code_type             = "inline"
-  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+  func_code             = base64encode(var.script_content)
+  description           = "Created by terraform script"
+  functiongraph_version = "v2"
 
   versions {
-    name = "%[1]s"
+    name = "%[2]s"
 
     aliases {
       name        = "custom_alias"
@@ -731,21 +979,24 @@ resource "huaweicloud_fgs_function" "test" {
     }
   }
 }
-`, name)
+`, functionScriptVariableDefinition, name)
 }
 
 func testAccFunction_versions_step3(name string) string {
 	return fmt.Sprintf(`
+%[1]s
+
 resource "huaweicloud_fgs_function" "test" {
-  functiongraph_version = "v2"
-  name                  = "%[1]s"
+  name                  = "%[2]s"
+  memory_size           = 128
+  runtime               = "Python2.7"
+  timeout               = 3
   app                   = "default"
   handler               = "index.handler"
-  memory_size           = 128
-  timeout               = 3
-  runtime               = "Python2.7"
   code_type             = "inline"
-  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+  func_code             = base64encode(var.script_content)
+  description           = "Created by terraform script"
+  functiongraph_version = "v2"
 
   versions {
     name = "latest"
@@ -755,28 +1006,24 @@ resource "huaweicloud_fgs_function" "test" {
     }
   }
   versions {
-    name = "%[1]s"
+    name = "%[2]s"
 
     aliases {
       name = "custom_alias_update"
     }
   }
 }
-`, name)
+`, functionScriptVariableDefinition, name)
 }
 
-func TestAccFgsV2Function_domain(t *testing.T) {
+func TestAccFunction_domain(t *testing.T) {
 	var (
-		f function.Function
+		obj interface{}
 
 		name         = acceptance.RandomAccResourceName()
 		resourceName = "huaweicloud_fgs_function.test"
-	)
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&f,
-		getResourceObj,
+		rc = acceptance.InitResourceCheck(resourceName, &obj, getFunction)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -812,6 +1059,8 @@ func testAccFunction_domain_base(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
+%[2]s
+
 resource "huaweicloud_dns_zone" "test" {
   count = 3
 
@@ -822,7 +1071,7 @@ resource "huaweicloud_dns_zone" "test" {
     router_id = huaweicloud_vpc.test.id
   }
 }
-`, common.TestVpc(name))
+`, functionScriptVariableDefinition, common.TestVpc(name))
 }
 
 func testAccFunction_domain_step1(name string) string {
@@ -831,13 +1080,14 @@ func testAccFunction_domain_step1(name string) string {
 
 resource "huaweicloud_fgs_function" "test" {
   name        = "%[2]s"
+  memory_size = 128
+  runtime     = "Python2.7"
+  timeout     = 3
   app         = "default"
   handler     = "index.handler"
   code_type   = "inline"
-  memory_size = 128
-  runtime     = "Python3.10"
-  timeout     = 3
-  func_code   = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+  func_code   = base64encode(var.script_content)
+  description = "Created by terraform script"
 
   # VPC access and DNS configuration
   agency     = "function_all_trust" # Allow VPC and DNS permissions for FunctionGraph service
@@ -856,13 +1106,14 @@ func testAccFunction_domain_step2(name string) string {
 
 resource "huaweicloud_fgs_function" "test" {
   name        = "%[2]s"
+  memory_size = 128
+  runtime     = "Python2.7"
+  timeout     = 3
   app         = "default"
   handler     = "index.handler"
   code_type   = "inline"
-  memory_size = 128
-  runtime     = "Python3.10"
-  timeout     = 3
-  func_code   = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+  func_code   = base64encode(var.script_content)
+  description = "Created by terraform script"
 
   # VPC access and DNS configuration
   agency     = "function_all_trust" # Allow VPC and DNS permissions for FunctionGraph service
@@ -875,197 +1126,112 @@ resource "huaweicloud_fgs_function" "test" {
 `, testAccFunction_domain_base(name), name)
 }
 
-func testAccFgsV2Function_logConfig(rName string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_lts_group" "test" {
-  group_name  = "%[1]s"
-  ttl_in_days = 30
-}
-
-resource "huaweicloud_lts_stream" "test" {
-  group_id    = huaweicloud_lts_group.test.id
-  stream_name = "%[1]s"
-}
-
-resource "huaweicloud_fgs_function" "test" {
-  name                  = "%[1]s"
-  app                   = "default"
-  description           = "fuction test"
-  handler               = "index.handler"
-  functiongraph_version = "v1"
-  memory_size           = 128
-  timeout               = 3
-  runtime               = "Python2.7"
-  code_type             = "inline"
-  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
-
-  log_group_id    = huaweicloud_lts_group.test.id
-  log_stream_id   = huaweicloud_lts_stream.test.id
-  log_group_name  = huaweicloud_lts_group.test.group_name
-  log_stream_name = huaweicloud_lts_stream.test.stream_name
-}
-`, rName)
-}
-
-func testAccFgsV2Function_logConfigUpdate(rName string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_lts_group" "test" {
-  group_name  = "%[1]s"
-  ttl_in_days = 30
-}
-
-resource "huaweicloud_lts_stream" "test" {
-  group_id    = huaweicloud_lts_group.test.id
-  stream_name = "%[1]s"
-}
-
-resource "huaweicloud_lts_group" "test1" {
-  group_name  = "%[1]s-new"
-  ttl_in_days = 30
-}
-
-resource "huaweicloud_lts_stream" "test1" {
-  group_id    = huaweicloud_lts_group.test1.id
-  stream_name = "%[1]s-new"
-}
-
-resource "huaweicloud_fgs_function" "test" {
-  name                  = "%[1]s"
-  app                   = "default"
-  description           = "fuction test"
-  handler               = "index.handler"
-  functiongraph_version = "v1"
-  memory_size           = 128
-  timeout               = 3
-  runtime               = "Python2.7"
-  code_type             = "inline"
-  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
-
-  log_group_id    = huaweicloud_lts_group.test1.id
-  log_stream_id   = huaweicloud_lts_stream.test1.id
-  log_group_name  = huaweicloud_lts_group.test1.group_name
-  log_stream_name = huaweicloud_lts_stream.test1.stream_name
-}
-`, rName)
-}
-
-func TestAccFgsV2Function_reservedInstance_version(t *testing.T) {
+func TestAccFunction_reservedInstance(t *testing.T) {
 	var (
-		f            function.Function
-		name         = acceptance.RandomAccResourceName()
-		resourceName = "huaweicloud_fgs_function.test"
-	)
+		obj interface{}
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&f,
-		getResourceObj,
+		name = acceptance.RandomAccResourceName()
+
+		withVersion   = "huaweicloud_fgs_function.with_version"
+		rcWithVersion = acceptance.InitResourceCheck(withVersion, &obj, getFunction)
+
+		withAlias   = "huaweicloud_fgs_function.with_alias"
+		rcWithAlias = acceptance.InitResourceCheck(withAlias, &obj, getFunction)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcWithVersion.CheckResourceDestroy(),
+			rcWithAlias.CheckResourceDestroy(),
+		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFgsV2Function_reservedInstance_step1(name),
+				Config: testAccFunction_reservedInstance_step1(name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.qualifier_name", "latest"),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.qualifier_type", "version"),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.count", "1"),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.idle_mode", "true"),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.tactics_config.0.cron_configs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.tactics_config.0.cron_configs.0.count", "2"),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.tactics_config.0.cron_configs.0.cron", "0 */10 * * * ?"),
-					resource.TestCheckResourceAttrSet(resourceName, "reserved_instances.0.tactics_config.0.cron_configs.0.start_time"),
-					resource.TestCheckResourceAttrSet(resourceName, "reserved_instances.0.tactics_config.0.cron_configs.0.expired_time"),
-					resource.TestCheckResourceAttrSet(resourceName, "reserved_instances.0.tactics_config.0.cron_configs.0.name"),
+					rcWithVersion.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withVersion, "reserved_instances.#", "1"),
+					resource.TestCheckResourceAttr(withVersion, "reserved_instances.0.qualifier_name", "latest"),
+					resource.TestCheckResourceAttr(withVersion, "reserved_instances.0.qualifier_type", "version"),
+					resource.TestCheckResourceAttr(withVersion, "reserved_instances.0.count", "1"),
+					resource.TestCheckResourceAttr(withVersion, "reserved_instances.0.idle_mode", "true"),
+					resource.TestCheckResourceAttr(withVersion, "reserved_instances.0.tactics_config.0.cron_configs.#", "1"),
+					resource.TestCheckResourceAttr(withVersion, "reserved_instances.0.tactics_config.0.cron_configs.0.count", "2"),
+					resource.TestCheckResourceAttr(withVersion, "reserved_instances.0.tactics_config.0.cron_configs.0.cron", "0 */10 * * * ?"),
+					resource.TestCheckResourceAttrSet(withVersion, "reserved_instances.0.tactics_config.0.cron_configs.0.start_time"),
+					resource.TestCheckResourceAttrSet(withVersion, "reserved_instances.0.tactics_config.0.cron_configs.0.expired_time"),
+					resource.TestCheckResourceAttrSet(withVersion, "reserved_instances.0.tactics_config.0.cron_configs.0.name"),
+					rcWithAlias.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withAlias, "versions.#", "1"),
+					resource.TestCheckResourceAttr(withAlias, "versions.0.name", "latest"),
+					resource.TestCheckResourceAttr(withAlias, "versions.0.aliases.#", "1"),
+					resource.TestCheckResourceAttr(withAlias, "versions.0.aliases.0.name", name),
+					resource.TestCheckResourceAttr(withAlias, "reserved_instances.#", "1"),
+					resource.TestCheckResourceAttr(withAlias, "reserved_instances.0.qualifier_name", name),
+					resource.TestCheckResourceAttr(withAlias, "reserved_instances.0.qualifier_type", "alias"),
+					resource.TestCheckResourceAttr(withAlias, "reserved_instances.0.count", "1"),
+					resource.TestCheckResourceAttr(withAlias, "reserved_instances.0.idle_mode", "true"),
+					resource.TestCheckResourceAttr(withAlias, "reserved_instances.0.tactics_config.0.cron_configs.#", "1"),
+					resource.TestCheckResourceAttr(withAlias, "reserved_instances.0.tactics_config.0.cron_configs.0.count", "2"),
+					resource.TestCheckResourceAttr(withAlias, "reserved_instances.0.tactics_config.0.cron_configs.0.cron", "0 */10 * * * ?"),
+					resource.TestCheckResourceAttrSet(withAlias, "reserved_instances.0.tactics_config.0.cron_configs.0.start_time"),
+					resource.TestCheckResourceAttrSet(withAlias, "reserved_instances.0.tactics_config.0.cron_configs.0.expired_time"),
+					resource.TestCheckResourceAttrSet(withAlias, "reserved_instances.0.tactics_config.0.cron_configs.0.name"),
 				),
 			},
 			{
-				Config: testAccFgsV2Function_reservedInstance_step2(name),
+				Config: testAccFunction_reservedInstance_step2(name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.count", "2"),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.idle_mode", "false"),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.tactics_config.#", "0"),
+					rcWithVersion.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withVersion, "reserved_instances.0.count", "2"),
+					resource.TestCheckResourceAttr(withVersion, "reserved_instances.0.idle_mode", "false"),
+					resource.TestCheckResourceAttr(withVersion, "reserved_instances.0.tactics_config.#", "0"),
+					rcWithAlias.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withAlias, "versions.#", "1"),
+					resource.TestCheckResourceAttr(withAlias, "versions.0.name", "latest"),
+					resource.TestCheckResourceAttr(withAlias, "versions.0.aliases.#", "1"),
+					resource.TestCheckResourceAttr(withAlias, "versions.0.aliases.0.name", name+"_new"),
+					resource.TestCheckResourceAttr(withAlias, "reserved_instances.0.qualifier_name", name+"_new"),
+					resource.TestCheckResourceAttr(withAlias, "reserved_instances.0.qualifier_type", "alias"),
+					resource.TestCheckResourceAttr(withAlias, "reserved_instances.0.count", "2"),
+					resource.TestCheckResourceAttr(withAlias, "reserved_instances.0.idle_mode", "false"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      withVersion,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"func_code",
-					"tags",
+				},
+			},
+			{
+				ResourceName:      withAlias,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"func_code",
 				},
 			},
 		},
 	})
 }
 
-func TestAccFgsV2Function_reservedInstance_alias(t *testing.T) {
-	var (
-		f               function.Function
-		name            = acceptance.RandomAccResourceName()
-		updateAliasName = acceptance.RandomAccResourceName()
-		resourceName    = "huaweicloud_fgs_function.test"
-	)
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&f,
-		getResourceObj,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFgsV2Function_reservedInstance_alias(name, name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.qualifier_name", name),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.qualifier_type", "alias"),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.count", "1"),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.idle_mode", "false"),
-				),
-			},
-			{
-				Config: testAccFgsV2Function_reservedInstance_alias(name, updateAliasName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.qualifier_name", updateAliasName),
-					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.qualifier_type", "alias"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"func_code",
-					"tags",
-				},
-			},
-		},
-	})
-}
-
-func testAccFgsV2Function_reservedInstance_step1(rName string) string {
+func testAccFunction_reservedInstance_step1(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_fgs_function" "test" {
-  name        = "%[1]s"
+%[1]s
+
+resource "huaweicloud_fgs_function" "with_version" {
+  name        = "%[2]s_with_version"
+  memory_size = 128
+  runtime     = "Node.js16.17"
+  timeout     = 3
   app         = "default"
   handler     = "index.handler"
-  memory_size = 128
-  timeout     = 3
-  runtime     = "Node.js16.17"
   code_type   = "inline"
+  func_code   = base64encode(var.script_content)
+  description = "Created by terraform script"
 
   reserved_instances {
     qualifier_type = "version"
@@ -1084,40 +1250,17 @@ resource "huaweicloud_fgs_function" "test" {
     }
   }
 }
-`, rName)
-}
 
-func testAccFgsV2Function_reservedInstance_step2(rName string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_fgs_function" "test" {
-  name        = "%s"
+resource "huaweicloud_fgs_function" "with_alias" {
+  name        = "%[2]s_with_alias"
+  memory_size = 128
+  runtime     = "Node.js16.17"
+  timeout     = 3
   app         = "default"
   handler     = "index.handler"
-  memory_size = 128
-  timeout     = 3
-  runtime     = "Node.js16.17"
   code_type   = "inline"
-	  
-  reserved_instances {
-    qualifier_type = "version"
-    qualifier_name = "latest"
-    count          = 2
-    idle_mode      = false
-  }
-}
-`, rName)
-}
-
-func testAccFgsV2Function_reservedInstance_alias(rName string, aliasName string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_fgs_function" "test" {
-  name        = "%[1]s"
-  app         = "default"
-  handler     = "index.handler"
-  memory_size = 128
-  timeout     = 3
-  runtime     = "Node.js16.17"
-  code_type   = "inline"
+  func_code   = base64encode(var.script_content)
+  description = "Created by terraform script"
 
   versions {
     name = "latest"
@@ -1131,24 +1274,82 @@ resource "huaweicloud_fgs_function" "test" {
     qualifier_type = "alias"
     qualifier_name = "%[2]s"
     count          = 1
+    idle_mode      = true
+
+    tactics_config {
+      cron_configs {
+        name         = "scheme-waekcy"
+        cron         = "0 */10 * * * ?"
+        start_time   = "1708342889"
+        expired_time = "1739878889"
+        count        = 2
+      }
+    }
+  }
+}
+`, functionScriptVariableDefinition, name)
+}
+
+func testAccFunction_reservedInstance_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_fgs_function" "with_version" {
+  name        = "%[2]s_with_version"
+  memory_size = 128
+  runtime     = "Node.js16.17"
+  timeout     = 3
+  app         = "default"
+  handler     = "index.handler"
+  code_type   = "inline"
+  func_code   = base64encode(var.script_content)
+  description = "Created by terraform script"
+	  
+  reserved_instances {
+    qualifier_type = "version"
+    qualifier_name = "latest"
+    count          = 2
     idle_mode      = false
   }
 }
-`, rName, aliasName)
+
+resource "huaweicloud_fgs_function" "with_alias" {
+  name        = "%[2]s_with_alias"
+  memory_size = 128
+  runtime     = "Node.js16.17"
+  timeout     = 3
+  app         = "default"
+  handler     = "index.handler"
+  code_type   = "inline"
+  func_code   = base64encode(var.script_content)
+  description = "Created by terraform script"
+
+  versions {
+    name = "latest"
+	
+    aliases {
+      name = "%[2]s_new"
+    }
+  }
+
+  reserved_instances {
+    qualifier_type = "alias"
+    qualifier_name = "%[2]s_new"
+    count          = 2
+    idle_mode      = false
+  }
+}
+`, functionScriptVariableDefinition, name)
 }
 
-func TestAccFgsV2Function_gpuMemory(t *testing.T) {
+func TestAccFunction_gpuMemory(t *testing.T) {
 	var (
-		f function.Function
+		obj interface{}
 
 		name         = acceptance.RandomAccResourceName()
 		resourceName = "huaweicloud_fgs_function.test"
-	)
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&f,
-		getResourceObj,
+		rc = acceptance.InitResourceCheck(resourceName, &obj, getFunction)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1161,7 +1362,15 @@ func TestAccFgsV2Function_gpuMemory(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFunction_gpuMemory(name, 1024),
+				Config: testAccFunction_gpuMemory_undefined(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "gpu_memory", "0"),
+					resource.TestCheckResourceAttr(resourceName, "gpu_type", ""),
+				),
+			},
+			{
+				Config: testAccFunction_gpuMemory_defined(name, 1024),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "gpu_memory", "1024"),
@@ -1169,7 +1378,7 @@ func TestAccFgsV2Function_gpuMemory(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccFunction_gpuMemory(name, 2048),
+				Config: testAccFunction_gpuMemory_defined(name, 2048),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "gpu_memory", "2048"),
@@ -1177,7 +1386,7 @@ func TestAccFgsV2Function_gpuMemory(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccFunction_default(name),
+				Config: testAccFunction_gpuMemory_undefined(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "gpu_memory", "0"),
@@ -1196,32 +1405,40 @@ func TestAccFgsV2Function_gpuMemory(t *testing.T) {
 	})
 }
 
-func testAccFunction_gpuMemory(name string, memory int) string {
+func testAccFunction_gpuMemory_undefined(name string) string {
 	return fmt.Sprintf(`
+%[1]s
+
 resource "huaweicloud_fgs_function" "test" {
-  name        = "%[1]s"
+  name        = "%[2]s"
+  memory_size = 128
+  runtime     = "Custom"
+  timeout     = 3
   app         = "default"
   handler     = "bootstrap"
-  memory_size = 128
-  timeout     = 3
-  runtime     = "Custom"
   code_type   = "inline"
-  gpu_memory  = %[2]d
-  gpu_type    = "%[3]s"
+  func_code   = base64encode(var.script_content)
+  description = "Created by terraform script"
 }
-`, name, memory, acceptance.HW_FGS_GPU_TYPE)
+`, functionScriptVariableDefinition, name)
 }
 
-func testAccFunction_default(name string) string {
+func testAccFunction_gpuMemory_defined(name string, memory int) string {
 	return fmt.Sprintf(`
+%[1]s
+
 resource "huaweicloud_fgs_function" "test" {
-  name        = "%[1]s"
+  name        = "%[2]s"
+  memory_size = 128
+  runtime     = "Custom"
+  timeout     = 3
   app         = "default"
   handler     = "bootstrap"
-  memory_size = 128
-  timeout     = 3
-  runtime     = "Custom"
   code_type   = "inline"
+  func_code   = base64encode(var.script_content)
+  description = "Created by terraform script"
+  gpu_memory  = %[3]d
+  gpu_type    = "%[4]s"
 }
-`, name)
+`, functionScriptVariableDefinition, name, memory, acceptance.HW_FGS_GPU_TYPE)
 }

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_trigger_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_trigger_test.go
@@ -34,7 +34,7 @@ func TestAccFunctionTrigger_basic(t *testing.T) {
 		resNameTimerRate = "huaweicloud_fgs_function_trigger.timer_rate"
 		resNameTimerCron = "huaweicloud_fgs_function_trigger.timer_cron"
 
-		rcFunc      = acceptance.InitResourceCheck(resNameFunc, &relatedFunc, getResourceObj)
+		rcFunc      = acceptance.InitResourceCheck(resNameFunc, &relatedFunc, getFunction)
 		rcTimerRate = acceptance.InitResourceCheck(resNameTimerRate, &timeTrigger, getFunctionTriggerFunc)
 		rcTimerCron = acceptance.InitResourceCheck(resNameTimerCron, &timeTrigger, getFunctionTriggerFunc)
 	)

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_component_instance_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_component_instance_test.go
@@ -38,7 +38,7 @@ func TestAccComponentInstance_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckComponentDeployment(t)
+			acceptance.TestAccPreCheckImageUrl(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Rename all function tests and remove the package part.
2. Remove some extra tests and supple to the basic and reserved instance tests.
3. adjust the resource coding and reorder the parameter definitions.
4. supplement some environment variables and corresponding precheck tests.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
5. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. adjust the acceptance tests.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFunction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_basic -timeout 360m -parallel 10
=== RUN   TestAccFunction_basic
=== PAUSE TestAccFunction_basic
=== CONT  TestAccFunction_basic
--- PASS: TestAccFunction_basic (81.63s)
PASS
coverage: 19.1% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       81.734s coverage: 19.1% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_withEpsId
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_withEpsId -timeout 360m -parallel 10
=== RUN   TestAccFunction_withEpsId
=== PAUSE TestAccFunction_withEpsId
=== CONT  TestAccFunction_withEpsId
--- PASS: TestAccFunction_withEpsId (13.57s)
PASS
coverage: 9.7% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       13.624s coverage: 9.7% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_logConfig
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_logConfig -timeout 360m -parallel 10
=== RUN   TestAccFunction_logConfig
=== PAUSE TestAccFunction_logConfig
=== CONT  TestAccFunction_logConfig
--- PASS: TestAccFunction_logConfig (29.14s)
PASS
coverage: 12.6% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       29.207s coverage: 12.6% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_strategy
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_strategy -timeout 360m -parallel 10
=== RUN   TestAccFunction_strategy
=== PAUSE TestAccFunction_strategy
=== CONT  TestAccFunction_strategy
--- PASS: TestAccFunction_strategy (43.66s)
PASS
coverage: 10.8% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       43.717s coverage: 10.8% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_domain
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_domain -timeout 360m -parallel 10
=== RUN   TestAccFunction_domain
=== PAUSE TestAccFunction_domain
=== CONT  TestAccFunction_domain
--- PASS: TestAccFunction_domain (67.38s)
PASS
coverage: 12.8% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       67.433s coverage: 12.8% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_versions
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_versions -timeout 360m -parallel 10
=== RUN   TestAccFunction_versions
=== PAUSE TestAccFunction_versions
=== CONT  TestAccFunction_versions
--- PASS: TestAccFunction_versions (40.01s)
PASS
coverage: 12.9% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       40.081s coverage: 12.9% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_reservedInstance
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_reservedInstance -timeout 360m -parallel 10
=== RUN   TestAccFunction_reservedInstance
=== PAUSE TestAccFunction_reservedInstance
=== CONT  TestAccFunction_reservedInstance
--- PASS: TestAccFunction_reservedInstance (27.48s)
PASS
coverage: 18.1% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       27.554s coverage: 18.1% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_gpuMemory
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_gpuMemory -timeout 360m -parallel 10
=== RUN   TestAccFunction_gpuMemory
=== PAUSE TestAccFunction_gpuMemory
=== CONT  TestAccFunction_gpuMemory
--- PASS: TestAccFunction_gpuMemory (41.91s)
PASS
coverage: 12.3% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       41.967s coverage: 12.3% of statements in ./huaweicloud/services/fgs
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
