### PR TITLE
feat(fgs/function): resource supports new parameters

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -13,6 +13,7 @@ Manages the function resource within HuaweiCloud.
 ~> Since version `1.73.1`, the requests of the function resource will send these parameters:
    <br>`enable_dynamic_memory`
    <br>`is_stateful_function`
+   <br>`network_controller`
    <br>For the regions that do not support this parameter, please use the lower version to deploy this resource.
 
 ## Example Usage
@@ -193,6 +194,9 @@ resource "huaweicloud_fgs_function" "test" {
 variable "function_name" {}
 variable "function_codes" {}
 variable "agency_name" {}
+variable "trigger_access_vpc_ids" {
+  type = list(string)
+}
 
 resource "huaweicloud_fgs_function" "test" {
   name                  = var.function_name
@@ -208,6 +212,18 @@ resource "huaweicloud_fgs_function" "test" {
   functiongraph_version = "v2"
   enable_dynamic_memory = true
   is_stateful_function  = true
+
+  network_controller {
+    disable_public_network = true
+
+    dynamic "trigger_access_vpcs" {
+      for_each = var.trigger_access_vpc_ids
+
+      content {
+        vpc_id = trigger_access_vpcs.value
+      }
+    }
+  }
 }
 ```
 
@@ -392,6 +408,9 @@ The following arguments are supported:
 * `is_stateful_function` - (Optional, Bool) Specifies whether the function is a stateful function.  
   Defaults to **false**.
 
+* `network_controller` - (Optional, List) Specifies the network configuration of the function.  
+  The [network_controller](#function_network_controller) structure is documented below.
+
 <a name="function_func_mounts"></a>
 The `func_mounts` block supports:
 
@@ -515,6 +534,19 @@ The `metric_configs` block supports:
   The valid value is range from `0` to `1,000`.
 
   -> The number of reserved instances must be greater than or equal to the number of reserved instances in the basic configuration.
+
+<a name="function_network_controller"></a>
+The `network_controller` block supports:
+
+* `trigger_access_vpcs` - (Required, List) Specifies the configuration of the VPCs that can trigger the function.  
+  The [trigger_access_vpcs](#function_network_controller_trigger_access_vpcs) structure is documented below.
+
+* `disable_public_network` - (Optional, Bool) Specifies whether to disable the public network access.
+
+<a name="function_network_controller_trigger_access_vpcs"></a>
+The `trigger_access_vpcs` block supports:
+
+* `vpc_id` - (Required, String) Specifies the ID of the VPC that can trigger the function.
 
 ## Attribute Reference
 

--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -10,6 +10,10 @@ description: |-
 
 Manages the function resource within HuaweiCloud.
 
+~> Since version `1.73.1`, the requests of the function resource will send these parameters:
+   <br>`enable_dynamic_memory`
+   <br>For the regions that do not support this parameter, please use the lower version to deploy this resource.
+
 ## Example Usage
 
 ### With base64 func code
@@ -179,6 +183,29 @@ resource "huaweicloud_fgs_function" "test" {
   log_stream_id   = var.log_stream_id
   log_group_name  = var.log_group_name
   log_stream_name = var.log_stream_name
+}
+```
+
+### With advanced configurations
+
+```hcl
+variable "function_name" {}
+variable "function_codes" {}
+variable "agency_name" {}
+
+resource "huaweicloud_fgs_function" "test" {
+  name                  = var.function_name
+  app                   = "default"
+  agency                = var.agency_name
+  description           = "fuction test"
+  handler               = "test.handler"
+  memory_size           = 128
+  timeout               = 3
+  runtime               = "Python2.7"
+  code_type             = "inline"
+  func_code             = base64encode(var.function_codes)
+  functiongraph_version = "v2"
+  enable_dynamic_memory = true
 }
 ```
 
@@ -356,6 +383,9 @@ The following arguments are supported:
   the [documentation](https://support.huaweicloud.com/intl/en-us/usermanual-ticket/topic_0065264094.html).
 
   -> If the `gpu_memory` and `gpu_type` configured, the `runtime` must be set to **Custom** or **Custom Image**.
+
+* `enable_dynamic_memory` - (Optional, Bool) Specifies whether the dynamic memory configuration is enabled.  
+  Defaults to **false**.
 
 <a name="function_func_mounts"></a>
 The `func_mounts` block supports:

--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -12,6 +12,7 @@ Manages the function resource within HuaweiCloud.
 
 ~> Since version `1.73.1`, the requests of the function resource will send these parameters:
    <br>`enable_dynamic_memory`
+   <br>`is_stateful_function`
    <br>For the regions that do not support this parameter, please use the lower version to deploy this resource.
 
 ## Example Usage
@@ -206,6 +207,7 @@ resource "huaweicloud_fgs_function" "test" {
   func_code             = base64encode(var.function_codes)
   functiongraph_version = "v2"
   enable_dynamic_memory = true
+  is_stateful_function  = true
 }
 ```
 
@@ -385,6 +387,9 @@ The following arguments are supported:
   -> If the `gpu_memory` and `gpu_type` configured, the `runtime` must be set to **Custom** or **Custom Image**.
 
 * `enable_dynamic_memory` - (Optional, Bool) Specifies whether the dynamic memory configuration is enabled.  
+  Defaults to **false**.
+
+* `is_stateful_function` - (Optional, Bool) Specifies whether the function is a stateful function.  
   Defaults to **false**.
 
 <a name="function_func_mounts"></a>

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -82,6 +82,7 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withBase64Code, "tags.key", "value"),
 					resource.TestCheckResourceAttr(withBase64Code, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withBase64Code, "enable_dynamic_memory", "true"),
+					resource.TestCheckResourceAttr(withBase64Code, "is_stateful_function", "true"),
 					resource.TestCheckResourceAttrSet(withBase64Code, "urn"),
 					resource.TestCheckResourceAttrSet(withBase64Code, "version"),
 					// Check the function which the code context is not base64 encoded.
@@ -105,6 +106,7 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withTextCode, "tags.key", "value"),
 					resource.TestCheckResourceAttr(withTextCode, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withTextCode, "enable_dynamic_memory", "true"),
+					resource.TestCheckResourceAttr(withTextCode, "is_stateful_function", "true"),
 					resource.TestCheckResourceAttrSet(withTextCode, "urn"),
 					resource.TestCheckResourceAttrSet(withTextCode, "version"),
 					// Check the function which the code file is storaged in the OBS bucket.
@@ -128,6 +130,7 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withObsStorage, "tags.key", "value"),
 					resource.TestCheckResourceAttr(withObsStorage, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withObsStorage, "enable_dynamic_memory", "true"),
+					resource.TestCheckResourceAttr(withObsStorage, "is_stateful_function", "true"),
 					resource.TestCheckResourceAttrSet(withObsStorage, "urn"),
 					resource.TestCheckResourceAttrSet(withObsStorage, "version"),
 					// Check the function which is build via an SWR image.
@@ -155,6 +158,7 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withCustomImage, "tags.key", "value"),
 					resource.TestCheckResourceAttr(withCustomImage, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withCustomImage, "enable_dynamic_memory", "true"),
+					resource.TestCheckResourceAttr(withCustomImage, "is_stateful_function", "true"),
 					resource.TestCheckResourceAttrSet(withCustomImage, "urn"),
 					resource.TestCheckResourceAttrSet(withCustomImage, "version"),
 				),
@@ -182,6 +186,7 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withBase64Code, "tags.new_key", "value"),
 					resource.TestCheckResourceAttr(withBase64Code, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withBase64Code, "enable_dynamic_memory", "false"),
+					resource.TestCheckResourceAttr(withBase64Code, "is_stateful_function", "false"),
 					resource.TestCheckResourceAttrSet(withBase64Code, "urn"),
 					resource.TestCheckResourceAttrSet(withBase64Code, "version"),
 					// Check the function which the code context is not base64 encoded.
@@ -204,6 +209,7 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withTextCode, "tags.new_key", "value"),
 					resource.TestCheckResourceAttr(withTextCode, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withTextCode, "enable_dynamic_memory", "false"),
+					resource.TestCheckResourceAttr(withTextCode, "is_stateful_function", "false"),
 					resource.TestCheckResourceAttrSet(withTextCode, "urn"),
 					resource.TestCheckResourceAttrSet(withTextCode, "version"),
 					// Check the function which the code file is storaged in the OBS bucket.
@@ -226,6 +232,7 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withObsStorage, "tags.new_key", "value"),
 					resource.TestCheckResourceAttr(withObsStorage, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withObsStorage, "enable_dynamic_memory", "false"),
+					resource.TestCheckResourceAttr(withObsStorage, "is_stateful_function", "false"),
 					resource.TestCheckResourceAttrSet(withObsStorage, "urn"),
 					resource.TestCheckResourceAttrSet(withObsStorage, "version"),
 					// Check the function which is build via an SWR image.
@@ -252,6 +259,7 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withCustomImage, "tags.new_key", "value"),
 					resource.TestCheckResourceAttr(withCustomImage, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withCustomImage, "enable_dynamic_memory", "false"),
+					resource.TestCheckResourceAttr(withCustomImage, "is_stateful_function", "false"),
 					resource.TestCheckResourceAttrSet(withCustomImage, "urn"),
 					resource.TestCheckResourceAttrSet(withCustomImage, "version"),
 				),
@@ -374,6 +382,7 @@ resource "huaweicloud_fgs_function" "with_base64_code" {
   description           = "Created by terraform script"
   functiongraph_version = "v2"
   enable_dynamic_memory = true
+  is_stateful_function  = true
 
   user_data = jsonencode({
     "owner": "terraform"
@@ -403,6 +412,7 @@ resource "huaweicloud_fgs_function" "with_text_code" {
   description           = "Created by terraform script"
   functiongraph_version = "v2"
   enable_dynamic_memory = true
+  is_stateful_function  = true
 
   user_data = jsonencode({
     "owner": "terraform"
@@ -433,6 +443,7 @@ resource "huaweicloud_fgs_function" "with_obs_storage" {
   description           = "Created by terraform script"
   functiongraph_version = "v2"
   enable_dynamic_memory = true
+  is_stateful_function  = true
 
   user_data = jsonencode({
     "owner": "terraform"
@@ -462,6 +473,7 @@ resource "huaweicloud_fgs_function" "with_custom_image" {
   description           = "Created by terraform script"
   functiongraph_version = "v2"
   enable_dynamic_memory = true
+  is_stateful_function  = true
   vpc_id                = huaweicloud_vpc.test.id
   network_id            = huaweicloud_vpc_subnet.test.id
 

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -81,6 +81,7 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withBase64Code, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(withBase64Code, "tags.key", "value"),
 					resource.TestCheckResourceAttr(withBase64Code, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttr(withBase64Code, "enable_dynamic_memory", "true"),
 					resource.TestCheckResourceAttrSet(withBase64Code, "urn"),
 					resource.TestCheckResourceAttrSet(withBase64Code, "version"),
 					// Check the function which the code context is not base64 encoded.
@@ -103,6 +104,7 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withTextCode, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(withTextCode, "tags.key", "value"),
 					resource.TestCheckResourceAttr(withTextCode, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttr(withTextCode, "enable_dynamic_memory", "true"),
 					resource.TestCheckResourceAttrSet(withTextCode, "urn"),
 					resource.TestCheckResourceAttrSet(withTextCode, "version"),
 					// Check the function which the code file is storaged in the OBS bucket.
@@ -125,6 +127,7 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withObsStorage, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(withObsStorage, "tags.key", "value"),
 					resource.TestCheckResourceAttr(withObsStorage, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttr(withObsStorage, "enable_dynamic_memory", "true"),
 					resource.TestCheckResourceAttrSet(withObsStorage, "urn"),
 					resource.TestCheckResourceAttrSet(withObsStorage, "version"),
 					// Check the function which is build via an SWR image.
@@ -151,6 +154,7 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withCustomImage, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(withCustomImage, "tags.key", "value"),
 					resource.TestCheckResourceAttr(withCustomImage, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttr(withCustomImage, "enable_dynamic_memory", "true"),
 					resource.TestCheckResourceAttrSet(withCustomImage, "urn"),
 					resource.TestCheckResourceAttrSet(withCustomImage, "version"),
 				),
@@ -177,6 +181,7 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withBase64Code, "tags.foo", "baar"),
 					resource.TestCheckResourceAttr(withBase64Code, "tags.new_key", "value"),
 					resource.TestCheckResourceAttr(withBase64Code, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttr(withBase64Code, "enable_dynamic_memory", "false"),
 					resource.TestCheckResourceAttrSet(withBase64Code, "urn"),
 					resource.TestCheckResourceAttrSet(withBase64Code, "version"),
 					// Check the function which the code context is not base64 encoded.
@@ -198,6 +203,7 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withTextCode, "tags.foo", "baar"),
 					resource.TestCheckResourceAttr(withTextCode, "tags.new_key", "value"),
 					resource.TestCheckResourceAttr(withTextCode, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttr(withTextCode, "enable_dynamic_memory", "false"),
 					resource.TestCheckResourceAttrSet(withTextCode, "urn"),
 					resource.TestCheckResourceAttrSet(withTextCode, "version"),
 					// Check the function which the code file is storaged in the OBS bucket.
@@ -219,6 +225,7 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withObsStorage, "tags.foo", "baar"),
 					resource.TestCheckResourceAttr(withObsStorage, "tags.new_key", "value"),
 					resource.TestCheckResourceAttr(withObsStorage, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttr(withObsStorage, "enable_dynamic_memory", "false"),
 					resource.TestCheckResourceAttrSet(withObsStorage, "urn"),
 					resource.TestCheckResourceAttrSet(withObsStorage, "version"),
 					// Check the function which is build via an SWR image.
@@ -244,6 +251,7 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withCustomImage, "tags.foo", "baar"),
 					resource.TestCheckResourceAttr(withCustomImage, "tags.new_key", "value"),
 					resource.TestCheckResourceAttr(withCustomImage, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttr(withCustomImage, "enable_dynamic_memory", "false"),
 					resource.TestCheckResourceAttrSet(withCustomImage, "urn"),
 					resource.TestCheckResourceAttrSet(withCustomImage, "version"),
 				),
@@ -365,6 +373,7 @@ resource "huaweicloud_fgs_function" "with_base64_code" {
   func_code             = base64encode(var.script_content)
   description           = "Created by terraform script"
   functiongraph_version = "v2"
+  enable_dynamic_memory = true
 
   user_data = jsonencode({
     "owner": "terraform"
@@ -393,6 +402,7 @@ resource "huaweicloud_fgs_function" "with_text_code" {
   func_code             = var.script_content
   description           = "Created by terraform script"
   functiongraph_version = "v2"
+  enable_dynamic_memory = true
 
   user_data = jsonencode({
     "owner": "terraform"
@@ -422,6 +432,7 @@ resource "huaweicloud_fgs_function" "with_obs_storage" {
   agency                = "%[4]s"
   description           = "Created by terraform script"
   functiongraph_version = "v2"
+  enable_dynamic_memory = true
 
   user_data = jsonencode({
     "owner": "terraform"
@@ -450,6 +461,7 @@ resource "huaweicloud_fgs_function" "with_custom_image" {
   agency                = "%[4]s"
   description           = "Created by terraform script"
   functiongraph_version = "v2"
+  enable_dynamic_memory = true
   vpc_id                = huaweicloud_vpc.test.id
   network_id            = huaweicloud_vpc_subnet.test.id
 

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -83,6 +83,9 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withBase64Code, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withBase64Code, "enable_dynamic_memory", "true"),
 					resource.TestCheckResourceAttr(withBase64Code, "is_stateful_function", "true"),
+					resource.TestCheckResourceAttr(withBase64Code, "network_controller.#", "1"),
+					resource.TestCheckResourceAttr(withBase64Code, "network_controller.0.trigger_access_vpcs.#", "2"),
+					resource.TestCheckResourceAttr(withBase64Code, "network_controller.0.disable_public_network", "true"),
 					resource.TestCheckResourceAttrSet(withBase64Code, "urn"),
 					resource.TestCheckResourceAttrSet(withBase64Code, "version"),
 					// Check the function which the code context is not base64 encoded.
@@ -107,6 +110,9 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withTextCode, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withTextCode, "enable_dynamic_memory", "true"),
 					resource.TestCheckResourceAttr(withTextCode, "is_stateful_function", "true"),
+					resource.TestCheckResourceAttr(withTextCode, "network_controller.#", "1"),
+					resource.TestCheckResourceAttr(withTextCode, "network_controller.0.trigger_access_vpcs.#", "2"),
+					resource.TestCheckResourceAttr(withTextCode, "network_controller.0.disable_public_network", "true"),
 					resource.TestCheckResourceAttrSet(withTextCode, "urn"),
 					resource.TestCheckResourceAttrSet(withTextCode, "version"),
 					// Check the function which the code file is storaged in the OBS bucket.
@@ -131,6 +137,9 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withObsStorage, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withObsStorage, "enable_dynamic_memory", "true"),
 					resource.TestCheckResourceAttr(withObsStorage, "is_stateful_function", "true"),
+					resource.TestCheckResourceAttr(withObsStorage, "network_controller.#", "1"),
+					resource.TestCheckResourceAttr(withObsStorage, "network_controller.0.trigger_access_vpcs.#", "2"),
+					resource.TestCheckResourceAttr(withObsStorage, "network_controller.0.disable_public_network", "true"),
 					resource.TestCheckResourceAttrSet(withObsStorage, "urn"),
 					resource.TestCheckResourceAttrSet(withObsStorage, "version"),
 					// Check the function which is build via an SWR image.
@@ -159,6 +168,9 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withCustomImage, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withCustomImage, "enable_dynamic_memory", "true"),
 					resource.TestCheckResourceAttr(withCustomImage, "is_stateful_function", "true"),
+					resource.TestCheckResourceAttr(withCustomImage, "network_controller.#", "1"),
+					resource.TestCheckResourceAttr(withCustomImage, "network_controller.0.trigger_access_vpcs.#", "2"),
+					resource.TestCheckResourceAttr(withCustomImage, "network_controller.0.disable_public_network", "true"),
 					resource.TestCheckResourceAttrSet(withCustomImage, "urn"),
 					resource.TestCheckResourceAttrSet(withCustomImage, "version"),
 				),
@@ -187,6 +199,9 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withBase64Code, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withBase64Code, "enable_dynamic_memory", "false"),
 					resource.TestCheckResourceAttr(withBase64Code, "is_stateful_function", "false"),
+					resource.TestCheckResourceAttr(withBase64Code, "network_controller.#", "1"),
+					resource.TestCheckResourceAttr(withBase64Code, "network_controller.0.trigger_access_vpcs.#", "2"),
+					resource.TestCheckResourceAttr(withBase64Code, "network_controller.0.disable_public_network", "false"),
 					resource.TestCheckResourceAttrSet(withBase64Code, "urn"),
 					resource.TestCheckResourceAttrSet(withBase64Code, "version"),
 					// Check the function which the code context is not base64 encoded.
@@ -210,6 +225,9 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withTextCode, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withTextCode, "enable_dynamic_memory", "false"),
 					resource.TestCheckResourceAttr(withTextCode, "is_stateful_function", "false"),
+					resource.TestCheckResourceAttr(withTextCode, "network_controller.#", "1"),
+					resource.TestCheckResourceAttr(withTextCode, "network_controller.0.trigger_access_vpcs.#", "2"),
+					resource.TestCheckResourceAttr(withTextCode, "network_controller.0.disable_public_network", "false"),
 					resource.TestCheckResourceAttrSet(withTextCode, "urn"),
 					resource.TestCheckResourceAttrSet(withTextCode, "version"),
 					// Check the function which the code file is storaged in the OBS bucket.
@@ -233,6 +251,9 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withObsStorage, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withObsStorage, "enable_dynamic_memory", "false"),
 					resource.TestCheckResourceAttr(withObsStorage, "is_stateful_function", "false"),
+					resource.TestCheckResourceAttr(withObsStorage, "network_controller.#", "1"),
+					resource.TestCheckResourceAttr(withObsStorage, "network_controller.0.trigger_access_vpcs.#", "2"),
+					resource.TestCheckResourceAttr(withObsStorage, "network_controller.0.disable_public_network", "false"),
 					resource.TestCheckResourceAttrSet(withObsStorage, "urn"),
 					resource.TestCheckResourceAttrSet(withObsStorage, "version"),
 					// Check the function which is build via an SWR image.
@@ -260,6 +281,9 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withCustomImage, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withCustomImage, "enable_dynamic_memory", "false"),
 					resource.TestCheckResourceAttr(withCustomImage, "is_stateful_function", "false"),
+					resource.TestCheckResourceAttr(withCustomImage, "network_controller.#", "1"),
+					resource.TestCheckResourceAttr(withCustomImage, "network_controller.0.trigger_access_vpcs.#", "2"),
+					resource.TestCheckResourceAttr(withCustomImage, "network_controller.0.disable_public_network", "false"),
 					resource.TestCheckResourceAttrSet(withCustomImage, "urn"),
 					resource.TestCheckResourceAttrSet(withCustomImage, "version"),
 				),
@@ -370,6 +394,13 @@ func testAccFunction_basic_step1(name, runtime string) string {
 	return fmt.Sprintf(`
 %[1]s
 
+resource "huaweicloud_vpc" "trigger_access" {
+  count = 3
+
+  name = format("%[2]s-trigger-%%d", count.index)
+  cidr = "192.168.0.0/16"
+}
+
 resource "huaweicloud_fgs_function" "with_base64_code" {
   name                  = "%[2]s-base64-code"
   memory_size           = 128
@@ -390,6 +421,18 @@ resource "huaweicloud_fgs_function" "with_base64_code" {
   encrypted_user_data = jsonencode({
     "owner": "terraform"
   })
+
+  network_controller {
+    disable_public_network = true
+
+    dynamic "trigger_access_vpcs" {
+      for_each = slice(huaweicloud_vpc.trigger_access[*].id, 0, 2)
+
+      content {
+        vpc_id = trigger_access_vpcs.value
+      }
+    }
+  }
 
   # Update the runtime value will trigger the dependency version change.
   depend_list = [huaweicloud_fgs_dependency_version.test.version_id]
@@ -421,6 +464,18 @@ resource "huaweicloud_fgs_function" "with_text_code" {
     "owner": "terraform"
   })
 
+  network_controller {
+    disable_public_network = true
+
+    dynamic "trigger_access_vpcs" {
+      for_each = slice(huaweicloud_vpc.trigger_access[*].id, 0, 2)
+
+      content {
+        vpc_id = trigger_access_vpcs.value
+      }
+    }
+  }
+
   # Update the runtime value will trigger the dependency version change.
   depend_list = [huaweicloud_fgs_dependency_version.test.version_id]
 
@@ -451,6 +506,18 @@ resource "huaweicloud_fgs_function" "with_obs_storage" {
   encrypted_user_data = jsonencode({
     "owner": "terraform"
   })
+
+  network_controller {
+    disable_public_network = true
+
+    dynamic "trigger_access_vpcs" {
+      for_each = slice(huaweicloud_vpc.trigger_access[*].id, 0, 2)
+
+      content {
+        vpc_id = trigger_access_vpcs.value
+      }
+    }
+  }
 
   # Update the runtime value will trigger the dependency version change.
   depend_list = [huaweicloud_fgs_dependency_version.test.version_id]
@@ -488,6 +555,18 @@ resource "huaweicloud_fgs_function" "with_custom_image" {
     "owner": "terraform"
   })
 
+  network_controller {
+    disable_public_network = true
+
+    dynamic "trigger_access_vpcs" {
+      for_each = slice(huaweicloud_vpc.trigger_access[*].id, 0, 2)
+
+      content {
+        vpc_id = trigger_access_vpcs.value
+      }
+    }
+  }
+
   tags = {
     foo = "bar"
     key = "value"
@@ -502,6 +581,13 @@ func testAccFunction_basic_step2(name, runtime string) string {
 	//nolint:revive
 	return fmt.Sprintf(`
 %[1]s
+
+resource "huaweicloud_vpc" "trigger_access" {
+  count = 3
+
+  name = format("%[2]s-trigger-%%d", count.index)
+  cidr = "192.168.0.0/16"
+}
 
 resource "huaweicloud_fgs_function" "with_base64_code" {
   name                  = "%[2]s-base64-code"
@@ -524,6 +610,16 @@ resource "huaweicloud_fgs_function" "with_base64_code" {
     "owner": "terraform",
     "usage": "acceptance test"
   })
+
+  network_controller {
+    dynamic "trigger_access_vpcs" {
+      for_each = slice(huaweicloud_vpc.trigger_access[*].id, 1, 3)
+
+      content {
+        vpc_id = trigger_access_vpcs.value
+      }
+    }
+  }
 
   # Update the runtime value will trigger the dependency version change.
   depend_list = [huaweicloud_fgs_dependency_version.test.version_id]
@@ -555,6 +651,16 @@ resource "huaweicloud_fgs_function" "with_text_code" {
     "owner": "terraform",
     "usage": "acceptance test"
   })
+
+  network_controller {
+    dynamic "trigger_access_vpcs" {
+      for_each = slice(huaweicloud_vpc.trigger_access[*].id, 1, 3)
+
+      content {
+        vpc_id = trigger_access_vpcs.value
+      }
+    }
+  }
 
   # Update the runtime value will trigger the dependency version change.
   depend_list = [huaweicloud_fgs_dependency_version.test.version_id]
@@ -589,6 +695,16 @@ resource "huaweicloud_fgs_function" "with_obs_storage" {
     "owner": "terraform",
     "usage": "acceptance test"
   })
+
+  network_controller {
+    dynamic "trigger_access_vpcs" {
+      for_each = slice(huaweicloud_vpc.trigger_access[*].id, 1, 3)
+
+      content {
+        vpc_id = trigger_access_vpcs.value
+      }
+    }
+  }
 
   # Update the runtime value will trigger the dependency version change.
   depend_list = [huaweicloud_fgs_dependency_version.test.version_id]
@@ -630,6 +746,16 @@ resource "huaweicloud_fgs_function" "with_custom_image" {
     "owner": "terraform",
     "usage": "acceptance test"
   })
+
+  network_controller {
+    dynamic "trigger_access_vpcs" {
+      for_each = slice(huaweicloud_vpc.trigger_access[*].id, 1, 3)
+
+      content {
+        vpc_id = trigger_access_vpcs.value
+      }
+    }
+  }
 
   tags = {
     foo     = "baar"

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -496,6 +496,35 @@ func ResourceFgsFunction() *schema.Resource {
 				// The stateful function can be closed, so computed behavior cannot be supported.
 				Description: `Whether the function is a stateful function.`,
 			},
+			"network_controller": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"trigger_access_vpcs": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"vpc_id": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: `The ID of the VPC that can trigger the function.`,
+									},
+								},
+							},
+							Description: `The configuration of the VPCs that can trigger the function.`,
+						},
+						"disable_public_network": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: `Whether to disable the public network access.`,
+						},
+					},
+				},
+				Description: `The network configuration of the function.`,
+			},
 
 			// Deprecated parameters.
 			"package": {
@@ -640,6 +669,33 @@ func buildFunctionLogConfig(d *schema.ResourceData) map[string]interface{} {
 	}
 }
 
+func buildNetworkControllerTriggerAccessVpcs(triggerAccessVpcs []interface{}) []map[string]interface{} {
+	if len(triggerAccessVpcs) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(triggerAccessVpcs))
+	for _, triggerAccessVpc := range triggerAccessVpcs {
+		result = append(result, map[string]interface{}{
+			"vpc_id": utils.PathSearch("vpc_id", triggerAccessVpc, nil),
+		})
+	}
+	return result
+}
+
+func buildFunctionNetworkController(networkControlers []interface{}) map[string]interface{} {
+	if len(networkControlers) < 1 {
+		return nil
+	}
+
+	networkControler := networkControlers[0]
+	return map[string]interface{}{
+		"trigger_access_vpcs": buildNetworkControllerTriggerAccessVpcs(utils.PathSearch("trigger_access_vpcs",
+			networkControler, schema.NewSet(schema.HashString, nil)).(*schema.Set).List()),
+		"disable_public_network": utils.PathSearch("disable_public_network", networkControler, nil),
+	}
+}
+
 func buildCreateFunctionBodyParams(cfg *config.Config, d *schema.ResourceData) map[string]interface{} {
 	// Parameter app is recommended to replace parameter package.
 	pkg, ok := d.GetOk("app")
@@ -681,6 +737,7 @@ func buildCreateFunctionBodyParams(cfg *config.Config, d *schema.ResourceData) m
 		"log_config":            buildFunctionLogConfig(d),
 		"enable_dynamic_memory": d.Get("enable_dynamic_memory"),
 		"is_stateful_function":  d.Get("is_stateful_function"),
+		"network_controller":    buildFunctionNetworkController(d.Get("network_controller").([]interface{})),
 	}
 }
 
@@ -803,6 +860,7 @@ func buildUpdateFunctionMetadataBodyParams(d *schema.ResourceData) map[string]in
 		"strategy_config":       buildFunctionStrategyConfig(d.Get("concurrency_num").(int)),
 		"enable_dynamic_memory": d.Get("enable_dynamic_memory"),
 		"is_stateful_function":  d.Get("is_stateful_function"),
+		"network_controller":    buildFunctionNetworkController(d.Get("network_controller").([]interface{})),
 	}
 }
 
@@ -1392,6 +1450,35 @@ func flattenFunctionVersionAliases(aliases []interface{}) []map[string]interface
 	return result
 }
 
+func flattenNetworkControllerTriggerAccessVpcs(triggerAccessVpcs []interface{}) []map[string]interface{} {
+	if len(triggerAccessVpcs) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(triggerAccessVpcs))
+	for _, triggerAccessVpc := range triggerAccessVpcs {
+		result = append(result, map[string]interface{}{
+			"vpc_id": utils.PathSearch("vpc_id", triggerAccessVpc, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenFunctionNetworkController(networkController interface{}) []map[string]interface{} {
+	if networkController == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"trigger_access_vpcs": flattenNetworkControllerTriggerAccessVpcs(utils.PathSearch("trigger_access_vpcs",
+				networkController, make([]interface{}, 0)).([]interface{})),
+			"disable_public_network": utils.PathSearch("disable_public_network", networkController, nil),
+		},
+	}
+}
+
 func flattenFunctionVersions(client *golangsdk.ServiceClient, functionUrn string) ([]map[string]interface{}, error) {
 	versionList, err := getFunctionVersions(client, functionUrn)
 	if err != nil {
@@ -1593,6 +1680,7 @@ func resourceFunctionRead(_ context.Context, d *schema.ResourceData, meta interf
 			function, make([]interface{}, 0)).([]interface{}))),
 		d.Set("enable_dynamic_memory", utils.PathSearch("enable_dynamic_memory", function, nil)),
 		d.Set("is_stateful_function", utils.PathSearch("is_stateful_function", function, nil)),
+		d.Set("network_controller", flattenFunctionNetworkController(utils.PathSearch("network_controller", function, nil))),
 		// Attributes.
 		d.Set("urn", utils.PathSearch("func_urn", function, nil)),
 		d.Set("version", utils.PathSearch("version", function, nil)),
@@ -1642,7 +1730,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		"user_data", "agency", "app_agency", "description", "initializer_handler", "initializer_timeout",
 		"vpc_id", "network_id", "dns_list", "mount_user_id", "mount_user_group_id", "func_mounts", "custom_image",
 		"log_group_id", "log_stream_id", "log_group_name", "log_stream_name", "concurrency_num", "gpu_memory", "gpu_type",
-		"enable_dynamic_memory", "is_stateful_function") {
+		"enable_dynamic_memory", "is_stateful_function", "network_controller") {
 		err := updateFunctionMetadata(client, d, funcUrnWithoutVersion)
 		if err != nil {
 			return diag.FromErr(err)

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -490,6 +490,12 @@ func ResourceFgsFunction() *schema.Resource {
 				// The dynamic memory function can be closed, so computed behavior cannot be supported.
 				Description: `Whether the dynamic memory configuration is enabled.`,
 			},
+			"is_stateful_function": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				// The stateful function can be closed, so computed behavior cannot be supported.
+				Description: `Whether the function is a stateful function.`,
+			},
 
 			// Deprecated parameters.
 			"package": {
@@ -674,6 +680,7 @@ func buildCreateFunctionBodyParams(cfg *config.Config, d *schema.ResourceData) m
 		"func_code":             buildFunctionCodeConfig(d.Get("func_code").(string)),
 		"log_config":            buildFunctionLogConfig(d),
 		"enable_dynamic_memory": d.Get("enable_dynamic_memory"),
+		"is_stateful_function":  d.Get("is_stateful_function"),
 	}
 }
 
@@ -795,6 +802,7 @@ func buildUpdateFunctionMetadataBodyParams(d *schema.ResourceData) map[string]in
 			d.Get("mount_user_id").(int), d.Get("mount_user_group_id").(int)),
 		"strategy_config":       buildFunctionStrategyConfig(d.Get("concurrency_num").(int)),
 		"enable_dynamic_memory": d.Get("enable_dynamic_memory"),
+		"is_stateful_function":  d.Get("is_stateful_function"),
 	}
 }
 
@@ -1584,6 +1592,7 @@ func resourceFunctionRead(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("func_mounts", flattenFuncionMounts(utils.PathSearch("mount_config.func_mounts",
 			function, make([]interface{}, 0)).([]interface{}))),
 		d.Set("enable_dynamic_memory", utils.PathSearch("enable_dynamic_memory", function, nil)),
+		d.Set("is_stateful_function", utils.PathSearch("is_stateful_function", function, nil)),
 		// Attributes.
 		d.Set("urn", utils.PathSearch("func_urn", function, nil)),
 		d.Set("version", utils.PathSearch("version", function, nil)),
@@ -1633,7 +1642,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		"user_data", "agency", "app_agency", "description", "initializer_handler", "initializer_timeout",
 		"vpc_id", "network_id", "dns_list", "mount_user_id", "mount_user_group_id", "func_mounts", "custom_image",
 		"log_group_id", "log_stream_id", "log_group_name", "log_stream_name", "concurrency_num", "gpu_memory", "gpu_type",
-		"enable_dynamic_memory") {
+		"enable_dynamic_memory", "is_stateful_function") {
 		err := updateFunctionMetadata(client, d, funcUrnWithoutVersion)
 		if err != nil {
 			return diag.FromErr(err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New parameters are supports as follows:
+ enable_dynamic_memory
+ is_stateful_function
+ network_controller

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. resource supports new parameters.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFunction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_basic -timeout 360m -parallel 10
=== RUN   TestAccFunction_basic
=== PAUSE TestAccFunction_basic
=== CONT  TestAccFunction_basic
--- PASS: TestAccFunction_basic (77.53s)
PASS
coverage: 21.7% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       77.593s coverage: 21.7% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.
