### PR TITLE
refactor(dns/ptrrecord): adjust the code and acceptance test

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1762,7 +1762,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rocketmq_migration_task":       dms.ResourceDmsRocketmqMigrationTask(),
 
 			"huaweicloud_dns_custom_line":             dns.ResourceCustomLine(),
-			"huaweicloud_dns_ptrrecord":               dns.ResourceDNSPtrRecord(),
+			"huaweicloud_dns_ptrrecord":               dns.ResourcePtrRecord(),
 			"huaweicloud_dns_recordset":               dns.ResourceDNSRecordset(),
 			"huaweicloud_dns_zone":                    dns.ResourceDNSZone(),
 			"huaweicloud_dns_endpoint_assignment":     dns.ResourceEndpointAssignment(),
@@ -2404,7 +2404,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_compute_volume_attach_v2":        ecs.ResourceComputeVolumeAttach(),
 			"huaweicloud_compute_floatingip_associate_v2": ecs.ResourceComputeEIPAssociate(),
 
-			"huaweicloud_dns_ptrrecord_v2": dns.ResourceDNSPtrRecord(),
+			"huaweicloud_dns_ptrrecord_v2": dns.ResourcePtrRecord(),
 			"huaweicloud_dns_recordset_v2": dns.ResourceDNSRecordSetV2(),
 			"huaweicloud_dns_zone_v2":      dns.ResourceDNSZone(),
 

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_ptrrecord.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_ptrrecord.go
@@ -20,16 +20,16 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API DNS POST /v2/{project_id}/DNS-ptr_record/{resource_id}/tags/action
-// @API DNS GET /v2/{project_id}/DNS-ptr_record/{resource_id}/tags
-// @API DNS GET /v2/reverse/floatingips/{region}:{floatingip_id}
 // @API DNS PATCH /v2/reverse/floatingips/{region}:{floatingip_id}
-func ResourceDNSPtrRecord() *schema.Resource {
+// @API DNS GET /v2/reverse/floatingips/{region}:{floatingip_id}
+// @API DNS GET /v2/{project_id}/DNS-ptr_record/{resource_id}/tags
+// @API DNS POST /v2/{project_id}/DNS-ptr_record/{resource_id}/tags/action
+func ResourcePtrRecord() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceDNSPtrRecordCreate,
-		ReadContext:   resourceDNSPtrRecordRead,
-		UpdateContext: resourceDNSPtrRecordUpdate,
-		DeleteContext: resourceDNSPtrRecordDelete,
+		CreateContext: resourcePtrRecordCreate,
+		ReadContext:   resourcePtrRecordRead,
+		UpdateContext: resourcePtrRecordUpdate,
+		DeleteContext: resourcePtrRecordDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -83,7 +83,7 @@ func ResourceDNSPtrRecord() *schema.Resource {
 	}
 }
 
-func resourceDNSPtrRecordCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePtrRecordCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	dnsClient, err := cfg.DnsV2Client(region)
@@ -100,20 +100,25 @@ func resourceDNSPtrRecordCreate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	log.Printf("[DEBUG] Create options: %#v", createOpts)
-	fipId := d.Get("floatingip_id").(string)
-	n, err := ptrrecords.Create(dnsClient, region, fipId, createOpts).Extract()
+	floatingIpId := d.Get("floatingip_id").(string)
+	respBody, err := ptrrecords.Create(dnsClient, region, floatingIpId, createOpts).Extract()
 	if err != nil {
 		return diag.Errorf("error creating DNS PTR record: %s", err)
 	}
 
