### PR TITLE
test(dns/line_groups): standardize method names and improve acceptance test

### DIFF
--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_line_groups_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_line_groups_test.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,10 +10,28 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceLineGroups_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_dns_line_groups.filter_by_line_id"
-	rName := acceptance.RandomAccResourceName()
-	dc := acceptance.InitDataSourceCheck(dataSource)
+func TestAccDataLineGroups_basic(t *testing.T) {
+	var (
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_dns_line_group.test"
+
+		dataSource = "data.huaweicloud_dns_line_groups.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byLineId           = "data.huaweicloud_dns_line_groups.filter_by_line_id"
+		dcByLineId         = acceptance.InitDataSourceCheck(byLineId)
+		byLineIdFuzzy      = "data.huaweicloud_dns_line_groups.filter_by_line_id_fuzzy"
+		dcByLineIdFuzzy    = acceptance.InitDataSourceCheck(byLineIdFuzzy)
+		byNotFoundLineId   = "data.huaweicloud_dns_line_groups.filter_by_not_found_line_id"
+		dcByNotFoundLineId = acceptance.InitDataSourceCheck(byNotFoundLineId)
+
+		byName           = "data.huaweicloud_dns_line_groups.filter_by_name"
+		dcByName         = acceptance.InitDataSourceCheck(byName)
+		byNameFuzzy      = "data.huaweicloud_dns_line_groups.filter_by_name_fuzzy"
+		dcByNameFuzzy    = acceptance.InitDataSourceCheck(byNameFuzzy)
+		byNotFoundName   = "data.huaweicloud_dns_line_groups.filter_by_not_found_name"
+		dcByNotFoundName = acceptance.InitDataSourceCheck(byNotFoundName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -21,28 +40,51 @@ func TestAccDataSourceLineGroups_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceDataSourceLineGroups_basic(rName),
+				Config: testAccDataLineGroups_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSource, "groups.0.lines.#"),
-					resource.TestCheckResourceAttrSet(dataSource, "groups.0.description"),
-					resource.TestCheckResourceAttrSet(dataSource, "groups.0.status"),
-					resource.TestCheckResourceAttrSet(dataSource, "groups.0.created_at"),
-					resource.TestCheckResourceAttrSet(dataSource, "groups.0.updated_at"),
-
+					resource.TestMatchResourceAttr(dataSource, "groups.#", regexp.MustCompile(`[1-9][0-9]*`)),
+					// Filter by line group ID.
+					dcByLineId.CheckResourceExists(),
 					resource.TestCheckOutput("is_line_id_filter_useful", "true"),
+					dcByLineIdFuzzy.CheckResourceExists(),
+					resource.TestCheckOutput("is_line_id_fuzzy_filter_useful", "true"),
+					dcByNotFoundLineId.CheckResourceExists(),
+					resource.TestCheckOutput("line_id_not_found_validation_pass", "true"),
+					// Exact match by line group name.
+					dcByName.CheckResourceExists(),
 					resource.TestCheckOutput("is_name_filter_useful", "true"),
-					resource.TestCheckOutput("not_found_name", "true"),
+					// Fuzzy match by line group name.
+					dcByNameFuzzy.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_fuzzy_filter_useful", "true"),
+					dcByNotFoundName.CheckResourceExists(),
+					resource.TestCheckOutput("name_not_found_validation_pass", "true"),
+					// Check attributes.
+					resource.TestCheckResourceAttrPair(byLineId, "groups.0.lines", rName, "lines"),
+					resource.TestCheckResourceAttrPair(byLineId, "groups.0.description", rName, "description"),
+					resource.TestCheckResourceAttrPair(byLineId, "groups.0.status", rName, "status"),
+					// Time is not the time corresponding to the local computer.
+					resource.TestCheckResourceAttrPair(byLineId, "groups.0.created_at", rName, "created_at"),
+					resource.TestCheckResourceAttrPair(byLineId, "groups.0.updated_at", rName, "updated_at"),
 				),
 			},
 		},
 	})
 }
 
