### PR TITLE
refactor(fgs/dependency): using auto-gen style to replace the old coding

### DIFF
--- a/docs/data-sources/fgs_dependencies.md
+++ b/docs/data-sources/fgs_dependencies.md
@@ -2,26 +2,27 @@
 subcategory: "FunctionGraph"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_fgs_dependencies"
-description: ""
+description: |-
+  Use this data source to query dependency packages within HuaweiCloud.
 ---
 
 # huaweicloud_fgs_dependencies
 
-Use this data source to filter dependent packages of FGS from HuaweiCloud.
+Use this data source to query dependency packages within HuaweiCloud.
 
-~> Between `1.64.2` and `1.72.1`., the version list of each dependent package is queried by default.
+~> Between `1.64.2` and `1.72.1`, the version list of each dependency package is queried by default.
    <br>This will cause the query to take up a lot of time and may trigger flow control.
    <br>There are not recommended to use.
 
 ## Example Usage
 
-### Obtain all public dependent packages
+### Obtain all public dependency packages
 
 ```hcl
 data "huaweicloud_fgs_dependencies" "test" {}
 ```
 
-### Obtain specific public dependent package by name
+### Obtain specific public dependency package by name
 
 ```hcl
 data "huaweicloud_fgs_dependencies" "test" {
@@ -30,7 +31,7 @@ data "huaweicloud_fgs_dependencies" "test" {
 }
 ```
 
