### PR TITLE
fix(fgs/function): saving corresponding values if deprecated params set

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -515,7 +515,7 @@ $ terraform import huaweicloud_fgs_function.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to the attribute missing from the
-API response. The missing attributes are: `app`, `func_code`, `encrypted_user_data`, `tags`.
+API response. The missing attributes are: `func_code`, `encrypted_user_data`, `tags`.
 It is generally recommended running `terraform plan` after importing a function.
 You can then decide if changes should be applied to the function, or the resource definition should be updated to align
 with the function. Also you can ignore changes as below.

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -1516,6 +1516,22 @@ func flattenReservedInstances(reservedInstances []interface{}) []map[string]inte
 	return result
 }
 
+func setFunctionFieldApp(d *schema.ResourceData, app string) error {
+	// If the deprecated parameter package is not set, saving value to the parameter app.
+	if _, ok := d.GetOk("package"); !ok {
+		return d.Set("app", app)
+	}
+	return d.Set("package", app)
+}
+
+func setFunctionFieldAgency(d *schema.ResourceData, agency string) error {
+	// If the deprecated parameter xrole is not set, saving value to the parameter agency.
+	if _, ok := d.GetOk("xrole"); !ok {
+		return d.Set("agency", agency)
+	}
+	return d.Set("xrole", agency)
+}
+
 func resourceFunctionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg                   = meta.(*config.Config)
@@ -1541,7 +1557,7 @@ func resourceFunctionRead(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("timeout", utils.PathSearch("timeout", function, nil)),
 		d.Set("memory_size", utils.PathSearch("memory_size", function, nil)),
 		// Optional parameters but required in documentation.
-		d.Set("app", utils.PathSearch("package", function, nil)),
+		setFunctionFieldApp(d, utils.PathSearch("package", function, "").(string)),
 		d.Set("handler", utils.PathSearch("handler", function, nil)),
 		d.Set("code_type", utils.PathSearch("code_type", function, nil)),
 		// Optional parameters.
@@ -1550,7 +1566,7 @@ func resourceFunctionRead(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("code_url", utils.PathSearch("code_url", function, nil)),
 		d.Set("code_filename", utils.PathSearch("code_filename", function, nil)),
 		d.Set("user_data", utils.PathSearch("user_data", function, nil)),
-		d.Set("agency", utils.PathSearch("xrole", function, nil)),
+		setFunctionFieldAgency(d, utils.PathSearch("xrole", function, "").(string)),
 		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", function, nil)),
 		d.Set("custom_image", flattenFgsCustomImage(utils.PathSearch("custom_image",
 			function, make(map[string]interface{})).(map[string]interface{}))),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The value setting of the deprecated parameters are missing, such as the `package` and the `xrole`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. saving corresponding values if deprecated params set
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFunction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_basic -timeout 360m -parallel 10
=== RUN   TestAccFunction_basic
=== PAUSE TestAccFunction_basic
=== CONT  TestAccFunction_basic
--- PASS: TestAccFunction_basic (87.83s)
PASS
coverage: 21.3% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       87.908s coverage: 21.3% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.
