### PR TITLE
refactor(fgs/trigger): adjust the resource coding

### DIFF
--- a/docs/resources/fgs_function_trigger.md
+++ b/docs/resources/fgs_function_trigger.md
@@ -58,7 +58,8 @@ The following arguments are supported:
 
   -> For more available values, please refer to the [documentation table 3](https://support.huaweicloud.com/intl/en-us/api-functiongraph/functiongraph_06_0122.html#section2).
 
-* `event_data` - (Required, String) Specifies the detailed configuration of the function trigger event.  
+* `event_data` - (Required, String) Specifies the detailed configuration of the function trigger event, in JSON
+  format.  
   For various types of trigger parameter configurations, please refer to the
   [documentation](https://support.huaweicloud.com/intl/en-us/api-functiongraph/functiongraph_06_0122.html#functiongraph_06_0122__request_TriggerEventDataRequestBody).
 

--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_function_triggers.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_function_triggers.go
@@ -192,7 +192,7 @@ func flattenTriggers(triggers []interface{}) []interface{} {
 			"id":         utils.PathSearch("trigger_id", trigger, nil),
 			"type":       utils.PathSearch("trigger_type_code", trigger, nil),
 			"status":     utils.PathSearch("trigger_status", trigger, nil),
-			"event_data": parseEventData(utils.PathSearch("event_data", trigger, nil)),
+			"event_data": utils.JsonToString(utils.PathSearch("event_data", trigger, nil)),
 			"created_at": convertTimeToRFC339(utils.PathSearch("created_time", trigger, "").(string)),
 			"updated_at": convertTimeToRFC339(utils.PathSearch("last_updated_time", trigger, "").(string)),
 		})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adjust the trigger resource coding.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. adjust the trigger resource coding.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFunctionTrigger_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunctionTrigger_basic -timeout 360m -parallel 10
=== RUN   TestAccFunctionTrigger_basic
=== PAUSE TestAccFunctionTrigger_basic
=== CONT  TestAccFunctionTrigger_basic
--- PASS: TestAccFunctionTrigger_basic (33.17s)
PASS
coverage: 17.5% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       33.225s coverage: 17.5% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccDataFunctionTriggers_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataFunctionTriggers_basic -timeout 360m -parallel 10
=== RUN   TestAccDataFunctionTriggers_basic
=== PAUSE TestAccDataFunctionTriggers_basic
=== CONT  TestAccDataFunctionTriggers_basic
--- PASS: TestAccDataFunctionTriggers_basic (20.43s)
PASS
coverage: 18.3% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       20.488s coverage: 18.3% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![eff557a9ed26159331a132cf4d75d30](https://github.com/user-attachments/assets/aaeaa4c4-4938-4381-a780-ba83e582d5b8)

    ab. Related resources (parent resources) not found
    ![44054fcca7d84de77268651c87d1027](https://github.com/user-attachments/assets/cf21615b-b405-4f83-b36a-973b1d587ab3)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![c1b6681afcbb2e05a8632f4f567d5ef](https://github.com/user-attachments/assets/114c2f87-b48d-4fa7-9b77-c253e9630f4a)

    bb. Related resources (parent resources) not found
    ![c516774061c52893b8cbf6fb5d3f81c](https://github.com/user-attachments/assets/e71d515c-50ac-47f2-b254-107e0064fe94)

