### PR TITLE
refactor(iotda/device_group): refactor device group resource code style

### DIFF
--- a/docs/resources/iotda_device_group.md
+++ b/docs/resources/iotda_device_group.md
@@ -2,19 +2,20 @@
 subcategory: "IoT Device Access (IoTDA)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_iotda_device_group"
-description: ""
+description: |-
+  Manages an IoTDA device group resource within HuaweiCloud.
 ---
 
 # huaweicloud_iotda_device_group
 
-Manages an IoTDA device group within HuaweiCloud.
+Manages an IoTDA device group resource within HuaweiCloud.
 
 -> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
-endpoint in `provider` block.
-You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
-to view the HTTPS application access address. An example of the access address might be
-**9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
-`provider` block as follows:
+  endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  **9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+  `provider` block as follows:
 
   ```hcl
   provider "huaweicloud" {
@@ -27,11 +28,12 @@ to view the HTTPS application access address. An example of the access address m
 ## Example Usage
 
 ```hcl
+variable "name" {}
 variable "space_id" {}
 variable "device_id" {}
 
-resource "huaweicloud_iotda_device_group" "group" {
-  name       = "demo_group"
+resource "huaweicloud_iotda_device_group" "test" {
+  name       = var.name
   space_id   = var.space_id
   device_ids = [var.device_id]
 }
@@ -42,20 +44,20 @@ resource "huaweicloud_iotda_device_group" "group" {
 The following arguments are supported:
 
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the IoTDA device group resource.
-If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
 * `name` - (Required, String) Specifies the name of device group. The name contains a maximum of `64` characters.
-Only letters, digits, hyphens (-) and underscores (_) are allowed.
+  Only letters, digits, hyphens (-) and underscores (_) are allowed.
 
 * `space_id` - (Required, String, ForceNew) Specifies the resource space ID to which the device group belongs.
-Changing this parameter will create a new resource.
+  Changing this parameter will create a new resource.
 
 * `description` - (Optional, String) Specifies the description of device group.
-The description contains a maximum of `64` characters. Only letters, Chinese characters, digits, hyphens (-),
-underscores (_) and the following special characters are allowed: `?'#().,&%@!`.
+  The description contains a maximum of `64` characters. Only letters, Chinese characters, digits, hyphens (-),
+  underscores (_) and the following special characters are allowed: `?'#().,&%@!`.
 
 * `parent_group_id` - (Optional, String, ForceNew) Specifies the parent group id.
-Changing this parameter will create a new resource.
+  Changing this parameter will create a new resource.
 
 * `type` - (Optional, String, ForceNew) Specifies the device group type.
   The valid values are as follows:
@@ -86,16 +88,16 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Groups can be imported using the `id`, e.g.
+The device group can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_iotda_device_group.test 10022532f4f94f26b01daa1e424853e1
+$ terraform import huaweicloud_iotda_device_group.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `space_id`. It is generally
 recommended running `terraform plan` after importing the resource. You can then decide if changes should be applied to
-the resource, or the resource definition should be updated to align with the group. Also you can ignore changes as
+the resource, or the resource definition should be updated to align with the group. Also, you can ignore changes as
 below.
 
 ```hcl

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_group_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_group_test.go
@@ -2,33 +2,56 @@ package iotda
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iotda"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getDeviceGroupResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, WithDerivedAuth())
+func getDeviceGroupResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region    = acceptance.HW_REGION_NAME
+		isDerived = iotda.WithDerivedAuth(cfg, region)
+		product   = "iotda"
+	)
+
+	client, err := cfg.NewServiceClientWithDerivedAuth(product, region, isDerived)
 	if err != nil {
-		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
+		return nil, fmt.Errorf("error creating IoTDA client: %s", err)
 	}
 
-	return client.ShowDeviceGroup(&model.ShowDeviceGroupRequest{GroupId: state.Primary.ID})
+	getPath := client.Endpoint + "v5/iot/{project_id}/device-group/{group_id}"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{group_id}", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving IoTDA device group: %s", err)
+
+	}
+
+	return utils.FlattenResponse(getResp)
 }
 
 func TestAccDeviceGroup_basic(t *testing.T) {
-	var obj model.ShowDeviceGroupResponse
-
-	deviceName := acceptance.RandomAccResourceName()
-	name := acceptance.RandomAccResourceName()
-	updateName := acceptance.RandomAccResourceName()
-	rName := "huaweicloud_iotda_device_group.test"
+	var (
+		obj        interface{}
+		deviceName = acceptance.RandomAccResourceName()
+		name       = acceptance.RandomAccResourceName()
+		updateName = name + "_update"
+		rName      = "huaweicloud_iotda_device_group.test"
+	)
 
 	rc := acceptance.InitResourceCheck(
 		rName,
@@ -49,8 +72,8 @@ func TestAccDeviceGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "description", name),
-					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
+					resource.TestCheckResourceAttr(rName, "description", "description test"),
+					resource.TestCheckResourceAttrPair(rName, "space_id", "data.huaweicloud_iotda_spaces.test", "spaces.0.id"),
 					resource.TestCheckResourceAttr(rName, "device_ids.#", "1"),
 					resource.TestCheckResourceAttrPair(rName, "device_ids.0", "huaweicloud_iotda_device.test", "id"),
 				),
@@ -59,8 +82,8 @@ func TestAccDeviceGroup_basic(t *testing.T) {
 				Config: testDeviceGroup_basic_update(updateName, deviceName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(rName, "name", updateName),
-					resource.TestCheckResourceAttr(rName, "description", updateName),
-					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
+					resource.TestCheckResourceAttr(rName, "description", "description update"),
+					resource.TestCheckResourceAttrPair(rName, "space_id", "data.huaweicloud_iotda_spaces.test", "spaces.0.id"),
 					resource.TestCheckResourceAttr(rName, "device_ids.#", "1"),
 					resource.TestCheckResourceAttrPair(rName, "device_ids.0", "huaweicloud_iotda_device.test2", "id"),
 				),
@@ -77,9 +100,10 @@ func TestAccDeviceGroup_basic(t *testing.T) {
 
 func TestAccDeviceGroup_withDynamicGroup(t *testing.T) {
 	var (
-		obj        model.ShowDeviceGroupResponse
+		obj        interface{}
+		deviceName = acceptance.RandomAccResourceName()
 		name       = acceptance.RandomAccResourceName()
-		updateName = acceptance.RandomAccResourceName()
+		updateName = name + "_update"
 		rName      = "huaweicloud_iotda_device_group.test"
 	)
 
@@ -99,23 +123,23 @@ func TestAccDeviceGroup_withDynamicGroup(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testDeviceGroup_dynamicGroup(name),
+				Config: testDeviceGroup_dynamicGroup_basic(name, deviceName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "description", "description test"),
 					resource.TestCheckResourceAttr(rName, "type", "DYNAMIC"),
-					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "space_id", "data.huaweicloud_iotda_spaces.test", "spaces.0.id"),
 					resource.TestCheckResourceAttr(rName, "device_ids.#", "2"),
 				),
 			},
 			{
-				Config: testDeviceGroup_dynamicGroup_update(updateName),
+				Config: testDeviceGroup_dynamicGroup_update(updateName, deviceName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(rName, "name", updateName),
 					resource.TestCheckResourceAttr(rName, "description", "description update"),
 					resource.TestCheckResourceAttr(rName, "type", "DYNAMIC"),
-					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "space_id", "data.huaweicloud_iotda_spaces.test", "spaces.0.id"),
 					resource.TestCheckResourceAttr(rName, "device_ids.#", "2"),
 				),
 			},
@@ -129,62 +153,93 @@ func TestAccDeviceGroup_withDynamicGroup(t *testing.T) {
 	})
 }
 
-func testDeviceGroup_basic(name, deviceName string) string {
-	baseConfig := testDevice_basic(deviceName, deviceName)
+func testDeviceGroup_base(deviceName string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
+
+data "huaweicloud_iotda_spaces" "test" {
+  is_default = true
+}
+
+resource "huaweicloud_iotda_product" "test" {
+  name        = "%[2]s"
+  device_type = "test"
+  protocol    = "MQTT"
+  space_id    = data.huaweicloud_iotda_spaces.test.spaces[0].id
+  data_type   = "json"
+
+  services {
+    id   = "service_1"
+    type = "serv_type"
+  }
+}
+
+resource "huaweicloud_iotda_device" "test" {
+  node_id    = "%[2]s_1"
+  name       = "%[2]s_1"
+  space_id   = data.huaweicloud_iotda_spaces.test.spaces[0].id
+  product_id = huaweicloud_iotda_product.test.id
+}
+
+resource "huaweicloud_iotda_device" "test2" {
+  node_id    = "%[2]s_2"
+  name       = "%[2]s_2"
+  space_id   = data.huaweicloud_iotda_spaces.test.spaces[0].id
+  product_id = huaweicloud_iotda_product.test.id
+}
+`, buildIoTDAEndpoint(), deviceName)
+}
+
+func testDeviceGroup_basic(name, deviceName string) string {
+	return fmt.Sprintf(`
+%[1]s
 
 resource "huaweicloud_iotda_device_group" "test" {
-  name        = "%s"
-  space_id    = huaweicloud_iotda_space.test.id
-  description = "%s"
+  name        = "%[2]s"
+  space_id    = data.huaweicloud_iotda_spaces.test.spaces[0].id
+  description = "description test"
   device_ids  = [huaweicloud_iotda_device.test.id]
 }
-`, baseConfig, name, name)
+`, testDeviceGroup_base(deviceName), name)
 }
 
 func testDeviceGroup_basic_update(name, deviceName string) string {
-	baseConfig := testDevice_basic(deviceName, deviceName)
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_iotda_device_group" "test" {
-  name        = "%s"
-  space_id    = huaweicloud_iotda_space.test.id
-  description = "%s"
+  name        = "%[2]s"
+  space_id    = data.huaweicloud_iotda_spaces.test.spaces[0].id
+  description = "description update"
   device_ids  = [huaweicloud_iotda_device.test2.id]
 }
-`, baseConfig, name, name)
+`, testDeviceGroup_base(deviceName), name)
 }
 
-func testDeviceGroup_dynamicGroup(name string) string {
-	baseConfig := testDevice_basic(name, name)
-
+func testDeviceGroup_dynamicGroup_basic(name, deviceName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_iotda_device_group" "test" {
   name               = "%[2]s"
-  space_id           = huaweicloud_iotda_space.test.id
+  space_id           = data.huaweicloud_iotda_spaces.test.spaces[0].id
   description        = "description test"
   type               = "DYNAMIC"
   dynamic_group_rule = "device_id = '${huaweicloud_iotda_device.test.id}' or device_id = '${huaweicloud_iotda_device.test2.id}'"
 }
-`, baseConfig, name)
+`, testDeviceGroup_base(deviceName), name)
 }
 
-func testDeviceGroup_dynamicGroup_update(name string) string {
-	baseConfig := testDevice_basic(name, name)
-
+func testDeviceGroup_dynamicGroup_update(name, deviceName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_iotda_device_group" "test" {
   name               = "%[2]s"
-  space_id           = huaweicloud_iotda_space.test.id
+  space_id           = data.huaweicloud_iotda_spaces.test.spaces[0].id
   description        = "description update"
   type               = "DYNAMIC"
   dynamic_group_rule = "device_id = '${huaweicloud_iotda_device.test.id}' or device_id = '${huaweicloud_iotda_device.test2.id}'"
 }
-`, baseConfig, name)
+`, testDeviceGroup_base(deviceName), name)
 }

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_group.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_group.go
@@ -3,14 +3,13 @@ package iotda
 import (
 	"context"
 	"fmt"
-	"log"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	iotdav5 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5"
-	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -81,92 +80,225 @@ func ResourceDeviceGroup() *schema.Resource {
 	}
 }
 
+func buildCreateDeviceGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":               d.Get("name"),
+		"description":        utils.ValueIgnoreEmpty(d.Get("description")),
+		"super_group_id":     utils.ValueIgnoreEmpty(d.Get("parent_group_id")),
+		"app_id":             d.Get("space_id"),
+		"group_type":         utils.ValueIgnoreEmpty(d.Get("type")),
+		"dynamic_group_rule": utils.ValueIgnoreEmpty(d.Get("dynamic_group_rule")),
+	}
+}
+
 func resourceDeviceGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	isDerived := WithDerivedAuth(c, region)
-	client, err := c.HcIoTdaV5Client(region, isDerived)
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+		product   = "iotda"
+	)
+
+	client, err := cfg.NewServiceClientWithDerivedAuth(product, region, isDerived)
 	if err != nil {
-		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+		return diag.Errorf("error creating IoTDA client: %s", err)
 	}
 
-	createOpts := model.AddDeviceGroupRequest{
-		Body: &model.AddDeviceGroupDto{
-			Name:             utils.String(d.Get("name").(string)),
-			Description:      utils.StringIgnoreEmpty(d.Get("description").(string)),
-			SuperGroupId:     utils.StringIgnoreEmpty(d.Get("parent_group_id").(string)),
-			AppId:            utils.String(d.Get("space_id").(string)),
-			GroupType:        utils.StringIgnoreEmpty(d.Get("type").(string)),
-			DynamicGroupRule: utils.StringIgnoreEmpty(d.Get("dynamic_group_rule").(string)),
-		},
+	createPath := client.Endpoint + "v5/iot/{project_id}/device-group"
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateDeviceGroupBodyParams(d)),
 	}
-	log.Printf("[DEBUG] Create IoTDA device group params: %#v", createOpts)
 
-	resp, err := client.AddDeviceGroup(&createOpts)
+	createResp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA device group: %s", err)
 	}
 
-	if resp.GroupId == nil {
-		return diag.Errorf("error creating IoTDA device group: id is not found in API response")
-	}
-
-	d.SetId(*resp.GroupId)
-
-	// add device to group
-	addIds := d.Get("device_ids").(*schema.Set)
-	err = addDevicesToGroup(client, d.Id(), addIds)
+	createRespBody, err := utils.FlattenResponse(createResp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	groupId := utils.PathSearch("group_id", createRespBody, "").(string)
+	if groupId == "" {
+		return diag.Errorf("error creating IoTDA device group: ID is not found in API response")
+	}
+
+	d.SetId(groupId)
+
+	// Add devices to group.
+	addDeviceIds := d.Get("device_ids").(*schema.Set)
+	err = addOrRemoveDevicesFromGroup(client, "addDevice", groupId, addDeviceIds)
+	if err != nil {
+		return diag.Errorf("error adding devices to IoTDA device group in creation operation: %s", err)
+	}
+
 	return resourceDeviceGroupRead(ctx, d, meta)
 }
 
-func resourceDeviceGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	isDerived := WithDerivedAuth(c, region)
-	client, err := c.HcIoTdaV5Client(region, isDerived)
-	if err != nil {
-		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+func buildAddOrRemoveDevicesFromGroupQueryParams(action, deviceId string) string {
+	return fmt.Sprintf("?action_id=%v&device_id=%v", action, deviceId)
+}
+
+func addOrRemoveDevicesFromGroup(client *golangsdk.ServiceClient, action, groupId string, addDeviceIds *schema.Set) error {
+	requestPath := client.Endpoint + "v5/iot/{project_id}/device-group/{group_id}/action"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{group_id}", groupId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
 
-	detail, err := client.ShowDeviceGroup(&model.ShowDeviceGroupRequest{GroupId: d.Id()})
+	for _, deviceId := range addDeviceIds.List() {
+		currentPath := requestPath + buildAddOrRemoveDevicesFromGroupQueryParams(action, deviceId.(string))
+		_, err := client.Request("POST", currentPath, &requestOpt)
+		if err != nil {
+			return fmt.Errorf("error operating device (%s) in the IoTDA device group (%s): %s", deviceId, groupId, err)
+		}
+	}
+
+	return nil
+}
+
+func resourceDeviceGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+		product   = "iotda"
+	)
+
+	client, err := cfg.NewServiceClientWithDerivedAuth(product, region, isDerived)
 	if err != nil {
+		return diag.Errorf("error creating IoTDA client: %s", err)
+	}
+
+	getPath := client.Endpoint + "v5/iot/{project_id}/device-group/{group_id}"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{group_id}", d.Id())
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		// When the resource does not exist, the query API will return `404` error code.
 		return common.CheckDeletedDiag(d, err, "error retrieving IoTDA device group")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	mErr := multierror.Append(
 		d.Set("region", region),
-		d.Set("name", detail.Name),
-		d.Set("description", detail.Description),
-		d.Set("parent_group_id", detail.SuperGroupId),
-		d.Set("type", detail.GroupType),
-		d.Set("dynamic_group_rule", detail.DynamicGroupRule),
-		setDeviceIdsToState(d, client, d.Id()),
+		d.Set("name", utils.PathSearch("name", getRespBody, nil)),
+		d.Set("description", utils.PathSearch("description", getRespBody, nil)),
+		d.Set("parent_group_id", utils.PathSearch("super_group_id", getRespBody, nil)),
+		d.Set("type", utils.PathSearch("group_type", getRespBody, nil)),
+		d.Set("dynamic_group_rule", utils.PathSearch("dynamic_group_rule", getRespBody, nil)),
+	)
+
+	devicesIds, err := getDeviceIdsFromGroup(client, d.Id())
+	if err != nil {
+		return diag.Errorf("error setting device_ids field: %s", err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("device_ids", devicesIds),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
+func buildQueryDevicesFromGroupQueryParams(marker string) string {
+	if marker != "" {
+		return fmt.Sprintf("?marker=%v", marker)
+	}
+
+	return ""
+}
+
+func getDeviceIdsFromGroup(client *golangsdk.ServiceClient, groupId string) ([]string, error) {
+	var (
+		marker     string
+		devicesIds = make([]string, 0)
+	)
+
+	getPath := client.Endpoint + "v5/iot/{project_id}/device-group/{group_id}/devices"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{group_id}", groupId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := getPath + buildQueryDevicesFromGroupQueryParams(marker)
+		getResp, err := client.Request("GET", currentPath, &getOpt)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving devices in IoTDA device group: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return nil, err
+		}
+
+		devicesResp := utils.PathSearch("devices", getRespBody, make([]interface{}, 0)).([]interface{})
+		if len(devicesResp) == 0 {
+			break
+		}
+
+		for _, v := range devicesResp {
+			deviceId := utils.PathSearch("device_id", v, "").(string)
+			if deviceId != "" {
+				devicesIds = append(devicesIds, deviceId)
+			}
+		}
+
+		marker = utils.PathSearch("page.marker", getRespBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	return devicesIds, nil
+}
+
+func buildUpdateDeviceGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+}
+
 func resourceDeviceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	isDerived := WithDerivedAuth(c, region)
-	client, err := c.HcIoTdaV5Client(region, isDerived)
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+		product   = "iotda"
+		groupId   = d.Id()
+	)
+
+	client, err := cfg.NewServiceClientWithDerivedAuth(product, region, isDerived)
 	if err != nil {
-		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+		return diag.Errorf("error creating IoTDA client: %s", err)
 	}
 
 	if d.HasChanges("name", "description") {
-		updateOpts := &model.UpdateDeviceGroupRequest{
-			GroupId: d.Id(),
-			Body: &model.UpdateDeviceGroupDto{
-				Name:        utils.String(d.Get("name").(string)),
-				Description: utils.StringIgnoreEmpty(d.Get("description").(string)),
-			},
+		updatePath := client.Endpoint + "v5/iot/{project_id}/device-group/{group_id}"
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{group_id}", groupId)
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody:         utils.RemoveNil(buildUpdateDeviceGroupBodyParams(d)),
 		}
-		_, err = client.UpdateDeviceGroup(updateOpts)
+
+		_, err := client.Request("PUT", updatePath, &updateOpt)
 		if err != nil {
 			return diag.Errorf("error updating IoTDA device group: %s", err)
 		}
@@ -177,18 +309,18 @@ func resourceDeviceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 		oldIds := o.(*schema.Set)
 		newIds := n.(*schema.Set)
 
-		// remove device from group
+		// Remove devices from group.
 		deleteIds := oldIds.Difference(newIds)
-		err = deleteDevicesFromGroup(client, d.Id(), deleteIds)
+		err = addOrRemoveDevicesFromGroup(client, "removeDevice", groupId, deleteIds)
 		if err != nil {
-			return diag.FromErr(err)
+			return diag.Errorf("error deleting devices from IoTDA device group in update operation: %s", err)
 		}
 
-		// add device to group
+		// Add devices to group.
 		addIds := newIds.Difference(oldIds)
-		err = addDevicesToGroup(client, d.Id(), addIds)
+		err = addOrRemoveDevicesFromGroup(client, "addDevice", groupId, addIds)
 		if err != nil {
-			return diag.FromErr(err)
+			return diag.Errorf("error adding devices to IoTDA device group in update operation: %s", err)
 		}
 	}
 
@@ -196,80 +328,40 @@ func resourceDeviceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceDeviceGroupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	region := c.GetRegion(d)
-	isDerived := WithDerivedAuth(c, region)
-	client, err := c.HcIoTdaV5Client(region, isDerived)
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+		product   = "iotda"
+		groupId   = d.Id()
+	)
+
+	client, err := cfg.NewServiceClientWithDerivedAuth(product, region, isDerived)
 	if err != nil {
-		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+		return diag.Errorf("error creating IoTDA client: %s", err)
 	}
 
 	// Remove devices from static device group, dynamic device group does not require this operation.
 	if d.Get("type").(string) == "STATIC" {
-		addIds := d.Get("device_ids").(*schema.Set)
-		err = deleteDevicesFromGroup(client, d.Id(), addIds)
+		deleteDeviceIds := d.Get("device_ids").(*schema.Set)
+		err = addOrRemoveDevicesFromGroup(client, "removeDevice", groupId, deleteDeviceIds)
 		if err != nil {
-			return diag.FromErr(err)
+			return diag.Errorf("error deleting devices from IoTDA device group in deletion operation: %s", err)
 		}
 	}
 
-	deleteOpts := &model.DeleteDeviceGroupRequest{
-		GroupId: d.Id(),
+	deletePath := client.Endpoint + "v5/iot/{project_id}/device-group/{group_id}"
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{group_id}", groupId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
-	_, err = client.DeleteDeviceGroup(deleteOpts)
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return diag.Errorf("error deleting IoTDA device group: %s", err)
+		// When the resource does not exist, the delete API will return `404` error code.
+		return common.CheckDeletedDiag(d, err, "error deleting IoTDA device group")
 	}
 
 	return nil
-}
-
-func addDevicesToGroup(client *iotdav5.IoTDAClient, groupId string, addIds *schema.Set) error {
-	for _, v := range addIds.List() {
-		_, err := client.CreateOrDeleteDeviceInGroup(&model.CreateOrDeleteDeviceInGroupRequest{
-			GroupId:  groupId,
-			ActionId: "addDevice",
-			DeviceId: v.(string),
-		})
-
-		if err != nil {
-			return fmt.Errorf("error adding device=%s to IoTDA device group=%s: %s", v.(string), groupId, err)
-		}
-	}
-	return nil
-}
-
-func deleteDevicesFromGroup(client *iotdav5.IoTDAClient, groupId string, addIds *schema.Set) error {
-	for _, v := range addIds.List() {
-		_, err := client.CreateOrDeleteDeviceInGroup(&model.CreateOrDeleteDeviceInGroupRequest{
-			GroupId:  groupId,
-			ActionId: "removeDevice",
-			DeviceId: v.(string),
-		})
-
-		if err != nil {
-			return fmt.Errorf("error deleting device=%s from IoTDA device group=%s: %s", v.(string), groupId, err)
-		}
-	}
-	return nil
-}
-
-func setDeviceIdsToState(d *schema.ResourceData, client *iotdav5.IoTDAClient, groupId string) error {
-	var rst []string
-	var marker *string
-	for {
-		resp, err := client.ShowDevicesInGroup(&model.ShowDevicesInGroupRequest{GroupId: groupId, Marker: marker})
-		if err != nil {
-			return fmt.Errorf("error setting the device_ids: %s", err)
-		}
-		if resp.Devices == nil || len(*resp.Devices) == 0 {
-			break
-		}
-		for _, v := range *resp.Devices {
-			rst = append(rst, *v.DeviceId)
-		}
-		marker = resp.Page.Marker
-	}
-
-	return d.Set("device_ids", rst)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

refactor device group resource code style

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

refactor device group resource code style

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDeviceGroup_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceGroup_ -timeout 360m -parallel 4
=== RUN   TestAccDeviceGroup_basic
--- PASS: TestAccDeviceGroup_basic (17.81s)
=== RUN   TestAccDeviceGroup_withDynamicGroup
--- PASS: TestAccDeviceGroup_withDynamicGroup (16.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     34.451s

```
![image](https://github.com/user-attachments/assets/dde42a70-09e8-47f5-aaf0-e3c4e8b51b18)


* [x] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/ce8ef4d6-7c20-4efb-9c59-9a345035f3cf)


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/user-attachments/assets/0c972c16-0864-4767-be1c-f0143f540657)


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
