### PR TITLE
refactor(fgs/datasource): unified the function naming and test steps

### DIFF
--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_application_templates_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_application_templates_test.go
@@ -14,14 +14,14 @@ func TestAccDataApplicationTemplates_basic(t *testing.T) {
 		all               = "data.huaweicloud_fgs_application_templates.all"
 		dcForAllTemplates = acceptance.InitDataSourceCheck(all)
 
-		byRuntime           = "data.huaweicloud_fgs_application_templates.filter_by_app_runtime"
+		byRuntime           = "data.huaweicloud_fgs_application_templates.filter_by_runtime"
 		dcByRuntime         = acceptance.InitDataSourceCheck(byRuntime)
-		byNotFoundRuntime   = "data.huaweicloud_fgs_application_templates.filter_by_not_found_app_runtime"
+		byNotFoundRuntime   = "data.huaweicloud_fgs_application_templates.filter_by_not_found_runtime"
 		dcByNotFoundRuntime = acceptance.InitDataSourceCheck(byNotFoundRuntime)
 
-		byCategory           = "data.huaweicloud_fgs_application_templates.filter_by_app_category"
+		byCategory           = "data.huaweicloud_fgs_application_templates.filter_by_category"
 		dcByCategory         = acceptance.InitDataSourceCheck(byCategory)
-		byNotFoundCategory   = "data.huaweicloud_fgs_application_templates.filter_by_not_found_app_category"
+		byNotFoundCategory   = "data.huaweicloud_fgs_application_templates.filter_by_not_found_category"
 		dcByNotFoundCategory = acceptance.InitDataSourceCheck(byNotFoundCategory)
 	)
 
