### PR TITLE
feat(workspace): add new parameters for user resource

### DIFF
--- a/docs/resources/workspace_user.md
+++ b/docs/resources/workspace_user.md
@@ -43,7 +43,7 @@ The following arguments are supported:
 
   Changing this will create a new resource.
 
-* `email` - (Required, String) Specifies the email address of user. The value can contain `1` to `64` characters.
+* `email` - (Optional, String) Specifies the email address of user. The value can contain `1` to `64` characters.
 
 * `description` - (Optional, String) Specifies the description of user. The maximum length is `255` characters.
 

--- a/docs/resources/workspace_user.md
+++ b/docs/resources/workspace_user.md
@@ -43,7 +43,19 @@ The following arguments are supported:
 
   Changing this will create a new resource.
 
+* `active_type` - (Optional, String) Specifies the activation mode of the user. Defaults to **USER_ACTIVATE**.  
+  The valid values are as follows:
+  + **USER_ACTIVATE**: Activated by the user.
+  + **ADMIN_ACTIVATE**: Activated by the administator.
+
 * `email` - (Optional, String) Specifies the email address of user. The value can contain `1` to `64` characters.
+
+* `phone` - (Optional, String) Specifies the phone number of user.
+
+-> At least one of `email` and `phone` parameters must be provided.
+
+* `password` - (Optional, String) Specifies the initial passowrd of user.  
+  This parameter is available and required when `active_type` is set to **ADMIN_ACTIVATE**.
 
 * `description` - (Optional, String) Specifies the description of user. The maximum length is `255` characters.
 
@@ -83,5 +95,24 @@ In addition to all arguments above, the following attributes are exported:
 Users can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_workspace_user.test a96e632a399d452eb29e5091e0af806a
+$ terraform import huaweicloud_workspace_user.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes include: `password`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the user, or the resource definition should be updated to
+align with the user. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_workspace_user" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      password,
+    ]
+  }
+}
 ```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20250217034539-d16a3d7dc780
+	github.com/chnsz/golangsdk v0.0.0-20250218015804-069acf83754c
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20250217034539-d16a3d7dc780 h1:diWEvRNeM/FktUT+HWiv6z9LLpG3smWeKCNpAyGq5m0=
-github.com/chnsz/golangsdk v0.0.0-20250217034539-d16a3d7dc780/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20250218015804-069acf83754c h1:kn7DY4ztPd6SltVU0qmw82xKMDc6xG2ADPqyP+vMyr0=
+github.com/chnsz/golangsdk v0.0.0-20250218015804-069acf83754c/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_user_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_user_test.go
@@ -25,15 +25,15 @@ func getUserFunc(conf *config.Config, state *terraform.ResourceState) (interface
 
 func TestAccUser_basic(t *testing.T) {
 	var (
-		user         users.UserDetail
-		resourceName = "huaweicloud_workspace_user.test"
-		rName        = acceptance.RandomAccResourceNameWithDash()
-		currentTime  = time.Now().Format("2006-01-02T15:04:05Z")
-	)
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&user,
-		getUserFunc,
+		user              users.UserDetail
+		resourceName      = "huaweicloud_workspace_user.test"
+		withAdminActive   = "huaweicloud_workspace_user.with_admin_active"
+		rc                = acceptance.InitResourceCheck(resourceName, &user, getUserFunc)
+		rcWithAdminActive = acceptance.InitResourceCheck(withAdminActive, &user, getUserFunc)
+
+		rName       = acceptance.RandomAccResourceNameWithDash()
+		currentTime = time.Now().Format("2006-01-02T15:04:05Z")
+		password    = acceptance.RandomPassword()
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -42,36 +42,50 @@ func TestAccUser_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUser_basic(rName),
+				Config: testAccUser_basic_step1(rName, password),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "active_type", "USER_ACTIVATE"),
 					resource.TestCheckResourceAttr(resourceName, "email", "basic@example.com"),
+					resource.TestCheckResourceAttr(resourceName, "phone", "+8612345678987"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Created by acc test"),
 					resource.TestCheckResourceAttr(resourceName, "account_expires", "0"),
 					resource.TestCheckResourceAttr(resourceName, "password_never_expires", "false"),
 					resource.TestCheckResourceAttr(resourceName, "enable_change_password", "true"),
 					resource.TestCheckResourceAttr(resourceName, "next_login_change_password", "true"),
 					resource.TestCheckResourceAttr(resourceName, "disabled", "false"),
+					rcWithAdminActive.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withAdminActive, "active_type", "ADMIN_ACTIVATE"),
+					resource.TestCheckResourceAttr(withAdminActive, "disabled", "true"),
+					resource.TestCheckResourceAttr(withAdminActive, "email", ""),
+					resource.TestCheckResourceAttr(withAdminActive, "phone", "+8612345678978"),
 				),
 			},
 			{
-				Config: testAccUser_update(rName, currentTime),
+				Config: testAccUser_basic_step2(rName, currentTime, password),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "email", "update@example.com"),
+					resource.TestCheckResourceAttr(resourceName, "active_type", "ADMIN_ACTIVATE"),
+					resource.TestCheckResourceAttr(resourceName, "email", ""),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttrSet(resourceName, "account_expires"),
 					resource.TestCheckResourceAttr(resourceName, "password_never_expires", "true"),
 					resource.TestCheckResourceAttr(resourceName, "enable_change_password", "false"),
 					resource.TestCheckResourceAttr(resourceName, "next_login_change_password", "false"),
 					resource.TestCheckResourceAttr(resourceName, "disabled", "true"),
+					rcWithAdminActive.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withAdminActive, "active_type", "USER_ACTIVATE"),
+					resource.TestCheckResourceAttr(withAdminActive, "disabled", "false"),
+					resource.TestCheckResourceAttr(withAdminActive, "phone", ""),
+					resource.TestCheckResourceAttr(withAdminActive, "email", "update@example.com"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
 			},
 		},
 	})
@@ -93,7 +107,7 @@ resource "huaweicloud_workspace_service" "test" {
 `, common.TestBaseNetwork(rName))
 }
 
