### PR TITLE
refactor: feat(fgs/function): adjust the versions parameter and supports new params

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -87,7 +87,7 @@ resource "huaweicloud_fgs_function" "by_swr_image" {
 }
 ```
 
-### Create function with an alias for latest version
+### Create function with a custom version and an alias for the latest version
 
 ```hcl
 variable "function_name" {}
@@ -107,7 +107,17 @@ resource "huaweicloud_fgs_function" "with_alias" {
     name = "latest"
 
     aliases {
-      name = "demo"
+      name        = "demo"
+      description = "This is a description of the alias demo under the version latest."
+    }
+  }
+  # The value of the parameter func_code must be modified before each custom version add.
+  versions {
+    name = "v1.0"
+
+    aliases {
+      name        = "v1_0-alias"
+      description = "This is a description of the alias v1_0-alias under the version v1.0."
     }
   }
 }
@@ -326,6 +336,9 @@ The following arguments are supported:
 * `versions` - (Optional, List) Specifies the versions management of the function.  
   The [versions](#function_versions) structure is documented below.
 
+  -> The value of the parameter `func_code`, `code_url` or `func_filename` must be modified before each custom version
+     add.
+
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the function.
 
 * `log_group_id` - (Optional, String) Specifies the LTS group ID for collecting logs.
@@ -391,17 +404,22 @@ The `custom_image` block supports:
 <a name="function_versions"></a>
 The `versions` block supports:
 
-* `name` - (Required, String) Specifies the version name.
+* `name` - (Required, String) Specifies the version name.  
+  The valid length is limited from `1` to `42` characters, only letters, digits, underscores (_), hyphens (-) and
+  periods (.) are allowed. The name must start and end with a letter or digit.
 
 * `aliases` - (Optional, List) Specifies the aliases management for specified version.  
   The [aliases](#function_aliases) structure is documented below.
 
-  -> A version can configure at most **one** alias.
+  -> 1. A version can configure at most **one** alias.
+     <br>2. A function can have a maximum of `10` aliases.
 
 <a name="function_aliases"></a>
 The `aliases` block supports:
 
-* `name` - (Required, String) Specifies the name of the version alias.
+* `name` - (Required, String) Specifies the name of the version alias.  
+  The valid length is limited from `1` to `63` characters, only letters, digits, underscores (_) and hyphens (-) are
+  allowed. The name must start with a letter and end with a letter or digit.
 
 * `description` - (Optional, String) Specifies the description of the version alias.
 

--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -121,6 +121,47 @@ resource "huaweicloud_fgs_function" "with_alias" {
       description = "This is a description of the alias v1_0-alias under the version v1.0."
     }
   }
+  versions {
+    name        = "v2.0"
+    description = "This is a description of the version v2.0."
+
+    aliases {
+      name        = "v2_0-alias"
+      description = "This is a description of the alias v2_0-alias under the version v2.0."
+
+      additional_version_weights = jsonencode({
+        "v1.0": 15
+      })
+    }
+  }
+  versions {
+    name        = "v3.0"
+    description = "This is a description of the version v2.0."
+
+    aliases {
+      name        = "v3_0-alias"
+      description = "This is a description of the alias v2_0-alias under the version v3.0."
+      additional_version_strategy = jsonencode({
+        "v2.0": {
+          "combine_type": "or",
+          "rules": [
+            {
+              "rule_type": "Header",
+              "param": "version",
+              "op": "=",
+              "value": "v2_value"
+            },
+            {
+              "rule_type": "Header",
+              "param": "Owner",
+              "op": "in",
+              "value": "terraform,administrator"
+            }
+          ]
+        }
+      })
+    }
+  }
 }
 ```
 
@@ -428,6 +469,14 @@ The `aliases` block supports:
   allowed. The name must start with a letter and end with a letter or digit.
 
 * `description` - (Optional, String) Specifies the description of the version alias.
+
+* `additional_version_weights` - (Optional, String) Specifies the percentage grayscale configuration of the version
+  alias, in JSON format.
+
+* `additional_version_strategy` - (Optional, String) Specifies the rule grayscale configuration of the version
+  alias, in JSON format.
+
+~> Only one of `additional_version_weights` and `additional_version_strategy` can be configured.
 
 <a name="function_reserved_instances"></a>
 The `reserved_instances` block supports:

--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -113,7 +113,8 @@ resource "huaweicloud_fgs_function" "with_alias" {
   }
   # The value of the parameter func_code must be modified before each custom version add.
   versions {
-    name = "v1.0"
+    name        = "v1.0"
+    description = "This is a description of the version v1.0."
 
     aliases {
       name        = "v1_0-alias"
@@ -408,13 +409,18 @@ The `versions` block supports:
   The valid length is limited from `1` to `42` characters, only letters, digits, underscores (_), hyphens (-) and
   periods (.) are allowed. The name must start and end with a letter or digit.
 
+* `description` - (Optional, String) Specifies the description of the version.
+
+  -> The **latest** version does not support configuration through this parameter, the root parameter `description` is
+  the correct configuration parameter.
+
 * `aliases` - (Optional, List) Specifies the aliases management for specified version.  
-  The [aliases](#function_aliases) structure is documented below.
+  The [aliases](#function_versions_aliases) structure is documented below.
 
   -> 1. A version can configure at most **one** alias.
      <br>2. A function can have a maximum of `10` aliases.
 
-<a name="function_aliases"></a>
+<a name="function_versions_aliases"></a>
 The `aliases` block supports:
 
 * `name` - (Required, String) Specifies the name of the version alias.  

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -917,7 +917,14 @@ func TestAccFunction_versions(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccFunction_versions_step3(functionScriptContentDefinition("Yo, world!"), name),
+				Config: testAccFunction_versions_step3(functionScriptContentDefinition("Hi, world!"), name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "versions.#", "1"),
+				),
+			},
+			{
+				Config: testAccFunction_versions_step4(functionScriptContentDefinition("Yo, world!"), name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "versions.#", "2"),
@@ -996,7 +1003,8 @@ resource "huaweicloud_fgs_function" "test" {
   }
   # The value of the parameter func_code must be modified before each custom version add.
   versions {
-    name = "v1.0"
+    name        = "v1.0"
+    description = "This is a description of the version v1.0. (Prepare to update)"
 
     aliases {
       name        = "v1_0-alias"
@@ -1007,7 +1015,7 @@ resource "huaweicloud_fgs_function" "test" {
 `, funcScript, name)
 }
 