-### Obtain all public Python2.7 dependent packages
+### Obtain all public Python2.7 dependency packages
 
 ```hcl
 data "huaweicloud_fgs_dependencies" "test" {
@@ -41,49 +42,73 @@ data "huaweicloud_fgs_dependencies" "test" {
 
 ## Argument Reference
 
-* `region` - (Optional, String) Specifies the region in which to obtain the dependent packages. If omitted, the
-  provider-level region will be used.
+* `region` - (Optional, String) Specifies the region where the dependency packages are located.  
+  If omitted, the provider-level region will be used.
 
-* `type` - (Optional, String) Specifies the dependent package type to match. Valid values: **public** and **private**.
+* `type` - (Optional, String) Specifies the type of the dependency package.  
+  The valid values are as follows:
+  + **public**
+  + **private**
 
-* `runtime` - (Optional, String) Specifies the dependent package runtime to match. Valid values: **Java8**,
-  **Node.js6.10**, **Node.js8.10**, **Node.js10.16**, **Node.js12.13**, **Python2.7**, **Python3.6**, **Go1.8**,
-  **Go1.x**, **C#(.NET Core 2.0)**, **C#(.NET Core 2.1)**, **C#(.NET Core 3.1)** and **PHP7.3**.
+* `runtime` - (Optional, String) Specifies the runtime of the dependency package.  
+  The valid values are as follows:
+  + **Java8**
+  + **Java11**
+  + **Node.js6.10**
+  + **Node.js8.10**
+  + **Node.js10.16**
+  + **Node.js12.13**
+  + **Node.js14.18**
+  + **Node.js16.17**
+  + **Node.js18.15**
+  + **Python2.7**
+  + **Python3.6**
+  + **Python3.9**
+  + **Python3.10**
+  + **Go1.x**
+  + **C#(.NET Core 2.0)**
+  + **C#(.NET Core 2.1)**
+  + **C#(.NET Core 3.1)**
+  + **Custom**
+  + **PHP7.3**
+  + **Cangjie1.0**
+  + **http**
+  + **Custom Image**
 
-* `name` - (Optional, String) Specifies the dependent package runtime to match.
+* `name` - (Optional, String) Specifies the name of the dependency package.
 
-* `is_versions_query_allowed` - (Optional, Bool) Specifies whether to query the versions of each dependent package.
+* `is_versions_query_allowed` - (Optional, Bool) Specifies whether to query the versions of each dependency package.
   Defaults to **false**.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - A data source ID.
+* `id` - The data source ID.
 
-* `packages` - All dependent packages that match.
+* `packages` - All dependency packages that match the filter parameters.
   The [packages](#dependency_packages) structure is documented below.
 
 <a name="dependency_packages"></a>
 The `packages` block supports:
 
-* `id` - Dependent package ID.
+* `id` - The ID of the dependency package.
 
-* `name` - Dependent package name.
+* `name` - The name of the dependency package.
 
-* `owner` - Dependent package owner.
+* `owner` - The owner of the dependency package.
 
-* `link` - URL of the dependent package in the OBS console.
+* `link` - The OBS bucket path where the dependency package is located (FunctionGraph serivce side).
 
-* `etag` - Unique ID of the dependent package.
+* `etag` - The unique ID of the dependency package.
 
-* `size` - Dependent package size.
+* `size` - The size of the dependency package.
 
-* `file_name` - File name of the Dependent package.
+* `file_name` - The file name of the stored dependency package.
 
-* `runtime` - Dependent package runtime.
+* `runtime` - The runtime of the dependency package.
 
-* `versions` - The list of the versions.
+* `versions` - The list of the versions for the dependency package.
   The [versions](#dependency_versions) structure is documented below.
 
 <a name="dependency_versions"></a>

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -823,7 +823,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_fgs_applications":          fgs.DataSourceApplications(),
 			"huaweicloud_fgs_application_templates": fgs.DataSourceApplicationTemplates(),
-			"huaweicloud_fgs_dependencies":          fgs.DataSourceFunctionGraphDependencies(),
+			"huaweicloud_fgs_dependencies":          fgs.DataSourceDependencies(),
 			"huaweicloud_fgs_dependency_versions":   fgs.DataSourceDependencieVersions(),
 			"huaweicloud_fgs_function_events":       fgs.DataSourceFunctionEvents(),
 			"huaweicloud_fgs_function_triggers":     fgs.DataSourceFunctionTriggers(),

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependencies_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependencies_test.go
@@ -1,6 +1,7 @@
 package fgs
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -9,98 +10,171 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccFunctionGraphDependencies_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_fgs_dependencies.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFunctionGraphDependenciesBasic,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(dataSourceName, "packages.#", regexp.MustCompile(`[1-9][0-9]*`)),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFunctionGraphDependencies_filterByName(t *testing.T) {
+func TestAccDataDependencies_basic(t *testing.T) {
 	var (
-		byName   = "data.huaweicloud_fgs_dependencies.filter_by_name"
-		notFound = "data.huaweicloud_fgs_dependencies.not_found"
+		base = "huaweicloud_fgs_dependency_version.test"
 
-		dcByName   = acceptance.InitDataSourceCheck(byName)
-		dcNotFound = acceptance.InitDataSourceCheck(notFound)
+		all                  = "data.huaweicloud_fgs_dependencies.all"
+		dcForAllDependencies = acceptance.InitDataSourceCheck(all)
+
+		byType   = "data.huaweicloud_fgs_dependencies.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+
+		byName                    = "data.huaweicloud_fgs_dependencies.filter_by_name"
+		dcByName                  = acceptance.InitDataSourceCheck(byName)
+		byNotFoundName            = "data.huaweicloud_fgs_dependencies.filter_by_not_found_name"
+		dcByNotFoundName          = acceptance.InitDataSourceCheck(byNotFoundName)
+		byNameWithVersionsQuery   = "data.huaweicloud_fgs_dependencies.filter_by_name_with_versions_query"
+		dcByNameWithVersionsQuery = acceptance.InitDataSourceCheck(byNameWithVersionsQuery)
+
+		byRuntime   = "data.huaweicloud_fgs_dependencies.filter_by_runtime"
+		dcByRuntime = acceptance.InitDataSourceCheck(byRuntime)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckFgsDependencyLink(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFunctionGraphDependenciesName,
+				Config:      testAccDataDependencies_invalidRuntime,
+				ExpectError: regexp.MustCompile(`Invalid runtime.`),
+			},
+			{
+				Config: testAccDataDependencies_basic(),
 				Check: resource.ComposeTestCheckFunc(
+					// Without filter parameters.
+					dcForAllDependencies.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "packages.#", regexp.MustCompile(`[1-9][0-9]*`)),
+					// Filter by dependency type.
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					// Filter by dependency name.
 					dcByName.CheckResourceExists(),
 					resource.TestCheckOutput("is_name_filter_useful", "true"),
-					resource.TestMatchResourceAttr(byName, "packages.0.versions.#", regexp.MustCompile(`[1-9][0-9]*`)),
-					resource.TestCheckResourceAttrSet(byName, "packages.0.versions.0.id"),
-					resource.TestCheckResourceAttrSet(byName, "packages.0.versions.0.version"),
-					dcNotFound.CheckResourceExists(),
-					resource.TestCheckOutput("not_found_validation_pass", "true"),
+					dcByNotFoundName.CheckResourceExists(),
+					resource.TestCheckOutput("name_not_found_validation_pass", "true"),
+					dcByNameWithVersionsQuery.CheckResourceExists(),
+					resource.TestCheckOutput("is_versions_query_allowed_param_useful", "true"),
+					// Filter by dependency runtime.
+					dcByRuntime.CheckResourceExists(),
+					resource.TestCheckOutput("is_runtime_filter_useful", "true"),
+					// Check attributes.
+					// The behavior of the filter parameter 'name' is exact match.
+					resource.TestCheckResourceAttrPair(byName, "packages.0.id", base, "dependency_id"),
+					resource.TestCheckResourceAttrPair(byName, "packages.0.name", base, "name"),
+					resource.TestCheckResourceAttrPair(byName, "packages.0.owner", base, "owner"),
+					// The link will be replaced with a new link which belongs to the FunctionGraph service.
+					resource.TestCheckResourceAttrSet(byName, "packages.0.link"),
+					resource.TestCheckResourceAttrPair(byName, "packages.0.etag", base, "etag"),
+					resource.TestCheckResourceAttrPair(byName, "packages.0.size", base, "size"),
+					resource.TestCheckResourceAttrPair(byName, "packages.0.runtime", base, "runtime"),
+					// The dependency version does not have the parameter 'file_name'.
+					resource.TestCheckResourceAttrSet(byName, "packages.0.file_name"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccFunctionGraphDependencies_runtime(t *testing.T) {
-	dataSourceName := "data.huaweicloud_fgs_dependencies.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFunctionGraphDependenciesRuntime,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "type", "public"),
-					resource.TestCheckResourceAttr(dataSourceName, "runtime", "Python2.7"),
-					resource.TestMatchResourceAttr(dataSourceName, "packages.#", regexp.MustCompile(`[1-9][0-9]*`)),
-				),
-			},
-		},
-	})
-}
-
-const testAccFunctionGraphDependenciesBasic = `data "huaweicloud_fgs_dependencies" "test" {}`
-
-const testAccFunctionGraphDependenciesName = `
-data "huaweicloud_fgs_dependencies" "filter_by_name" {
-  type = "public"
-  name = "obssdk-3.0.2"
-}
-
-locals {
-  filter_result = [for v in data.huaweicloud_fgs_dependencies.filter_by_name.packages[*].name : v == "obssdk-3.0.2"]
-}
-
-output "is_name_filter_useful" {
-  value = length(local.filter_result) > 0
-}
-
-data "huaweicloud_fgs_dependencies" "not_found" {
-  type = "public"
-  name = "not_found"
-}
-
-output "not_found_validation_pass" {
-  value = length(data.huaweicloud_fgs_dependencies.not_found.packages) == 0
+const testAccDataDependencies_invalidRuntime = `
+data "huaweicloud_fgs_dependencies" "invalid_runtime" {
+  runtime = "runtime_not_found"
 }
 `
 
-const testAccFunctionGraphDependenciesRuntime = `data "huaweicloud_fgs_dependencies" "test" {
-  type    = "public"
-  runtime = "Python2.7"
-}`
+func testAccDataDependencies_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_fgs_dependencies" "all" {}
+
+# Filter by dependency type.
+locals {
+  dependency_type = "public"
+}
+
+data "huaweicloud_fgs_dependencies" "filter_by_type" {
+  type = local.dependency_type
+}
+
+output "is_type_filter_useful" {
+  value = length(data.huaweicloud_fgs_dependencies.filter_by_type.packages) > 0
+}
+
+# Filter by dependency name.
+locals {
+  dependency_name = huaweicloud_fgs_dependency_version.test.name
+}
+
+data "huaweicloud_fgs_dependencies" "filter_by_name" {
+  # The behavior of parameter 'name' of the application resource is 'Required', means this parameter does not
+  # have 'Know After Apply' behavior.
+  depends_on = [
+    huaweicloud_fgs_dependency_version.test,
+  ]
+
+  name = local.dependency_name
+}
+
+data "huaweicloud_fgs_dependencies" "filter_by_not_found_name" {
+  name = "name_not_found"
+}
+
+data "huaweicloud_fgs_dependencies" "filter_by_name_with_versions_query" {
+  # The behavior of parameter 'name' of the application resource is 'Required', means this parameter does not
+  # have 'Know After Apply' behavior.
+  depends_on = [
+    huaweicloud_fgs_dependency_version.test,
+  ]
+
+  name                      = huaweicloud_fgs_dependency_version.test.name
+  is_versions_query_allowed = true
+}
+
+locals {
+  name_filter_result = [for v in data.huaweicloud_fgs_dependencies.filter_by_name.packages[*].name :
+    v == local.dependency_name]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+output "name_not_found_validation_pass" {
+  value = length(data.huaweicloud_fgs_dependencies.filter_by_not_found_name.packages) == 0
+}
+
+locals {
+  name_filter_with_versions_query_result = data.huaweicloud_fgs_dependencies.filter_by_name_with_versions_query.packages[0].versions
+}
+
+output "is_versions_query_allowed_param_useful" {
+  value = length(local.name_filter_with_versions_query_result) > 0 && alltrue([
+	for v in local.name_filter_with_versions_query_result : v.id != "" && v.version != 0
+  ])
+}	
+
+# Filter by dependency runtime.
+locals {
+  dependency_runtime = data.huaweicloud_fgs_dependencies.all.packages[0].runtime
+}
+
+data "huaweicloud_fgs_dependencies" "filter_by_runtime" {
+  runtime = local.dependency_runtime
+}
+
+locals {
+  runtime_filter_result = [for v in data.huaweicloud_fgs_dependencies.filter_by_runtime.packages[*].runtime :
+    v == local.dependency_runtime]
+}
+
+output "is_runtime_filter_useful" {
+  value = length(local.runtime_filter_result) > 0 && alltrue(local.runtime_filter_result)
+}
+`, testAccDependencyVersion_basic(name))
+}

--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_dependencies.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_dependencies.go
@@ -2,7 +2,9 @@ package fgs
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
@@ -11,22 +13,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API FunctionGraph GET /v2/{project_id}/fgs/dependencies
-// DataSourceFunctionGraphDependencies provides some parameters to filter dependent packages on the server.
-func DataSourceFunctionGraphDependencies() *schema.Resource {
+// DataSourceDependencies provides some parameters to filter dependent packages on the server.
+func DataSourceDependencies() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceFunctionGraphDependenciesRead,
+		ReadContext: dataSourceDependenciesRead,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the dependency packages are located.`,
 			},
 			"type": {
 				Type:     schema.TypeString,
@@ -34,18 +37,22 @@ func DataSourceFunctionGraphDependencies() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"public", "private",
 				}, false),
