### PR TITLE
feat(dns): add new arguments and attributes for recordsets

### DIFF
--- a/docs/data-sources/dns_recordsets.md
+++ b/docs/data-sources/dns_recordsets.md
@@ -60,6 +60,18 @@ The following arguments are supported:
 
   If not specified, fuzzy matching will be used.
 
+* `sort_key` - (Optional, String) Specifies the sorting field for the list of the recordsets to be queried.  
+  The parameter is left blank by default, indicating that the query results are not sorted.  
+  The valid values are as follows:
+  + **name**: The name of the recordset.
+  + **type**: The type of the recordset.
+
+* `sort_dir` - (Optional, String) Specifies the sorting mode for the list of the recordsets to be queried.  
+  The parameter is left blank by default, indicating that the query results are not sorted.  
+  The valid values are as follows:
+  + **asc**: Ascending order.
+  + **desc**: Descending order.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -96,3 +108,7 @@ The `recordsets` block supports:
 * `line_id` - The resolution line ID. This attribute is only valid when `zone_id` is a public zone ID.
 
 * `weight` - The weight of the recordset. This attribute is only valid when `zone_id` is a public zone ID.
+
+* `created_at` - The creation time of the recordset, in RFC3339 format.
+
+* `updated_at` - The latest update time of the recordset, in RFC3339 format.

