### PR TITLE
test(dns): adjust the acceptance tests of the recordsets

### DIFF
--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_recordsets_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_recordsets_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDatasourceDNSRecordsets_basic(t *testing.T) {
+func TestAccDatasourceRecordsets_basic(t *testing.T) {
 	rName := "data.huaweicloud_dns_recordsets.test"
 	dc := acceptance.InitDataSourceCheck(rName)
 	name := fmt.Sprintf("acpttest-recordset-%s.com.", acctest.RandString(5))
@@ -20,7 +20,7 @@ func TestAccDatasourceDNSRecordsets_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceDNSRecordsets_basic(name),
+				Config: testAccDatasourceRecordsets_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(rName, "recordsets.0.id"),
@@ -48,7 +48,7 @@ func TestAccDatasourceDNSRecordsets_basic(t *testing.T) {
 	})
 }
 
-func TestAccDatasourceDNSRecordsets_private(t *testing.T) {
+func TestAccDatasourceRecordsets_private(t *testing.T) {
 	rName := "data.huaweicloud_dns_recordsets.test"
 	dc := acceptance.InitDataSourceCheck(rName)
 	name := fmt.Sprintf("acpttest-recordset-%s.com.", acctest.RandString(5))
@@ -58,7 +58,7 @@ func TestAccDatasourceDNSRecordsets_private(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceDNSRecordsets_private(name),
+				Config: testAccDatasourceRecordsets_private(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(rName, "recordsets.0.id"),
@@ -83,7 +83,7 @@ func TestAccDatasourceDNSRecordsets_private(t *testing.T) {
 	})
 }
 
-func testAccDatasourceDNSRecordsets_basic(name string) string {
+func testAccDatasourceRecordsets_basic(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -149,7 +149,7 @@ data "huaweicloud_dns_recordsets" "tags_filter" {
 `, testDNSRecordset_basic(name))
 }
 
-func testAccDatasourceDNSRecordsets_private(name string) string {
+func testAccDatasourceRecordsets_private(name string) string {
 	return fmt.Sprintf(`
 %s
 

--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_recordsets_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_recordsets_test.go
@@ -2,205 +2,465 @@ package dns
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDatasourceRecordsets_basic(t *testing.T) {
-	rName := "data.huaweicloud_dns_recordsets.test"
-	dc := acceptance.InitDataSourceCheck(rName)
-	name := fmt.Sprintf("acpttest-recordset-%s.com.", acctest.RandString(5))
+func TestAccDataRecordsets_basic(t *testing.T) {
+	var (
+		name  = fmt.Sprintf("acpttest-recordset-%s.com.", acctest.RandString(5))
+		rName = "huaweicloud_dns_recordset.test.0"
+
+		dataSource = "data.huaweicloud_dns_recordsets.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byRecordsetId           = "data.huaweicloud_dns_recordsets.filter_by_recordset_id"
+		dcByRecordsetId         = acceptance.InitDataSourceCheck(byRecordsetId)
+		byNotFoundRecordsetId   = "data.huaweicloud_dns_recordsets.filter_by_not_found_recordset_id"
+		dcByNotFoundRecordsetId = acceptance.InitDataSourceCheck(byNotFoundRecordsetId)
+
+		byNameFuzzy      = "data.huaweicloud_dns_recordsets.filter_by_name_fuzzy"
+		dcByNameFuzzy    = acceptance.InitDataSourceCheck(byNameFuzzy)
+		byNameExact      = "data.huaweicloud_dns_recordsets.filter_by_name_exact"
+		dcByNameExact    = acceptance.InitDataSourceCheck(byNameExact)
+		byNotFoundName   = "data.huaweicloud_dns_recordsets.filter_by_not_found_name"
+		dcByNotFoundName = acceptance.InitDataSourceCheck(byNotFoundName)
+
+		byLineId           = "data.huaweicloud_dns_recordsets.filter_by_line_id"
+		dcByLineId         = acceptance.InitDataSourceCheck(byLineId)
+		byNotFoundLineId   = "data.huaweicloud_dns_recordsets.filter_by_not_found_line_id"
+		dcByNotFoundLineId = acceptance.InitDataSourceCheck(byNotFoundLineId)
+
+		byStatus           = "data.huaweicloud_dns_recordsets.filter_by_status"
+		dcByStatus         = acceptance.InitDataSourceCheck(byStatus)
+		byNotFoundStatus   = "data.huaweicloud_dns_recordsets.filter_by_not_found_status"
+		dcByNotFoundStatus = acceptance.InitDataSourceCheck(byNotFoundStatus)
+
+		byType           = "data.huaweicloud_dns_recordsets.filter_by_type"
+		dcByType         = acceptance.InitDataSourceCheck(byType)
+		byNotFoundType   = "data.huaweicloud_dns_recordsets.filter_by_not_found_type"
+		dcByNotFoundType = acceptance.InitDataSourceCheck(byNotFoundType)
+
+		byTags           = "data.huaweicloud_dns_recordsets.filter_by_tags"
+		dcByTags         = acceptance.InitDataSourceCheck(byTags)
+		byNotFoundTags   = "data.huaweicloud_dns_recordsets.filter_by_not_found_tags"
+		dcByNotFoundTags = acceptance.InitDataSourceCheck(byNotFoundTags)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceRecordsets_basic(name),
+				Config:      testAccDataRecordsets_notFound(),
+				ExpectError: regexp.MustCompile(`This zone does not exist`),
+			},
+			{
+				Config: testAccDataRecordsets_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.id"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.name"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.zone_id"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.zone_name"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.type"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.ttl"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.records.#"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.status"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.default"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.line_id"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.weight"),
-
-					resource.TestCheckOutput("line_id_filter_is_useful", "true"),
-					resource.TestCheckOutput("status_filter_is_useful", "true"),
-					resource.TestCheckOutput("type_filter_is_useful", "true"),
-					resource.TestCheckOutput("name_filter_is_useful", "true"),
-					resource.TestCheckOutput("recordset_id_filter_is_useful", "true"),
-
-					resource.TestCheckResourceAttr("data.huaweicloud_dns_recordsets.tags_filter", "recordsets.#", "1"),
+					resource.TestMatchResourceAttr(dataSource, "recordsets.#", regexp.MustCompile(`[1-9][0-9]*`)),
+					// Filter by recordset ID.
+					dcByRecordsetId.CheckResourceExists(),
+					resource.TestCheckOutput("is_recordset_id_filter_useful", "true"),
+					dcByNotFoundRecordsetId.CheckResourceExists(),
+					resource.TestCheckOutput("recordset_id_not_found_validation_pass", "true"),
+					// Fuzzy search by recordset name.
+					dcByNameFuzzy.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_fuzzy_filter_useful", "true"),
+					// Exactly search by recordset name.
+					dcByNameExact.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_exact_filter_useful", "true"),
+					dcByNotFoundName.CheckResourceExists(),
+					resource.TestCheckOutput("name_not_found_validation_pass", "true"),
+					// Filter by line ID.
+					dcByLineId.CheckResourceExists(),
+					resource.TestCheckOutput("is_line_id_filter_useful", "true"),
+					dcByNotFoundLineId.CheckResourceExists(),
+					resource.TestCheckOutput("line_id_not_found_validation_pass", "true"),
+					// Filter by recordset status.
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					dcByNotFoundStatus.CheckResourceExists(),
+					resource.TestCheckOutput("status_not_found_validation_pass", "true"),
+					// Filter by recordset type.
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					dcByNotFoundType.CheckResourceExists(),
+					resource.TestCheckOutput("type_not_found_validation_pass", "true"),
+					// Filter by recordset tags.
+					dcByTags.CheckResourceExists(),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
+					dcByNotFoundTags.CheckResourceExists(),
+					resource.TestCheckOutput("tags_not_found_validation_pass", "true"),
+					// Check attributes.
+					// The ID of the corresponding resource consists of zone ID and recordset ID.
+					resource.TestCheckResourceAttrSet(byRecordsetId, "recordsets.0.id"),
+					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.name", rName, "name"),
+					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.zone_id", rName, "zone_id"),
+					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.zone_name", rName, "zone_name"),
+					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.type", rName, "type"),
+					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.ttl", rName, "ttl"),
+					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.records", rName, "records"),
+					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.weight", rName, "weight"),
+					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.description", rName, "description"),
+					// This value is false when created by the Terraform script.
+					resource.TestCheckResourceAttr(byRecordsetId, "recordsets.0.default", "false"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccDatasourceRecordsets_private(t *testing.T) {
-	rName := "data.huaweicloud_dns_recordsets.test"
-	dc := acceptance.InitDataSourceCheck(rName)
-	name := fmt.Sprintf("acpttest-recordset-%s.com.", acctest.RandString(5))
+func testAccDataRecordsets_notFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dns_recordsets" "test" {
+  zone_id = "%[1]s"
+}
+`, randomId)
+}
+
+func testAccDataRecordsets_base() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dns_recordsets" "test" {
+  zone_id = huaweicloud_dns_recordset.test.0.zone_id
+}
+
+# Filter by recordset ID.
+locals {
+  recordset_id = try(split("/", huaweicloud_dns_recordset.test.0.id)[1], "")
+}
+
+data "huaweicloud_dns_recordsets" "filter_by_recordset_id" {
+  zone_id      = huaweicloud_dns_recordset.test.0.zone_id
+  recordset_id = local.recordset_id
+}
+
+locals {
+  recordset_id_filter_result = [for v in data.huaweicloud_dns_recordsets.filter_by_recordset_id.recordsets[*].id :
+  v == local.recordset_id]
+}
+
+output "is_recordset_id_filter_useful" {
+  value = length(local.recordset_id_filter_result) > 0 && alltrue(local.recordset_id_filter_result)
+}
+
+data "huaweicloud_dns_recordsets" "filter_by_not_found_recordset_id" {
+  zone_id      = huaweicloud_dns_recordset.test.0.zone_id
+  recordset_id = "recordset_id_not_found"
+}
+
+output "recordset_id_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_recordsets.filter_by_not_found_recordset_id.recordsets) == 0
+}
+
+# Filter by recordset name (fuzzy search).
+locals {
+  recordset_name = huaweicloud_dns_recordset.test.0.name
+  name_suffix    = huaweicloud_dns_zone.test.name
+}
+
+data "huaweicloud_dns_recordsets" "filter_by_name_fuzzy" {
+  zone_id = huaweicloud_dns_recordset.test.0.zone_id
+  name    = local.name_suffix
+}
+
+locals {
+  name_fuzzy_filter_result = [for v in data.huaweicloud_dns_recordsets.filter_by_name_fuzzy.recordsets[*].name :
+  strcontains(v, local.name_suffix)]
+}
+
+output "is_name_fuzzy_filter_useful" {
+  value = length(local.name_fuzzy_filter_result) >= 2 && alltrue(local.name_fuzzy_filter_result)
+}
+
+# Filter by recordset name (exact search).
+data "huaweicloud_dns_recordsets" "filter_by_name_exact" {
+  zone_id     = huaweicloud_dns_recordset.test.0.zone_id
+  name        = local.recordset_name
+  search_mode = "equal"
+}
+
+locals {
+  name_exact_filter_result = [for v in data.huaweicloud_dns_recordsets.filter_by_name_exact.recordsets[*].name :
+  v == local.recordset_name]
+}
+
+output "is_name_exact_filter_useful" {
+  value = length(local.name_exact_filter_result) > 0 && alltrue(local.name_exact_filter_result)
+}
+
+data "huaweicloud_dns_recordsets" "filter_by_not_found_name" {
+  zone_id = huaweicloud_dns_recordset.test.0.zone_id
+  name    = "recordset_name_not_found"
+}
+
+output "name_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_recordsets.filter_by_not_found_name.recordsets) == 0
+}
+
+# By filter recordset status.
+data "huaweicloud_dns_recordsets" "filter_by_status" {
+  zone_id = huaweicloud_dns_recordset.test.0.zone_id
+  # In the corresponding resource, the value of status is ENABLE.
+  status = "ACTIVE"
+}
+
+locals {
+  status_filter_result = [for v in data.huaweicloud_dns_recordsets.filter_by_status.recordsets[*].status : v == "ACTIVE"]
+}
+
+output "is_status_filter_useful" {
+  value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
+}
+
+data "huaweicloud_dns_recordsets" "filter_by_not_found_status" {
+  zone_id = huaweicloud_dns_recordset.test.0.zone_id
+  status  = "status_not_found"
+}
+
+output "status_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_recordsets.filter_by_not_found_status.recordsets) == 0
+}
+
+# By filter recordset type.
+locals {
+  recordset_type = huaweicloud_dns_recordset.test.0.type
+}
+
+data "huaweicloud_dns_recordsets" "filter_by_type" {
+  zone_id = huaweicloud_dns_recordset.test.0.zone_id
+  type    = local.recordset_type
+}
+
+locals {
+  type_filter_result = [for v in data.huaweicloud_dns_recordsets.filter_by_type.recordsets[*].type : v == local.recordset_type]
+}
+
+output "is_type_filter_useful" {
+  value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
+}
+
+data "huaweicloud_dns_recordsets" "filter_by_not_found_type" {
+  zone_id = huaweicloud_dns_recordset.test.0.zone_id
+  type    = "type_not_found"
+}
+
+output "type_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_recordsets.filter_by_not_found_type.recordsets) == 0
+}
+
+# Filter by recordset tags.
+data "huaweicloud_dns_recordsets" "filter_by_tags" {
+  zone_id = huaweicloud_dns_recordset.test.0.zone_id
+  tags    = join("|", [for key, value in huaweicloud_dns_recordset.test.0.tags : format("%%v,%%v", key, value)])
+}
+
+output "is_tags_filter_useful" {
+  value = length(data.huaweicloud_dns_recordsets.filter_by_tags.recordsets) >= 2
+}
+
+data "huaweicloud_dns_recordsets" "filter_by_not_found_tags" {
+  zone_id = huaweicloud_dns_recordset.test.0.zone_id
+  tags    = "not_found_tags,not_found"
+}
+
+output "tags_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_recordsets.filter_by_not_found_tags.recordsets) == 0
+}
+`)
+}
+
+func testAccDataRecordsets_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dns_zone" "test" {
+  name      = "%[1]s"
+  zone_type = "public"
+}
+
+resource "huaweicloud_dns_recordset" "test" {
+  count = 2
+
+  zone_id     = huaweicloud_dns_zone.test.id
+  name        = "${count.index}test.%[1]s"
+  type        = "A"
+  description = "Created recordset"
+  ttl         = 300
+  records     = ["10.1.0.0"]
+  line_id     = "Dianxin_Shanxi"
+  weight      = 3
+
+  tags = {
+    key1 = "value1"
+    key2 = "value2"
+  }
+}
+
+%[2]s
+
+# By filter line ID.
+locals {
+  line_id = huaweicloud_dns_recordset.test.0.line_id
+}
+
+data "huaweicloud_dns_recordsets" "filter_by_line_id" {
+  zone_id = huaweicloud_dns_recordset.test.0.zone_id
+  line_id = local.line_id
+}
+
+locals {
+  line_id_filter_result = [for v in data.huaweicloud_dns_recordsets.filter_by_line_id.recordsets[*].line_id :
+  v == local.line_id]
+}
+
+output "is_line_id_filter_useful" {
+  value = length(local.line_id_filter_result) > 0 && alltrue(local.line_id_filter_result)
+}
+
+data "huaweicloud_dns_recordsets" "filter_by_not_found_line_id" {
+  zone_id = huaweicloud_dns_recordset.test.0.zone_id
+  line_id = "line_id_not_found"
+}
+
+output "line_id_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_recordsets.filter_by_not_found_line_id.recordsets) == 0
+}
+`, name, testAccDataRecordsets_base())
+}
+
+func TestAccDataRecordsets_private(t *testing.T) {
+	var (
+		name  = fmt.Sprintf("acpttest-recordset-%s.com.", acctest.RandString(5))
+		rName = "huaweicloud_dns_recordset.test.0"
+
+		dataSource = "data.huaweicloud_dns_recordsets.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byRecordsetId           = "data.huaweicloud_dns_recordsets.filter_by_recordset_id"
+		dcByRecordsetId         = acceptance.InitDataSourceCheck(byRecordsetId)
+		byNotFoundRecordsetId   = "data.huaweicloud_dns_recordsets.filter_by_not_found_recordset_id"
+		dcByNotFoundRecordsetId = acceptance.InitDataSourceCheck(byNotFoundRecordsetId)
+
+		byNameFuzzy      = "data.huaweicloud_dns_recordsets.filter_by_name_fuzzy"
+		dcByNameFuzzy    = acceptance.InitDataSourceCheck(byNameFuzzy)
+		byNameExact      = "data.huaweicloud_dns_recordsets.filter_by_name_exact"
+		dcByNameExact    = acceptance.InitDataSourceCheck(byNameExact)
+		byNotFoundName   = "data.huaweicloud_dns_recordsets.filter_by_not_found_name"
+		dcByNotFoundName = acceptance.InitDataSourceCheck(byNotFoundName)
+
+		byStatus           = "data.huaweicloud_dns_recordsets.filter_by_status"
+		dcByStatus         = acceptance.InitDataSourceCheck(byStatus)
+		byNotFoundStatus   = "data.huaweicloud_dns_recordsets.filter_by_not_found_status"
+		dcByNotFoundStatus = acceptance.InitDataSourceCheck(byNotFoundStatus)
+
+		byType           = "data.huaweicloud_dns_recordsets.filter_by_type"
+		dcByType         = acceptance.InitDataSourceCheck(byType)
+		byNotFoundType   = "data.huaweicloud_dns_recordsets.filter_by_not_found_type"
+		dcByNotFoundType = acceptance.InitDataSourceCheck(byNotFoundType)
+
+		byTags           = "data.huaweicloud_dns_recordsets.filter_by_tags"
+		dcByTags         = acceptance.InitDataSourceCheck(byTags)
+		byNotFoundTags   = "data.huaweicloud_dns_recordsets.filter_by_not_found_tags"
+		dcByNotFoundTags = acceptance.InitDataSourceCheck(byNotFoundTags)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceRecordsets_private(name),
+				Config:      testAccDataRecordsets_notFound(),
+				ExpectError: regexp.MustCompile(`This zone does not exist`),
+			},
+			{
+				Config: testAccDataRecordsets_private(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.id"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.name"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.zone_id"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.zone_name"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.type"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.ttl"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.records.#"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.status"),
-					resource.TestCheckResourceAttrSet(rName, "recordsets.0.default"),
-
-					resource.TestCheckOutput("status_filter_is_useful", "true"),
-					resource.TestCheckOutput("type_filter_is_useful", "true"),
-					resource.TestCheckOutput("name_filter_is_useful", "true"),
-					resource.TestCheckOutput("recordset_id_filter_is_useful", "true"),
-
-					resource.TestCheckResourceAttr("data.huaweicloud_dns_recordsets.tags_filter", "recordsets.#", "1"),
+					resource.TestMatchResourceAttr(dataSource, "recordsets.#", regexp.MustCompile(`[1-9][0-9]*`)),
+					// Filter by recordset ID.
+					dcByRecordsetId.CheckResourceExists(),
+					resource.TestCheckOutput("is_recordset_id_filter_useful", "true"),
+					dcByNotFoundRecordsetId.CheckResourceExists(),
+					resource.TestCheckOutput("recordset_id_not_found_validation_pass", "true"),
+					// Fuzzy search by recordset name.
+					dcByNameFuzzy.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_fuzzy_filter_useful", "true"),
+					// Exactly search by recordset name.
+					dcByNameExact.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_exact_filter_useful", "true"),
+					dcByNotFoundName.CheckResourceExists(),
+					resource.TestCheckOutput("name_not_found_validation_pass", "true"),
+					// Filter by recordset status.
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					dcByNotFoundStatus.CheckResourceExists(),
+					resource.TestCheckOutput("status_not_found_validation_pass", "true"),
+					// Filter by recordset type.
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					dcByNotFoundType.CheckResourceExists(),
+					resource.TestCheckOutput("type_not_found_validation_pass", "true"),
+					// Filter by recordset tags.
+					dcByTags.CheckResourceExists(),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
+					dcByNotFoundTags.CheckResourceExists(),
+					resource.TestCheckOutput("tags_not_found_validation_pass", "true"),
+					// Check attributes.
+					// The ID of the corresponding resource consists of zone ID and recordset ID.
+					resource.TestCheckResourceAttrSet(byRecordsetId, "recordsets.0.id"),
+					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.name", rName, "name"),
+					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.zone_id", rName, "zone_id"),
+					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.zone_name", rName, "zone_name"),
+					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.type", rName, "type"),
+					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.ttl", rName, "ttl"),
+					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.records", rName, "records"),
+					resource.TestCheckResourceAttrPair(byRecordsetId, "recordsets.0.description", rName, "description"),
+					// This value is false when created by the Terraform script.
+					resource.TestCheckResourceAttr(byRecordsetId, "recordsets.0.default", "false"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDatasourceRecordsets_basic(name string) string {
+func testAccDataRecordsets_private(name string) string {
 	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_dns_recordsets" "test" {
-  zone_id = huaweicloud_dns_recordset.test.zone_id
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
 }
 
-data "huaweicloud_dns_recordsets" "line_id_filter" {
-  zone_id = huaweicloud_dns_recordset.test.zone_id
-  line_id = huaweicloud_dns_recordset.test.line_id
-}
-data "huaweicloud_dns_recordsets" "status_filter" {
-  zone_id = huaweicloud_dns_recordset.test.zone_id
-  status  = "ACTIVE"
-}
-data "huaweicloud_dns_recordsets" "type_filter" {
-  zone_id = huaweicloud_dns_recordset.test.zone_id
-  type    = huaweicloud_dns_recordset.test.type
-}
-data "huaweicloud_dns_recordsets" "name_filter" {
-  zone_id = huaweicloud_dns_recordset.test.zone_id
-  name    = huaweicloud_dns_recordset.test.name
-}
-data "huaweicloud_dns_recordsets" "recordset_id_filter" {
-  zone_id      = huaweicloud_dns_recordset.test.zone_id
-  recordset_id = split("/", huaweicloud_dns_recordset.test.id).1
+resource "huaweicloud_dns_zone" "test" {
+  name      = "%[2]s"
+  zone_type = "private"
+
+  router {
+    router_id = huaweicloud_vpc.test.id
+  }
 }
 
-locals {
-  line_id_filter_result = [for v in data.huaweicloud_dns_recordsets.line_id_filter.recordsets[*].line_id :
-v == huaweicloud_dns_recordset.test.line_id]
-  status_filter_result = [for v in data.huaweicloud_dns_recordsets.status_filter.recordsets[*].status : v == "ACTIVE"]
-  type_filter_result = [for v in data.huaweicloud_dns_recordsets.type_filter.recordsets[*].type : v == huaweicloud_dns_recordset.test.type]
-  name_filter_result = [for v in data.huaweicloud_dns_recordsets.name_filter.recordsets[*].name : v == huaweicloud_dns_recordset.test.name]
-  recordset_id_filter_result = [for v in data.huaweicloud_dns_recordsets.recordset_id_filter.recordsets[*].id :
-v == split("/", huaweicloud_dns_recordset.test.id).1]
+resource "huaweicloud_dns_recordset" "test" {
+  count =2
+
+  zone_id     = huaweicloud_dns_zone.test.id
+  name        = "${count.index}test.%[2]s"
+  type        = "A"
+  description = "Created a recordset by script"
+  ttl         = 600
+  records     = ["10.1.0.3"]
+
+  tags = {
+    foo = "bar_private"
+  }
 }
 
-output "line_id_filter_is_useful" {
-  value = alltrue(local.line_id_filter_result) && length(local.line_id_filter_result) > 0
-}
-
-output "status_filter_is_useful" {
-  value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
-}
-
-output "type_filter_is_useful" {
-  value = alltrue(local.type_filter_result) && length(local.type_filter_result) > 0
-}
-
-output "name_filter_is_useful" {
-  value = alltrue(local.name_filter_result) && length(local.name_filter_result) > 0
-}
-
-output "recordset_id_filter_is_useful" {
-  value = alltrue(local.recordset_id_filter_result) && length(local.recordset_id_filter_result) > 0
-}
-
-data "huaweicloud_dns_recordsets" "tags_filter" {
-  zone_id = huaweicloud_dns_recordset.test.zone_id
-  tags    = "key1,value1"
-}
-`, testDNSRecordset_basic(name))
-}
-
-func testAccDatasourceRecordsets_private(name string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_dns_recordsets" "test" {
-  zone_id = huaweicloud_dns_recordset.test.zone_id
-}
-
-data "huaweicloud_dns_recordsets" "status_filter" {
-  zone_id = huaweicloud_dns_recordset.test.zone_id
-  status  = "ACTIVE"
-}
-data "huaweicloud_dns_recordsets" "type_filter" {
-  zone_id = huaweicloud_dns_recordset.test.zone_id
-  type    = huaweicloud_dns_recordset.test.type
-}
-data "huaweicloud_dns_recordsets" "name_filter" {
-  zone_id = huaweicloud_dns_recordset.test.zone_id
-  name    = huaweicloud_dns_recordset.test.name
-}
-data "huaweicloud_dns_recordsets" "recordset_id_filter" {
-  zone_id      = huaweicloud_dns_recordset.test.zone_id
-  recordset_id = split("/", huaweicloud_dns_recordset.test.id).1
-}
-
-locals {
-  status_filter_result = [for v in data.huaweicloud_dns_recordsets.status_filter.recordsets[*].status : v == "ACTIVE"]
-  type_filter_result = [for v in data.huaweicloud_dns_recordsets.type_filter.recordsets[*].type : v == huaweicloud_dns_recordset.test.type]
-  name_filter_result = [for v in data.huaweicloud_dns_recordsets.name_filter.recordsets[*].name : v == huaweicloud_dns_recordset.test.name]
-  recordset_id_filter_result = [for v in data.huaweicloud_dns_recordsets.recordset_id_filter.recordsets[*].id :
-v == split("/", huaweicloud_dns_recordset.test.id).1]
-}
-
-output "status_filter_is_useful" {
-  value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
-}
-
-output "type_filter_is_useful" {
-  value = alltrue(local.type_filter_result) && length(local.type_filter_result) > 0
-}
-
-output "name_filter_is_useful" {
-  value = alltrue(local.name_filter_result) && length(local.name_filter_result) > 0
-}
-
-output "recordset_id_filter_is_useful" {
-  value = alltrue(local.recordset_id_filter_result) && length(local.recordset_id_filter_result) > 0
-}
-
-data "huaweicloud_dns_recordsets" "tags_filter" {
-  zone_id = huaweicloud_dns_recordset.test.zone_id
-  tags    = "foo,bar_private"
-}
-`, testDNSRecordset_privateZone(name))
+%[3]s
+`, acceptance.RandomAccResourceName(), name, testAccDataRecordsets_base())
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Adjust the acceptance tests of the recordsets.
2. Remove the package name from all method names.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
adjust the acceptance tests.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
./scripts/coverage.sh -o dns -f TestAccDatasourceRecordsets_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDatasourceRecordsets_ -timeout 360m -parallel 10
=== RUN   TestAccDatasourceRecordsets_basic
=== PAUSE TestAccDatasourceRecordsets_basic
=== RUN   TestAccDatasourceRecordsets_private
=== PAUSE TestAccDatasourceRecordsets_private
=== CONT  TestAccDatasourceRecordsets_basic
=== CONT  TestAccDatasourceRecordsets_private
--- PASS: TestAccDatasourceRecordsets_basic (269.37s)
--- PASS: TestAccDatasourceRecordsets_private (278.51s)
PASS
coverage: 17.1% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       278.614s        coverage: 17.1% of statements in ./huaweicloud/services/dns
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