+				Description: `The type of the dependency package.`,
 			},
 			"runtime": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The runtime of the dependency package.`,
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the dependency package.`,
 			},
 			"is_versions_query_allowed": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to query the versions of each dependency package.`,
 			},
 			"packages": {
 				Type:     schema.TypeList,
@@ -53,36 +60,44 @@ func DataSourceFunctionGraphDependencies() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the dependency package.`,
 						},
 						"name": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the dependency package.`,
 						},
 						"owner": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The owner of the dependency package.`,
 						},
 						"link": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The OBS bucket path where the dependency package is located (FunctionGraph serivce side).`,
 						},
 						"etag": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The unique ID of the dependency package.`,
 						},
 						"size": {
-							Type:     schema.TypeInt,
-							Computed: true,
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The size of the dependency package.`,
 						},
 						"file_name": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The file name of the stored dependency package.`,
 						},
 						"runtime": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The runtime of the dependency package.`,
 						},
 						"versions": {
 							Type:     schema.TypeList,
@@ -101,31 +116,93 @@ func DataSourceFunctionGraphDependencies() *schema.Resource {
 									},
 								},
 							},
+							Description: `The list of the versions for the dependency package.`,
 						},
 					},
 				},
+				Description: `All dependency packages that match the filter parameters.`,
 			},
 		},
 	}
 }
 
-func dataSourceFunctionGraphDependenciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.FgsV2Client(region)
-	if err != nil {
-		return diag.Errorf("error creating FunctionGraph v2 client: %s", err)
+func buildDependenciesQueryParams(d *schema.ResourceData) string {
+	result := ""
+
+	if pkgType, ok := d.GetOk("type"); ok {
+		result = fmt.Sprintf("%s&dependency_type=%v", result, pkgType)
 	}
-	// Limit and Marker use default values.
-	listOpts := dependencies.ListOpts{
-		Name:           d.Get("name").(string),
-		Runtime:        d.Get("runtime").(string),
-		DependencyType: d.Get("type").(string),
+	if pkgRuntime, ok := d.GetOk("runtime"); ok {
+		result = fmt.Sprintf("%s&runtime=%v", result, pkgRuntime)
+	}
+	if pkgName, ok := d.GetOk("name"); ok {
+		result = fmt.Sprintf("%s&name=%v", result, pkgName)
 	}
 
-	allPages, err := dependencies.List(client, listOpts).AllPages()
+	return result
+}
+
+func getDependencies(client *golangsdk.ServiceClient, queryParams ...string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/fgs/dependencies?maxitems=100"
+		marker  float64
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	if len(queryParams) > 0 {
+		listPath += queryParams[0]
+	}
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithMarker := fmt.Sprintf("%s&marker=%v", listPath, marker)
+		requestResp, err := client.Request("GET", listPathWithMarker, &listOpt)
+		if err != nil {
+			return nil, fmt.Errorf("error querying dependency packages: %s", err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		dependencies := utils.PathSearch("dependencies", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dependencies) < 1 {
+			break
+		}
+		result = append(result, dependencies...)
+		// In this API, marker has the same meaning as offset.
+		nextMarker := utils.PathSearch("next_marker", respBody, float64(0)).(float64)
+		if nextMarker == marker || nextMarker == 0 {
+			// Make sure the next marker value is correct, not the previous marker or zero (in the last page).
+			break
+		}
+		marker = nextMarker
+	}
+
+	return result, nil
+}
+
+func dataSourceDependenciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
 	if err != nil {
-		return diag.Errorf("error retrieving dependent packages: %s", err)
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	dependencies, err := getDependencies(client, buildDependenciesQueryParams(d))
+	if err != nil {
+		return diag.Errorf("error retrieving dependency packages: %s", err)
 	}
 
 	randUUID, err := uuid.GenerateUUID()
@@ -134,60 +211,57 @@ func dataSourceFunctionGraphDependenciesRead(_ context.Context, d *schema.Resour
 	}
 	d.SetId(randUUID)
 
-	resp, _ := dependencies.ExtractDependencies(allPages)
-	packages := flatFunctionGraphDependencies(client, resp.Dependencies, d.Get("is_versions_query_allowed").(bool))
 	mErr := multierror.Append(
-		d.Set("packages", packages),
+		d.Set("packages", flattenDependencies(client, dependencies, d.Get("is_versions_query_allowed").(bool))),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error setting packages of FunctionGraph dependencies: %s", err)
+		return diag.Errorf("error saving data source fields of the dependency packages: %s", err)
 	}
 	return nil
 }
 
-func flatFunctionGraphDependencies(client *golangsdk.ServiceClient, pkgs []dependencies.Dependency,
+func flattenDependencies(client *golangsdk.ServiceClient, dependencies []interface{},
 	isVersionsQueryAllowed bool) []map[string]interface{} {
-	packages := make([]map[string]interface{}, len(pkgs))
+	result := make([]map[string]interface{}, 0, len(dependencies))
 
-	names := schema.NewSet(schema.HashString, nil)
-	for i, pkg := range pkgs {
-		names.Add(pkg.Name)
+	for _, dependency := range dependencies {
+		dependencyId := utils.PathSearch("id", dependency, "").(string)
 		elem := map[string]interface{}{
-			"id":        pkg.ID,
-			"name":      pkg.Name,
-			"owner":     pkg.Owner,
-			"link":      pkg.Link,
-			"etag":      pkg.Etag,
-			"size":      pkg.Size,
-			"file_name": pkg.FileName,
-			"runtime":   pkg.Runtime,
+			"id":        dependencyId,
+			"name":      utils.PathSearch("name", dependency, nil),
+			"owner":     utils.PathSearch("owner", dependency, nil),
+			"link":      utils.PathSearch("link", dependency, nil),
+			"etag":      utils.PathSearch("etag", dependency, nil),
+			"size":      utils.PathSearch("size", dependency, nil),
+			"file_name": utils.PathSearch("file_name", dependency, nil),
+			"runtime":   utils.PathSearch("runtime", dependency, nil),
 		}
 
-		if isVersionsQueryAllowed {
-			elem["versions"] = flattenPckVersions(client, pkg.ID)
+		if isVersionsQueryAllowed && dependencyId != "" {
+			dependencyVersions, err := getDependencyVersions(client, dependencyId)
+			if err != nil {
+				log.Printf("error retrieving versions under specified dependency package (%s): %s", dependencyId, err)
+			} else {
+				elem["versions"] = flattenDependencyVersionInfos(dependencyVersions)
+			}
 		}
-		packages[i] = elem
+		result = append(result, elem)
 	}
 
-	return packages
+	return result
 }
 
-func flattenPckVersions(client *golangsdk.ServiceClient, dependencyId string) []map[string]interface{} {
-	listOpts := dependencies.ListVersionsOpts{
-		DependId: dependencyId,
-	}
-	dependencyVersions, err := dependencies.ListVersions(client, listOpts)
-	if err != nil {
-		log.Printf("error retrieving versions under specified dependency package (%s): %s", dependencyId, err)
+func flattenDependencyVersionInfos(dependencyVersions []interface{}) []map[string]interface{} {
+	if len(dependencyVersions) < 1 {
 		return nil
 	}
 
 	result := make([]map[string]interface{}, len(dependencyVersions))
-	for i, version := range dependencyVersions {
-		result[i] = map[string]interface{}{
-			"id":      version.ID,
-			"version": version.Version,
-		}
+	for _, dependencyVersion := range dependencyVersions {
+		result = append(result, map[string]interface{}{
+			"id":      utils.PathSearch("id", dependencyVersion, nil),
+			"version": int(utils.PathSearch("version", dependencyVersion, float64(0)).(float64)),
+		})
 	}
 
 	return result

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency_version.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency_version.go
@@ -266,43 +266,6 @@ func resourceDependencyVersionDelete(_ context.Context, d *schema.ResourceData, 
 	return nil
 }
 
-func getDependencies(client *golangsdk.ServiceClient) ([]interface{}, error) {
-	var (
-		httpUrl = "v2/{project_id}/fgs/dependencies?maxitems=100"
-		marker  = 0
-	)
-
-	listPath := client.Endpoint + httpUrl
-	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
-	listOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-		},
-	}
-
-	result := make([]interface{}, 0)
-	for {
-		listPathWithMarker := fmt.Sprintf("%s&&marker=%v", listPath, marker)
-		requestResp, err := client.Request("GET", listPathWithMarker, &listOpt)
-		if err != nil {
-			return nil, fmt.Errorf("error querying dependency packages: %s", err)
-		}
-		respBody, err := utils.FlattenResponse(requestResp)
-		if err != nil {
-			return nil, err
-		}
-		dependencies := utils.PathSearch("dependencies", respBody, make([]interface{}, 0)).([]interface{})
-		if len(dependencies) < 1 {
-			break
-		}
-		result = append(result, dependencies...)
-		marker += len(dependencies)
-	}
-
-	return result, nil
-}
-
 func getDependencyVersions(client *golangsdk.ServiceClient, dependId string) ([]interface{}, error) {
 	var (
 		httpUrl = "v2/{project_id}/fgs/dependencies/{depend_id}/version?maxitems=100"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adjust the acceptance test and union three tests to a new basic test.
![image](https://github.com/user-attachments/assets/cd153e9c-7647-4719-a61c-0f0b950800c6)

Using auto-generate style to replace the data source coding.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. adjust the acceptance tests of the FunctionGraph dependency packages data source.
2. using auto-gen style to replace the old coding.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccDataDependencies_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataDependencies_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDependencies_basic
=== PAUSE TestAccDataDependencies_basic
=== CONT  TestAccDataDependencies_basic
--- PASS: TestAccDataDependencies_basic (15.89s)
PASS
coverage: 11.2% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       15.990s coverage: 11.2% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