-func testAccUser_basic(rName string) string {
+func testAccUser_basic_step1(rName, password string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -102,23 +116,38 @@ resource "huaweicloud_workspace_user" "test" {
 
   name        = "%[2]s"
   email       = "basic@example.com"
+  phone       = "+8612345678987"
   description = "Created by acc test"
 
   password_never_expires = false
   disabled               = false
 }
-`, testAccUser_base(rName), rName)
+
+resource "huaweicloud_workspace_user" "with_admin_active" {
+  depends_on = [huaweicloud_workspace_service.test]
+
+  name        = "%[2]s_with_admin"
+  active_type = "ADMIN_ACTIVATE"
+  password    = "%[3]s"
+  phone       = "+8612345678978"
+
+  password_never_expires = false
+  disabled               = true
+}
+`, testAccUser_base(rName), rName, password)
 }
 
-func testAccUser_update(rName, currentTime string) string {
+func testAccUser_basic_step2(rName, currentTime, password string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_workspace_user" "test" {
   depends_on = [huaweicloud_workspace_service.test]
 
-  name  = "%[2]s"
-  email = "update@example.com"
+  name        = "%[2]s"
+  active_type = "ADMIN_ACTIVATE"
+  phone       = "+8612345678987"
+  password    = "%[4]s"
 
   account_expires            = timeadd("%[3]s", "1h")
   password_never_expires     = true
@@ -126,5 +155,16 @@ resource "huaweicloud_workspace_user" "test" {
   next_login_change_password = false
   disabled                   = true
 }
-`, testAccUser_base(rName), rName, currentTime)
+
+resource "huaweicloud_workspace_user" "with_admin_active" {
+  depends_on = [huaweicloud_workspace_service.test]
+
+  name        = "%[2]s_with_admin"
+  active_type = "USER_ACTIVATE"
+  email       = "update@example.com"
+
+  password_never_expires = false
+  disabled               = false
+}
+`, testAccUser_base(rName), rName, currentTime, password)
 }

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_user.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_user.go
@@ -50,9 +50,26 @@ func ResourceUser() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"active_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The activation mode of the user.`,
+			},
 			"email": {
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+			"phone": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The phone number of the user.`,
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: `The initial passowrd of user.`,
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -112,7 +129,10 @@ func translateUTC0Time(timeStr string) (string, error) {
 func buildUserCreateOpts(d *schema.ResourceData) (users.CreateOpts, error) {
 	result := users.CreateOpts{
 		Name:                    d.Get("name").(string),
+		ActiveType:              d.Get("active_type").(string),
 		Email:                   d.Get("email").(string),
+		Phone:                   d.Get("phone").(string),
+		Password:                d.Get("password").(string),
 		Description:             d.Get("description").(string),
 		EnableChangePassword:    utils.Bool(d.Get("enable_change_password").(bool)),
 		NextLoginChangePassword: utils.Bool(d.Get("next_login_change_password").(bool)),
@@ -173,7 +193,9 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
 		d.Set("name", resp.Name),
+		d.Set("active_type", resp.ActiveType),
 		d.Set("email", resp.Email),
+		d.Set("phone", resp.Phone),
 		d.Set("description", resp.Description),
 		d.Set("account_expires", parseUserAccountExpires(resp.AccountExpires)),
 		d.Set("enable_change_password", resp.EnableChangePassword),
@@ -191,7 +213,9 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 
 func buildUserUpdateOpts(d *schema.ResourceData) (users.UpdateOpts, error) {
 	result := users.UpdateOpts{
+		ActiveType:              d.Get("active_type").(string),
 		Email:                   utils.String(d.Get("email").(string)),
+		Phone:                   utils.String(d.Get("phone").(string)),
 		Description:             utils.String(d.Get("description").(string)),
 		EnableChangePassword:    utils.Bool(d.Get("enable_change_password").(bool)),
 		NextLoginChangePassword: utils.Bool(d.Get("next_login_change_password").(bool)),

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_user.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_user.go
@@ -52,7 +52,7 @@ func ResourceUser() *schema.Resource {
 			},
 			"email": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -191,7 +191,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 
 func buildUserUpdateOpts(d *schema.ResourceData) (users.UpdateOpts, error) {
 	result := users.UpdateOpts{
-		Email:                   d.Get("email").(string),
+		Email:                   utils.String(d.Get("email").(string)),
 		Description:             utils.String(d.Get("description").(string)),
 		EnableChangePassword:    utils.Bool(d.Get("enable_change_password").(bool)),
 		NextLoginChangePassword: utils.Bool(d.Get("next_login_change_password").(bool)),

--- a/vendor/github.com/chnsz/golangsdk/openstack/workspace/v2/users/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/workspace/v2/users/requests.go
@@ -6,8 +6,16 @@ import "github.com/chnsz/golangsdk"
 type CreateOpts struct {
 	// User name.
 	Name string `json:"user_name" required:"true"`
+	// The activation mode of the user. Defaults to USER_ACTIVATE.
+	// + USER_ACTIVATE: Activated by the user.
+	// + ADMIN_ACTIVATE: Activated by the administator.
+	ActiveType string `json:"active_type,omitempty"`
 	// User email. The value can contain from 1 to 64 characters.
-	Email string `json:"user_email" required:"true"`
+	Email string `json:"user_email,omitempty"`
+	// Mobile number of the user. At least one of email and phone number must be provided.
+	Phone string `json:"user_phone,omitempty"`
+	// Initial passowrd of the user. The parameter is required for the administator activation mode.
+	Password string `json:"password,omitempty"`
 	// The expires time of Workspace user. The format is "yyyy-MM-ddTHH:mm:ss.000 Z".
 	// 0 means it will never expire.
 	AccountExpires string `json:"account_expires,omitempty"`
@@ -81,10 +89,16 @@ func List(c *golangsdk.ServiceClient, opts ListOpts) (*QueryResp, error) {
 
 // UpdateOpts is the structure required by the Update method to change user information.
 type UpdateOpts struct {
+	// The activation mode of the user.
+	// + USER_ACTIVATE: Activated by the user.
+	// + ADMIN_ACTIVATE: Activated by the administator.
+	ActiveType string `json:"active_type,omitempty"`
 	// User email. The value can contain from 1 to 64 characters.
-	Email string `json:"user_email" required:"true"`
+	Email *string `json:"user_email,omitempty"`
 	// User description.
 	Description *string `json:"description,omitempty"`
+	// Mobile number of the user.
+	Phone *string `json:"user_phone,omitempty"`
 	// The expires time of Workspace user. The format is "yyyy-MM-ddTHH:mm:ss.000Z".
 	// 0 means it will never expire.
 	AccountExpires string `json:"account_expires,omitempty"`

--- a/vendor/github.com/chnsz/golangsdk/openstack/workspace/v2/users/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/workspace/v2/users/results.go
@@ -22,8 +22,14 @@ type UserDetail struct {
 	ID string `json:"id"`
 	// User name.
 	Name string `json:"user_name"`
+	// The activation mode of the user.
+	// + USER_ACTIVATE: Activated by the user.
+	// + ADMIN_ACTIVATE: Activated by the administator.
+	ActiveType string `json:"active_type"`
 	// User email.
 	Email string `json:"user_email"`
+	// Mobile number of the user.
+	Phone string `json:"user_phone"`
 	// User description.
 	Description string `json:"description"`
 	// User SID.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20250217034539-d16a3d7dc780
+# github.com/chnsz/golangsdk v0.0.0-20250218015804-069acf83754c
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Add new parameters are as follows:
  + active_type
  + password
  + phone
2. The email parameter changed from required to optional, and at least one of the phone paramter must be provided.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new parameter.
2. the "email" parameter changed from required to optional.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o workspace -f TestAccUser_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccUser_basic -timeout 360m -parallel 10
=== RUN   TestAccUser_basic
--- PASS: TestAccUser_basic (797.80s)
PASS
coverage: 6.7% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 797.886s        coverage: 6.7% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
