### PR TITLE
fix: endpoint generates client to increase data copy

### DIFF
--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -445,8 +445,11 @@ func (c *Config) newServiceClientByEndpoint(client *golangsdk.ProviderClient, sr
 		return nil, fmt.Errorf("service type %s is invalid or not supportted", srv)
 	}
 
+	// Copy the client to prevent interference with the original data.
+	clone := new(golangsdk.ProviderClient)
+	*clone = *client
 	sc := &golangsdk.ServiceClient{
-		ProviderClient: client,
+		ProviderClient: clone,
 		Endpoint:       endpoint,
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

endpoint generates client to increase data copy.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

Before modification, the following error was reported when executing the test case：
```
go test -v ./huaweicloud/config/ -run TestCheckNewServiceClientWithDerivedAuth
=== RUN   TestCheckNewServiceClientWithDerivedAuth
    convenience.go:35: Failure in config_test.go, line 125: expected false but got true
--- FAIL: TestCheckNewServiceClientWithDerivedAuth (0.00s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config        0.014s
FAIL

```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
go test -v ./huaweicloud/config/ -run TestCheckNewServiceClientWithDerivedAuth
=== RUN   TestCheckNewServiceClientWithDerivedAuth
--- PASS: TestCheckNewServiceClientWithDerivedAuth (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config        0.014s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