-	err = waitForDNSPtrRecordCreateOrUpdate(ctx, dnsClient, n.ID, d.Timeout(schema.TimeoutCreate))
-	if err != nil {
-		return diag.FromErr(err)
+	ptrRecordId := respBody.ID
+	if ptrRecordId == "" {
+		return diag.Errorf("unable to find PTR record ID from API response")
 	}
-	d.SetId(n.ID)
 
-	log.Printf("[DEBUG] Created DNS PTR record %s: %#v", n.ID, n)
-	return resourceDNSPtrRecordRead(ctx, d, meta)
+	err = waitForPtrRecordCreateOrUpdate(ctx, dnsClient, ptrRecordId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for PTR record (%s) to be created: %s", ptrRecordId, err)
+	}
+	d.SetId(ptrRecordId)
+
+	log.Printf("[DEBUG] Created DNS PTR record %s: %#v", ptrRecordId, respBody)
+	return resourcePtrRecordRead(ctx, d, meta)
 }
 
 func getPtrRecordsTagList(d *schema.ResourceData) []ptrrecords.Tag {
@@ -128,69 +133,71 @@ func getPtrRecordsTagList(d *schema.ResourceData) []ptrrecords.Tag {
 	return tagList
 }
 
-func waitForDNSPtrRecordCreateOrUpdate(ctx context.Context, dnsClient *golangsdk.ServiceClient, id string,
+func waitForPtrRecordCreateOrUpdate(ctx context.Context, dnsClient *golangsdk.ServiceClient, ptrRecordId string,
 	timeout time.Duration) error {
-	log.Printf("[DEBUG] Waiting for DNS PTR record (%s) to become ACTIVE", id)
+	log.Printf("[DEBUG] Waiting for DNS PTR record (%s) to become ACTIVE", ptrRecordId)
 	stateConf := &resource.StateChangeConf{
-		Target:       []string{"ACTIVE"},
-		Pending:      []string{"PENDING_CREATE"},
-		Refresh:      waitForDNSPtrRecord(dnsClient, id),
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      waitForPtrRecord(dnsClient, ptrRecordId, false),
 		Timeout:      timeout,
 		Delay:        5 * time.Second,
 		PollInterval: 3 * time.Second,
 	}
-	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf(
-			"error waiting for PTR record (%s) create or update: %s", id, err)
-	}
-	return nil
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
 }
 
-func resourceDNSPtrRecordRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
-
+func resourcePtrRecordRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		conf        = meta.(*config.Config)
+		region      = conf.GetRegion(d)
+		ptrRecordId = d.Id()
+	)
 	dnsClient, err := conf.DnsV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
 	}
 
-	n, err := ptrrecords.Get(dnsClient, d.Id()).Extract()
+	respBody, err := ptrrecords.Get(dnsClient, ptrRecordId).Extract()
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "ptr_record")
+		return common.CheckDeletedDiag(d, err, "error retrieving DNS PTR record")
 	}
 
-	log.Printf("[DEBUG] Retrieved PTR record %s: %#v", d.Id(), n)
+	log.Printf("[DEBUG] Retrieved PTR record %s: %#v", ptrRecordId, respBody)
 
 	// Obtain relevant info from parsing the ID
-	fipID, err := parseDNSPtrRecordID(d.Id())
+	floatingIpId, err := parsePtrRecordId(ptrRecordId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("name", n.PtrName),
-		d.Set("description", n.Description),
-		d.Set("floatingip_id", fipID),
-		d.Set("ttl", n.TTL),
-		d.Set("address", n.Address),
-		d.Set("enterprise_project_id", n.EnterpriseProjectID),
+		d.Set("name", respBody.PtrName),
+		d.Set("description", respBody.Description),
+		d.Set("floatingip_id", floatingIpId),
+		d.Set("ttl", respBody.TTL),
+		d.Set("address", respBody.Address),
+		d.Set("enterprise_project_id", respBody.EnterpriseProjectID),
 	)
 	if mErr.ErrorOrNil() != nil {
 		return diag.Errorf("error setting resource: %s", mErr)
 	}
 
-	if err := utils.SetResourceTagsToState(d, dnsClient, "DNS-ptr_record", d.Id()); err != nil {
+	if err := utils.SetResourceTagsToState(d, dnsClient, "DNS-ptr_record", ptrRecordId); err != nil {
 		return diag.FromErr(err)
 	}
 
 	return nil
 }
 
-func resourceDNSPtrRecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
+func resourcePtrRecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		conf        = meta.(*config.Config)
+		region      = conf.GetRegion(d)
+		ptrRecordId = d.Id()
+	)
 	dnsClient, err := conf.DnsV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
@@ -204,17 +211,17 @@ func resourceDNSPtrRecordUpdate(ctx context.Context, d *schema.ResourceData, met
 		}
 
 		log.Printf("[DEBUG] Update options: %#v", updateOpts)
-		fipId := d.Get("floatingip_id").(string)
-		n, err := ptrrecords.Create(dnsClient, region, fipId, updateOpts).Extract()
+		respBody, err := ptrrecords.Create(dnsClient, region, d.Get("floatingip_id").(string), updateOpts).Extract()
 		if err != nil {
 			return diag.Errorf("error updating DNS PTR record: %s", err)
 		}
 
-		if err = waitForDNSPtrRecordCreateOrUpdate(ctx, dnsClient, n.ID, d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.FromErr(err)
+		err = waitForPtrRecordCreateOrUpdate(ctx, dnsClient, ptrRecordId, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return diag.Errorf("error waiting for PTR record (%s) to be updated: %s", ptrRecordId, err)
 		}
 
-		log.Printf("[DEBUG] Updated DNS PTR record %s: %#v", n.ID, n)
+		log.Printf("[DEBUG] Updated DNS PTR record %s: %#v", ptrRecordId, respBody)
 	}
 
 	// update tags
@@ -223,26 +230,30 @@ func resourceDNSPtrRecordUpdate(ctx context.Context, d *schema.ResourceData, met
 		return diag.Errorf("error updating tags of DNS PTR record %s: %s", d.Id(), tagErr)
 	}
 
