### PR TITLE
feat(CodeArts/Inspector): support to get website scan tasks

### DIFF
--- a/docs/data-sources/codearts_inspector_website_scan_tasks.md
+++ b/docs/data-sources/codearts_inspector_website_scan_tasks.md
@@ -1,0 +1,115 @@
+---
+subcategory: "CodeArts Inspector""
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_codearts_inspector_website_scan_tasks"
+description: |-
+  Use this data source to get the list of CodeArts inspector website scan tasks.
+---
+
+# huaweicloud_codearts_inspector_website_scan_tasks
+
+Use this data source to get the list of CodeArts inspector website scan tasks.
+
+## Example Usage
+
+```hcl
+variable "domain_id" {}
+
+data "huaweicloud_codearts_inspector_website_scan_tasks" "test" {
+  domain_id = var.domain_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_id` - (Required, String) Specifies the domain ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tasks` - Indicates the tasks list.
+
+  The [tasks](#tasks_struct) structure is documented below.
+
+<a name="tasks_struct"></a>
+The `tasks` block supports:
+
+* `task_id` - Indicates the task ID.
+
+* `task_name` - Indicates the task name.
+
+* `task_type` - Indicates the task type.
+  Value can be as follows:
+  + **normal**: Normal task type.
+  + **monitor**: Monitor task type.
+
+* `url` - Indicates the destination URL to scan.
+
+* `task_status` - Indicates the task status.
+  Value can be **running**, **success**, **waiting**, **ready** and **failure**.
+
+* `reason` - Indicates the description of task status.
+
+* `created_at` - Indicates the create time of the task.
+
+* `start_time` - Indicates the start time of the task.
+
+* `end_time` - Indicates the end time of the task.
+
+* `schedule_status` - Indicates the monitor task status.
+  Value can be **running**, **waiting** and **finished**.
+
+* `safe_level` - Indicates the security level.
+  Value can be **safety**, **average** and **highrisk**.
+
+* `progress` - Indicates the task progress.
+
+* `pack_num` - Indicates the total number of packages.
+
+* `score` - Indicates the safety score.
+
+* `domain_name` - Indicates the domain name.
+
+* `high` - Indicates the number of high-risk vulnerabilities.
+
+* `middle` - Indicates the number of medium-risk vulnerabilities.
+
+* `low` - Indicates the number of low-severity vulnerabilities.
+
+* `hint` - Indicates the number of hint-risk vulnerabilities.
+
+* `task_period` - Indicates the scheduled trigger period of the monitor task.
+  Value can be as follows:
+  + **everyday**: Trigger monitor task every day.
+  + **threedays**: Trigger monitor task every three days.
+  + **everyweek**: Trigger monitor task every week.
+  + **everymonth**: Trigger monitor task every month.
+
+* `timer` - Indicates the scheduled trigger time of the normal task.
+
+* `trigger_time` - Indicates the scheduled trigger time of the monitor task.
+
+* `malicious_link` - Indicates whether to perform link health detection.
+
+* `scan_mode` - Indicates the task scan mode.
+  Value can be as follows:
+  + **fast**: Quick scan.
+  + **normal**: Normal scan.
+  + **deep**: Deep scan.
+
+* `port_scan` - Indicates whether to perform port scanning.
+
+* `weak_pwd_scan` - Indicates whether to scan for weak passwords.
+
+* `cve_check` - Indicates whether to perform CVE vulnerability scanning.
+
+* `text_check` - Indicates whether to conduct website content compliance text detection.
+
+* `picture_check` - Indicates whether to conduct website content compliance image detection.
+
+* `malicious_code` - Indicates whether to perform malicious code scanning.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -609,9 +609,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_codearts_deploy_application_deployment_records": codeartsdeploy.DataSourceCodeartsDeployApplicationDeploymentRecords(),
 			"huaweicloud_codearts_deploy_environments":                   codeartsdeploy.DataSourceCodeartsDeployEnvironments(),
 
-			"huaweicloud_codearts_inspector_websites":    codeartsinspector.DataSourceCodeartsInspectorWebsites(),
-			"huaweicloud_codearts_inspector_host_groups": codeartsinspector.DataSourceCodeartsInspectorHostGroups(),
-			"huaweicloud_codearts_inspector_hosts":       codeartsinspector.DataSourceCodeartsInspectorHosts(),
+			"huaweicloud_codearts_inspector_websites":           codeartsinspector.DataSourceCodeartsInspectorWebsites(),
+			"huaweicloud_codearts_inspector_website_scan_tasks": codeartsinspector.DataSourceCodeartsInspectorWebsiteScanTasks(),
+			"huaweicloud_codearts_inspector_host_groups":        codeartsinspector.DataSourceCodeartsInspectorHostGroups(),
+			"huaweicloud_codearts_inspector_hosts":              codeartsinspector.DataSourceCodeartsInspectorHosts(),
 
 			"huaweicloud_cts_notifications": cts.DataSourceNotifications(),
 			"huaweicloud_cts_traces":        cts.DataSourceCtsTraces(),

--- a/huaweicloud/services/acceptance/codeartsinspector/data_source_huaweicloud_codearts_inspector_website_scan_tasks_test.go
+++ b/huaweicloud/services/acceptance/codeartsinspector/data_source_huaweicloud_codearts_inspector_website_scan_tasks_test.go
@@ -1,0 +1,71 @@
+package codeartsinspector
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func TestAccDataSourceCodeartsInspectorWebsiteScanTasks_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_codearts_inspector_website_scan_tasks.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+	timer := utils.FormatTimeStampUTC(time.Now().Add(48 * time.Hour).Unix())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCodeartsInspectorWebsiteScanTasks_basic(rName, timer),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.#"),
+					resource.TestCheckResourceAttr(dataSource, "tasks.0.task_name", rName),
+					resource.TestCheckResourceAttr(dataSource, "tasks.0.task_type", "normal"),
+					resource.TestCheckResourceAttrPair(dataSource, "tasks.0.url",
+						"huaweicloud_codearts_inspector_website.test", "website_address"),
+					resource.TestCheckResourceAttr(dataSource, "tasks.0.timer", timer),
+					resource.TestCheckResourceAttr(dataSource, "tasks.0.scan_mode", "deep"),
+					resource.TestCheckResourceAttr(dataSource, "tasks.0.port_scan", "true"),
+					resource.TestCheckResourceAttr(dataSource, "tasks.0.weak_pwd_scan", "false"),
+					resource.TestCheckResourceAttr(dataSource, "tasks.0.cve_check", "false"),
+					resource.TestCheckResourceAttr(dataSource, "tasks.0.text_check", "false"),
+					resource.TestCheckResourceAttr(dataSource, "tasks.0.picture_check", "false"),
+					resource.TestCheckResourceAttr(dataSource, "tasks.0.malicious_code", "false"),
+					resource.TestCheckResourceAttr(dataSource, "tasks.0.malicious_link", "false"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.task_status"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.progress"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.reason"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.pack_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.score"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.safe_level"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.high"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.middle"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.low"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.hint"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCodeartsInspectorWebsiteScanTasks_basic(name, timer string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_codearts_inspector_website_scan_tasks" "test" {
+  depends_on = [huaweicloud_codearts_inspector_website_scan.test]
+  
+  domain_id = huaweicloud_codearts_inspector_website.test.id
+}
+`, testInspectorWebsiteScan_basic(name, timer))
+}

