### PR TITLE
feat(fgs/function): new LTS parameter is supported and other LTS parameters supports update

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -466,6 +466,8 @@ The following arguments are supported:
 * `network_controller` - (Optional, List) Specifies the network configuration of the function.  
   The [network_controller](#function_network_controller) structure is documented below.
 
+* `lts_custom_tag` - (Optional, Map) Specifies the custom tags configuration that used to filter the LTS logs.
+
 <a name="function_func_mounts"></a>
 The `func_mounts` block supports:
 

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -867,33 +867,94 @@ func TestAccFunction_logConfig(t *testing.T) {
 	var (
 		obj interface{}
 
-		name         = acceptance.RandomAccResourceName()
-		resourceName = "huaweicloud_fgs_function.test"
+		name = acceptance.RandomAccResourceName()
 
-		rc = acceptance.InitResourceCheck(resourceName, &obj, getFunction)
+		createWithLtsParams      = "huaweicloud_fgs_function.create_with_lts_params"
+		rcCreateWithLtsParams    = acceptance.InitResourceCheck(createWithLtsParams, &obj, getFunction)
+		createWithoutLtsParams   = "huaweicloud_fgs_function.create_without_lts_params"
+		rcCreateWithoutLtsParams = acceptance.InitResourceCheck(createWithoutLtsParams, &obj, getFunction)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcCreateWithLtsParams.CheckResourceDestroy(),
+			rcCreateWithoutLtsParams.CheckResourceDestroy(),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFunction_logConfig_step1(name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "functiongraph_version", "v1"),
-					resource.TestCheckResourceAttrSet(resourceName, "log_group_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "log_stream_id"),
+					rcCreateWithLtsParams.CheckResourceExists(),
+					resource.TestCheckResourceAttr(createWithLtsParams, "functiongraph_version", "v1"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_group_id",
+						"huaweicloud_lts_group.test.0", "id"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_group_name",
+						"huaweicloud_lts_group.test.0", "group_name"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_stream_id",
+						"huaweicloud_lts_stream.test.0", "id"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_stream_name",
+						"huaweicloud_lts_stream.test.0", "stream_name"),
+					resource.TestCheckResourceAttr(createWithLtsParams, "lts_custom_tag.%", "2"),
+					resource.TestCheckResourceAttr(createWithLtsParams, "lts_custom_tag.foo", "bar"),
+					resource.TestCheckResourceAttr(createWithLtsParams, "lts_custom_tag.key", "value"),
+					rcCreateWithoutLtsParams.CheckResourceExists(),
+					resource.TestCheckResourceAttr(createWithoutLtsParams, "functiongraph_version", "v1"),
+					// In some regions (such as 'cn-north-4'), the FunctionGraph service automatically binds the groups
+					// and streams created by FunctionGraph to functions that do not have LTS set.
+					resource.TestCheckResourceAttrSet(createWithoutLtsParams, "log_group_id"),
+					resource.TestCheckNoResourceAttr(createWithoutLtsParams, "log_group_name"),
+					resource.TestCheckResourceAttrSet(createWithoutLtsParams, "log_stream_id"),
+					resource.TestCheckNoResourceAttr(createWithoutLtsParams, "log_stream_name"),
+					resource.TestCheckResourceAttr(createWithoutLtsParams, "lts_custom_tag.%", "0"),
 				),
 			},
 			{
 				Config: testAccFunction_logConfig_step2(name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "functiongraph_version", "v1"),
-					resource.TestCheckResourceAttrSet(resourceName, "log_group_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "log_stream_id"),
+					rcCreateWithLtsParams.CheckResourceExists(),
+					resource.TestCheckResourceAttr(createWithLtsParams, "functiongraph_version", "v1"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_group_id",
+						"huaweicloud_lts_group.test.1", "id"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_group_name",
+						"huaweicloud_lts_group.test.1", "group_name"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_stream_id",
+						"huaweicloud_lts_stream.test.1", "id"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_stream_name",
+						"huaweicloud_lts_stream.test.1", "stream_name"),
+					resource.TestCheckResourceAttr(createWithLtsParams, "lts_custom_tag.%", "2"),
+					resource.TestCheckResourceAttr(createWithLtsParams, "lts_custom_tag.foo", "baar"),
+					resource.TestCheckResourceAttr(createWithLtsParams, "lts_custom_tag.new_key", "value"),
+					rcCreateWithoutLtsParams.CheckResourceExists(),
+					resource.TestCheckResourceAttr(createWithoutLtsParams, "functiongraph_version", "v1"),
+					resource.TestCheckResourceAttrPair(createWithoutLtsParams, "log_group_id",
+						"huaweicloud_lts_group.test.0", "id"),
+					resource.TestCheckResourceAttrPair(createWithoutLtsParams, "log_group_name",
+						"huaweicloud_lts_group.test.0", "group_name"),
+					resource.TestCheckResourceAttrPair(createWithoutLtsParams, "log_stream_id",
+						"huaweicloud_lts_stream.test.0", "id"),
+					resource.TestCheckResourceAttrPair(createWithoutLtsParams, "log_stream_name",
+						"huaweicloud_lts_stream.test.0", "stream_name"),
+					resource.TestCheckResourceAttr(createWithoutLtsParams, "lts_custom_tag.%", "2"),
+					resource.TestCheckResourceAttr(createWithoutLtsParams, "lts_custom_tag.foo", "bar"),
+					resource.TestCheckResourceAttr(createWithoutLtsParams, "lts_custom_tag.key", "value"),
+				),
+			},
+			{
+				Config: testAccFunction_logConfig_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rcCreateWithLtsParams.CheckResourceExists(),
+					resource.TestCheckResourceAttr(createWithLtsParams, "functiongraph_version", "v1"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_group_id",
+						"huaweicloud_lts_group.test.1", "id"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_group_name",
+						"huaweicloud_lts_group.test.1", "group_name"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_stream_id",
+						"huaweicloud_lts_stream.test.1", "id"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_stream_name",
+						"huaweicloud_lts_stream.test.1", "stream_name"),
+					resource.TestCheckResourceAttr(createWithLtsParams, "lts_custom_tag.%", "0"),
 				),
 			},
 		},