--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_recordsets_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_recordsets_test.go
@@ -51,6 +51,11 @@ func TestAccDataRecordsets_basic(t *testing.T) {
 		dcByTags         = acceptance.InitDataSourceCheck(byTags)
 		byNotFoundTags   = "data.huaweicloud_dns_recordsets.filter_by_not_found_tags"
 		dcByNotFoundTags = acceptance.InitDataSourceCheck(byNotFoundTags)
+
+		bySortAsc    = "data.huaweicloud_dns_recordsets.filter_by_sort_asc"
+		dcBySortAsc  = acceptance.InitDataSourceCheck(bySortAsc)
+		bySortDesc   = "data.huaweicloud_dns_recordsets.filter_by_sort_desc"
+		dcBySortDesc = acceptance.InitDataSourceCheck(bySortDesc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -99,6 +104,10 @@ func TestAccDataRecordsets_basic(t *testing.T) {
 					resource.TestCheckOutput("is_tags_filter_useful", "true"),
 					dcByNotFoundTags.CheckResourceExists(),
 					resource.TestCheckOutput("tags_not_found_validation_pass", "true"),
+					// Check the sort results.
+					dcBySortAsc.CheckResourceExists(),
+					dcBySortDesc.CheckResourceExists(),
+					resource.TestCheckOutput("sort_filter_is_useful", "true"),
 					// Check attributes.
 					// The ID of the corresponding resource consists of zone ID and recordset ID.
 					resource.TestCheckResourceAttrSet(byRecordsetId, "recordsets.0.id"),
@@ -110,6 +119,10 @@ func TestAccDataRecordsets_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.records", rName, "records"),
 					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.weight", rName, "weight"),
 					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.description", rName, "description"),
+					resource.TestMatchResourceAttr(byRecordsetId, "recordsets.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(byRecordsetId, "recordsets.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 					// This value is false when created by the Terraform script.
 					resource.TestCheckResourceAttr(byRecordsetId, "recordsets.0.default", "false"),
 				),
@@ -275,6 +288,30 @@ data "huaweicloud_dns_recordsets" "filter_by_not_found_tags" {
 output "tags_not_found_validation_pass" {
   value = length(data.huaweicloud_dns_recordsets.filter_by_not_found_tags.recordsets) == 0
 }
+
+# Sort ascending order using name as the sort field.
+data "huaweicloud_dns_recordsets" "filter_by_sort_asc" {
+  zone_id  = huaweicloud_dns_recordset.test.0.zone_id
+  sort_key = "name"
+  sort_dir = "asc"
+}
+
+# Sort descending order using name as the sort field.
+data "huaweicloud_dns_recordsets" "filter_by_sort_desc" {
+  zone_id  = huaweicloud_dns_recordset.test.0.zone_id
+  sort_key = "name"
+  sort_dir = "desc"
+}
+
+locals {
+  sort_desc_filter_result = data.huaweicloud_dns_recordsets.filter_by_sort_desc.recordsets
+  sort_asc_first_name     = try(data.huaweicloud_dns_recordsets.filter_by_sort_asc.recordsets[0].name, "")
+  sort_desc_last_name     = try(data.huaweicloud_dns_recordsets.filter_by_sort_desc.recordsets[length(local.sort_desc_filter_result) - 1].name, "")
+}
+
+output "sort_filter_is_useful" {
+  value = length(local.sort_desc_filter_result) > 0 && local.sort_asc_first_name == local.sort_desc_last_name
+}
 `)
 }
 
@@ -369,6 +406,11 @@ func TestAccDataRecordsets_private(t *testing.T) {
 		dcByTags         = acceptance.InitDataSourceCheck(byTags)
 		byNotFoundTags   = "data.huaweicloud_dns_recordsets.filter_by_not_found_tags"
 		dcByNotFoundTags = acceptance.InitDataSourceCheck(byNotFoundTags)
+
+		bySortAsc    = "data.huaweicloud_dns_recordsets.filter_by_sort_asc"
+		dcBySortAsc  = acceptance.InitDataSourceCheck(bySortAsc)
+		bySortDesc   = "data.huaweicloud_dns_recordsets.filter_by_sort_desc"
+		dcBySortDesc = acceptance.InitDataSourceCheck(bySortDesc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -412,6 +454,10 @@ func TestAccDataRecordsets_private(t *testing.T) {
 					resource.TestCheckOutput("is_tags_filter_useful", "true"),
 					dcByNotFoundTags.CheckResourceExists(),
 					resource.TestCheckOutput("tags_not_found_validation_pass", "true"),
+					// Check the sort results.
+					dcBySortAsc.CheckResourceExists(),
+					dcBySortDesc.CheckResourceExists(),
+					resource.TestCheckOutput("sort_filter_is_useful", "true"),
 					// Check attributes.
 					// The ID of the corresponding resource consists of zone ID and recordset ID.
 					resource.TestCheckResourceAttrSet(byRecordsetId, "recordsets.0.id"),
@@ -422,6 +468,10 @@ func TestAccDataRecordsets_private(t *testing.T) {
 					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.ttl", rName, "ttl"),
 					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.records", rName, "records"),
 					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.description", rName, "description"),
+					resource.TestMatchResourceAttr(byRecordsetId, "recordsets.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(byRecordsetId, "recordsets.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 					// This value is false when created by the Terraform script.
 					resource.TestCheckResourceAttr(byRecordsetId, "recordsets.0.default", "false"),
 				),

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_recordsets.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_recordsets.go
@@ -73,6 +73,16 @@ func DataSourceRecordsets() *schema.Resource {
 				Optional:    true,
 				Description: `Specifies the query criteria search mode.`,
 			},
+			"sort_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The sorting field for the list of the recordsets to be queried.`,
+			},
+			"sort_dir": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The sorting mode for the list of the recordsets to be queried.`,
+			},
 			"recordsets": {
 				Type:        schema.TypeList,
 				Elem:        recordsetSchema(),
@@ -146,6 +156,16 @@ func recordsetSchema() *schema.Resource {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: `The weight of the recordset.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the recordset, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the recordset, in RFC3339 format.`,
 			},
 		},
 	}
@@ -228,9 +248,33 @@ func flattenListRecordsets(resp interface{}) []interface{} {
 			"default":     utils.PathSearch("default", v, nil),
 			"line_id":     utils.PathSearch("line", v, nil),
 			"weight":      utils.PathSearch("weight", v, nil),
+			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(getZoneCreatedAt(v),
+				"2006-01-02T15:04:05")/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(getZoneUpdatedAt(v),
+				"2006-01-02T15:04:05")/1000, false),
 		}
 	}
 	return rst
+}
+
+func getZoneCreatedAt(resp interface{}) string {
+	// The private recordset response field is `create_at`.
+	// The public recordset response field is `created_at`.
+	createdAt := utils.PathSearch("create_at", resp, "").(string)
+	if createdAt == "" {
+		return utils.PathSearch("created_at", resp, "").(string)
+	}
+	return createdAt
+}
+
+func getZoneUpdatedAt(resp interface{}) string {
+	// The private recordset response field is `update_at`.
+	// The public recordset response field is `updated_at`.
+	createdAt := utils.PathSearch("update_at", resp, "").(string)
+	if createdAt == "" {
+		return utils.PathSearch("updated_at", resp, "").(string)
+	}
+	return createdAt
 }
 
 func buildListRecordsetsQueryParams(d *schema.ResourceData, zoneType string) string {
@@ -261,6 +305,14 @@ func buildListRecordsetsQueryParams(d *schema.ResourceData, zoneType string) str
 
 	if v, ok := d.GetOk("search_mode"); ok {
 		queryParam = fmt.Sprintf("%s&search_mode=%v", queryParam, v)
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		queryParam = fmt.Sprintf("%s&sort_key=%v", queryParam, v)
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		queryParam = fmt.Sprintf("%s&sort_dir=%v", queryParam, v)
 	}
 
 	if queryParam != "" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new arguments and attributes for recordsets.
+ Add new arguments : `sort_key`, `sort_dir`.
+ Add new attributes: `created_at`, `updated_at`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new arguments and attributes for recordsets.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccDatasourceDNSRecordsets_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDatasourceDNSRecordsets_ -timeout 360m -parallel 10
=== RUN   TestAccDatasourceDNSRecordsets_basic
=== PAUSE TestAccDatasourceDNSRecordsets_basic
=== RUN   TestAccDatasourceDNSRecordsets_private
=== PAUSE TestAccDatasourceDNSRecordsets_private
=== CONT  TestAccDatasourceDNSRecordsets_basic
=== CONT  TestAccDatasourceDNSRecordsets_private
--- PASS: TestAccDatasourceDNSRecordsets_basic (192.48s)
--- PASS: TestAccDatasourceDNSRecordsets_private (210.25s)
PASS
coverage: 16.9% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       210.318s        coverage: 16.9% of statements in ./huaweicloud/services/dns
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