-// Before this configuration supplement, the func_code must be updated.
+// Delete the alias configuration and recreate the version A.
 func testAccFunction_versions_step3(funcScript, name string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -1026,7 +1034,39 @@ resource "huaweicloud_fgs_function" "test" {
 
   # The value of the parameter func_code must be modified before each custom version add.
   versions {
-    name = "v1.0"
+    name        = "v1.0"
+    description = "This is a description of the version v1.0."
+
+    aliases {
+      name        = "v1_0-alias"
+      description = "This is a description of the alias v1_0-alias under the version v1.0."
+    }
+  }
+}
+`, funcScript, name)
+}
+
+// Before this configuration supplement, the func_code must be updated.
+func testAccFunction_versions_step4(funcScript, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_fgs_function" "test" {
+  name                  = "%[2]s"
+  memory_size           = 128
+  runtime               = "Python2.7"
+  timeout               = 3
+  app                   = "default"
+  handler               = "index.handler"
+  code_type             = "inline"
+  func_code             = base64encode(var.script_content)
+  description           = "Created by terraform script"
+  functiongraph_version = "v2"
+
+  # The value of the parameter func_code must be modified before each custom version add.
+  versions {
+    name        = "v1.0"
+    description = "This is a description of the version v1.0."
 
     aliases {
       name        = "v1_0-alias"
@@ -1034,7 +1074,8 @@ resource "huaweicloud_fgs_function" "test" {
     }
   }
   versions {
-    name = "v2.0"
+    name        = "v2.0"
+    description = "This is a description of the version v2.0."
 
     aliases {
       name        = "v2_0-alias"

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -338,7 +339,6 @@ func ResourceFgsFunction() *schema.Resource {
 			"versions": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -905,80 +905,6 @@ func createFunctionTags(client *golangsdk.ServiceClient, functionUrn string, tag
 	return nil
 }
 
-func createFunctionVersion(client *golangsdk.ServiceClient, functionUrn, versionName string) error {
-	httpUrl := "v2/{project_id}/fgs/functions/{function_urn}/versions"
-
-	createPath := client.Endpoint + httpUrl
-	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
-	createPath = strings.ReplaceAll(createPath, "{function_urn}", functionUrn)
-	createOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-		},
-		JSONBody: map[string]interface{}{
-			"version": versionName,
-		},
-	}
-
-	_, err := client.Request("POST", createPath, &createOpt)
-	if err != nil {
-		return fmt.Errorf("failed to create the function version: %s", err)
-	}
-	return nil
-}
-
-func createFunctionVersionAlias(client *golangsdk.ServiceClient, functionUrn, versionName string, aliasCfg interface{}) error {
-	if aliasCfg == nil {
-		return nil
-	}
-
-	httpUrl := "v2/{project_id}/fgs/functions/{function_urn}/aliases"
-
-	createPath := client.Endpoint + httpUrl
-	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
-	createPath = strings.ReplaceAll(createPath, "{function_urn}", functionUrn)
-	createOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-		},
-		JSONBody: map[string]interface{}{
-			"version":     versionName,
-			"name":        utils.ValueIgnoreEmpty(utils.PathSearch("name", aliasCfg, nil)),
-			"description": utils.ValueIgnoreEmpty(utils.PathSearch("description", aliasCfg, nil)),
-		},
-	}
-
-	_, err := client.Request("POST", createPath, &createOpt)
-	if err != nil {
-		return fmt.Errorf("failed to create the function version alias: %s", err)
-	}
-	return nil
-}
-
-func createFunctionVersions(client *golangsdk.ServiceClient, functionUrn string, versions []interface{}) error {
-	for _, version := range versions {
-		versionName := utils.PathSearch("name", version, "").(string)
-		if versionName != "latest" {
-			err := createFunctionVersion(client, functionUrn, versionName)
-			if err != nil {
-				return err
-			}
-		}
-		// In the future, the function will support manage multiple versions, and will add the corresponding logic to
-		// create versions based on the related API (Create) in this place.
-		aliases := utils.PathSearch("aliases", version, make([]interface{}, 0)).([]interface{})
-		for _, alias := range aliases {
-			err := createFunctionVersionAlias(client, functionUrn, versionName, alias)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 func getFunctionVersionUrn(client *golangsdk.ServiceClient, functionUrn string, qualifierName string) (string, error) {
 	httpUrl := "v2/{project_id}/fgs/functions/{function_urn}/versions"
 
@@ -1240,8 +1166,10 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 	}
 
-	if err = createFunctionVersions(client, funcUrnWithoutVersion, d.Get("versions").(*schema.Set).List()); err != nil {
-		return diag.FromErr(err)
+	if d.HasChanges("versions") {
+		if err = updateFunctionVersions(client, d); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	if d.HasChanges("reserved_instances") {
@@ -1749,26 +1677,54 @@ func deleteFunctionVersionAlias(client *golangsdk.ServiceClient, functionUrn, al
 	return nil
 }
 
-func deleteFunctionVersions(client *golangsdk.ServiceClient, functionUrn string, versions []interface{}) error {
-	// In the future, the function will support manage multiple versions.
-	for _, version := range versions {
-		versionNum := utils.PathSearch("name", version, "").(string) // The version name, also name as the version number.
-		if versionNum != "latest" {
-			// Deletes a function version, also deleting all aliases beneath it.
-			err := deleteFunctionOrVersion(client, fmt.Sprintf("%s:%s", functionUrn, versionNum))
-			if err != nil {
-				return err
-			}
-			continue
-		}
-		// Since the latest version cannot be deleted, only the version alias under it can be deleted.
-		aliases := utils.PathSearch("aliases", version, make([]interface{}, 0)).([]interface{})
-		for _, alias := range aliases {
-			err := deleteFunctionVersionAlias(client, functionUrn, utils.PathSearch("name", alias, "").(string))
-			if err != nil {
-				return err
-			}
-		}
+func createFunctionVersion(client *golangsdk.ServiceClient, functionUrn, versionName string) error {
+	httpUrl := "v2/{project_id}/fgs/functions/{function_urn}/versions"
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{function_urn}", functionUrn)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"version": versionName,
+		},
+	}
+
+	_, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return fmt.Errorf("failed to create the function version: %s", err)
+	}
+	return nil
+}
+
+func createFunctionVersionAlias(client *golangsdk.ServiceClient, functionUrn, versionName string, aliasCfg interface{}) error {
+	if aliasCfg == nil {
+		return nil
+	}
+
+	httpUrl := "v2/{project_id}/fgs/functions/{function_urn}/aliases"
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{function_urn}", functionUrn)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"version":     versionName,
+			"name":        utils.ValueIgnoreEmpty(utils.PathSearch("name", aliasCfg, nil)),
+			"description": utils.ValueIgnoreEmpty(utils.PathSearch("description", aliasCfg, nil)),
+		},
+	}
+
+	_, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return fmt.Errorf("failed to create the function version alias: %s", err)
 	}
 	return nil
 }
@@ -1777,19 +1733,81 @@ func updateFunctionVersions(client *golangsdk.ServiceClient, d *schema.ResourceD
 	var (
 		functionUrn = parseFunctionUrnWithoutVersion(d.Id())
 
-		oldSet, newSet = d.GetChange("versions")
-		decrease       = oldSet.(*schema.Set).Difference(newSet.(*schema.Set))
-		increase       = newSet.(*schema.Set).Difference(oldSet.(*schema.Set))
+		oldVal, newVal  = d.GetChange("versions")
+		oldVersions     = oldVal.(*schema.Set).List()
+		newVersions     = newVal.(*schema.Set).List()
+		newVersionNames = utils.PathSearch("[*].name", newVersions, make([]interface{}, 0)).([]interface{})
+		oldVersionNames = utils.PathSearch("[*].name", oldVersions, make([]interface{}, 0)).([]interface{})
+
+		err error
 	)
 
-	err := deleteFunctionVersions(client, functionUrn, decrease.List())
-	if err != nil {
-		return fmt.Errorf("error deleting function versions: %s", err)
+	// Version         -> null:                Remove version
+	// Version + Alias -> null:                Remove version
+	// Version + Alias -> Version:             Remove alias
+	// Version + Alias -> Version + New Alias: Remove alias before new alias create
+	// Do not use the difference function of the type schema set, and use the custom compare function as follows.
+	for _, oldVersion := range oldVersions {
+		versionName := utils.PathSearch("name", oldVersion, nil)
+		// Check if the version (by name) has changed and decide whether to delete it and the latest version is check in
+		// particular, because the latest version cannot be deleted, so, if the version structure has been removed
+		// (delete alias), skip the version delete logic and just only delete the corresponding alias.
+		// For versions with other names, deleting the version will also delete the alias, regardless of whether it has
+		// an alias.
+		if fmt.Sprint(versionName) != "latest" && !utils.SliceContains(newVersionNames, versionName) {
+			// Delete a specified function version.
+			err = deleteFunctionOrVersion(client, fmt.Sprintf("%s:%s", functionUrn, versionName))
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		aliases := utils.PathSearch("aliases", oldVersion, make([]interface{}, 0)).([]interface{})
+		// If the version info does not change, check if the alias information is removed or updated and decide whether
+		// to delete current alias, because these is no API to update the alias, just have APIs for create and delete.
+		// Any configuration update needs to be implemented by delete function (if the alias configuration has been
+		// configured in the history list) before new configuration create.
+		if len(aliases) > 0 && !reflect.DeepEqual(aliases, utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0].aliases", versionName),
+			newVersions, make([]interface{}, 0)).([]interface{})) {
+			// Delete an alias from a specified function version.
+			err = deleteFunctionVersionAlias(client, functionUrn, utils.PathSearch("[0].name", aliases, "").(string))
+			if err != nil {
+				return err
+			}
+		}
 	}
 
-	err = createFunctionVersions(client, functionUrn, increase.List())
-	if err != nil {
-		return fmt.Errorf("error creating function versions: %s", err)
+	// null            -> Version:             Create version
+	// null            -> Version + Alias:     Create version + Create alias
+	// Version         -> Version + Alias:     Create alias
+	// Version + Alias -> Version + New Alias: Create alias after old alias removed
+	for _, newVersion := range newVersions {
+		versionName := utils.PathSearch("name", newVersion, nil)
+		// Check if the new version (by name) is supported and decide whether to create a new version and the latest
+		// version is check in particular, because the create version name cannot be 'latest', so, if the version
+		// name has been updated (ignore alias change), new a new version first.
+		isCreateNewVersion := versionName != "latest" && !utils.SliceContains(oldVersionNames, versionName)
+		if isCreateNewVersion {
+			// Create a new function version.
+			err := createFunctionVersion(client, functionUrn, fmt.Sprint(versionName))
+			if err != nil {
+				return err
+			}
+		}
+
+		aliases := utils.PathSearch("aliases", newVersion, make([]interface{}, 0)).([]interface{})
+		// If the version is supported or alias is changed (also can be supported), it means that a new alias needs to
+		// be created according to the alias configuration in the current script (the latter will delete the old alias
+		// configuration first).
+		if isCreateNewVersion || (len(aliases) > 0 && !reflect.DeepEqual(aliases,
+			utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0].aliases", versionName), oldVersions, make([]interface{}, 0)).([]interface{}))) {
+			// Create a new alias under a specified function version.
+			err := createFunctionVersionAlias(client, functionUrn, fmt.Sprint(versionName), utils.PathSearch("[0]", aliases, nil))
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For the old function logic, it has some problem if we changes versions list and both add and modify the versions at the same time.
The description of the versions parameter is not enough.
After logic fixed, supports some new parameter as follows:
+ versions.description
+ versions.aliases.additional_version_weights
+ versions.aliases.additional_version_strategy

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. adjust the versions update logic.
2. supplement the description of the versions param.
3. versions supports description param.
4. alias supports configure grayscale configs.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFunction_versions
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_versions -timeout 360m -parallel 10
=== RUN   TestAccFunction_versions
=== PAUSE TestAccFunction_versions
=== CONT  TestAccFunction_versions
--- PASS: TestAccFunction_versions (57.11s)
PASS
coverage: 17.2% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       57.191s coverage: 17.2% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

