### PR TITLE
feat(dns): add new arguments and attributes for zones

### DIFF
--- a/docs/data-sources/dns_zones.md
+++ b/docs/data-sources/dns_zones.md
@@ -30,6 +30,8 @@ The following arguments are supported:
 
 * `zone_type` - (Required, String) Specifies the zone type. The value can be **public** or **private**.
 
+* `zone_id` - (Optional, String) Specifies the ID of the zone.
+
 * `tags` - (Optional, String) Specifies the resource tag. The format is as follows: key1,value1|key2,value2.
   Multiple tags are separated by vertical bar (|). The key and value of each tag are separated by comma (,). The tags
   are in `AND` relationship. Exact matching will work. If the value starts with an asterisk (*), fuzzy matching will
@@ -52,6 +54,20 @@ The following arguments are supported:
   If not specified, fuzzy matching will be used.
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID which the zone associated.
+
+* `router_id` - (Optional, String) Specifies the ID of the VPC associated with the private zone.  
+  This parameter is available only when the `zone_type` parameter is set to **private**.
+
+* `sort_key` - (Optional, String) Specifies the sorting filed for the list of the zones.  
+  The valid values are as follows:
+  + **name**: The zone name.
+  + **created_at**: The creation time of the zone.
+  + **updated_at** The update time of the zone.
+
+* `sort_dir` - (Optional, String) Specifies the sorting mode for the list of the zones.  
+  The valid values are as follows:
+  + **DESC**: Descending order.
+  + **ASC**: Ascending order.
 
 ## Attribute Reference
 
