### PR TITLE
feat(dns): the private zone supports  `proxy_pattern` parameter and modification status

### DIFF
--- a/docs/resources/dns_zone.md
+++ b/docs/resources/dns_zone.md
@@ -57,6 +57,8 @@ The following arguments are supported:
 * `router` - (Optional, List) Router configuration block which is required if zone_type is private. The router
   structure is documented below.
 
+  -> Before changing this parameter, make sure the zone status is enabled.
+
 * `ttl` - (Optional, Int) The time to live (TTL) of the zone.  
   The valid value is range from `1` to `2,147,483,647`.
 
@@ -73,7 +75,7 @@ The following arguments are supported:
   + **ENABLE**
   + **DISABLE**
 
-  -> This parameter is only supported by the public zone, and it is a one-time action.
+  -> This is a one-time action.
 
 The `router` block supports:
 

--- a/docs/resources/dns_zone.md
+++ b/docs/resources/dns_zone.md
@@ -77,6 +77,17 @@ The following arguments are supported:
 
   -> This is a one-time action.
 
+* `proxy_pattern` - (Optional, String, ForceNew) Specifies the recursive resolution proxy mode for subdomains of
+  the private zone.  
+  Defaults to **AUTHORITY**.  
+  The valid values are as follows:
+  + **AUTHORITY**: The recursive resolution proxy is disabled for the private zone.
+  + **RECURSIVE**: The recursive resolution proxy is enabled for the private zone.
+  
+  -> 1. This parameter ia available only when the `zone_type` parameter is set to **private**.
+     <br>2. If this parameter is set to **RECURSIVE**, but you query subdomains that are not configured in the zone namespace,
+     the DNS will recursively resolve the subdomains on the Internet and use the result from authoritative DNS servers.
+
 The `router` block supports:
 
 * `router_id` - (Required, String) ID of the associated VPC.

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_test.go
@@ -107,6 +107,7 @@ func TestAccDNSZone_private(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "router.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.zone_type", "private"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "status", "DISABLE"),
 				),
 			},
 			{
@@ -117,6 +118,7 @@ func TestAccDNSZone_private(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "router.#", "2"),
 					resource.TestCheckResourceAttrSet(resourceName, "router.0.router_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "router.0.router_region"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ENABLE"),
 				),
 			},
 			{
@@ -253,6 +255,7 @@ resource "huaweicloud_dns_zone" "test" {
   email       = "email@example.com"
   description = "a private zone"
   zone_type   = "private"
+  status      = "DISABLE"
 
   dynamic "router" {
     for_each = slice(huaweicloud_vpc.test[*].id, 0, 2)
@@ -279,6 +282,7 @@ resource "huaweicloud_dns_zone" "test" {
   email       = "email@example.com"
   description = "a private zone"
   zone_type   = "private"
+  status      = "ENABLE"
 
   dynamic "router" {
     for_each = slice(huaweicloud_vpc.test[*].id, 1, 3)

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_test.go
@@ -108,6 +108,7 @@ func TestAccDNSZone_private(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.zone_type", "private"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "status", "DISABLE"),
+					resource.TestCheckResourceAttr(resourceName, "proxy_pattern", "RECURSIVE"),
 				),
 			},
 			{
@@ -184,6 +185,7 @@ func TestAccDNSZone_withEpsId(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", nameWithDotSuffix),
 					resource.TestCheckResourceAttr(resourceName, "zone_type", "private"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "proxy_pattern", "AUTHORITY"),
 				),
 			},
 			{
@@ -265,6 +267,8 @@ resource "huaweicloud_dns_zone" "test" {
     }
   }
 
+  proxy_pattern = "RECURSIVE"
+
   tags = {
     zone_type = "private"
     owner     = "terraform"
@@ -291,6 +295,8 @@ resource "huaweicloud_dns_zone" "test" {
       router_id = router.value
     }
   }
+
+  proxy_pattern = "RECURSIVE"
 
   tags = {
     zone_type = "private"

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_zone.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_zone.go
@@ -114,6 +114,13 @@ func ResourceDNSZone() *schema.Resource {
 				Computed:    true,
 				Description: `The status of the zone.`,
 			},
+			"proxy_pattern": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The recursive resolution proxy mode for subdomains of the private zone.`,
+			},
 			"masters": {
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -176,6 +183,7 @@ func resourceDNSZoneCreate(ctx context.Context, d *schema.ResourceData, meta int
 		ZoneType:            zoneType,
 		EnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
 		Router:              resourceDNSRouter(d, region),
+		ProxyPattern:        d.Get("proxy_pattern").(string),
 	}
 
 	log.Printf("[DEBUG] Create options: %#v", createOpts)
@@ -305,8 +313,8 @@ func resourceDNSZoneRead(_ context.Context, d *schema.ResourceData, meta interfa
 		d.Set("zone_type", zoneInfo.ZoneType),
 		d.Set("router", flattenPrivateZoneRouters(zoneInfo.Routers)),
 		d.Set("enterprise_project_id", zoneInfo.EnterpriseProjectID),
-		// The private zone also returns the "status" attribute.
 		d.Set("status", parseZoneStatus(zoneInfo.Status)),
+		d.Set("proxy_pattern", zoneInfo.ProxyPattern),
 		// Attributes
 		d.Set("masters", zoneInfo.Masters),
 	)

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_zone.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_zone.go
@@ -112,7 +112,7 @@ func ResourceDNSZone() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Description: `Specifies the status of the public zone.`,
+				Description: `The status of the zone.`,
 			},
 			"masters": {
 				Type:     schema.TypeSet,
@@ -242,11 +242,7 @@ func resourceDNSZoneCreate(ctx context.Context, d *schema.ResourceData, meta int
 	// After zone is created, the status is ACTIVE (ENABLE).
 	// This action cannot be called repeatedly.
 	if v, ok := d.GetOk("status"); ok && v != "ENABLE" {
-		if zoneType == "private" {
-			return diag.Errorf("The private zone do not support updating status.")
-		}
-
-		if err := updatePublicZoneStatus(ctx, d, dnsClient, d.Timeout(schema.TimeoutCreate)); err != nil {
+		if err := updateZoneStatus(ctx, d, dnsClient, d.Timeout(schema.TimeoutCreate)); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -386,18 +382,15 @@ func resourceDNSZoneUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 	}
 
-	if d.HasChange("router") && zoneType == "private" {
-		if err := updateDNSZoneRouters(ctx, d, dnsClient, region); err != nil {
+	if d.HasChange("status") {
+		if err := updateZoneStatus(ctx, d, dnsClient, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	if d.HasChange("status") {
-		if zoneType == "private" {
-			return diag.Errorf("The private zone do not support updating status.")
-		}
-
-		if err := updatePublicZoneStatus(ctx, d, dnsClient, d.Timeout(schema.TimeoutUpdate)); err != nil {
+	// This operation is supported only when the zone status is enabled.
+	if d.HasChange("router") && zoneType == "private" {
+		if err := updateDNSZoneRouters(ctx, d, dnsClient, region); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -514,14 +507,14 @@ func updateDNSZoneRouters(ctx context.Context, d *schema.ResourceData, client *g
 	return nil
 }
 
-func updatePublicZoneStatus(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient, timeout time.Duration) error {
+func updateZoneStatus(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient, timeout time.Duration) error {
 	opts := zones.UpdateStatusOpts{
 		ZoneId: d.Id(),
 		Status: d.Get("status").(string),
 	}
 	err := zones.UpdateZoneStatus(client, opts)
 	if err != nil {
-		return fmt.Errorf("error updating public zone status: %s", err)
+		return fmt.Errorf("error updating the status of the zone: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -534,7 +527,7 @@ func updatePublicZoneStatus(ctx context.Context, d *schema.ResourceData, client 
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmt.Errorf("error waiting for updating public zone status completed: %s", err)
+		return fmt.Errorf("error waiting for updating the zone status completed: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The private zone resource supports  `proxy_pattern` parameter and modification status.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
the private zone resource supports  `proxy_pattern` parameter and modification status.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccDNSZone_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDNSZone_ -timeout 360m -parallel 10
=== RUN   TestAccDNSZone_basic
=== PAUSE TestAccDNSZone_basic
=== RUN   TestAccDNSZone_private
=== PAUSE TestAccDNSZone_private
=== RUN   TestAccDNSZone_readTTL
=== PAUSE TestAccDNSZone_readTTL
=== RUN   TestAccDNSZone_withEpsId
=== PAUSE TestAccDNSZone_withEpsId
=== CONT  TestAccDNSZone_basic
=== CONT  TestAccDNSZone_readTTL
=== CONT  TestAccDNSZone_withEpsId
=== CONT  TestAccDNSZone_private
--- PASS: TestAccDNSZone_readTTL (46.37s)
--- PASS: TestAccDNSZone_withEpsId (64.74s)
--- PASS: TestAccDNSZone_basic (76.40s)
--- PASS: TestAccDNSZone_private (141.47s)
PASS
coverage: 14.5% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       141.540s        coverage: 14.5% of statements in ./huaweicloud/services/dns
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
