### PR TITLE
fix(dns): fix some issues of the ptr record resource

### DIFF
--- a/docs/resources/dns_ptrrecord.md
+++ b/docs/resources/dns_ptrrecord.md
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies the description of the PTR record.
 
-* `ttl` - (Optional, Int) Specifies the time to live (TTL) of the record set (in seconds).
+* `ttl` - (Optional, Int) Specifies the time to live (TTL) of the record set (in seconds), defaults to `300`.  
   The valid value is range from `1` to `2,147,483,647`.
 
 * `tags` - (Optional, Map) Tags key/value pairs to associate with the PTR record.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20250222073519-5b8821f34fbc
+	github.com/chnsz/golangsdk v0.0.0-20250225032204-25154fdef892
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20250222073519-5b8821f34fbc h1:VMWFELue1yT+hN7elY38iZTmGZfet5DAUW1EtKGDBtk=
-github.com/chnsz/golangsdk v0.0.0-20250222073519-5b8821f34fbc/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
+github.com/chnsz/golangsdk v0.0.0-20250225032204-25154fdef892 h1:K0RW/Y5YHNxOjxE8w3lkpIDUuHWIMGoq3v61PIauOAk=
+github.com/chnsz/golangsdk v0.0.0-20250225032204-25154fdef892/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_ptrrecord_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_ptrrecord_test.go
@@ -55,7 +55,7 @@ func TestAccDNSPtrRecord_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("update-%s", nameWithDotSuffix)),
-					resource.TestCheckResourceAttr(resourceName, "description", "ptr record updated"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "7000"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttrPair(resourceName, "floatingip_id", "huaweicloud_vpc_eip.test", "id"),
@@ -96,7 +96,7 @@ func TestAccDNSPtrRecord_withEpsId(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", nameWithDotSuffix),
 					resource.TestCheckResourceAttr(resourceName, "description", "a ptr record"),
-					resource.TestCheckResourceAttr(resourceName, "ttl", "6000"),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "300"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttrPair(resourceName, "floatingip_id", "huaweicloud_vpc_eip.test", "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "address"),
@@ -144,7 +144,6 @@ func testAccDNSPtrRecord_update(ptrName string) string {
 
 resource "huaweicloud_dns_ptrrecord" "test" {
   name          = "update-%s"
-  description   = "ptr record updated"
   floatingip_id = huaweicloud_vpc_eip.test.id
   ttl           = 7000
 
@@ -163,7 +162,6 @@ resource "huaweicloud_dns_ptrrecord" "test" {
   name                  = "%s"
   description           = "a ptr record"
   floatingip_id         = huaweicloud_vpc_eip.test.id
-  ttl                   = 6000
   enterprise_project_id = "%s"
 }
 `, testAccDNSPtrRecord_base(), ptrName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_ptrrecord.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_ptrrecord.go
@@ -66,6 +66,7 @@ func ResourceDNSPtrRecord() *schema.Resource {
 			"ttl": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
@@ -92,7 +93,7 @@ func resourceDNSPtrRecordCreate(ctx context.Context, d *schema.ResourceData, met
 
 	createOpts := ptrrecords.CreateOpts{
 		PtrName:             d.Get("name").(string),
-		Description:         d.Get("description").(string),
+		Description:         utils.String(d.Get("description").(string)),
 		TTL:                 d.Get("ttl").(int),
 		Tags:                getPtrRecordsTagList(d),
 		EnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
@@ -198,7 +199,7 @@ func resourceDNSPtrRecordUpdate(ctx context.Context, d *schema.ResourceData, met
 	if d.HasChanges("name", "description", "ttl") {
 		updateOpts := ptrrecords.CreateOpts{
 			PtrName:     d.Get("name").(string),
-			Description: d.Get("description").(string),
+			Description: utils.String(d.Get("description").(string)),
 			TTL:         d.Get("ttl").(int),
 		}
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/ptrrecords/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/ptrrecords/requests.go
@@ -22,7 +22,7 @@ type CreateOpts struct {
 	PtrName string `json:"ptrdname" required:"true"`
 
 	// Description of the ptr.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// TTL is the time to live of the ptr.
 	TTL int `json:"-"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20250222073519-5b8821f34fbc
+# github.com/chnsz/golangsdk v0.0.0-20250225032204-25154fdef892
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth
@@ -186,11 +186,9 @@ github.com/chnsz/golangsdk/openstack/evs/v1/jobs
 github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes
 github.com/chnsz/golangsdk/openstack/evs/v2/snapshots
 github.com/chnsz/golangsdk/openstack/evs/v5/cloudvolumes
-github.com/chnsz/golangsdk/openstack/fgs/v2/aliases
 github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies
 github.com/chnsz/golangsdk/openstack/fgs/v2/function
 github.com/chnsz/golangsdk/openstack/fgs/v2/trigger
-github.com/chnsz/golangsdk/openstack/fgs/v2/versions
 github.com/chnsz/golangsdk/openstack/geminidb/v3/backups
 github.com/chnsz/golangsdk/openstack/geminidb/v3/configurations
 github.com/chnsz/golangsdk/openstack/geminidb/v3/flavors


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixed the following two issues:
+ The description cannot be modified to empty.
+ If `ttl` parameter is not set when creating a resource, the interface will return a default value, causing the resource to change.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fixed the problem that description cannot be set to empty and the resource change when ttl is not specified.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccDNSPtrRecord_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDNSPtrRecord_ -timeout 360m -parallel 10
=== RUN   TestAccDNSPtrRecord_basic
=== PAUSE TestAccDNSPtrRecord_basic
=== RUN   TestAccDNSPtrRecord_withEpsId
=== PAUSE TestAccDNSPtrRecord_withEpsId
=== CONT  TestAccDNSPtrRecord_basic
=== CONT  TestAccDNSPtrRecord_withEpsId
--- PASS: TestAccDNSPtrRecord_withEpsId (63.75s)
--- PASS: TestAccDNSPtrRecord_basic (94.23s)
PASS
coverage: 5.9% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       94.298s coverage: 5.9% of statements in ./huaweicloud/services/dns
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