@@ -89,6 +105,16 @@ The `zones` block supports:
 
 * `routers` - The list of VPCs associated with the zone. This attribute is only valid when `zone_type` is **private**.
   The [routers](#Zones_routers) structure is documented below.
+
+* `proxy_pattern` - The recursive resolution proxy mode for subdomains of the private zone.
+  + **AUTHORITY**: The recursive resolution proxy is disabled for the private zone.
+  + **RECURSIVE**: The recursive resolution proxy is enabled for the private zone.
+
+* `pool_id` - The ID of the pool to which the zone belongs, assigned by the system.
+
+* `created_at` - The creation time of the zone, in RFC3339 format.
+
+* `updated_at` - The latest update time of the zone, in RFC3339 format.
 
 <a name="Zones_routers"></a>
 The `routers` block supports:

--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_zones_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_zones_test.go
@@ -14,10 +14,16 @@ import (
 
 func TestAccDataZones_basic(t *testing.T) {
 	var (
-		name = fmt.Sprintf("acpttest-zone-%s.com.", acctest.RandString(5))
+		name  = fmt.Sprintf("acpttest-zone-%s.com.", acctest.RandString(5))
+		rName = "huaweicloud_dns_zone.test.0"
 
 		all           = "data.huaweicloud_dns_zones.test"
 		dcForAllZones = acceptance.InitDataSourceCheck(all)
+
+		byZoneId           = "data.huaweicloud_dns_zones.filter_by_zone_id"
+		dcByZoneId         = acceptance.InitDataSourceCheck(byZoneId)
+		byNotFoundZoneId   = "data.huaweicloud_dns_zones.filter_by_not_found_zone_id"
+		dcByNotFoundZoneId = acceptance.InitDataSourceCheck(byNotFoundZoneId)
 
 		byNameFuzzy      = "data.huaweicloud_dns_zones.filter_by_name_fuzzy"
 		dcByNameFuzzy    = acceptance.InitDataSourceCheck(byNameFuzzy)
@@ -38,6 +44,16 @@ func TestAccDataZones_basic(t *testing.T) {
 		dcByTags         = acceptance.InitDataSourceCheck(byTags)
 		byNotFoundTags   = "data.huaweicloud_dns_zones.filter_by_not_found_tags"
 		dcByNotFoundTags = acceptance.InitDataSourceCheck(byNotFoundTags)
+
+		byRouterId           = "data.huaweicloud_dns_zones.filter_by_router_id"
+		dcByRouterId         = acceptance.InitDataSourceCheck(byRouterId)
+		byNotFoundRouterId   = "data.huaweicloud_dns_zones.filter_by_not_found_router_id"
+		dcByNotFoundRouterId = acceptance.InitDataSourceCheck(byNotFoundRouterId)
+
+		bySortAsc    = "data.huaweicloud_dns_zones.filter_by_sort_asc"
+		dcBySortAsc  = acceptance.InitDataSourceCheck(bySortAsc)
+		bySortDesc   = "data.huaweicloud_dns_zones.filter_by_sort_desc"
+		dcBySortDesc = acceptance.InitDataSourceCheck(bySortDesc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -52,6 +68,11 @@ func TestAccDataZones_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					dcForAllZones.CheckResourceExists(),
 					resource.TestMatchResourceAttr(all, "zones.#", regexp.MustCompile(`[1-9][0-9]*`)),
+					// Filter by zone ID.
+					dcByZoneId.CheckResourceExists(),
+					resource.TestCheckOutput("is_zone_id_filter_useful", "true"),
+					dcByNotFoundZoneId.CheckResourceExists(),
+					resource.TestCheckOutput("zone_id_not_found_validation_pass", "true"),
 					// Fuzzy search by zone name.
 					dcByNameFuzzy.CheckResourceExists(),
 					resource.TestCheckOutput("is_name_fuzzy_filter_useful", "true"),
@@ -73,32 +94,73 @@ func TestAccDataZones_basic(t *testing.T) {
 					resource.TestCheckOutput("is_tags_filter_useful", "true"),
 					dcByNotFoundTags.CheckResourceExists(),
 					resource.TestCheckOutput("tags_not_found_validation_pass", "true"),
+					// Filter by the ID of the VPC associated with the private zone.
+					dcByRouterId.CheckResourceExists(),
+					resource.TestCheckOutput("is_router_id_filter_useful", "true"),
+					dcByNotFoundRouterId.CheckResourceExists(),
+					resource.TestCheckOutput("router_id_not_found_validation_pass", "true"),
+					// Check ascending and descending results.
+					dcBySortAsc.CheckResourceExists(),
+					dcBySortDesc.CheckResourceExists(),
+					resource.TestCheckOutput("sort_filter_is_useful", "true"),
 					// Check attributes
-					// Cannot query unique data by name.
-					// A VPC cannot be bound to a private network with the same name, so after the router_id query parameter is provided,
-					// the router_id and name can be used together to query and determine the unique data.
-					resource.TestCheckResourceAttrSet(byNameExact, "zones.0.id"),
-					resource.TestCheckResourceAttrSet(byNameExact, "zones.0.name"),
-					resource.TestCheckResourceAttrSet(byNameExact, "zones.0.description"),
-					resource.TestCheckResourceAttrSet(byNameExact, "zones.0.email"),
-					resource.TestCheckResourceAttr(byNameExact, "zones.0.zone_type", "private"),
-					resource.TestCheckResourceAttrSet(byNameExact, "zones.0.enterprise_project_id"),
-					resource.TestCheckResourceAttrSet(byNameExact, "zones.0.routers.0.router_id"),
-					resource.TestCheckResourceAttrSet(byNameExact, "zones.0.routers.0.router_region"),
-					resource.TestCheckResourceAttrSet(byNameExact, "zones.0.ttl"),
-					resource.TestCheckResourceAttrSet(byNameExact, "zones.0.record_num"),
-					resource.TestCheckResourceAttr(byNameExact, "zones.0.masters.#", "0"),
+					resource.TestCheckResourceAttrPair(byZoneId, "zones.0.id", rName, "id"),
+					resource.TestCheckResourceAttrPair(byZoneId, "zones.0.name", rName, "name"),
+					resource.TestCheckResourceAttrPair(byZoneId, "zones.0.description", rName, "description"),
+					resource.TestCheckResourceAttrPair(byZoneId, "zones.0.email", rName, "email"),
+					resource.TestCheckResourceAttr(byZoneId, "zones.0.zone_type", "private"),
+					resource.TestCheckResourceAttrPair(byZoneId, "zones.0.enterprise_project_id", rName, "enterprise_project_id"),
+					resource.TestCheckResourceAttrPair(byZoneId, "zones.0.routers.0.router_id", rName, "router.0.router_id"),
+					resource.TestCheckResourceAttrPair(byZoneId, "zones.0.routers.0.router_region", rName, "router.0.router_region"),
+					resource.TestCheckResourceAttrPair(byZoneId, "zones.0.ttl", rName, "ttl"),
+					resource.TestCheckResourceAttrPair(byZoneId, "zones.0.proxy_pattern", rName, "proxy_pattern"),
+					resource.TestMatchResourceAttr(byZoneId, "zones.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(byZoneId, "zones.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// The zone resource does not have 'record_num' and 'pool_id' parameters.
+					resource.TestCheckResourceAttrSet(byZoneId, "zones.0.record_num"),
+					resource.TestCheckResourceAttrSet(byZoneId, "zones.0.pool_id"),
+					// The 'masters' parameter has no corresponding scenario and is an empty list.
+					resource.TestCheckResourceAttr(byZoneId, "zones.0.masters.#", "0"),
+					// The 'masters' parameter has no corresponding scenario and is an empty list.
 				),
 			},
 		},
 	})
 }
 
-func testAccDataZones_base(name string) string {
-	randomId, _ := uuid.GenerateUUID()
+func testAccDataZones_base(name, randomId string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_dns_zones" "test" {
   zone_type = huaweicloud_dns_zone.test.0.zone_type
+}
+
+# Filter by zone ID.
+locals {
+  zone_id = huaweicloud_dns_zone.test.0.id
+}
+
+data "huaweicloud_dns_zones" "filter_by_zone_id" {
+  zone_type = huaweicloud_dns_zone.test.0.zone_type
+  zone_id   = local.zone_id
+}
+
+locals {
+  zone_id_filter_result = [for v in data.huaweicloud_dns_zones.filter_by_zone_id.zones[*].id : v == local.zone_id]
+}
+
+output "is_zone_id_filter_useful" {
+  value = length(local.zone_id_filter_result) > 0 && alltrue(local.zone_id_filter_result)
+}
+
+data "huaweicloud_dns_zones" "filter_by_not_found_zone_id" {
+  zone_type = huaweicloud_dns_zone.test.0.zone_type
+  zone_id   = "%[2]s"
+}
+
+output "zone_id_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_zones.filter_by_not_found_zone_id.zones) == 0
 }
 
 # Filter by zone name (Fuzzy search).
@@ -194,7 +256,7 @@ output "eps_id_not_found_validation_pass" {
   value = length(data.huaweicloud_dns_zones.filter_by_not_found_eps_id.zones) == 0
 }
 
-# Filter by recordset tags.
+# Filter by zone tags.
 data "huaweicloud_dns_zones" "filter_by_tags" {
   zone_type = huaweicloud_dns_zone.test.0.zone_type
   tags      = join("|", [for key, value in huaweicloud_dns_zone.test.0.tags : format("%%v,%%v", key, value)])
@@ -212,10 +274,35 @@ data "huaweicloud_dns_zones" "filter_by_not_found_tags" {
 output "tags_not_found_validation_pass" {
   value = length(data.huaweicloud_dns_zones.filter_by_not_found_tags.zones) == 0
 }
+
+# Filter in ascending order using 'name' field as key.
+data "huaweicloud_dns_zones" "filter_by_sort_asc" {
+  zone_type = huaweicloud_dns_zone.test.0.zone_type
+  sort_key  = "name"
+  sort_dir  = "asc"
+}
+
+# Filter in descending order using 'name' field as key.
+data "huaweicloud_dns_zones" "filter_by_sort_desc" {
+  zone_type = huaweicloud_dns_zone.test.0.zone_type
+  sort_key  = "name"
+  sort_dir  = "desc"
+}
+
+locals {
+  sort_desc_filter_result = data.huaweicloud_dns_zones.filter_by_sort_desc.zones
+  sort_asc_first_name     = data.huaweicloud_dns_zones.filter_by_sort_asc.zones[0].name
+  sort_desc_last_name     = data.huaweicloud_dns_zones.filter_by_sort_desc.zones[length(local.sort_desc_filter_result) - 1].name
+}
+
+output "sort_filter_is_useful" {
+  value = local.sort_asc_first_name == local.sort_desc_last_name
+}
 `, name, randomId)
 }
 
 func testAccDataZones_basic(name string) string {
+	randomId, _ := uuid.GenerateUUID()
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "test" {
   name = "%[1]s"
@@ -242,7 +329,36 @@ resource "huaweicloud_dns_zone" "test" {
 }
 
 %[4]s
-`, acceptance.RandomAccResourceName(), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, testAccDataZones_base(name))
+
+# Filter by router Id.
+locals {
+  router_id = try(tolist(huaweicloud_dns_zone.test.0.router)[0].router_id, "")
+}
+
+data "huaweicloud_dns_zones" "filter_by_router_id" {
+  zone_type = huaweicloud_dns_zone.test.0.zone_type
+  router_id = local.router_id
+}
+
+locals {
+  router_id_filter_result = [for v in flatten(data.huaweicloud_dns_zones.filter_by_router_id.zones[*].routers[*].router_id) :
+  v == local.router_id]
+}
+
+output "is_router_id_filter_useful" {
+  value = alltrue(local.router_id_filter_result) && length(local.router_id_filter_result) > 0
+}
+
+data "huaweicloud_dns_zones" "filter_by_not_found_router_id" {
+  zone_type = huaweicloud_dns_zone.test.0.zone_type
+  router_id = "%[5]s"
+}
+
+output "router_id_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_zones.filter_by_not_found_router_id.zones) == 0
+}
+`, acceptance.RandomAccResourceName(), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST,
+		testAccDataZones_base(name, randomId), randomId)
 }
 
 func TestAccDataZones_public(t *testing.T) {
@@ -253,6 +369,11 @@ func TestAccDataZones_public(t *testing.T) {
 
 		all           = "data.huaweicloud_dns_zones.test"
 		dcForAllZones = acceptance.InitDataSourceCheck(all)
+
+		byZoneId           = "data.huaweicloud_dns_zones.filter_by_zone_id"
+		dcByZoneId         = acceptance.InitDataSourceCheck(byZoneId)
+		byNotFoundZoneId   = "data.huaweicloud_dns_zones.filter_by_not_found_zone_id"
+		dcByNotFoundZoneId = acceptance.InitDataSourceCheck(byNotFoundZoneId)
 
 		byNameFuzzy      = "data.huaweicloud_dns_zones.filter_by_name_fuzzy"
 		dcByNameFuzzy    = acceptance.InitDataSourceCheck(byNameFuzzy)
@@ -273,6 +394,11 @@ func TestAccDataZones_public(t *testing.T) {
 		dcByTags         = acceptance.InitDataSourceCheck(byTags)
 		byNotFoundTags   = "data.huaweicloud_dns_zones.filter_by_not_found_tags"
 		dcByNotFoundTags = acceptance.InitDataSourceCheck(byNotFoundTags)
+
+		bySortAsc    = "data.huaweicloud_dns_zones.filter_by_sort_asc"
+		dcBySortAsc  = acceptance.InitDataSourceCheck(bySortAsc)
+		bySortDesc   = "data.huaweicloud_dns_zones.filter_by_sort_desc"
+		dcBySortDesc = acceptance.InitDataSourceCheck(bySortDesc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -287,6 +413,11 @@ func TestAccDataZones_public(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					dcForAllZones.CheckResourceExists(),
 					resource.TestMatchResourceAttr(all, "zones.#", regexp.MustCompile(`[1-9][0-9]*`)),
+					// Filter by zone ID.
+					dcByZoneId.CheckResourceExists(),
+					resource.TestCheckOutput("is_zone_id_filter_useful", "true"),
+					dcByNotFoundZoneId.CheckResourceExists(),
+					resource.TestCheckOutput("zone_id_not_found_validation_pass", "true"),
 					// Fuzzy search by zone name.
 					dcByNameFuzzy.CheckResourceExists(),
 					resource.TestCheckOutput("is_name_fuzzy_filter_useful", "true"),
@@ -308,17 +439,26 @@ func TestAccDataZones_public(t *testing.T) {
 					resource.TestCheckOutput("is_tags_filter_useful", "true"),
 					dcByNotFoundTags.CheckResourceExists(),
 					resource.TestCheckOutput("tags_not_found_validation_pass", "true"),
+					// Check ascending and descending results.
+					dcBySortAsc.CheckResourceExists(),
+					dcBySortDesc.CheckResourceExists(),
+					resource.TestCheckOutput("sort_filter_is_useful", "true"),
 					// Check attributes
-					resource.TestCheckResourceAttrPair(byNameExact, "zones.0.id", rName, "id"),
-					resource.TestCheckResourceAttrPair(byNameExact, "zones.0.name", rName, "name"),
-					resource.TestCheckResourceAttrPair(byNameExact, "zones.0.description", rName, "description"),
-					resource.TestCheckResourceAttr(byNameExact, "zones.0.zone_type", "public"),
-					resource.TestCheckResourceAttrPair(byNameExact, "zones.0.email", rName, "email"),
-					resource.TestCheckResourceAttrPair(byNameExact, "zones.0.ttl", rName, "ttl"),
-					// The zone resource does not have 'record_num' parameter.
-					resource.TestCheckResourceAttrSet(byNameExact, "zones.0.record_num"),
+					resource.TestCheckResourceAttrPair(byZoneId, "zones.0.id", rName, "id"),
+					resource.TestCheckResourceAttrPair(byZoneId, "zones.0.name", rName, "name"),
+					resource.TestCheckResourceAttrPair(byZoneId, "zones.0.description", rName, "description"),
+					resource.TestCheckResourceAttr(byZoneId, "zones.0.zone_type", "public"),
+					resource.TestCheckResourceAttrPair(byZoneId, "zones.0.email", rName, "email"),
+					resource.TestCheckResourceAttrPair(byZoneId, "zones.0.ttl", rName, "ttl"),
+					resource.TestMatchResourceAttr(byZoneId, "zones.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(byZoneId, "zones.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// The zone resource does not have 'record_num' and 'pool_id' parameters.
+					resource.TestCheckResourceAttrSet(byZoneId, "zones.0.record_num"),
+					resource.TestCheckResourceAttrSet(byZoneId, "zones.0.pool_id"),
 					// The 'masters' parameter has no corresponding scenario and is an empty list.
-					resource.TestCheckResourceAttr(byNameExact, "zones.0.masters.#", "0"),
+					resource.TestCheckResourceAttr(byZoneId, "zones.0.masters.#", "0"),
 				),
 			},
 		},
@@ -326,6 +466,7 @@ func TestAccDataZones_public(t *testing.T) {
 }
 
 func testAccDataZones_public(name string) string {
+	randomId, _ := uuid.GenerateUUID()
 	return fmt.Sprintf(`
 resource "huaweicloud_dns_zone" "test" {
   count = 2
@@ -343,5 +484,5 @@ resource "huaweicloud_dns_zone" "test" {
 }
 
 %[3]s
-`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, testAccDataZones_base(name))
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, testAccDataZones_base(name, randomId))
 }

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_zones.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_zones.go
@@ -1,8 +1,3 @@
-// ---------------------------------------------------------------
-// *** AUTO GENERATED CODE ***
-// @Product DNS
-// ---------------------------------------------------------------
-
 package dns
 
 import (
@@ -37,6 +32,11 @@ func DataSourceZones() *schema.Resource {
 				Required:    true,
 				Description: `Specifies the zone type. The value can be **public** or **private**.`,
 			},
+			"zone_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the zone.`,
+			},
 			"tags": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -61,6 +61,21 @@ func DataSourceZones() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: `Specifies the enterprise project ID which the zone associated.`,
+			},
+			"router_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the VPC associated with the private zone.`,
+			},
+			"sort_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The sorting filed for the list of the zones.`,
+			},
+			"sort_dir": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The sorting mode for the list of the zones.`,
 			},
 			"zones": {
 				Type:        schema.TypeList,
@@ -133,6 +148,26 @@ func zoneSchema() *schema.Resource {
 				Description: `The list of VPCs associated with the zone.`,
 			},
 			"tags": common.TagsComputedSchema(),
+			"proxy_pattern": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The recursive resolution proxy mode for subdomains of the private zone.`,
+			},
+			"pool_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the zone, in RFC3339 format.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the zone, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the zone, in RFC3339 format.`,
+			},
 		},
 	}
 	return &sc