--- a/huaweicloud/services/codeartsinspector/data_source_huaweicloud_codearts_inspector_website_scan_tasks.go
+++ b/huaweicloud/services/codeartsinspector/data_source_huaweicloud_codearts_inspector_website_scan_tasks.go
@@ -1,0 +1,284 @@
+package codeartsinspector
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API VSS GET /v3/{project_id}/webscan/tasks/histories
+func DataSourceCodeartsInspectorWebsiteScanTasks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCodeartsInspectorWebsiteScanTasksRead,
+
+		Schema: map[string]*schema.Schema{
+			"domain_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the website domain ID.`,
+			},
+			"tasks": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Indicates the tasks list.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"task_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the task ID.`,
+						},
+						"task_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the task name.`,
+						},
+						"task_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the task type.`,
+						},
+						"url": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the destination URL to scan.`,
+						},
+						"task_status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the task status.`,
+						},
+						"reason": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the description of task status.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the create time of the task.`,
+						},
+						"start_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the start time of the task.`,
+						},
+						"end_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the end time of the task.`,
+						},
+						"schedule_status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the monitor task status.`,
+						},
+						"safe_level": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the security level.`,
+						},
+						"high": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the number of high-risk vulnerabilities.`,
+						},
+						"middle": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the number of medium-risk vulnerabilities.`,
+						},
+						"low": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the number of low-severity vulnerabilities.`,
+						},
+						"hint": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the number of hint-risk vulnerabilities.`,
+						},
+						"progress": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the task progress.`,
+						},
+						"pack_num": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the total number of packages.`,
+						},
+						"score": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Indicates the safety score.`,
+						},
+						"domain_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the domain name.`,
+						},
+						"task_period": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the scheduled trigger period of the monitor task.`,
+						},
+						"timer": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the scheduled trigger time of the normal task.`,
+						},
+						"trigger_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the scheduled trigger time of the monitor task.`,
+						},
+						"malicious_link": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Indicates whether to perform link health detection.`,
+						},
+						"scan_mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the task scan mode.`,
+						},
+						"port_scan": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Indicates whether to perform port scanning.`,
+						},
+						"weak_pwd_scan": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Indicates whether to scan for weak passwords.`,
+						},
+						"cve_check": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Indicates whether to perform CVE vulnerability scanning.`,
+						},
+						"text_check": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Indicates whether to conduct website content compliance text detection.`,
+						},
+						"picture_check": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Indicates whether to conduct website content compliance image detection.`,
+						},
+						"malicious_code": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Indicates whether to perform malicious code scanning.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceCodeartsInspectorWebsiteScanTasksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vss", region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts inspector client: %s", err)
+	}
+
+	getHttpUrl := "v3/{project_id}/webscan/tasks/histories"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	// pageLimit is `10`
+	getPath += fmt.Sprintf("?limit=%v", pageLimit)
+	getPath += buildCodeartsInspectorWebsitesQueryParams(d)
+
+	currentTotal := 0
+
+	rst := make([]map[string]interface{}, 0)
+	for {
+		currentPath := getPath + fmt.Sprintf("&offset=%d", currentTotal)
+		getResp, err := client.Request("GET", currentPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving tasks: %s", err)
+		}
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.Errorf("error flatten response: %s", err)
+		}
+
+		tasks := utils.PathSearch("data", getRespBody, make([]interface{}, 0)).([]interface{})
+		for _, task := range tasks {
+			rst = append(rst, flattenCodeartsInspectorWebsiteScanTasks(task))
+		}
+
+		currentTotal += len(tasks)
+		totalCount := utils.PathSearch("total", getRespBody, float64(0))
+		if int(totalCount.(float64)) <= currentTotal {
+			break
+		}
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("tasks", rst),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCodeartsInspectorWebsiteScanTasks(task interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"task_id":         utils.PathSearch("task_id", task, nil),
+		"task_name":       utils.PathSearch("task_name", task, nil),
+		"task_type":       utils.PathSearch("task_type", task, nil),
+		"url":             utils.PathSearch("url", task, nil),
+		"task_period":     utils.PathSearch("task_settings.task_period", task, nil),
+		"timer":           utils.PathSearch("task_settings.timer", task, nil),
+		"trigger_time":    utils.PathSearch("task_settings.trigger_time", task, nil),
+		"malicious_link":  utils.PathSearch("task_settings.task_config.malicious_link", task, nil),
+		"scan_mode":       utils.PathSearch("task_settings.task_config.scan_mode", task, nil),
+		"port_scan":       utils.PathSearch("task_settings.task_config.port_scan", task, nil),
+		"weak_pwd_scan":   utils.PathSearch("task_settings.task_config.weak_pwd_scan", task, nil),
+		"cve_check":       utils.PathSearch("task_settings.task_config.cve_check", task, nil),
+		"text_check":      utils.PathSearch("task_settings.task_config.text_check", task, nil),
+		"picture_check":   utils.PathSearch("task_settings.task_config.picture_check", task, nil),
+		"malicious_code":  utils.PathSearch("task_settings.task_config.malicious_code", task, nil),
+		"task_status":     utils.PathSearch("task_status", task, nil),
+		"reason":          utils.PathSearch("reason", task, nil),
+		"created_at":      utils.PathSearch("create_time", task, nil),
+		"start_time":      utils.PathSearch("start_time", task, nil),
+		"end_time":        utils.PathSearch("end_time", task, nil),
+		"schedule_status": utils.PathSearch("schedule_status", task, nil),
+		"safe_level":      utils.PathSearch("safe_level", task, nil),
+		"progress":        utils.PathSearch("progress", task, nil),
+		"pack_num":        utils.PathSearch("pack_num", task, nil),
+		"score":           utils.PathSearch("score", task, nil),
+		"domain_name":     utils.PathSearch("domain_name", task, nil),
+		"high":            utils.PathSearch("statistics.high", task, nil),
+		"low":             utils.PathSearch("statistics.low", task, nil),
+		"middle":          utils.PathSearch("statistics.middle", task, nil),
+		"hint":            utils.PathSearch("statistics.hint", task, nil),
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to get website scan tasks
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support to get website scan tasks
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/codeartsinspector" TESTARGS="-run TestAccDataSourceCodeartsInspectorWebsiteScanTasks_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codeartsinspector -v -run TestAccDataSourceCodeartsInspectorWebsiteScanTasks_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCodeartsInspectorWebsiteScanTasks_basic
=== PAUSE TestAccDataSourceCodeartsInspectorWebsiteScanTasks_basic
=== CONT  TestAccDataSourceCodeartsInspectorWebsiteScanTasks_basic
--- PASS: TestAccDataSourceCodeartsInspectorWebsiteScanTasks_basic (31.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codeartsinspector 31.437s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
