### PR TITLE
fix(dns): fix some issues of the custom line resource

### DIFF
--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_custom_line_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_custom_line_test.go
@@ -94,9 +94,8 @@ func TestAccDNSCustomLine_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
-					resource.TestCheckResourceAttr(rName, "description", "test description update"),
-					resource.TestCheckResourceAttr(rName, "ip_segments.0", "100.100.100.101-100.100.100.101"),
-					resource.TestCheckResourceAttr(rName, "ip_segments.1", "100.100.100.102-100.100.100.102"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "ip_segments.#", "2"),
 				),
 			},
 			{
@@ -122,8 +121,7 @@ func testDNSCustomLine_basic_update(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dns_custom_line" "test" {
   name        = "%s_update"
-  description = "test description update"
-  ip_segments = ["100.100.100.101-100.100.100.101", "100.100.100.102-100.100.100.102"]
+  ip_segments = ["100.100.100.102-100.100.100.102", "100.100.100.101-100.100.100.101"]
 }
 `, name)
 }

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_custom_line.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_custom_line.go
@@ -56,7 +56,7 @@ func ResourceDNSCustomLine() *schema.Resource {
 				Description: `Specifies the custom line name.`,
 			},
 			"ip_segments": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				MinItems:    1,
@@ -66,7 +66,6 @@ func ResourceDNSCustomLine() *schema.Resource {
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Computed:    true,
 				Description: `Specifies the custom line description. A maximum of 255 characters are allowed.`,
 			},
 			"status": {
@@ -150,9 +149,10 @@ func waitForDNSCustomLineCreateOrUpdate(ctx context.Context, customLineClient *g
 
 func buildCreateOrUpdateDNSCustomLineBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
-		"name":        utils.ValueIgnoreEmpty(d.Get("name")),
-		"description": utils.ValueIgnoreEmpty(d.Get("description")),
-		"ip_segments": utils.ValueIgnoreEmpty(d.Get("ip_segments")),
+		"name":        d.Get("name"),
+		"ip_segments": utils.ExpandToStringList(d.Get("ip_segments").(*schema.Set).List()),
+		// When description is updated to empty, the value of this field must be specified as an empty string.
+		"description": d.Get("description"),
 	}
 	return bodyParams
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Fixed the issue that the `description` parameter cannot be modified to empty.
2. Fixed the change problem caused by the inconsistent order of the value specified by the ip_segments parameter and the value returned in the interface.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. delete the Computed of the description parameter.
2. the ip_segments parameter is changed from list type to Set type.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccDNSCustomLine_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDNSCustomLine_basic -timeout 360m -parallel 10
=== RUN   TestAccDNSCustomLine_basic
=== PAUSE TestAccDNSCustomLine_basic
=== CONT  TestAccDNSCustomLine_basic
--- PASS: TestAccDNSCustomLine_basic (53.95s)
PASS
coverage: 7.7% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       54.009s coverage: 7.7% of statements in ./huaweicloud/services/dns
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