-func testDataSourceDataSourceLineGroups_basic(name string) string {
+func testAccDataLineGroups_basic(name string) string {
 	return fmt.Sprintf(`
-%s
+resource "huaweicloud_dns_line_group" "test" {
+  name        = "%[1]s"
+  description = "test description"
+  lines       = ["Dianxin_Tianjin", "Dianxin_Jilin"]
+}
 
+data "huaweicloud_dns_line_groups" "test" {
+  depends_on = [huaweicloud_dns_line_group.test]
+}
+
+# Filter by line group ID.
 locals {
   line_id = huaweicloud_dns_line_group.test.id
 }
@@ -51,12 +93,41 @@ data "huaweicloud_dns_line_groups" "filter_by_line_id" {
   line_id = local.line_id
 }
 
-output "is_line_id_filter_useful" {
-  value = length(data.huaweicloud_dns_line_groups.filter_by_line_id.groups) > 0 && alltrue(
-    [for v in data.huaweicloud_dns_line_groups.filter_by_line_id.groups[*].id : v == local.line_id]
-  )
+locals {
+  line_id_filter_result = [for v in data.huaweicloud_dns_line_groups.filter_by_line_id.groups[*].id : v == local.line_id]
 }
 
+output "is_line_id_filter_useful" {
+  value = length(local.line_id_filter_result) > 0 && alltrue(local.line_id_filter_result)
+}
+
+locals {
+  line_id_fuzzy = substr(huaweicloud_dns_line_group.test.id, 0, 6)
+}
+
+data "huaweicloud_dns_line_groups" "filter_by_line_id_fuzzy" {
+  line_id = local.line_id_fuzzy
+}
+
+locals {
+  line_id_fuzzy_filter_result = [for v in data.huaweicloud_dns_line_groups.filter_by_line_id_fuzzy.groups[*].id :
+  strcontains(v, local.line_id_fuzzy)]
+}
+
+output "is_line_id_fuzzy_filter_useful" {
+  value = length(local.line_id_fuzzy_filter_result) > 0 && alltrue(local.line_id_fuzzy_filter_result)
+}
+
+data "huaweicloud_dns_line_groups" "filter_by_not_found_line_id" {
+  depends_on = [huaweicloud_dns_line_group.test]
+  line_id    = "not_found_line_id"
+}
+
+output "line_id_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_line_groups.filter_by_not_found_line_id.groups) == 0
+}
+
+# Exact match by line group name.
 locals {
   name = huaweicloud_dns_line_group.test.name
 }
@@ -66,19 +137,40 @@ data "huaweicloud_dns_line_groups" "filter_by_name" {
   name       = local.name
 }
 
-output "is_name_filter_useful" {
-  value = length(data.huaweicloud_dns_line_groups.filter_by_name.groups) > 0 && alltrue(
-    [for v in data.huaweicloud_dns_line_groups.filter_by_name.groups[*].name : v == local.name]
-  )
+locals {
+  name_filter_result = [for v in data.huaweicloud_dns_line_groups.filter_by_name.groups[*].name : v == local.name]
 }
 
-data "huaweicloud_dns_line_groups" "filter_not_found_name" {
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Fuzzy match by line group name.
+locals {
+  name_prefix = "tf_test"
+}
+
+data "huaweicloud_dns_line_groups" "filter_by_name_fuzzy" {
+  depends_on = [huaweicloud_dns_line_group.test]
+  name       = local.name_prefix
+}
+
+locals {
+  name_fuzzy_filter_result = [for v in data.huaweicloud_dns_line_groups.filter_by_name.groups[*].name :
+  strcontains(v, local.name_prefix)]
+}
+
+output "is_name_fuzzy_filter_useful" {
+  value = length(local.name_fuzzy_filter_result) > 0 && alltrue(local.name_fuzzy_filter_result)
+}
+
+data "huaweicloud_dns_line_groups" "filter_by_not_found_name" {
   depends_on = [huaweicloud_dns_line_group.test]
   name       = "not_found_name"
 }
 
-output "not_found_name" {
-  value = length(data.huaweicloud_dns_line_groups.filter_not_found_name.groups) == 0
+output "name_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_line_groups.filter_by_not_found_name.groups) == 0
 }
-`, testAccLineGroup_basic_step1(name))
+`, name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Standardize method names and improve acceptance test.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
standardize method names and improve acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccDataLineGroups_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDataLineGroups_basic -timeout 360m -parallel 10
=== RUN   TestAccDataLineGroups_basic
=== PAUSE TestAccDataLineGroups_basic
=== CONT  TestAccDataLineGroups_basic
--- PASS: TestAccDataLineGroups_basic (84.51s)
PASS
coverage: 6.9% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       84.561s coverage: 6.9% of statements in ./huaweicloud/services/dns
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
