### PR TITLE
feat(ecs): support to update uuid and fixed_ip_v4 in ecs network

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -382,11 +382,9 @@ The following arguments are supported:
 
 The `network` block supports:
 
-* `uuid` - (Required, String, ForceNew) Specifies the network UUID to attach to the instance.
-  Changing this creates a new instance.
+* `uuid` - (Required, String) Specifies the network UUID to attach to the instance.
 
-* `fixed_ip_v4` - (Optional, String, ForceNew) Specifies a fixed IPv4 address to be used on this network.
-  Changing this creates a new instance.
+* `fixed_ip_v4` - (Optional, String) Specifies a fixed IPv4 address to be used on this network.
 
 * `ipv6_enable` - (Optional, Bool, ForceNew) Specifies whether the IPv6 function is enabled for the nic.
   Defaults to false. Changing this creates a new instance.
@@ -397,6 +395,8 @@ The `network` block supports:
 
 * `access_network` - (Optional, Bool) Specifies if this network should be used for provisioning access.
   Accepts true or false. Defaults to false.
+
+  ~> The `uuid` and `fixed_ip_v4` can be updated when there is only one network block.
 
 The `data_disks` block supports:
 

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
@@ -324,6 +324,42 @@ func TestAccComputeInstance_withEPS(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_changeNetwork(t *testing.T) {
+	var instance cloudservers.CloudServer
+
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_compute_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckComputeInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_changeNetwork(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform test"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttrPair(resourceName, "network.0.uuid",
+						"huaweicloud_vpc_subnet.test1", "id"),
+				),
+			},
+			{
+				Config: testAccComputeInstance_changeNetworkUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform test update"),
+					resource.TestCheckResourceAttrPair(resourceName, "network.0.uuid",
+						"huaweicloud_vpc_subnet.test2", "id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeInstanceDestroy(s *terraform.State) error {
 	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
 	computeClient, err := cfg.ComputeV1Client(acceptance.HW_REGION_NAME)
@@ -684,6 +720,89 @@ resource "huaweicloud_compute_instance" "test" {
     size       = "50"
     iops       = 5000
     throughput = 300
+  }
+}
+`, testAccCompute_data, rName)
+}
+
+func testAccComputeInstance_changeNetwork(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[2]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test1" {
+  name       = "%[2]s-1"
+  cidr       = "192.168.1.0/24"
+  gateway_ip = "192.168.1.1"
+  vpc_id     = huaweicloud_vpc.test.id
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s"
+  description        = "terraform test"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test1.id
+  }
+
+  system_disk_type = "SAS"
+  system_disk_size = 50
+
+  data_disks {
+    type = "SAS"
+    size = "10"
+  }
+}
+`, testAccCompute_data, rName)
+}
+
+func testAccComputeInstance_changeNetworkUpdate(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[2]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test1" {
+  name       = "%[2]s-1"
+  cidr       = "192.168.1.0/24"
+  gateway_ip = "192.168.1.1"
+  vpc_id     = huaweicloud_vpc.test.id
+}
+
+resource "huaweicloud_vpc_subnet" "test2" {
+  name       = "%[2]s-2"
+  cidr       = "192.168.2.0/24"
+  gateway_ip = "192.168.2.1"
+  vpc_id     = huaweicloud_vpc.test.id
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s-update"
+  description        = "terraform test update"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test2.id
+  }
+
+  system_disk_type = "SAS"
+  system_disk_size = 50
+
+  data_disks {
+    type = "SAS"
+    size = "10"
   }
 }
 `, testAccCompute_data, rName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #6433

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/ecs' TESTARGS='-run TestAccComputeInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== CONT  TestAccComputeInstance_basic
--- PASS: TestAccComputeInstance_basic (322.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       322.270s

make testacc TEST='./huaweicloud/services/acceptance/ecs' TESTARGS='-run TestAccComputeInstance_changeNetwork'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeInstance_changeNetwork -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_changeNetwork
=== PAUSE TestAccComputeInstance_changeNetwork
=== CONT  TestAccComputeInstance_changeNetwork
--- PASS: TestAccComputeInstance_changeNetwork (323.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       323.272s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
