### PR TITLE
refactor(dns): adjust the code and acceptance test of the line group

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1751,7 +1751,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_endpoint":                dns.ResourceDNSEndpoint(),
 			"huaweicloud_dns_resolver_rule":           dns.ResourceDNSResolverRule(),
 			"huaweicloud_dns_resolver_rule_associate": dns.ResourceDNSResolverRuleAssociate(),
-			"huaweicloud_dns_line_group":              dns.ResourceDNSLineGroup(),
+			"huaweicloud_dns_line_group":              dns.ResourceLineGroup(),
 
 			"huaweicloud_drs_job":                        drs.ResourceDrsJob(),
 			"huaweicloud_drs_job_primary_standby_switch": drs.ResourceDRSPrimaryStandbySwitch(),

--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_line_groups_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_line_groups_test.go
@@ -80,5 +80,5 @@ data "huaweicloud_dns_line_groups" "filter_not_found_name" {
 output "not_found_name" {
   value = length(data.huaweicloud_dns_line_groups.filter_not_found_name.groups) == 0
 }
-`, testDNSLineGroup_basic(name))
+`, testAccLineGroup_basic_step1(name))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adjust the code and acceptance test of the line group resource.
+ Standardize method naming.
+ Remove redundant code.

![image](https://github.com/user-attachments/assets/62374a9c-fb61-464c-84e9-cd1b90c174e2)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
 1. standardize method naming and remove redundant code.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccLineGroup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccLineGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccLineGroup_basic
=== PAUSE TestAccLineGroup_basic
=== CONT  TestAccLineGroup_basic
--- PASS: TestAccLineGroup_basic (59.51s)
PASS
coverage: 6.5% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       59.610s coverage: 6.5% of statements in ./huaweicloud/services/dns
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/b4f6006e-810a-4275-9d82-559ee4290600)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![image](https://github.com/user-attachments/assets/0d140069-de27-4852-86f8-5d7bdd0d43a5)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<



    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
