### PR TITLE
chore(fgs/function): adjust the API and function's reference

### DIFF
--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -25,7 +25,6 @@ import (
 // @API FunctionGraph PUT /v2/{project_id}/fgs/functions/{function_urn}/config-max-instance
 // @API FunctionGraph GET /v2/{project_id}/fgs/functions/{function_urn}/config
 // @API FunctionGraph GET /v2/{project_id}/fgs/functions/{function_urn}/versions
-// @API FunctionGraph GET /v2/{project_id}/fgs/functions/reservedinstances
 // @API FunctionGraph POST /v2/{project_id}/fgs/functions/{function_urn}/tags/create
 // @API FunctionGraph DELETE /v2/{project_id}/fgs/functions/{function_urn}/tags/delete
 // @API FunctionGraph PUT /v2/{project_id}/fgs/functions/{function_urn}/code

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -980,53 +980,22 @@ func createFunctionVersions(client *golangsdk.ServiceClient, functionUrn string,
 }
 
 func getFunctionVersionUrn(client *golangsdk.ServiceClient, functionUrn string, qualifierName string) (string, error) {
-	httpUrl := "v2/{project_id}/fgs/functions/{function_urn}/versions"
-
-	// The query parameter 'marker' and 'maxitems' are not available.
-	listPath := client.Endpoint + httpUrl
-	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
-	listPath = strings.ReplaceAll(listPath, "{function_urn}", functionUrn)
-	listOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-		},
-	}
-	requestResp, err := client.Request("GET", listPath, &listOpt)
-	if err != nil {
-		return "", fmt.Errorf("failed to query the function versions: %s", err)
-	}
-	respBody, err := utils.FlattenResponse(requestResp)
+	versions, err := getFunctionVersions(client, functionUrn)
 	if err != nil {
 		return "", err
 	}
 
-	return utils.PathSearch(fmt.Sprintf("versions[?version=='%s']|[0].func_urn", qualifierName), respBody, "").(string), nil
+	return utils.PathSearch(fmt.Sprintf("[?version=='%s']|[0].func_urn", qualifierName), versions, "").(string), nil
 }
 
 func getFunctionAliasUrn(client *golangsdk.ServiceClient, functionUrn string, qualifierName string) (string, error) {
-	httpUrl := "v2/{project_id}/fgs/functions/{function_urn}/aliases"
-
-	listPath := client.Endpoint + httpUrl
-	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
-	listPath = strings.ReplaceAll(listPath, "{function_urn}", functionUrn)
-	listOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-		},
-	}
-	requestResp, err := client.Request("GET", listPath, &listOpt)
-	if err != nil {
-		return "", fmt.Errorf("failed to query the function aliases: %s", err)
-	}
-	respBody, err := utils.FlattenResponse(requestResp)
+	aliases, err := getFunctionAliases(client, functionUrn)
 	if err != nil {
 		return "", err
 	}
 
 	// There will be no aliases with the same name even between different versions.
-	return utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0].alias_urn", qualifierName), respBody, "").(string), nil
+	return utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0].alias_urn", qualifierName), aliases, "").(string), nil
 }
 
 func getReservedInstanceUrn(client *golangsdk.ServiceClient, functionUrn, qualifierType, qualifierName string) (string, error) {
@@ -1313,6 +1282,7 @@ func flattenFuncionMounts(mounts []interface{}) []map[string]interface{} {
 func getFunctionVersions(client *golangsdk.ServiceClient, functionUrn string) ([]interface{}, error) {
 	httpUrl := "v2/{project_id}/fgs/functions/{function_urn}/versions"
 
+	// The query parameter 'marker' and 'maxitems' are not available.
 	listPath := client.Endpoint + httpUrl
 	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
 	listPath = strings.ReplaceAll(listPath, "{function_urn}", functionUrn)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Extra API reference: GET /v2/{project_id}/fgs/functions/reservedinstances
Adjust the version and alias functions reference because they have already exists with the same logic.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. adjust the API and function's reference
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFunction_versions
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_versions -timeout 360m -parallel 10
=== RUN   TestAccFunction_versions
=== PAUSE TestAccFunction_versions
=== CONT  TestAccFunction_versions
--- PASS: TestAccFunction_versions (33.38s)
PASS
coverage: 15.5% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       33.437s coverage: 15.5% of statements in ./huaweicloud/services/fgs
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.
