### PR TITLE
refactor(dns/floating_ptrrecords): improve test and standardize method names

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -800,7 +800,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rocketmq_messages":                    dms.DataSourceDmsRocketMQMessages(),
 
 			"huaweicloud_dns_custom_lines":        dns.DataSourceDNSCustomLines(),
-			"huaweicloud_dns_floating_ptrrecords": dns.DataSourceFloatingPtrrecords(),
+			"huaweicloud_dns_floating_ptrrecords": dns.DataSourceFloatingPtrRecords(),
 			"huaweicloud_dns_line_groups":         dns.DataSourceLineGroups(),
 			"huaweicloud_dns_nameservers":         dns.DataSourceNameservers(),
 			"huaweicloud_dns_quotas":              dns.DataSourceDNSQuotas(),

--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_floating_ptrrecords_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_floating_ptrrecords_test.go
@@ -2,66 +2,125 @@ package dns
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceFloatingPtrrecords_basic(t *testing.T) {
+func TestAccDataFloatingPtrRecords_basic(t *testing.T) {
 	var (
-		domainName   = fmt.Sprintf("acpttest-ptr-%s.com.", acctest.RandString(5))
-		byRecordId   = "data.huaweicloud_dns_floating_ptrrecords.filter_by_record_id"
-		dcByRecordId = acceptance.InitDataSourceCheck(byRecordId)
+		domainName = fmt.Sprintf("acpttest-ptr-%s.com.", acctest.RandString(5))
+		rName      = "huaweicloud_dns_ptrrecord.test"
+
+		all                = "data.huaweicloud_dns_floating_ptrrecords.test"
+		dcForAllPtrRecords = acceptance.InitDataSourceCheck(all)
+
+		byRecordId      = "data.huaweicloud_dns_floating_ptrrecords.filter_by_record_id"
+		dcByRecordId    = acceptance.InitDataSourceCheck(byRecordId)
+		byNotRecordId   = "data.huaweicloud_dns_floating_ptrrecords.filter_by_not_found_record_id"
+		dcByNotRecordId = acceptance.InitDataSourceCheck(byNotRecordId)
+
+		byDomainName           = "data.huaweicloud_dns_floating_ptrrecords.filter_by_domain_name"
+		dcByDomainName         = acceptance.InitDataSourceCheck(byDomainName)
+		byNotFoundDomainName   = "data.huaweicloud_dns_floating_ptrrecords.filter_by_not_found_domain_name"
+		dcByNotFoundDomainName = acceptance.InitDataSourceCheck(byNotFoundDomainName)
+
+		byPublicIp      = "data.huaweicloud_dns_floating_ptrrecords.filter_by_public_ip"
+		dcByPublicIp    = acceptance.InitDataSourceCheck(byPublicIp)
+		byNotPublicIp   = "data.huaweicloud_dns_floating_ptrrecords.filter_by_not_found_public_ip"
+		dcByNotPublicIp = acceptance.InitDataSourceCheck(byNotPublicIp)
+
+		byEpsId                   = "data.huaweicloud_dns_floating_ptrrecords.filter_by_eps_id"
+		dcByEpsId                 = acceptance.InitDataSourceCheck(byEpsId)
+		byNotfoundEpsId           = "data.huaweicloud_dns_floating_ptrrecords.filter_by_not_found_eps_id"
+		dcByNotfoundNotfoundEpsId = acceptance.InitDataSourceCheck(byNotfoundEpsId)
+
+		byTags                   = "data.huaweicloud_dns_floating_ptrrecords.filter_by_tags"
+		dcByTags                 = acceptance.InitDataSourceCheck(byTags)
+		byNotfoundTags           = "data.huaweicloud_dns_floating_ptrrecords.filter_by_not_found_tags"
+		dcByNotfoundNotfoundTags = acceptance.InitDataSourceCheck(byNotfoundTags)
+
+		byStatus   = "data.huaweicloud_dns_floating_ptrrecords.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceFloatingPtrrecords_basic(domainName),
+				Config: testAccDataFloatingPtrRecords_basic(domainName),
 				Check: resource.ComposeTestCheckFunc(
+					dcForAllPtrRecords.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "ptrrecords.#", regexp.MustCompile(`[1-9][0-9]*`)),
+					// Filter by PTR record ID.
 					dcByRecordId.CheckResourceExists(),
-					resource.TestCheckResourceAttr(byRecordId, "ptrrecords.0.ttl", "300"),
-					resource.TestCheckResourceAttr(byRecordId, "ptrrecords.0.description", "Created by terraform"),
-
 					resource.TestCheckOutput("is_record_id_filter_useful", "true"),
-					resource.TestCheckOutput("is_public_ip_filter_useful", "true"),
+					dcByNotRecordId.CheckResourceExists(),
+					resource.TestCheckOutput("record_id_not_found_validation_pass", "true"),
+					// Filter by PTR record name.
+					dcByDomainName.CheckResourceExists(),
 					resource.TestCheckOutput("is_domain_name_filter_useful", "true"),
-					resource.TestCheckOutput("not_found_domain_name", "true"),
+					dcByNotFoundDomainName.CheckResourceExists(),
+					resource.TestCheckOutput("domain_name_not_found_validation_pass", "true"),
+					// Filter by PTR record public IP.
+					dcByPublicIp.CheckResourceExists(),
+					resource.TestCheckOutput("is_public_ip_filter_useful", "true"),
+					dcByNotPublicIp.CheckResourceExists(),
+					resource.TestCheckOutput("public_ip_not_found_validation_pass", "true"),
+					// Filter by PTR record enterprise project ID.
+					dcByEpsId.CheckResourceExists(),
 					resource.TestCheckOutput("is_eps_id_filter_useful", "true"),
-					resource.TestCheckResourceAttr("data.huaweicloud_dns_floating_ptrrecords.filter_by_tags", "ptrrecords.#", "1"),
+					dcByNotfoundNotfoundEpsId.CheckResourceExists(),
+					resource.TestCheckOutput("is_eps_id_not_found_validation_pass", "true"),
+					// Filter by PTR record tags.
+					dcByTags.CheckResourceExists(),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
+					dcByNotfoundNotfoundTags.CheckResourceExists(),
+					resource.TestCheckOutput("tags_not_found_validation_pass", "true"),
+					// Filter by PTR record status.
+					dcByStatus.CheckResourceExists(),
 					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					// Check attributes.
+					resource.TestCheckResourceAttrPair(byRecordId, "ptrrecords.0.ttl", rName, "ttl"),
+					resource.TestCheckResourceAttrPair(byRecordId, "ptrrecords.0.description", rName, "description"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceFloatingPtrrecords_basic(domainName string) string {
+func testAccDataFloatingPtrRecords_basic(domainName string) string {
+	randomId, _ := uuid.GenerateUUID()
 	return fmt.Sprintf(`
-%s
+%[1]s
 
-locals {
+resource "huaweicloud_dns_ptrrecord" "test" {
+  name                  = "%[2]s"
+  description           = "Created by terraform"
+  floatingip_id         = huaweicloud_vpc_eip.test.id
+  ttl                   = 300
+  enterprise_project_id = "%[3]s"
+
   tags = {
     foo       = "bar"
     terraform = "ptrrecord"
   }
 }
 
-resource "huaweicloud_dns_ptrrecord" "test" {
-  name          = "%s"
-  description   = "Created by terraform"
-  floatingip_id = huaweicloud_vpc_eip.test.id
-  ttl           = 300
-  tags          = local.tags
+data "huaweicloud_dns_floating_ptrrecords" "test" {
+  depends_on = [huaweicloud_dns_ptrrecord.test]
 }
 
+# Filter by PTR record ID.
 locals {
   record_id = huaweicloud_dns_ptrrecord.test.id
 }
@@ -70,79 +129,154 @@ data "huaweicloud_dns_floating_ptrrecords" "filter_by_record_id" {
   record_id = local.record_id
 }
 
-output "is_record_id_filter_useful" {
-  value = length(data.huaweicloud_dns_floating_ptrrecords.filter_by_record_id.ptrrecords) > 0 && alltrue(
-    [for v in data.huaweicloud_dns_floating_ptrrecords.filter_by_record_id.ptrrecords[*].id : v == local.record_id]
-  )
-}
-
 locals {
-  public_ip = huaweicloud_vpc_eip.test.address
+  record_id_filter_result = [for v in data.huaweicloud_dns_floating_ptrrecords.filter_by_record_id.ptrrecords[*].id : v == local.record_id]
 }
 
-data "huaweicloud_dns_floating_ptrrecords" "filter_by_public_id" {
+output "is_record_id_filter_useful" {
+  value = length(local.record_id_filter_result) > 0 && alltrue(local.record_id_filter_result)
+}
+
+data "huaweicloud_dns_floating_ptrrecords" "filter_by_not_found_record_id" {
   depends_on = [huaweicloud_dns_ptrrecord.test]
-  public_ip  = local.public_ip
+  record_id  = "%[4]s"
 }
 
-output "is_public_ip_filter_useful" {
-  value = length(data.huaweicloud_dns_floating_ptrrecords.filter_by_public_id.ptrrecords) > 0 && alltrue(
-    [for v in data.huaweicloud_dns_floating_ptrrecords.filter_by_public_id.ptrrecords[*].public_ip : v == local.public_ip]
-  )
+output "record_id_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_floating_ptrrecords.filter_by_not_found_record_id.ptrrecords) == 0
 }
 
+# Filter by PTR record name.
 locals {
   domain_name = huaweicloud_dns_ptrrecord.test.name
 }
 
-data "huaweicloud_dns_floating_ptrrecords" "by_domain_name_filter" {
+data "huaweicloud_dns_floating_ptrrecords" "filter_by_domain_name" {
   depends_on  = [huaweicloud_dns_ptrrecord.test]
   domain_name = local.domain_name
 }
 
+locals {
+  domain_name_filter_result = [for v in data.huaweicloud_dns_floating_ptrrecords.filter_by_domain_name.ptrrecords[*].domain_name :
+  v == local.domain_name]
+}
+
 output "is_domain_name_filter_useful" {
-  value = length(data.huaweicloud_dns_floating_ptrrecords.by_domain_name_filter.ptrrecords) > 0 && alltrue(
-    [for v in data.huaweicloud_dns_floating_ptrrecords.by_domain_name_filter.ptrrecords[*].domain_name : v == local.domain_name]
-  )
+  value = length(local.domain_name_filter_result) > 0 && alltrue(local.domain_name_filter_result)
 }
 
-data "huaweicloud_dns_floating_ptrrecords" "not_found_domain_name" {
+data "huaweicloud_dns_floating_ptrrecords" "filter_by_not_found_domain_name" {
   depends_on  = [huaweicloud_dns_ptrrecord.test]
-  domain_name = "not-found.com."
+  domain_name = "not_found_ptrrecord_name"
 }
 
-output "not_found_domain_name" {
-  value = length(data.huaweicloud_dns_floating_ptrrecords.not_found_domain_name.ptrrecords) == 0
+output "domain_name_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_floating_ptrrecords.filter_by_not_found_domain_name.ptrrecords) == 0
 }
 
+# Filter by PTR record public IP.
+locals {
+  public_ip = huaweicloud_dns_ptrrecord.test.address
+}
+
+data "huaweicloud_dns_floating_ptrrecords" "filter_by_public_ip" {
+  public_ip = local.public_ip
+}
+
+locals {
+  public_ip_filter_result = [for v in data.huaweicloud_dns_floating_ptrrecords.filter_by_public_ip.ptrrecords[*].public_ip : v == local.public_ip]
+}
+
+output "is_public_ip_filter_useful" {
+  value = length(local.public_ip_filter_result) > 0 && alltrue(local.public_ip_filter_result)
+}
+
+data "huaweicloud_dns_floating_ptrrecords" "filter_by_not_found_public_ip" {
+  depends_on = [huaweicloud_dns_ptrrecord.test]
+  public_ip  = "not_found_public_ip"
+}
+
+output "public_ip_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_floating_ptrrecords.filter_by_not_found_public_ip.ptrrecords) == 0
+}
+
+# Filter by PTR record enterprise project ID.
 locals {
   enterprise_project_id = huaweicloud_dns_ptrrecord.test.enterprise_project_id
 }
 
 data "huaweicloud_dns_floating_ptrrecords" "filter_by_eps_id" {
+  depends_on = [huaweicloud_dns_ptrrecord.test]
+
   enterprise_project_id = local.enterprise_project_id
 }
 
+locals {
+  eps_id_filter_result = [for v in data.huaweicloud_dns_floating_ptrrecords.filter_by_eps_id.ptrrecords[*].enterprise_project_id :
+  v == local.enterprise_project_id]
+}
+
 output "is_eps_id_filter_useful" {
-  value = length(data.huaweicloud_dns_floating_ptrrecords.filter_by_eps_id.ptrrecords) > 0 && alltrue(
-    [for v in data.huaweicloud_dns_floating_ptrrecords.filter_by_eps_id.ptrrecords[*].enterprise_project_id : v == local.enterprise_project_id]
-  )
+  value = length(local.eps_id_filter_result) > 0 && alltrue(local.eps_id_filter_result)
+}
+
+data "huaweicloud_dns_floating_ptrrecords" "filter_by_not_found_eps_id" {
+  depends_on = [huaweicloud_dns_ptrrecord.test]
+
+  enterprise_project_id = "%[4]s"
+}
+
+output "is_eps_id_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_floating_ptrrecords.filter_by_not_found_eps_id.ptrrecords) == 0
+}
+
+# Filter by PTR record tags.
+locals {
+  tags = huaweicloud_dns_ptrrecord.test.tags
 }
 
 data "huaweicloud_dns_floating_ptrrecords" "filter_by_tags" {
   depends_on = [huaweicloud_dns_ptrrecord.test]
-  tags       = local.tags
+
+  tags = local.tags
+}
+
+locals {
+  tags_filter_result = [for v in data.huaweicloud_dns_floating_ptrrecords.filter_by_tags.ptrrecords[*].tags : v == local.tags]
+}
+
+output "is_tags_filter_useful" {
+  value = length(local.tags_filter_result) > 0 && alltrue(local.tags_filter_result)
+}
+
+data "huaweicloud_dns_floating_ptrrecords" "filter_by_not_found_tags" {
+  depends_on = [huaweicloud_dns_ptrrecord.test]
+
+  tags = {
+    key = "not_found_value"
+  }
+}
+
+output "tags_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_floating_ptrrecords.filter_by_not_found_tags.ptrrecords) == 0
+}
+
+# Filter by PTR record status.
+locals {
+  status = try(data.huaweicloud_dns_floating_ptrrecords.filter_by_record_id.ptrrecords[0].status, "")
 }
 
 data "huaweicloud_dns_floating_ptrrecords" "filter_by_status" {
   depends_on = [huaweicloud_dns_ptrrecord.test]
-  status     = "ACTIVE"
+  status     = local.status
+}
+
+locals {
+  status_filter_result = [for v in data.huaweicloud_dns_floating_ptrrecords.filter_by_status.ptrrecords[*].status : v == local.status]
 }
 
 output "is_status_filter_useful" {
-  value = length(data.huaweicloud_dns_floating_ptrrecords.filter_by_status.ptrrecords) > 0 && alltrue(
-    [for v in data.huaweicloud_dns_floating_ptrrecords.filter_by_status.ptrrecords[*].status : v == "ACTIVE"]
-  )
+  value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
 }
-`, testAccDNSPtrRecord_base(), domainName)
+`, testAccPtrRecord_base(), domainName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, randomId)
 }

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_ptrrecord_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_ptrrecord_test.go
@@ -106,7 +106,7 @@ func TestAccDNSPtrRecord_withEpsId(t *testing.T) {
 	})
 }
 
-func testAccDNSPtrRecord_base() string {
+func testAccPtrRecord_base() string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc_eip" "test" {
   publicip {
@@ -135,7 +135,7 @@ resource "huaweicloud_dns_ptrrecord" "test" {
     key = "value"
   }
 }
-`, testAccDNSPtrRecord_base(), ptrName)
+`, testAccPtrRecord_base(), ptrName)
 }
 
 func testAccDNSPtrRecord_update(ptrName string) string {
@@ -152,7 +152,7 @@ resource "huaweicloud_dns_ptrrecord" "test" {
     foo = "bar"
   }
 }
-`, testAccDNSPtrRecord_base(), ptrName)
+`, testAccPtrRecord_base(), ptrName)
 }
 
 func testAccDNSPtrRecord_withEpsId(ptrName string) string {
@@ -166,5 +166,5 @@ resource "huaweicloud_dns_ptrrecord" "test" {
   ttl                   = 6000
   enterprise_project_id = "%s"
 }
-`, testAccDNSPtrRecord_base(), ptrName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccPtrRecord_base(), ptrName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_floating_ptrrecords.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_floating_ptrrecords.go
@@ -18,9 +18,9 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func DataSourceFloatingPtrrecords() *schema.Resource {
+func DataSourceFloatingPtrRecords() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceFloatingPtrrecordsRead,
+		ReadContext: dataSourceFloatingPtrRecordsRead,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -126,7 +126,7 @@ func newFloatingPtrrecordsDSWrapper(d *schema.ResourceData, meta interface{}) *F
 	}
 }
 
-func dataSourceFloatingPtrrecordsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceFloatingPtrRecordsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	wrapper := newFloatingPtrrecordsDSWrapper(d, meta)
 	lisPtrRecRst, err := wrapper.ListPtrRecords()
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Improve and standardize appeptance test of the **huaweicloud_dns_floating_ptrrecords**.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
improve and standardize appeptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccDataFloatingPtrrecords_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDataFloatingPtrrecords_basic -timeout 360m -parallel 10
=== RUN   TestAccDataFloatingPtrrecords_basic
=== PAUSE TestAccDataFloatingPtrrecords_basic
=== CONT  TestAccDataFloatingPtrrecords_basic
--- PASS: TestAccDataFloatingPtrrecords_basic (182.72s)
PASS
coverage: 7.0% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       182.783s        coverage: 7.0% of statements in ./huaweicloud/services/dns
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