@@ -32,19 +32,20 @@ func TestAccDataApplicationTemplates_basic(t *testing.T) {
 			{
 				Config: testAccDataApplicationTemplates_basic,
 				Check: resource.ComposeTestCheckFunc(
+					// Without filter parameters.
 					dcForAllTemplates.CheckResourceExists(),
 					resource.TestMatchResourceAttr(all, "templates.#", regexp.MustCompile(`[1-9][0-9]*`)),
 					// Filter by application runtime.
 					dcByRuntime.CheckResourceExists(),
-					resource.TestCheckOutput("is_app_runtime_filter_useful", "true"),
+					resource.TestCheckOutput("is_runtime_filter_useful", "true"),
 					dcByNotFoundRuntime.CheckResourceExists(),
-					resource.TestCheckOutput("app_runtime_not_found_validation_pass", "true"),
+					resource.TestCheckOutput("runtime_not_found_validation_pass", "true"),
 					// Filter by application category.
 					dcByCategory.CheckResourceExists(),
-					resource.TestCheckOutput("is_app_category_filter_useful", "true"),
+					resource.TestCheckOutput("is_category_filter_useful", "true"),
 					dcByNotFoundCategory.CheckResourceExists(),
-					resource.TestCheckOutput("app_category_not_found_validation_pass", "true"),
-					// Check attributes.
+					resource.TestCheckOutput("category_not_found_validation_pass", "true"),
+					// Check the attributes.
 					resource.TestCheckResourceAttrSet(all, "templates.0.id"),
 					resource.TestCheckResourceAttrSet(all, "templates.0.name"),
 					resource.TestCheckResourceAttrSet(all, "templates.0.runtime"),
@@ -61,55 +62,55 @@ const testAccDataApplicationTemplates_basic = `
 # Without any filter parameter.
 data "huaweicloud_fgs_application_templates" "all" {}
 
-// Filter by application runtime.
+# Filter by application runtime.
 locals {
-  app_runtime = data.huaweicloud_fgs_application_templates.all.templates[0].runtime
+  application_runtime = data.huaweicloud_fgs_application_templates.all.templates[0].runtime
 }
 
-data "huaweicloud_fgs_application_templates" "filter_by_app_runtime" {
-  runtime = local.app_runtime
+data "huaweicloud_fgs_application_templates" "filter_by_runtime" {
+  runtime = local.application_runtime
 }
 
-data "huaweicloud_fgs_application_templates" "filter_by_not_found_app_runtime" {
-  runtime = "app_runtime_not_found"
-}
-
-locals {
-  app_runtime_filter_result = [for v in data.huaweicloud_fgs_application_templates.filter_by_app_runtime.templates[*].runtime :
-    v == local.app_runtime]
-}
-
-output "is_app_runtime_filter_useful" {
-  value = length(local.app_runtime_filter_result) > 0 && alltrue(local.app_runtime_filter_result)
-}
-
-output "app_runtime_not_found_validation_pass" {
-  value = length(data.huaweicloud_fgs_application_templates.filter_by_not_found_app_runtime.templates) == 0
-}
-
-// Filter by application category.
-locals {
-  app_category = data.huaweicloud_fgs_application_templates.all.templates[0].category
-}
-
-data "huaweicloud_fgs_application_templates" "filter_by_app_category" {
-  category = local.app_category
-}
-
-data "huaweicloud_fgs_application_templates" "filter_by_not_found_app_category" {
-  category = "app_category_not_found"
+data "huaweicloud_fgs_application_templates" "filter_by_not_found_runtime" {
+  runtime = "runtime_not_found"
 }
 
 locals {
-  app_category_filter_result = [for v in data.huaweicloud_fgs_application_templates.filter_by_app_category.templates[*].category :
-    v == local.app_category]
+  runtime_filter_result = [for v in data.huaweicloud_fgs_application_templates.filter_by_runtime.templates[*].runtime :
+    v == local.application_runtime]
 }
 
-output "is_app_category_filter_useful" {
-  value = length(local.app_category_filter_result) > 0 && alltrue(local.app_category_filter_result)
+output "is_runtime_filter_useful" {
+  value = length(local.runtime_filter_result) > 0 && alltrue(local.runtime_filter_result)
 }
 
-output "app_category_not_found_validation_pass" {
-  value = length(data.huaweicloud_fgs_application_templates.filter_by_not_found_app_category.templates) == 0
+output "runtime_not_found_validation_pass" {
+  value = length(data.huaweicloud_fgs_application_templates.filter_by_not_found_runtime.templates) == 0
+}
+
+# Filter by application category.
+locals {
+  application_category = data.huaweicloud_fgs_application_templates.all.templates[0].category
+}
+
+data "huaweicloud_fgs_application_templates" "filter_by_category" {
+  category = local.application_category
+}
+
+data "huaweicloud_fgs_application_templates" "filter_by_not_found_category" {
+  category = "category_not_found"
+}
+
+locals {
+  category_filter_result = [for v in data.huaweicloud_fgs_application_templates.filter_by_category.templates[*].category :
+    v == local.application_category]
+}
+
+output "is_category_filter_useful" {
+  value = length(local.category_filter_result) > 0 && alltrue(local.category_filter_result)
+}
+
+output "category_not_found_validation_pass" {
+  value = length(data.huaweicloud_fgs_application_templates.filter_by_not_found_category.templates) == 0
 }
 `

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_applications_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_applications_test.go
@@ -13,28 +13,29 @@ import (
 
 func TestAccDataApplications_basic(t *testing.T) {
 	var (
-		rcName       = "huaweicloud_fgs_application.test"
+		base = "huaweicloud_fgs_application.test"
+
 		all          = "data.huaweicloud_fgs_applications.all"
 		dcForAllApps = acceptance.InitDataSourceCheck(all)
 
-		byAppId           = "data.huaweicloud_fgs_applications.filter_by_app_id"
+		byAppId           = "data.huaweicloud_fgs_applications.filter_by_application_id"
 		dcByAppId         = acceptance.InitDataSourceCheck(byAppId)
-		byNotFoundAppId   = "data.huaweicloud_fgs_applications.filter_by_not_found_app_id"
+		byNotFoundAppId   = "data.huaweicloud_fgs_applications.filter_by_not_found_application_id"
 		dcByNotFoundAppId = acceptance.InitDataSourceCheck(byNotFoundAppId)
 
-		byAppName           = "data.huaweicloud_fgs_applications.filter_by_app_name"
+		byAppName           = "data.huaweicloud_fgs_applications.filter_by_name"
 		dcByAppName         = acceptance.InitDataSourceCheck(byAppName)
-		byNotFoundAppName   = "data.huaweicloud_fgs_applications.filter_by_not_found_app_name"
+		byNotFoundAppName   = "data.huaweicloud_fgs_applications.filter_by_not_found_name"
 		dcByNotFoundAppName = acceptance.InitDataSourceCheck(byNotFoundAppName)
 
-		byAppStatus           = "data.huaweicloud_fgs_applications.filter_by_app_status"
+		byAppStatus           = "data.huaweicloud_fgs_applications.filter_by_status"
 		dcByAppStatus         = acceptance.InitDataSourceCheck(byAppStatus)
-		byNotFoundAppStatus   = "data.huaweicloud_fgs_applications.filter_by_not_found_app_status"
+		byNotFoundAppStatus   = "data.huaweicloud_fgs_applications.filter_by_not_found_status"
 		dcByNotFoundAppStatus = acceptance.InitDataSourceCheck(byNotFoundAppStatus)
 
-		byAppDesc           = "data.huaweicloud_fgs_applications.filter_by_app_desc"
+		byAppDesc           = "data.huaweicloud_fgs_applications.filter_by_description"
 		dcByAppDesc         = acceptance.InitDataSourceCheck(byAppDesc)
-		byNotFoundAppDesc   = "data.huaweicloud_fgs_applications.filter_by_not_found_app_desc"
+		byNotFoundAppDesc   = "data.huaweicloud_fgs_applications.filter_by_not_found_description"
 		dcByNotFoundAppDesc = acceptance.InitDataSourceCheck(byNotFoundAppDesc)
 	)
 
@@ -47,35 +48,37 @@ func TestAccDataApplications_basic(t *testing.T) {
 			{
 				Config: testAccDataApplications_basic(),
 				Check: resource.ComposeTestCheckFunc(
+					// Without filter parameters.
 					dcForAllApps.CheckResourceExists(),
 					resource.TestMatchResourceAttr(all, "applications.#", regexp.MustCompile(`[1-9][0-9]*`)),
 					// Filter by application ID.
 					dcByAppId.CheckResourceExists(),
-					resource.TestCheckOutput("is_app_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_application_id_filter_useful", "true"),
 					dcByNotFoundAppId.CheckResourceExists(),
-					resource.TestCheckOutput("app_id_not_found_validation_pass", "true"),
+					resource.TestCheckOutput("application_id_not_found_validation_pass", "true"),
 					// Filter by application name.
 					dcByAppName.CheckResourceExists(),
-					resource.TestCheckOutput("is_app_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
 					dcByNotFoundAppName.CheckResourceExists(),
-					resource.TestCheckOutput("app_name_not_found_validation_pass", "true"),
+					resource.TestCheckOutput("name_not_found_validation_pass", "true"),
 					// Filter by application status.
 					dcByAppStatus.CheckResourceExists(),
-					resource.TestCheckOutput("is_app_status_filter_useful", "true"),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
 					dcByNotFoundAppStatus.CheckResourceExists(),
-					resource.TestCheckOutput("app_status_not_found_validation_pass", "true"),
+					resource.TestCheckOutput("status_not_found_validation_pass", "true"),
 					// Filter by application description.
 					dcByAppDesc.CheckResourceExists(),
-					resource.TestCheckOutput("is_app_desc_filter_useful", "true"),
+					resource.TestCheckOutput("is_description_filter_useful", "true"),
 					dcByNotFoundAppDesc.CheckResourceExists(),
-					resource.TestCheckOutput("app_desc_not_found_validation_pass", "true"),
-					// Check attributes.
-					resource.TestCheckResourceAttrPair(byAppId, "applications.0.id", rcName, "id"),
-					resource.TestCheckResourceAttrPair(byAppId, "applications.0.name", rcName, "name"),
-					resource.TestCheckResourceAttrPair(byAppId, "applications.0.status", rcName, "status"),
-					resource.TestCheckResourceAttrPair(byAppId, "applications.0.description", rcName, "description"),
+					resource.TestCheckOutput("description_not_found_validation_pass", "true"),
+					// Check the attributes.
+					resource.TestCheckResourceAttrPair(byAppId, "applications.0.id", base, "id"),
+					resource.TestCheckResourceAttrPair(byAppId, "applications.0.name", base, "name"),
+					resource.TestCheckResourceAttrPair(byAppId, "applications.0.status", base, "status"),
+					resource.TestCheckResourceAttrPair(byAppId, "applications.0.description", base, "description"),
 					resource.TestMatchResourceAttr(byAppId, "applications.0.updated_at",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Attribute 'created_at' has been deprecated from the API and the corresponding documentation.
 				),
 			},
 		},
@@ -91,23 +94,23 @@ func testAccDataApplications_basic() string {
 
 # Without any filter parameter.
 data "huaweicloud_fgs_applications" "all" {
-  // Query applications after application resource create.
+  # Query applications after application resource create.
   depends_on = [
     huaweicloud_fgs_application.test,
   ]
 }
 
-// Filter by application ID.
+# Filter by application ID.
 locals {
-  app_id = huaweicloud_fgs_application.test.id
+  application_id = huaweicloud_fgs_application.test.id
 }
 
-data "huaweicloud_fgs_applications" "filter_by_app_id" {
-  application_id = local.app_id
+data "huaweicloud_fgs_applications" "filter_by_application_id" {
+  application_id = local.application_id
 }
 
-data "huaweicloud_fgs_applications" "filter_by_not_found_app_id" {
-  // Query applications using a not exist ID after application resource create.
+data "huaweicloud_fgs_applications" "filter_by_not_found_application_id" {
+  # Query applications using a not exist ID after application resource create.
   depends_on = [
     huaweicloud_fgs_application.test,
   ]
@@ -116,121 +119,121 @@ data "huaweicloud_fgs_applications" "filter_by_not_found_app_id" {
 }
 
 locals {
-  app_id_filter_result = [for v in data.huaweicloud_fgs_applications.filter_by_app_id.applications[*].id :
-    v == local.app_id]
+  application_id_filter_result = [for v in data.huaweicloud_fgs_applications.filter_by_application_id.applications[*].id :
+    v == local.application_id]
 }
 
-output "is_app_id_filter_useful" {
-  value = length(local.app_id_filter_result) > 0 && alltrue(local.app_id_filter_result)
+output "is_application_id_filter_useful" {
+  value = length(local.application_id_filter_result) > 0 && alltrue(local.application_id_filter_result)
 }
 
-output "app_id_not_found_validation_pass" {
-  value = length(data.huaweicloud_fgs_applications.filter_by_not_found_app_id.applications) == 0
+output "application_id_not_found_validation_pass" {
+  value = length(data.huaweicloud_fgs_applications.filter_by_not_found_application_id.applications) == 0
 }
 
-// Filter by application name.
+# Filter by application name.
 locals {
-  app_name = huaweicloud_fgs_application.test.name
+  application_name = huaweicloud_fgs_application.test.name
 }
 
-data "huaweicloud_fgs_applications" "filter_by_app_name" {
-  // The behavior of parameter 'name' of the application resource is 'Required', means this parameter does not
-  // have 'Know After Apply' behavior.
+data "huaweicloud_fgs_applications" "filter_by_name" {
+  # The behavior of parameter 'name' of the application resource is 'Required', means this parameter does not
+  # have 'Know After Apply' behavior.
   depends_on = [
     huaweicloud_fgs_application.test,
   ]
 
-  name = local.app_name
+  name = local.application_name
 }
 
-data "huaweicloud_fgs_applications" "filter_by_not_found_app_name" {
-  // Query applications using a not exist name after application resource create.
+data "huaweicloud_fgs_applications" "filter_by_not_found_name" {
+  # Query applications using a not exist name after application resource create.
   depends_on = [
     huaweicloud_fgs_application.test,
   ]
 
-  name = "app_name_not_found"
+  name = "name_not_found"
 }
 
 locals {
-  app_name_filter_result = [for v in data.huaweicloud_fgs_applications.filter_by_app_name.applications[*].name :
-    v == local.app_name]
+  name_filter_result = [for v in data.huaweicloud_fgs_applications.filter_by_name.applications[*].name :
+    v == local.application_name]
 }
 
-output "is_app_name_filter_useful" {
-  value = length(local.app_name_filter_result) > 0 && alltrue(local.app_name_filter_result)
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
 }
 
-output "app_name_not_found_validation_pass" {
-  value = length(data.huaweicloud_fgs_applications.filter_by_not_found_app_name.applications) == 0
+output "name_not_found_validation_pass" {
+  value = length(data.huaweicloud_fgs_applications.filter_by_not_found_name.applications) == 0
 }
 
-// Filter by application status.
+# Filter by application status.
 locals {
-  app_status = huaweicloud_fgs_application.test.status
+  application_status = huaweicloud_fgs_application.test.status
 }
 
-data "huaweicloud_fgs_applications" "filter_by_app_status" {
-  status = local.app_status
+data "huaweicloud_fgs_applications" "filter_by_status" {
+  status = local.application_status
 }
 
-data "huaweicloud_fgs_applications" "filter_by_not_found_app_status" {
-  // Query application using a not exist status after application resource create.
+data "huaweicloud_fgs_applications" "filter_by_not_found_status" {
+  # Query application using a not exist status after application resource create.
   depends_on = [
     huaweicloud_fgs_application.test,
   ]
 
-  status = "app_status_not_found"
+  status = "status_not_found"
 }
 
 locals {
-  app_status_filter_result = [for v in data.huaweicloud_fgs_applications.filter_by_app_status.applications[*].status :
-    v == local.app_status]
+  status_filter_result = [for v in data.huaweicloud_fgs_applications.filter_by_status.applications[*].status :
+    v == local.application_status]
 }
 
-output "is_app_status_filter_useful" {
-  value = length(local.app_status_filter_result) > 0 && alltrue(local.app_status_filter_result)
+output "is_status_filter_useful" {
+  value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
 }
 
-output "app_status_not_found_validation_pass" {
-  value = length(data.huaweicloud_fgs_applications.filter_by_not_found_app_status.applications) == 0
+output "status_not_found_validation_pass" {
+  value = length(data.huaweicloud_fgs_applications.filter_by_not_found_status.applications) == 0
 }
 
-// Filter by application description.
+# Filter by application description.
 locals {
-  app_desc = huaweicloud_fgs_application.test.description
+  application_description = huaweicloud_fgs_application.test.description
 }
 
-data "huaweicloud_fgs_applications" "filter_by_app_desc" {
-  // The behavior of parameter 'description' of the resource is not have the 'Computed', means this parameter does not
-  // have 'Know After Apply' behavior.
+data "huaweicloud_fgs_applications" "filter_by_description" {
+  # The behavior of parameter 'description' of the resource is not have the 'Computed', means this parameter does not
+  # have 'Know After Apply' behavior.
   depends_on = [
     huaweicloud_fgs_application.test,
   ]
 
-  description = local.app_desc
+  description = local.application_description
 }
 
-data "huaweicloud_fgs_applications" "filter_by_not_found_app_desc" {
-  // Query applications using a not exist description after application resource create.
+data "huaweicloud_fgs_applications" "filter_by_not_found_description" {
+  # Query applications using a not exist description after application resource create.
   depends_on = [
     huaweicloud_fgs_application.test,
   ]
 
-  description = "app_desc_not_found"
+  description = "description_not_found"
 }
 
 locals {
-  app_desc_filter_result = [for v in data.huaweicloud_fgs_applications.filter_by_app_desc.applications[*].description :
-    v == local.app_desc]
+  description_filter_result = [for v in data.huaweicloud_fgs_applications.filter_by_description.applications[*].description :
+    v == local.application_description]
 }
 
-output "is_app_desc_filter_useful" {
-  value = length(local.app_desc_filter_result) > 0 && alltrue(local.app_desc_filter_result)
+output "is_description_filter_useful" {
+  value = length(local.description_filter_result) > 0 && alltrue(local.description_filter_result)
 }
 
-output "app_desc_not_found_validation_pass" {
-  value = length(data.huaweicloud_fgs_applications.filter_by_not_found_app_desc.applications) == 0
+output "description_not_found_validation_pass" {
+  value = length(data.huaweicloud_fgs_applications.filter_by_not_found_description.applications) == 0
 }
 `, testAccApplication_basic(name), randAppId)
 }

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependencies_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependencies_test.go
@@ -61,7 +61,7 @@ func TestAccDataDependencies_basic(t *testing.T) {
 					// Filter by dependency runtime.
 					dcByRuntime.CheckResourceExists(),
 					resource.TestCheckOutput("is_runtime_filter_useful", "true"),
-					// Check attributes.
+					// Check the attributes.
 					// The behavior of the filter parameter 'name' is exact match.
 					resource.TestCheckResourceAttrPair(byName, "packages.0.id", base, "dependency_id"),
 					resource.TestCheckResourceAttrPair(byName, "packages.0.name", base, "name"),
@@ -91,6 +91,7 @@ func testAccDataDependencies_basic() string {
 	return fmt.Sprintf(`
 %[1]s
 
+# Without any filter parameter.
 data "huaweicloud_fgs_dependencies" "all" {}
 
 # Filter by dependency type.

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependency_versions_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependency_versions_test.go
@@ -14,7 +14,8 @@ import (
 
 func TestAccDataDependencyVersions_basic(t *testing.T) {
 	var (
-		rName                      = "huaweicloud_fgs_dependency_version.test"
+		base = "huaweicloud_fgs_dependency_version.test"
+
 		all                        = "data.huaweicloud_fgs_dependency_versions.all"
 		dcForAllDependencyVersions = acceptance.InitDataSourceCheck(all)
 
@@ -44,6 +45,7 @@ func TestAccDataDependencyVersions_basic(t *testing.T) {
 			{
 				Config: testAccDataDependencyVersions_basic(),
 				Check: resource.ComposeTestCheckFunc(
+					// Without filter parameters.
 					dcForAllDependencyVersions.CheckResourceExists(),
 					resource.TestMatchResourceAttr(all, "versions.#", regexp.MustCompile(`[1-9][0-9]*`)),
 					// Filter by version ID.
@@ -61,18 +63,18 @@ func TestAccDataDependencyVersions_basic(t *testing.T) {
 					resource.TestCheckOutput("is_runtime_filter_useful", "true"),
 					dcByNotFoundRuntime.CheckResourceExists(),
 					resource.TestCheckOutput("runtime_not_found_validation_pass", "true"),
-					// Check attributes.
-					dcByVersionId.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.id", rName, "version_id"),
-					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.version", rName, "version"),
-					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.dependency_id", rName, "dependency_id"),
-					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.dependency_name", rName, "name"),
-					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.runtime", rName, "runtime"),
+					// Check the attributes.
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.id", base, "version_id"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.version", base, "version"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.dependency_id", base, "dependency_id"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.dependency_name", base, "name"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.runtime", base, "runtime"),
+					// The link will be replaced with a new link which belongs to the FunctionGraph service.
 					resource.TestCheckResourceAttrSet(byVersionId, "versions.0.link"),
-					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.size", rName, "size"),
-					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.etag", rName, "etag"),
-					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.owner", rName, "owner"),
-					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.description", rName, "description"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.size", base, "size"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.etag", base, "etag"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.owner", base, "owner"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.description", base, "description"),
 				),
 			},
 		},
@@ -138,7 +140,7 @@ data "huaweicloud_fgs_dependency_versions" "filter_by_version" {
 }
 
 data "huaweicloud_fgs_dependency_versions" "filter_by_not_found_version" {
-  # Query dependency versions using a not exist version ID after dependency version resource create.
+  # Query dependency versions using a not exist version number after dependency version resource create.
   depends_on = [
     huaweicloud_fgs_dependency_version.test,
   ]
@@ -162,18 +164,18 @@ output "version_not_found_validation_pass" {
 
 # Filter by runtime.
 locals {
-  runtime = huaweicloud_fgs_dependency_version.test.runtime
+  version_runtime = huaweicloud_fgs_dependency_version.test.runtime
 }
 
 data "huaweicloud_fgs_dependency_versions" "filter_by_runtime" {
   # The behavior of parameter 'runtime' of the resource is 'Required', means this parameter does not
   # have 'Know After Apply' behavior.
   dependency_id = huaweicloud_fgs_dependency_version.test.dependency_id
-  runtime       = local.runtime
+  runtime       = local.version_runtime
 }
 
 data "huaweicloud_fgs_dependency_versions" "filter_by_not_found_runtime" {
-  # Query dependency versions using a not exist version ID after dependency version resource create.
+  # Query dependency versions using a not exist version runtime after dependency version resource create.
   depends_on = [
     huaweicloud_fgs_dependency_version.test,
   ]
@@ -184,7 +186,7 @@ data "huaweicloud_fgs_dependency_versions" "filter_by_not_found_runtime" {
 
 locals {
   runtime_filter_result = [for v in data.huaweicloud_fgs_dependency_versions.filter_by_runtime.versions[*].runtime :
-    v == local.runtime]
+    v == local.version_runtime]
 }
 
 output "is_runtime_filter_useful" {

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_function_events_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_function_events_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceFunctionEvents_basic(t *testing.T) {
+func TestAccDataFunctionEvents_basic(t *testing.T) {
 	var (
 		all = "data.huaweicloud_fgs_function_events.test"
 		dc  = acceptance.InitDataSourceCheck(all)
@@ -23,10 +23,11 @@ func TestAccDataSourceFunctionEvents_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceFunctionEvents_basic(),
+				Config: testAccDataFunctionEvents_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(all, "events.#", "1"),
+					// Check the attributes.
 					resource.TestCheckResourceAttrPair(all, "events.0.id", "huaweicloud_fgs_function_event.test", "id"),
 					resource.TestCheckResourceAttrPair(all, "events.0.name", "huaweicloud_fgs_function_event.test", "name"),
 					resource.TestMatchResourceAttr(all, "events.0.updated_at",
@@ -37,8 +38,9 @@ func TestAccDataSourceFunctionEvents_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceFunctionEvents_base() string {
+func testAccDataFunctionEvents_basic() string {
 	name := acceptance.RandomAccResourceName()
+
 	return fmt.Sprintf(`
 variable "js_script_content" {
   default = <<EOT
@@ -74,17 +76,14 @@ resource "huaweicloud_fgs_function_event" "test" {
   name         = "%[1]s"
   content      = base64encode(jsonencode({"foo": "bar"}))
 }
-`, name)
-}
-
-func testAccDataSourceFunctionEvents_basic() string {
-	return fmt.Sprintf(`
-%[1]s
 
 data "huaweicloud_fgs_function_events" "test" {
-  depends_on = [huaweicloud_fgs_function_event.test]
+  depends_on = [
+	# Query function events after function event create.
+    huaweicloud_fgs_function_event.test
+  ]
 
   function_urn = huaweicloud_fgs_function.test.urn
 }
-`, testAccDataSourceFunctionEvents_base())
+`, name)
 }

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_function_triggers_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_function_triggers_test.go
@@ -5,28 +5,38 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccFunctionTriggers_basic(t *testing.T) {
+func TestAccDataFunctionTriggers_basic(t *testing.T) {
 	var (
-		rName      = acceptance.RandomAccResourceName()
-		dataSource = "data.huaweicloud_fgs_function_triggers.test"
-		dc         = acceptance.InitDataSourceCheck(dataSource)
+		base = "huaweicloud_fgs_function_trigger.test"
 
-		byId   = "data.huaweicloud_fgs_function_triggers.filter_by_id"
-		dcById = acceptance.InitDataSourceCheck(byId)
+		all              = "data.huaweicloud_fgs_function_triggers.all"
+		dcForAllTriggers = acceptance.InitDataSourceCheck(all)
 
-		byType   = "data.huaweicloud_fgs_function_triggers.filter_by_type"
-		dcByType = acceptance.InitDataSourceCheck(byType)
+		byTriggerId           = "data.huaweicloud_fgs_function_triggers.filter_by_trigger_id"
+		dcByTriggerId         = acceptance.InitDataSourceCheck(byTriggerId)
+		byNotFoundTriggerId   = "data.huaweicloud_fgs_function_triggers.filter_by_not_found_trigger_id"
+		dcByNotFoundTriggerId = acceptance.InitDataSourceCheck(byNotFoundTriggerId)
 
-		byStatus   = "data.huaweicloud_fgs_function_triggers.filter_by_status"
-		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+		byType           = "data.huaweicloud_fgs_function_triggers.filter_by_type"
+		dcByType         = acceptance.InitDataSourceCheck(byType)
+		byNotFoundType   = "data.huaweicloud_fgs_function_triggers.filter_by_not_found_type"
+		dcByNotFoundType = acceptance.InitDataSourceCheck(byNotFoundType)
 
-		byCreatedAt   = "data.huaweicloud_fgs_function_triggers.filter_by_created_at"
-		dcByCreatedAt = acceptance.InitDataSourceCheck(byCreatedAt)
+		byStatus           = "data.huaweicloud_fgs_function_triggers.filter_by_status"
+		dcByStatus         = acceptance.InitDataSourceCheck(byStatus)
+		byNotFoundStatus   = "data.huaweicloud_fgs_function_triggers.filter_by_not_found_status"
+		dcByNotFoundStatus = acceptance.InitDataSourceCheck(byNotFoundStatus)
+
+		byStartTime   = "data.huaweicloud_fgs_function_triggers.filter_by_start_time"
+		dcByStartTime = acceptance.InitDataSourceCheck(byStartTime)
+		byEndTime     = "data.huaweicloud_fgs_function_triggers.filter_by_end_time"
+		dcByEndTime   = acceptance.InitDataSourceCheck(byEndTime)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -36,68 +46,132 @@ func TestAccFunctionTriggers_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFunctionTriggers_basic(rName),
+				Config: testAccDataFunctionTriggers_basic(),
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dataSource, "triggers.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					dcById.CheckResourceExists(),
-					resource.TestCheckOutput("is_id_filter_useful", "true"),
-					resource.TestMatchResourceAttr(dataSource, "triggers.0.created_at",
-						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
-					resource.TestMatchResourceAttr(dataSource, "triggers.0.updated_at",
-						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Without filter parameters.
+					dcForAllTriggers.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "triggers.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by trigger ID.
+					dcByTriggerId.CheckResourceExists(),
+					resource.TestCheckOutput("is_trigger_id_filter_useful", "true"),
+					dcByNotFoundTriggerId.CheckResourceExists(),
+					resource.TestCheckOutput("trigger_id_not_found_validation_pass", "true"),
+					// Filter by trigger type.
 					dcByType.CheckResourceExists(),
 					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					dcByNotFoundType.CheckResourceExists(),
+					resource.TestCheckOutput("type_not_found_validation_pass", "true"),
+					// Filter by trigger status.
 					dcByStatus.CheckResourceExists(),
 					resource.TestCheckOutput("is_status_filter_useful", "true"),
-					dcByCreatedAt.CheckResourceExists(),
-					resource.TestCheckOutput("is_created_at_filter_useful", "true"),
+					dcByNotFoundStatus.CheckResourceExists(),
+					resource.TestCheckOutput("status_not_found_validation_pass", "true"),
+					// Filter by trigger start time.
+					dcByStartTime.CheckResourceExists(),
+					resource.TestCheckOutput("is_start_time_filter_useful", "true"),
+					// Filter by trigger end time.
+					dcByEndTime.CheckResourceExists(),
+					resource.TestCheckOutput("is_end_time_filter_useful", "true"),
+					// Check the attributes.
+					resource.TestCheckResourceAttrPair(byTriggerId, "triggers.0.id", base, "id"),
+					resource.TestCheckResourceAttrPair(byTriggerId, "triggers.0.type", base, "type"),
+					resource.TestCheckResourceAttrPair(byTriggerId, "triggers.0.event_data", base, "event_data"),
+					resource.TestCheckResourceAttrPair(byTriggerId, "triggers.0.status", base, "status"),
+					resource.TestMatchResourceAttr(byTriggerId, "triggers.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(byTriggerId, "triggers.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
 		},
 	})
 }
 
-func testAccFunctionTriggers_basic(name string) string {
-	return fmt.Sprintf(`
-%s
+func testAccDataFunctionTriggers_basic() string {
+	name := acceptance.RandomAccResourceName()
+	randUUID, _ := uuid.GenerateUUID()
 
-data "huaweicloud_fgs_function_triggers" "test" {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_fgs_function_trigger" "test" {
+  function_urn = huaweicloud_fgs_function.test.urn
+  type         = "TIMER"
+  event_data   = jsonencode({
+    "name": "%[2]s_rate",
+    "schedule_type": "Rate",
+    "user_event": "Created by acc test",
+    "schedule": "3m"
+  })
+}
+
+# Without any filter parameter.
+data "huaweicloud_fgs_function_triggers" "all" {
   depends_on = [
-    huaweicloud_fgs_function_trigger.timer_rate
+    huaweicloud_fgs_function_trigger.test
   ]
 
   function_urn = huaweicloud_fgs_function.test.urn
 }
 
-// Filter by ID
+# Filter by trigger ID.
 locals {
-  trigger_id = huaweicloud_fgs_function_trigger.timer_rate.id
+  trigger_id = huaweicloud_fgs_function_trigger.test.id
 }
 
-data "huaweicloud_fgs_function_triggers" "filter_by_id" {
+data "huaweicloud_fgs_function_triggers" "filter_by_trigger_id" {
   function_urn = huaweicloud_fgs_function.test.urn
   trigger_id   = local.trigger_id
 }
 
+data "huaweicloud_fgs_function_triggers" "filter_by_not_found_trigger_id" {
+  # Query triggers using a not exist trigger ID after trigger resource create.
+  depends_on = [
+    huaweicloud_fgs_function_trigger.test,
+  ]
+
+  function_urn = huaweicloud_fgs_function.test.urn
+  trigger_id   = "%[3]s"
+}
+
 locals {
-  id_filter_result = [
-    for v in data.huaweicloud_fgs_function_triggers.filter_by_id.triggers[*].id : v == local.trigger_id
+  trigger_id_filter_result = [
+    for v in data.huaweicloud_fgs_function_triggers.filter_by_trigger_id.triggers[*].id : v == local.trigger_id
   ]
 }
 
-output "is_id_filter_useful" {
-  value = length(local.id_filter_result) > 0 && alltrue(local.id_filter_result)
+output "is_trigger_id_filter_useful" {
+  value = length(local.trigger_id_filter_result) > 0 && alltrue(local.trigger_id_filter_result)
 }
 
-// Filter by type
+output "trigger_id_not_found_validation_pass" {
+  value = length(data.huaweicloud_fgs_function_triggers.filter_by_not_found_trigger_id.triggers) == 0
+}
+
+# Filter by trigger type.
 locals {
-  trigger_type = data.huaweicloud_fgs_function_triggers.test.triggers[0].type
+  trigger_type = huaweicloud_fgs_function_trigger.test.type
 }
 
 data "huaweicloud_fgs_function_triggers" "filter_by_type" {
+  # The behavior of parameter 'type' of the trigger resource is 'Required', means this parameter does not
+  # have 'Know After Apply' behavior.
+  depends_on = [
+    huaweicloud_fgs_function_trigger.test,
+  ]
+
   function_urn = huaweicloud_fgs_function.test.urn
   type         = local.trigger_type
+}
+
+data "huaweicloud_fgs_function_triggers" "filter_by_not_found_type" {
+  # Query triggers using a not exist trigger type after trigger resource create.
+  depends_on = [
+    huaweicloud_fgs_function_trigger.test,
+  ]
+
+  function_urn = huaweicloud_fgs_function.test.urn
+  type         = "type_not_found"
 }
 
 locals {
@@ -110,14 +184,23 @@ output "is_type_filter_useful" {
   value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
 }
 
-// Filter by status
+output "type_not_found_validation_pass" {
+  value = length(data.huaweicloud_fgs_function_triggers.filter_by_not_found_type.triggers) == 0
+}
+
+# Filter by trigger status.
 locals {
-  trigger_status = huaweicloud_fgs_function_trigger.timer_rate.status
+  trigger_status = huaweicloud_fgs_function_trigger.test.status
 }
 
 data "huaweicloud_fgs_function_triggers" "filter_by_status" {
   function_urn = huaweicloud_fgs_function.test.urn
   status       = local.trigger_status
+}
+
+data "huaweicloud_fgs_function_triggers" "filter_by_not_found_status" {
+  function_urn = huaweicloud_fgs_function.test.urn
+  status       = "status_not_found"
 }
 
 locals {
@@ -130,25 +213,48 @@ output "is_status_filter_useful" {
   value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
 }
 
-// Filter by creation time
-locals {
-  created_time = huaweicloud_fgs_function_trigger.timer_rate.created_at
+output "status_not_found_validation_pass" {
+  value = length(data.huaweicloud_fgs_function_triggers.filter_by_not_found_status.triggers) == 0
 }
 
-data "huaweicloud_fgs_function_triggers" "filter_by_created_at" {
+# Filter by start time
+locals {
+  start_time = huaweicloud_fgs_function_trigger.test.created_at
+}
+
+data "huaweicloud_fgs_function_triggers" "filter_by_start_time" {
   function_urn = huaweicloud_fgs_function.test.urn
-  start_time   = local.created_time
-  end_time     = local.created_time
+  start_time   = timeadd(local.start_time, "-1s")
 }
 
 locals {
-  created_at_filter_result = [
-    for v in data.huaweicloud_fgs_function_triggers.filter_by_created_at.triggers[*].created_at : timecmp(v, local.created_time) == 0
+  start_time_filter_result = [
+    for v in data.huaweicloud_fgs_function_triggers.filter_by_start_time.triggers[*].created_at : timecmp(v, local.start_time) >= 0
   ]
 }
 
-output "is_created_at_filter_useful" {
-  value = length(local.created_at_filter_result) > 0 && alltrue(local.created_at_filter_result)
+output "is_start_time_filter_useful" {
+  value = length(local.start_time_filter_result) > 0 && alltrue(local.start_time_filter_result)
 }
-`, testAccFunctionTimingTrigger_basic_step1(name))
+
+# Filter by end time
+locals {
+  end_time = huaweicloud_fgs_function_trigger.test.created_at
+}
+
+data "huaweicloud_fgs_function_triggers" "filter_by_end_time" {
+  function_urn = huaweicloud_fgs_function.test.urn
+  end_time     = timeadd(local.end_time, "1s")
+}
+
+locals {
+  end_time_filter_result = [
+    for v in data.huaweicloud_fgs_function_triggers.filter_by_end_time.triggers[*].created_at : timecmp(v, local.end_time) <= 0
+  ]
+}
+
+output "is_end_time_filter_useful" {
+  value = length(local.end_time_filter_result) > 0 && alltrue(local.end_time_filter_result)
+}
+`, testAccDataFunctions_base(name), name, randUUID)
 }

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_quotas_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_quotas_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceQuotas_basic(t *testing.T) {
+func TestAccDataQuotas_basic(t *testing.T) {
 	var (
-		all = "data.huaweicloud_fgs_quotas.test"
+		all = "data.huaweicloud_fgs_quotas.all"
 		dc  = acceptance.InitDataSourceCheck(all)
 	)
 
@@ -23,10 +23,12 @@ func TestAccDataSourceQuotas_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceQuotas_basic(),
+				Config: testAccDataQuotas_basic(),
 				Check: resource.ComposeTestCheckFunc(
+					// Without filter parameters.
 					dc.CheckResourceExists(),
 					resource.TestMatchResourceAttr(all, "quotas.#", regexp.MustCompile(`[1-9][0-9]*`)),
+					// Check the attributes.
 					resource.TestCheckResourceAttrSet(all, "quotas.0.type"),
 					resource.TestCheckResourceAttrSet(all, "quotas.0.limit"),
 					resource.TestCheckOutput("is_quota_fgs_func_num_used", "true"),
@@ -38,7 +40,7 @@ func TestAccDataSourceQuotas_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceQuotas_basic() string {
+func testAccDataQuotas_basic() string {
 	name := acceptance.RandomAccResourceName()
 
 	return fmt.Sprintf(`
@@ -71,12 +73,12 @@ resource "huaweicloud_fgs_function" "test" {
   func_code   = base64encode(jsonencode(var.js_script_content))
 }
 
-data "huaweicloud_fgs_quotas" "test" {
+data "huaweicloud_fgs_quotas" "all" {
   depends_on = [huaweicloud_fgs_function.test]
 }
 
 locals {
-  all_used_quota_types = [for _, v in data.huaweicloud_fgs_quotas.test.quotas: v.type if v.used > 0]
+  all_used_quota_types = [for _, v in data.huaweicloud_fgs_quotas.all.quotas: v.type if v.used > 0]
 }
 
 output "is_quota_fgs_func_num_used" {
@@ -84,7 +86,7 @@ output "is_quota_fgs_func_num_used" {
 }
 
 locals {
-  all_quotas_that_contains_unit = [for _, v in data.huaweicloud_fgs_quotas.test.quotas: v if v.unit != ""]
+  all_quotas_that_contains_unit = [for _, v in data.huaweicloud_fgs_quotas.all.quotas: v if v.unit != ""]
 }
 
 output "is_just_fgs_func_code_size_contains_unit" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Unified the function name of the data source acceptance tests.
Unified the acceptance test checks and all test step's scripts.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. unified the function naming and test steps
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccDataApplicationTemplates_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataApplicationTemplates_basic -timeout 360m -parallel 10
=== RUN   TestAccDataApplicationTemplates_basic
=== PAUSE TestAccDataApplicationTemplates_basic
=== CONT  TestAccDataApplicationTemplates_basic
--- PASS: TestAccDataApplicationTemplates_basic (13.84s)
PASS
coverage: 5.0% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       13.930s coverage: 5.0% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccDataApplications_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataApplications_basic -timeout 360m -parallel 10
=== RUN   TestAccDataApplications_basic
=== PAUSE TestAccDataApplications_basic
=== CONT  TestAccDataApplications_basic
--- PASS: TestAccDataApplications_basic (66.66s)
PASS
coverage: 13.6% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       66.758s coverage: 13.6% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccDataDependencies_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataDependencies_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDependencies_basic
=== PAUSE TestAccDataDependencies_basic
=== CONT  TestAccDataDependencies_basic
--- PASS: TestAccDataDependencies_basic (15.33s)
PASS
coverage: 8.0% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       15.451s coverage: 8.0% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccDataDependencyVersions_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataDependencyVersions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDependencyVersions_basic
=== PAUSE TestAccDataDependencyVersions_basic
=== CONT  TestAccDataDependencyVersions_basic
--- PASS: TestAccDataDependencyVersions_basic (13.40s)
PASS
coverage: 8.8% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       13.480s coverage: 8.8% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccDataFunctionEvents_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataFunctionEvents_basic -timeout 360m -parallel 10
=== RUN   TestAccDataFunctionEvents_basic
=== PAUSE TestAccDataFunctionEvents_basic
=== CONT  TestAccDataFunctionEvents_basic
--- PASS: TestAccDataFunctionEvents_basic (14.27s)
PASS
coverage: 14.7% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       14.367s coverage: 14.7% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccDataFunctionTriggers_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataFunctionTriggers_basic -timeout 360m -parallel 10
=== RUN   TestAccDataFunctionTriggers_basic
=== PAUSE TestAccDataFunctionTriggers_basic
=== CONT  TestAccDataFunctionTriggers_basic
--- PASS: TestAccDataFunctionTriggers_basic (21.30s)
PASS
coverage: 17.6% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       21.348s coverage: 17.6% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccDataFunctions_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataFunctions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataFunctions_basic
=== PAUSE TestAccDataFunctions_basic
=== CONT  TestAccDataFunctions_basic
--- PASS: TestAccDataFunctions_basic (75.32s)
PASS
coverage: 13.4% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       75.387s coverage: 13.4% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccDataQuotas_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataQuotas_basic -timeout 360m -parallel 10
=== RUN   TestAccDataQuotas_basic
=== PAUSE TestAccDataQuotas_basic
=== CONT  TestAccDataQuotas_basic
--- PASS: TestAccDataQuotas_basic (13.29s)
PASS
coverage: 11.1% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       13.356s coverage: 11.1% of statements in ./huaweicloud/services/fgs
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.
