### PR TITLE
refactor(dns/custom_lines): standardize method naming and improve test

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -801,7 +801,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rocketmq_extend_flavors":              dms.DataSourceDmsRocketmqExtendFlavors(),
 			"huaweicloud_dms_rocketmq_messages":                    dms.DataSourceDmsRocketMQMessages(),
 
-			"huaweicloud_dns_custom_lines":        dns.DataSourceDNSCustomLines(),
+			"huaweicloud_dns_custom_lines":        dns.DataSourceCustomLines(),
 			"huaweicloud_dns_floating_ptrrecords": dns.DataSourceFloatingPtrRecords(),
 			"huaweicloud_dns_line_groups":         dns.DataSourceLineGroups(),
 			"huaweicloud_dns_nameservers":         dns.DataSourceNameservers(),

--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_custom_lines_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_custom_lines_test.go
@@ -10,23 +10,30 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceCustomLines_basic(t *testing.T) {
+func TestAccDataCustomLines_basic(t *testing.T) {
 	var (
-		rName      = acceptance.RandomAccResourceName()
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_dns_custom_line.test"
+
 		dataSource = "data.huaweicloud_dns_custom_lines.test"
 		dc         = acceptance.InitDataSourceCheck(dataSource)
 
-		byId   = "data.huaweicloud_dns_custom_lines.filter_by_id"
-		dcById = acceptance.InitDataSourceCheck(byId)
+		byLineId           = "data.huaweicloud_dns_custom_lines.filter_by_line_id"
+		dcByLineId         = acceptance.InitDataSourceCheck(byLineId)
+		byNotFoundLineId   = "data.huaweicloud_dns_custom_lines.filter_by_not_found_line_id"
+		dcByNotFoundLineId = acceptance.InitDataSourceCheck(byNotFoundLineId)
 
-		byName   = "data.huaweicloud_dns_custom_lines.filter_by_name"
-		dcByName = acceptance.InitDataSourceCheck(byName)
+		byName           = "data.huaweicloud_dns_custom_lines.filter_by_name"
+		dcByName         = acceptance.InitDataSourceCheck(byName)
+		byNameFuzzy      = "data.huaweicloud_dns_custom_lines.filter_by_name_fuzzy"
+		dcByNameFuzzy    = acceptance.InitDataSourceCheck(byNameFuzzy)
+		byNotFoundName   = "data.huaweicloud_dns_custom_lines.filter_by_not_found_name"
+		dcByNotFoundName = acceptance.InitDataSourceCheck(byNotFoundName)
 
-		notFound     = "data.huaweicloud_dns_custom_lines.filter_by_not_found_name"
-		dcByNotFound = acceptance.InitDataSourceCheck(notFound)
-
-		byIp   = "data.huaweicloud_dns_custom_lines.filter_by_ip"
-		dcByIp = acceptance.InitDataSourceCheck(byIp)
+		byIp           = "data.huaweicloud_dns_custom_lines.filter_by_ip"
+		dcByIp         = acceptance.InitDataSourceCheck(byIp)
+		byNotFoundIp   = "data.huaweicloud_dns_custom_lines.filter_by_not_found_ip"
+		dcByNotFoundIp = acceptance.InitDataSourceCheck(byNotFoundIp)
 
 		byStatus   = "data.huaweicloud_dns_custom_lines.filter_by_status"
 		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
@@ -39,35 +46,46 @@ func TestAccDataSourceCustomLines_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceDataSourceDnsCustomLines_basic(rName),
+				Config: testAccDataCustomLines_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestMatchResourceAttr(dataSource, "lines.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					resource.TestCheckResourceAttrSet(dataSource, "lines.0.ip_segments.#"),
-					// The format is the time corresponding to the local time zone of the computer.
-					resource.TestMatchResourceAttr(dataSource, "lines.0.created_at",
-						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
-					resource.TestMatchResourceAttr(dataSource, "lines.0.updated_at",
-						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
-					dcById.CheckResourceExists(),
-					resource.TestCheckOutput("is_id_filter_useful", "true"),
-					resource.TestCheckResourceAttrSet(byId, "lines.0.description"),
-					resource.TestCheckResourceAttr(byId, "lines.0.ip_segments.#", "1"),
+					// Filter by custom line ID.
+					dcByLineId.CheckResourceExists(),
+					resource.TestCheckOutput("is_line_id_filter_useful", "true"),
+					dcByNotFoundLineId.CheckResourceExists(),
+					resource.TestCheckOutput("line_id_not_found_validation_pass", "true"),
+					// Exact search by custom line name.
 					dcByName.CheckResourceExists(),
 					resource.TestCheckOutput("is_name_filter_useful", "true"),
-					dcByNotFound.CheckResourceExists(),
-					resource.TestCheckOutput("is_name_not_found_filter_useful", "true"),
+					// Fuzzy search by custom line name.
+					dcByNameFuzzy.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_fuzzy_filter_useful", "true"),
+					dcByNotFoundName.CheckResourceExists(),
+					resource.TestCheckOutput("name_not_found_validation_pass", "true"),
+					// Filter by IP address.
 					dcByIp.CheckResourceExists(),
 					resource.TestCheckOutput("is_ip_filter_useful", "true"),
+					dcByNotFoundIp.CheckResourceExists(),
+					resource.TestCheckOutput("ip_not_found_validation_pass", "true"),
+					// Filter by custom line status.
 					dcByStatus.CheckResourceExists(),
 					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					// Check attributes.
+					resource.TestCheckResourceAttrPair(byLineId, "lines.0.description", rName, "description"),
+					resource.TestCheckResourceAttrPair(byLineId, "lines.0.ip_segments", rName, "ip_segments"),
+					// The format is the time corresponding to the local time zone of the computer.
+					resource.TestMatchResourceAttr(byLineId, "lines.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(byLineId, "lines.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
 		},
 	})
 }
 
-func testDataSourceDataSourceDnsCustomLines_basic(name string) string {
+func testAccDataCustomLines_basic(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dns_custom_line" "test" {
   name        = "%s"
@@ -77,29 +95,36 @@ resource "huaweicloud_dns_custom_line" "test" {
 }
 
 data "huaweicloud_dns_custom_lines" "test" {
-  depends_on = [
-    huaweicloud_dns_custom_line.test
-  ]
+  depends_on = [huaweicloud_dns_custom_line.test]
 }
 
+# Filter by custom line ID.
 locals {
   line_id = huaweicloud_dns_custom_line.test.id
 }
 
-data "huaweicloud_dns_custom_lines" "filter_by_id" {
+data "huaweicloud_dns_custom_lines" "filter_by_line_id" {
   line_id = local.line_id
 }
 
 locals {
-  id_filter_result = [
-    for v in data.huaweicloud_dns_custom_lines.filter_by_id.lines[*].id : v == local.line_id
-  ]
+  line_id_filter_result = [for v in data.huaweicloud_dns_custom_lines.filter_by_line_id.lines[*].id : v == local.line_id]
 }
 
-output "is_id_filter_useful" {
-  value = length(local.id_filter_result) > 0 && alltrue(local.id_filter_result)
+output "is_line_id_filter_useful" {
+  value = length(local.line_id_filter_result) > 0 && alltrue(local.line_id_filter_result)
 }
 
+data "huaweicloud_dns_custom_lines" "filter_by_not_found_line_id" {
+  depends_on = [huaweicloud_dns_custom_line.test]
+  line_id    = "not_found_line_id"
+}
+
+output "line_id_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_custom_lines.filter_by_not_found_line_id.lines) == 0
+}
+
+# Exact search by custom line name.
 locals {
   line_name = huaweicloud_dns_custom_line.test.name
 }
@@ -111,37 +136,46 @@ data "huaweicloud_dns_custom_lines" "filter_by_name" {
 }
 
 locals {
-  name_filter_result = [
-    for v in data.huaweicloud_dns_custom_lines.filter_by_name.lines[*].name : v == local.line_name
-  ]
+  name_filter_result = [for v in data.huaweicloud_dns_custom_lines.filter_by_name.lines[*].name : v == local.line_name]
 }
 
 output "is_name_filter_useful" {
   value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
 }
 
+# Fuzzy search by custom line name.
 locals {
-  not_found_name = "not_found"
+  name_prefix = "tf_test"
+}
+
+data "huaweicloud_dns_custom_lines" "filter_by_name_fuzzy" {
+  depends_on = [huaweicloud_dns_custom_line.test]
+
+  name = local.name_prefix
+}
+
+locals {
+  name_fuzzy_filter_result = [for v in data.huaweicloud_dns_custom_lines.filter_by_name_fuzzy.lines[*].name :
+    strcontains(v, local.name_prefix)
+  ]
+}
+
+output "is_name_fuzzy_filter_useful" {
+  value = length(local.name_fuzzy_filter_result) > 0 && alltrue(local.name_fuzzy_filter_result)
 }
 
 data "huaweicloud_dns_custom_lines" "filter_by_not_found_name" {
   depends_on = [huaweicloud_dns_custom_line.test]
-
-  name = local.not_found_name
+  name       = "not_found_custom_name"
 }
 
+output "name_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_custom_lines.filter_by_not_found_name.lines) == 0
+}
+
+# Filter by IP address.
 locals {
-  not_found_name_filter_result = [
-    for v in data.huaweicloud_dns_custom_lines.filter_by_not_found_name.lines[*].name : strcontains(v, local.not_found_name)
-  ]
-}
-
-output "is_name_not_found_filter_useful" {
-  value = length(local.not_found_name_filter_result) == 0
-}
-
-locals {
-  ip = try(split("-", huaweicloud_dns_custom_line.test.ip_segments[0])[0], "")
+  ip = try(split("-", tolist(huaweicloud_dns_custom_line.test.ip_segments)[0])[0], "")
 }
 
 data "huaweicloud_dns_custom_lines" "filter_by_ip" {
@@ -158,6 +192,17 @@ output "is_ip_filter_useful" {
   value = length(local.ip_filter_result) > 0 && alltrue(local.ip_filter_result)
 }
 
+data "huaweicloud_dns_custom_lines" "filter_by_not_found_ip" {
+  depends_on = [huaweicloud_dns_custom_line.test]
+
+  ip = "0.0.0.0"
+}
+
+output "ip_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_custom_lines.filter_by_not_found_ip.lines) == 0
+}
+
+# Filter by custom line status.
 locals {
   status = huaweicloud_dns_custom_line.test.status
 }
@@ -167,9 +212,7 @@ data "huaweicloud_dns_custom_lines" "filter_by_status" {
 }
 
 locals {
-  status_filter_result = [
-    for v in data.huaweicloud_dns_custom_lines.filter_by_status.lines[*].status : v == local.status
-  ]
+  status_filter_result = [for v in data.huaweicloud_dns_custom_lines.filter_by_status.lines[*].status : v == local.status]
 }
 
 output "is_status_filter_useful" {

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_custom_lines.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_custom_lines.go
@@ -16,9 +16,9 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func DataSourceDNSCustomLines() *schema.Resource {
+func DataSourceCustomLines() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceDNSCustomLinesRead,
+		ReadContext: dataSourceCustomLinesRead,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -108,7 +108,7 @@ func newCustomLinesDSWrapper(d *schema.ResourceData, meta interface{}) *CustomLi
 	}
 }
 
-func dataSourceDNSCustomLinesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceCustomLinesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	wrapper := newCustomLinesDSWrapper(d, meta)
 	listCustomLineRst, err := wrapper.ListCustomLine()
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Standardize method naming and improve acceptace test.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
standardize method naming and improve acceptace test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccDataCustomLines_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDataCustomLines_basic -timeout 360m -parallel 10
=== RUN   TestAccDataCustomLines_basic
=== PAUSE TestAccDataCustomLines_basic
=== CONT  TestAccDataCustomLines_basic
--- PASS: TestAccDataCustomLines_basic (106.78s)
PASS
coverage: 7.9% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       106.872s        coverage: 7.9% of statements in ./huaweicloud/services/dns
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
