### PR TITLE
feat: add new utils function to filter map tag

### DIFF
--- a/huaweicloud/utils/tags.go
+++ b/huaweicloud/utils/tags.go
@@ -110,6 +110,14 @@ func FlattenTagsToMap(tags interface{}) map[string]interface{} {
 	return nil
 }
 
+// FlattenSameKeyTagsToMap using to flatten remote tag list and filter tag map with same key.
+// Parameters:
+// + d         : It is required that there is a `tags` field of map type in the parameter.
+// + remoteTags: It is required that the parameter is a tag list, for example: [{"key":"key1","value":"value1"}].
+func FlattenSameKeyTagsToMap(d *schema.ResourceData, remoteTags interface{}) map[string]interface{} {
+	return FilterMapWithSameKey(d.Get("tags").(map[string]interface{}), FlattenTagsToMap(remoteTags))
+}
+
 // ExpandResourceTags returns the tags for the given map of data.
 func ExpandResourceTags(tagmap map[string]interface{}) []tags.ResourceTag {
 	var taglist []tags.ResourceTag

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -567,3 +567,23 @@ func IsUUID(uuid string) bool {
 	match, _ := regexp.MatchString(pattern, uuid)
 	return match
 }
+
+// FilterMapWithSameKey using to filter the value of `filterMap` by the key of `rawMap`, and return the filtered map.
+// Example:
+// Parameters rawMap = {"a":"b"}, filterMap = {"a":"d"}; Return {"a":"d"}
+// Parameters rawMap = {"a":"b"}, filterMap = {"a":"d", "m":"n"}; Return {"a":"d"}
+// Parameters rawMap = {"a":"b", "c":"d"}, filterMap = {"a":"d", "m":"n"}; Return {"a":"d"}
+// Parameters rawMap = {"a":"b", "c":"d"}, filterMap = {"a":"d", "c":"a", "m":"n"}; Return {"a":"d", "c":"a"}
+// Parameters rawMap = {"a":"b"}, filterMap = {}; Return {}
+// Parameters rawMap = {}, filterMap = {"m":"n"}; Return {}
+// Parameters rawMap = {}, filterMap = {}; Return {}
+func FilterMapWithSameKey(rawMap, filterMap map[string]interface{}) map[string]interface{} {
+	rst := make(map[string]interface{})
+	for rawKey := range rawMap {
+		if filterValue, ok := filterMap[rawKey]; ok {
+			rst[rawKey] = filterValue
+		}
+	}
+
+	return rst
+}

--- a/huaweicloud/utils/utils_test.go
+++ b/huaweicloud/utils/utils_test.go
@@ -116,3 +116,50 @@ func TestAccFunction_IsUUID(t *testing.T) {
 		t.Logf("The processing result of IsUUID method meets expectation: %s", Green(expected[i]))
 	}
 }
+
+func TestAccFunction_FilterMapWithSameKey(t *testing.T) {
+	var (
+		rawArray = []map[string]interface{}{
+			{"a": "b"},
+			{"a": "b"},
+			{"a": "b", "c": "d"},
+			{"a": "b", "c": "d"},
+			{"a": "b"},
+			{},
+			{},
+		}
+
+		filterArray = []map[string]interface{}{
+			{"a": "d"},
+			{"a": "d", "m": "n"},
+			{"a": "d", "m": "n"},
+			{"a": "d", "c": "a", "m": "n"},
+			{},
+			{"m": "n"},
+			{},
+		}
+
+		expectedArray = []map[string]interface{}{
+			{"a": "d"},
+			{"a": "d"},
+			{"a": "d"},
+			{"a": "d", "c": "a"},
+			{},
+			{},
+			{},
+		}
+	)
+
+	for i := 0; i < 7; i++ {
+		rawMap := rawArray[i]
+		filterMap := filterArray[i]
+		expectedMap := expectedArray[i]
+		result := FilterMapWithSameKey(rawMap, filterMap)
+
+		if !reflect.DeepEqual(result, expectedMap) {
+			t.Fatalf("The processing result of the function 'FilterMapWithSameKey' is not as expected, want '%v', "+
+				"but got '%v'", Green(expectedMap), Yellow(result))
+		}
+		t.Logf("The processing result of `FilterMapWithSameKey` method meets expectation: %s", Green(expectedMap))
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new utils function to filter map tag.

The purpose of the new utils method is to perform backfill filtering for map type schema fields.
There is only one main thing to do, which is to ignore the impact of new map keys in the cloud.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
go test -v ./huaweicloud/utils/ -run TestAccFunction_FilterMapWithSameKey
=== RUN   TestAccFunction_FilterMapWithSameKey
    utils_test.go:163: The processing result of `FilterMapWithSameKey` method meets expectation: map[string]interface {}{"a":"d"}
    utils_test.go:163: The processing result of `FilterMapWithSameKey` method meets expectation: map[string]interface {}{"a":"d"}
    utils_test.go:163: The processing result of `FilterMapWithSameKey` method meets expectation: map[string]interface {}{"a":"d"}
    utils_test.go:163: The processing result of `FilterMapWithSameKey` method meets expectation: map[string]interface {}{"a":"d", "c":"a"}
    utils_test.go:163: The processing result of `FilterMapWithSameKey` method meets expectation: map[string]interface {}{}
    utils_test.go:163: The processing result of `FilterMapWithSameKey` method meets expectation: map[string]interface {}{}
    utils_test.go:163: The processing result of `FilterMapWithSameKey` method meets expectation: map[string]interface {}{}
--- PASS: TestAccFunction_FilterMapWithSameKey (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils 0.011s
```

```
go test -v ./huaweicloud/utils/ -run TestTagsFunc_FlattenSameKeyTagsToMap
=== RUN   TestTagsFunc_FlattenSameKeyTagsToMap
    tags_test.go:131: The processing result of `FlattenSameKeyTagsToMap` method meets expectation: map[string]interface {}{"a":"d"}
    tags_test.go:131: The processing result of `FlattenSameKeyTagsToMap` method meets expectation: map[string]interface {}{"a":"d"}
    tags_test.go:131: The processing result of `FlattenSameKeyTagsToMap` method meets expectation: map[string]interface {}{"a":"d"}
    tags_test.go:131: The processing result of `FlattenSameKeyTagsToMap` method meets expectation: map[string]interface {}{"a":"d", "c":"a"}
    tags_test.go:131: The processing result of `FlattenSameKeyTagsToMap` method meets expectation: map[string]interface {}{}
    tags_test.go:131: The processing result of `FlattenSameKeyTagsToMap` method meets expectation: map[string]interface {}{}
    tags_test.go:131: The processing result of `FlattenSameKeyTagsToMap` method meets expectation: map[string]interface {}{}
--- PASS: TestTagsFunc_FlattenSameKeyTagsToMap (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils 0.010s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
