### PR TITLE
test(fgs/function): using time provider to generate unix timestamp

### DIFF
--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -1142,6 +1142,12 @@ func TestAccFunction_reservedInstance(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.12.1",
+			},
+		},
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			rcWithVersion.CheckResourceDestroy(),
 			rcWithAlias.CheckResourceDestroy(),
@@ -1222,6 +1228,14 @@ func testAccFunction_reservedInstance_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
+# Using the current time as the start time.
+resource "time_static" "test" {}
+
+# Using the current time one day later as the expiration time.
+resource "time_offset" "test" {
+  offset_days = 1
+}
+
 resource "huaweicloud_fgs_function" "with_version" {
   name        = "%[2]s_with_version"
   memory_size = 128
@@ -1243,8 +1257,8 @@ resource "huaweicloud_fgs_function" "with_version" {
       cron_configs {
         name         = "scheme-waekcy"
         cron         = "0 */10 * * * ?"
-        start_time   = "1708342889"
-        expired_time = "1739878889"
+        start_time   = time_static.test.unix
+        expired_time = time_offset.test.unix
         count        = 2
       }
     }
@@ -1280,8 +1294,8 @@ resource "huaweicloud_fgs_function" "with_alias" {
       cron_configs {
         name         = "scheme-waekcy"
         cron         = "0 */10 * * * ?"
-        start_time   = "1708342889"
-        expired_time = "1739878889"
+        start_time   = time_static.test.unix
+        expired_time = time_offset.test.unix
         count        = 2
       }
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The hard coding values in the function acceptance test script is '2025-2-19', and has been expired.
```
{
  "error_code": "FSS.1321",
  "error_msg": "Invalid Elastic configurations expired."
}
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. using time provider to generate unix timestamp.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFunction_reservedInstance
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_reservedInstance -timeout 360m -parallel 10
=== RUN   TestAccFunction_reservedInstance
=== PAUSE TestAccFunction_reservedInstance
=== CONT  TestAccFunction_reservedInstance
--- PASS: TestAccFunction_reservedInstance (35.69s)
PASS
coverage: 18.1% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       35.742s coverage: 18.1% of statements in ./huaweicloud/services/fgs
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