@@ -924,8 +985,8 @@ func testAccFunction_logConfig_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_fgs_function" "test" {
-  name                  = "%[2]s"
+resource "huaweicloud_fgs_function" "create_with_lts_params" {
+  name                  = "%[2]s_with_lts_params"
   memory_size           = 128
   runtime               = "Python2.7"
   timeout               = 3
@@ -940,6 +1001,23 @@ resource "huaweicloud_fgs_function" "test" {
   log_stream_id   = huaweicloud_lts_stream.test[0].id
   log_group_name  = huaweicloud_lts_group.test[0].group_name
   log_stream_name = huaweicloud_lts_stream.test[0].stream_name
+  lts_custom_tag = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+resource "huaweicloud_fgs_function" "create_without_lts_params" {
+  name                  = "%[2]s_without_lts_params"
+  memory_size           = 128
+  runtime               = "Python2.7"
+  timeout               = 3
+  app                   = "default"
+  handler               = "index.handler"
+  code_type             = "inline"
+  func_code             = base64encode(var.script_content)
+  description           = "Created by terraform script"
+  functiongraph_version = "v1"
 }
 `, testAccFunction_logConfig_base(name), name)
 }
@@ -948,8 +1026,59 @@ func testAccFunction_logConfig_step2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_fgs_function" "test" {
-  name                  = "%[2]s"
+resource "huaweicloud_fgs_function" "create_with_lts_params" {
+  name                  = "%[2]s_with_lts_params"
+  memory_size           = 128
+  runtime               = "Python2.7"
+  timeout               = 3
+  app                   = "default"
+  handler               = "index.handler"
+  code_type             = "inline"
+  func_code             = base64encode(var.script_content)
+  description           = "Created by terraform script"
+  functiongraph_version = "v1"
+
+  log_group_id    = huaweicloud_lts_group.test[1].id
+  log_stream_id   = huaweicloud_lts_stream.test[1].id
+  log_group_name  = huaweicloud_lts_group.test[1].group_name
+  log_stream_name = huaweicloud_lts_stream.test[1].stream_name
+  lts_custom_tag = {
+    foo     = "baar"
+    new_key = "value"
+  }
+}
+
+resource "huaweicloud_fgs_function" "create_without_lts_params" {
+  name                  = "%[2]s_without_lts_params"
+  memory_size           = 128
+  runtime               = "Python2.7"
+  timeout               = 3
+  app                   = "default"
+  handler               = "index.handler"
+  code_type             = "inline"
+  func_code             = base64encode(var.script_content)
+  description           = "Created by terraform script"
+  functiongraph_version = "v1"
+
+  log_group_id    = huaweicloud_lts_group.test[0].id
+  log_stream_id   = huaweicloud_lts_stream.test[0].id
+  log_group_name  = huaweicloud_lts_group.test[0].group_name
+  log_stream_name = huaweicloud_lts_stream.test[0].stream_name
+
+  lts_custom_tag = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccFunction_logConfig_base(name), name)
+}
+
+func testAccFunction_logConfig_step3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_fgs_function" "create_with_lts_params" {
+  name                  = "%[2]s_with_lts_params"
   memory_size           = 128
   runtime               = "Python2.7"
   timeout               = 3

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -541,6 +541,13 @@ func ResourceFgsFunction() *schema.Resource {
 				},
 				Description: `The network configuration of the function.`,
 			},
+			"lts_custom_tag": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				// The custom tags can be set to empty, so computed behavior cannot be supported.
+				Description: `The custom tags configuration that used to filter the LTS logs.`,
+			},
 
 			// Deprecated parameters.
 			"package": {
@@ -754,6 +761,7 @@ func buildCreateFunctionBodyParams(cfg *config.Config, d *schema.ResourceData) m
 		"enable_dynamic_memory": d.Get("enable_dynamic_memory"),
 		"is_stateful_function":  d.Get("is_stateful_function"),
 		"network_controller":    buildFunctionNetworkController(d.Get("network_controller").([]interface{})),
+		"lts_custom_tag":        utils.ValueIgnoreEmpty(d.Get("lts_custom_tag")),
 	}
 }
 
@@ -877,6 +885,7 @@ func buildUpdateFunctionMetadataBodyParams(d *schema.ResourceData) map[string]in
 		"enable_dynamic_memory": d.Get("enable_dynamic_memory"),
 		"is_stateful_function":  d.Get("is_stateful_function"),
 		"network_controller":    buildFunctionNetworkController(d.Get("network_controller").([]interface{})),
+		"lts_custom_tag":        d.Get("lts_custom_tag"),
 	}
 }
 
@@ -1598,6 +1607,7 @@ func resourceFunctionRead(_ context.Context, d *schema.ResourceData, meta interf
 			function, make(map[string]interface{})).(map[string]interface{}))),
 		d.Set("gpu_type", utils.PathSearch("gpu_type", function, nil)),
 		d.Set("gpu_memory", utils.PathSearch("gpu_memory", function, nil)),
+		d.Set("lts_custom_tag", utils.PathSearch("lts_custom_tag", function, nil)),
 		d.Set("pre_stop_handler", utils.PathSearch("pre_stop_handler", function, nil)),
 		d.Set("pre_stop_timeout", utils.PathSearch("pre_stop_timeout", function, nil)),
 		d.Set("log_group_id", utils.PathSearch("log_group_id", function, nil)),
@@ -1669,7 +1679,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		"user_data", "agency", "app_agency", "description", "initializer_handler", "initializer_timeout",
 		"vpc_id", "network_id", "dns_list", "mount_user_id", "mount_user_group_id", "func_mounts", "custom_image",
 		"log_group_id", "log_stream_id", "log_group_name", "log_stream_name", "concurrency_num", "gpu_memory", "gpu_type",
-		"enable_dynamic_memory", "is_stateful_function", "network_controller") {
+		"enable_dynamic_memory", "is_stateful_function", "network_controller", "lts_custom_tag") {
 		err := updateFunctionMetadata(client, d, funcUrnWithoutVersion)
 		if err != nil {
 			return diag.FromErr(err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New parameter is supported: lts_custom_tag
Currently, only `cn-north-7`, `cn-north-9` and `cn-east-3` are available.
And the LTS parameters (`log_group_name`, `log_group_id`, `log_stream_name`, `log_stream_id`) does not supports update logic.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. resource supports lts_custom_tag parameter.
2. old LTS parameters supports update logic.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFunction_logConfig
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_logConfig -timeout 360m -parallel 10
=== RUN   TestAccFunction_logConfig
=== PAUSE TestAccFunction_logConfig
=== CONT  TestAccFunction_logConfig
--- PASS: TestAccFunction_logConfig (25.00s)
PASS
coverage: 14.3% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       25.052s coverage: 14.3% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.
