### PR TITLE
refactor(dns/datasource): standardize methods naming and adjust test

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -803,7 +803,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_floating_ptrrecords": dns.DataSourceFloatingPtrrecords(),
 			"huaweicloud_dns_line_groups":         dns.DataSourceLineGroups(),
 			"huaweicloud_dns_nameservers":         dns.DataSourceNameservers(),
-			"huaweicloud_dns_quotas":              dns.DataSourceDNSQuotas(),
+			"huaweicloud_dns_quotas":              dns.DataSourceQuotas(),
 			"huaweicloud_dns_recordsets":          dns.DataSourceRecordsets(),
 			"huaweicloud_dns_zones":               dns.DataSourceZones(),
 

--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_nameservers_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_nameservers_test.go
@@ -9,12 +9,16 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceNameservers_basic(t *testing.T) {
-	byType := "data.huaweicloud_dns_nameservers.filter_by_type"
-	dcByType := acceptance.InitDataSourceCheck(byType)
+func TestAccDataNameservers_basic(t *testing.T) {
+	var (
+		byType   = "data.huaweicloud_dns_nameservers.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
 
-	byServerRegion := "data.huaweicloud_dns_nameservers.filter_by_server_region"
-	dcByServerRegion := acceptance.InitDataSourceCheck(byServerRegion)
+		byServerRegion           = "data.huaweicloud_dns_nameservers.filter_by_server_region"
+		dcByServerRegion         = acceptance.InitDataSourceCheck(byServerRegion)
+		byNotFoundServerRegion   = "data.huaweicloud_dns_nameservers.filter_by_not_found_server_region"
+		dcByNotFoundServerRegion = acceptance.InitDataSourceCheck(byNotFoundServerRegion)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -23,29 +27,30 @@ func TestAccDataSourceNameservers_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceNameservers_basic(),
+				Config: testAccDataNameservers_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
 					resource.TestCheckResourceAttr(byType, "nameservers.0.type", "public"),
-					resource.TestCheckResourceAttrSet(byType, "nameservers.0.ns_records.0.priority"),
-					resource.TestCheckResourceAttrSet(byType, "nameservers.0.ns_records.0.hostname"),
-					resource.TestCheckResourceAttr(byType, "nameservers.0.ns_records.0.address", ""),
-					resource.TestCheckOutput("public_filter_is_useful", "true"),
-
-					dcByServerRegion.CheckResourceExists(),
-					resource.TestCheckResourceAttr(byServerRegion, "nameservers.0.type", "private"),
 					resource.TestCheckResourceAttrSet(byServerRegion, "nameservers.0.ns_records.0.priority"),
-					resource.TestCheckResourceAttrSet(byServerRegion, "nameservers.0.ns_records.0.address"),
-					resource.TestCheckResourceAttr(byServerRegion, "nameservers.0.ns_records.0.hostname", ""),
+					// For the public name server, the 'address' value is empty.
+					resource.TestCheckResourceAttr(byType, "nameservers.0.ns_records.0.address", ""),
+					// Filter by server region.
+					dcByServerRegion.CheckResourceExists(),
 					resource.TestCheckOutput("server_region_filter_is_useful", "true"),
-					resource.TestCheckOutput("not_found_region", "true"),
+					resource.TestCheckResourceAttr(byServerRegion, "nameservers.0.type", "private"),
+					dcByNotFoundServerRegion.CheckResourceExists(),
+					resource.TestCheckOutput("server_region_not_found_validation_pass", "true"),
+					resource.TestCheckResourceAttrSet(byServerRegion, "nameservers.0.ns_records.0.address"),
+					// For the private name server, the 'hostname' value is empty.
+					resource.TestCheckResourceAttr(byServerRegion, "nameservers.0.ns_records.0.hostname", ""),
 				),
 			},
 		},
 	})
 }
 
-func testDataSourceNameservers_basic() string {
+func testAccDataNameservers_basic() string {
 	return fmt.Sprintf(`
 data "huaweicloud_dns_nameservers" "filter_by_type" {
   type = "public"
@@ -55,7 +60,7 @@ locals {
   type_filter_result = [for v in data.huaweicloud_dns_nameservers.filter_by_type.nameservers[*].type : v == "public"]
 }
 
-output "public_filter_is_useful" {
+output "is_type_filter_useful" {
   value = alltrue(local.type_filter_result) && length(local.type_filter_result) > 0
 }
 
@@ -71,12 +76,12 @@ output "server_region_filter_is_useful" {
   value = alltrue(local.server_region_filter_result) && length(local.server_region_filter_result) == 1
 }
 
-data "huaweicloud_dns_nameservers" "not_found_region" {
+data "huaweicloud_dns_nameservers" "filter_by_not_found_server_region" {
   server_region = "not_fount"
 }
   
-output "not_found_region" {
-  value = length(data.huaweicloud_dns_nameservers.not_found_region.nameservers) == 0
+output "server_region_not_found_validation_pass" {
+  value = length(data.huaweicloud_dns_nameservers.filter_by_not_found_server_region.nameservers) == 0
 }
 `, acceptance.HW_REGION_NAME)
 }

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_quotas.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_quotas.go
@@ -17,9 +17,9 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func DataSourceDNSQuotas() *schema.Resource {
+func DataSourceQuotas() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceDNSQuotasRead,
+		ReadContext: dataSourceQuotasRead,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -83,7 +83,7 @@ func newQuotasDSWrapper(d *schema.ResourceData, meta interface{}) *QuotasDSWrapp
 	}
 }
 
-func dataSourceDNSQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	wrapper := newQuotasDSWrapper(d, meta)
 	showDomainQuotaRst, err := wrapper.ShowDomainQuota()
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Standardize methods naming and adjust test of the **huaweicloud_dns_nameservers** and **huaweicloud_dns_quotas**.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
 standardize methods naming and adjust test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o dns -f TestAccDataNameservers_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDataNameservers_basic -timeout 360m -parallel 10
=== RUN   TestAccDataNameservers_basic
=== PAUSE TestAccDataNameservers_basic
=== CONT  TestAccDataNameservers_basic
--- PASS: TestAccDataNameservers_basic (48.95s)
PASS
coverage: 2.7% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       49.015s coverage: 2.7% of statements in ./huaweicloud/services/dns
```
```
./scripts/coverage.sh -o dns -f TestAccDataQuotas_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDataQuotas_basic -timeout 360m -parallel 10
=== RUN   TestAccDataQuotas_basic
=== PAUSE TestAccDataQuotas_basic
=== CONT  TestAccDataQuotas_basic
--- PASS: TestAccDataQuotas_basic (59.35s)
PASS
coverage: 6.9% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       59.416s coverage: 6.9% of statements in ./huaweicloud/services/dns
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
