### PR TITLE
fix(css): fixed css cluster attributes error

### DIFF
--- a/huaweicloud/services/css/resource_huaweicloud_css_cluster.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_cluster.go
@@ -240,8 +240,9 @@ func ResourceCssCluster() *schema.Resource {
 							Required: true,
 						},
 						"whitelist": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:             schema.TypeString,
+							Optional:         true,
+							DiffSuppressFunc: utils.SuppressStringSepratedByCommaDiffs,
 						},
 						"public_ip": {
 							Type:     schema.TypeString,
@@ -284,8 +285,9 @@ func ResourceCssCluster() *schema.Resource {
 							Required: true,
 						},
 						"whitelist": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:             schema.TypeString,
+							DiffSuppressFunc: utils.SuppressStringSepratedByCommaDiffs,
+							Optional:         true,
 						},
 						"public_ip": {
 							Type:     schema.TypeString,
@@ -951,9 +953,9 @@ func flattenKibana(publicKibana interface{}) []interface{} {
 
 	result := map[string]interface{}{
 		"bandwidth":         int(utils.PathSearch("eipSize", publicKibana, float64(0)).(float64)),
-		"whitelist_enabled": utils.PathSearch("EnableWhiteList", elbWhiteListResp, nil),
-		"whitelist":         utils.PathSearch("WhiteList", elbWhiteListResp, nil),
-		"public_ip":         utils.PathSearch("PublicKibanaIp", publicKibana, nil),
+		"whitelist_enabled": utils.PathSearch("enableWhiteList", elbWhiteListResp, nil),
+		"whitelist":         utils.PathSearch("whiteList", elbWhiteListResp, nil),
+		"public_ip":         utils.PathSearch("publicKibanaIp", publicKibana, nil),
 	}
 	return []interface{}{result}
 }
@@ -969,7 +971,7 @@ func flattenPublicAccess(clusterDetail interface{}) []interface{} {
 	result := map[string]interface{}{
 		"bandwidth":         bandwidth,
 		"whitelist_enabled": utils.PathSearch("enableWhiteList", elbWhiteList, nil),
-		"whitelist":         utils.PathSearch("ehiteList", elbWhiteList, nil),
+		"whitelist":         utils.PathSearch("whiteList", elbWhiteList, nil),
 		"public_ip":         publicIp,
 	}
 	return []interface{}{result}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx
fixed css cluster attributes error

**Special notes for your reviewer**:

**Release note**:

```
fixed css cluster attributes error

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/css" TESTARGS="-run TestAccCssCluster_access"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssCluster_access -timeout 360m -parallel 4
=== RUN   TestAccCssCluster_access
=== PAUSE TestAccCssCluster_access
=== CONT  TestAccCssCluster_access
--- PASS: TestAccCssCluster_access (1396.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1396.909s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