-	return resourceDNSPtrRecordRead(ctx, d, meta)
+	return resourcePtrRecordRead(ctx, d, meta)
 }
 
-func resourceDNSPtrRecordDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
+func resourcePtrRecordDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		conf        = meta.(*config.Config)
+		ptrRecordId = d.Id()
+	)
 	dnsClient, err := conf.DnsV2Client(conf.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
 	}
 
-	err = ptrrecords.Delete(dnsClient, d.Id()).ExtractErr()
+	err = ptrrecords.Delete(dnsClient, ptrRecordId).ExtractErr()
 	if err != nil {
 		return diag.Errorf("error deleting DNS PTR record: %s", err)
 	}
 
-	log.Printf("[DEBUG] Waiting for DNS PTR record (%s) to be deleted", d.Id())
+	log.Printf("[DEBUG] Waiting for DNS PTR record (%s) to be deleted", ptrRecordId)
 	stateConf := &resource.StateChangeConf{
+		// Allows deletion of PTR record with status 'ERROR'.
+		Pending:      []string{"PENDING"},
 		Target:       []string{"DELETED"},
-		Pending:      []string{"ACTIVE", "PENDING_DELETE", "ERROR"},
-		Refresh:      waitForDNSPtrRecord(dnsClient, d.Id()),
+		Refresh:      waitForPtrRecord(dnsClient, ptrRecordId, true),
 		Timeout:      d.Timeout(schema.TimeoutDelete),
 		Delay:        5 * time.Second,
 		PollInterval: 3 * time.Second,
@@ -250,34 +261,41 @@ func resourceDNSPtrRecordDelete(ctx context.Context, d *schema.ResourceData, met
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf(
-			"error waiting for PTR record (%s) to become DELETED for deletion: %s",
-			d.Id(), err)
+		return diag.Errorf("error waiting for PTR record (%s) to deleted: %s", ptrRecordId, err)
 	}
-	d.SetId("")
 	return nil
 }
 
-func waitForDNSPtrRecord(dnsClient *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+func waitForPtrRecord(dnsClient *golangsdk.ServiceClient, ptrRecordId string, isDelete bool) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		ptrRecord, err := ptrrecords.Get(dnsClient, id).Extract()
+		ptrRecord, err := ptrrecords.Get(dnsClient, ptrRecordId).Extract()
 		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return ptrRecord, "DELETED", nil
+			if _, ok := err.(golangsdk.ErrDefault404); ok && isDelete {
+				return "Resource Not Found", "DELETED", nil
 			}
-			return nil, "", err
+			return nil, "ERROR", err
 		}
-		log.Printf("[DEBUG] DNS PTR record (%s) current status: %s", ptrRecord.ID, ptrRecord.Status)
-		return ptrRecord, ptrRecord.Status, nil
+
+		status := ptrRecord.Status
+		log.Printf("[DEBUG] DNS PTR record (%s) current status: %s", ptrRecord.ID, status)
+		if !isDelete {
+			if status == "ACTIVE" {
+				return ptrRecord, "COMPLETED", nil
+			}
+
+			if status == "ERROR" {
+				return ptrRecord, "ERROR", fmt.Errorf("unexpect status (%s)", status)
+			}
+		}
+		return ptrRecord, "PENDING", nil
 	}
 }
 
-func parseDNSPtrRecordID(id string) (string, error) {
-	idParts := strings.Split(id, ":")
-	if len(idParts) != 2 {
-		return "", fmt.Errorf("unable to determine DNS PTR record ID from raw ID: %s", id)
+func parsePtrRecordId(ptrRecordId string) (string, error) {
+	parts := strings.Split(ptrRecordId, ":")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid PTR record ID format (%s), want '<region>:<floatingip_id>'", ptrRecordId)
 	}
 
-	fipID := idParts[1]
-	return fipID, nil
+	return parts[1], nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adjust the code and acceptance test.
+ Naming of normalization methods.
+ Remove redundant codes.
+ Adjust the order of APIs reference.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. the naming of normalization methods.
2. remove redundant codes.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccPtrRecord_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccPtrRecord_ -timeout 360m -parallel 10
=== RUN   TestAccPtrRecord_basic
=== PAUSE TestAccPtrRecord_basic
=== RUN   TestAccPtrRecord_withEpsId
=== PAUSE TestAccPtrRecord_withEpsId
=== CONT  TestAccPtrRecord_basic
=== CONT  TestAccPtrRecord_withEpsId
--- PASS: TestAccPtrRecord_withEpsId (69.37s)
--- PASS: TestAccPtrRecord_basic (102.31s)
PASS
coverage: 6.1% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       102.376s        coverage: 6.1% of statements in ./huaweicloud/services/dns
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/9a40e530-e30c-4404-bc61-91dc52efb9e4)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