@@ -228,6 +263,12 @@ func flattenListZones(resp interface{}) []interface{} {
 			"masters":               utils.PathSearch("masters", v, nil),
 			"routers":               flattenZonesRouters(v),
 			"tags":                  utils.FlattenTagsToMap(utils.PathSearch("tags", v, nil)),
+			"proxy_pattern":         utils.PathSearch("proxy_pattern", v, nil),
+			"pool_id":               utils.PathSearch("pool_id", v, nil),
+			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("created_at",
+				v, "").(string), "2006-01-02T15:04:05")/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("updated_at",
+				v, "").(string), "2006-01-02T15:04:05")/1000, false),
 		}
 	}
 	return rst
@@ -251,6 +292,10 @@ func flattenZonesRouters(resp interface{}) []interface{} {
 
 func buildListZonesQueryParams(d *schema.ResourceData) string {
 	queryParam := fmt.Sprintf("?type=%v", d.Get("zone_type"))
+	if v, ok := d.GetOk("zone_id"); ok {
+		queryParam = fmt.Sprintf("%s&id=%v", queryParam, v)
+	}
+
 	if v, ok := d.GetOk("tags"); ok {
 		queryParam = fmt.Sprintf("%s&tags=%v", queryParam, v)
 	}
@@ -269,6 +314,18 @@ func buildListZonesQueryParams(d *schema.ResourceData) string {
 
 	if v, ok := d.GetOk("enterprise_project_id"); ok {
 		queryParam = fmt.Sprintf("%s&enterprise_project_id=%v", queryParam, v)
+	}
+
+	if v, ok := d.GetOk("router_id"); ok {
+		queryParam = fmt.Sprintf("%s&router_id=%v", queryParam, v)
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		queryParam = fmt.Sprintf("%s&sort_key=%v", queryParam, v)
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		queryParam = fmt.Sprintf("%s&sort_dir=%v", queryParam, v)
 	}
 	return queryParam
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new arguments and attributes for the `huaweicloud_dns_zones` data source.
+ new arguments: `zone_id`, `router_id`, `sort_dir`, `sort_key`.
+ new attributes: `proxy_pattern`, `pool_id`, `created_at`, `updated_at`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new arguments and attributes for the query zones.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccDataZones_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDataZones_ -timeout 360m -parallel 10
=== RUN   TestAccDataZones_basic
=== PAUSE TestAccDataZones_basic
=== RUN   TestAccDataZones_public
=== PAUSE TestAccDataZones_public
=== CONT  TestAccDataZones_basic
=== CONT  TestAccDataZones_public
--- PASS: TestAccDataZones_public (234.73s)
--- PASS: TestAccDataZones_basic (277.68s)
PASS
coverage: 11.3% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       277.783s        coverage: 11.3% of statements in ./huaweicloud/services/dns
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
