### PR TITLE
refactor(dns/resolver_rule_associate): adjust code and acceptance test

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1768,7 +1768,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_endpoint_assignment":     dns.ResourceEndpointAssignment(),
 			"huaweicloud_dns_endpoint":                dns.ResourceDNSEndpoint(),
 			"huaweicloud_dns_resolver_rule":           dns.ResourceDNSResolverRule(),
-			"huaweicloud_dns_resolver_rule_associate": dns.ResourceDNSResolverRuleAssociate(),
+			"huaweicloud_dns_resolver_rule_associate": dns.ResourceResolverRuleAssociate(),
 			"huaweicloud_dns_line_group":              dns.ResourceLineGroup(),
 
 			"huaweicloud_drs_job":                        drs.ResourceDrsJob(),

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_resolver_rule_associate.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_resolver_rule_associate.go
@@ -21,13 +21,13 @@ import (
 )
 
 // @API DNS POST /v2.1/resolverrules/{resolverrule_id}/associaterouter
-// @API DNS POST /v2.1/resolverrules/{resolverrule_id}/disassociaterouter
 // @API DNS GET /v2.1/resolverrules/{resolverrule_id}
-func ResourceDNSResolverRuleAssociate() *schema.Resource {
+// @API DNS POST /v2.1/resolverrules/{resolverrule_id}/disassociaterouter
+func ResourceResolverRuleAssociate() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceDNSResolverRuleAssociateCreate,
-		ReadContext:   resourceDNSResolverRuleAssociateRead,
-		DeleteContext: resourceDNSResolverRuleAssociateDelete,
+		CreateContext: resourceResolverRuleAssociateCreate,
+		ReadContext:   resourceResolverRuleAssociateRead,
+		DeleteContext: resourceResolverRuleAssociateDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -62,33 +62,31 @@ func ResourceDNSResolverRuleAssociate() *schema.Resource {
 	}
 }
 
-func resourceDNSResolverRuleAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceResolverRuleAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	dnsClient, err := cfg.DNSV21Client(region)
+	dnsClient, err := cfg.DNSV21Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
 	}
 
-	ruleID := d.Get("resolver_rule_id").(string)
-	vpcID := d.Get("vpc_id").(string)
+	resolverRuleId := d.Get("resolver_rule_id").(string)
+	vpcId := d.Get("vpc_id").(string)
 	opts := associate.RouterOpts{
-		RouterID: vpcID,
+		RouterID: vpcId,
 	}
 
-	body, err := associate.Associate(dnsClient, ruleID, opts).Extract()
+	_, err = associate.Associate(dnsClient, resolverRuleId, opts).Extract()
 	if err != nil {
-		return diag.Errorf("error creating DNS resolver rule associate: %s", err)
+		return diag.Errorf("error associating VPC (%s) to DNS resolver rule (%s): %s", vpcId, resolverRuleId, err)
 	}
 
-	id := fmt.Sprintf("%s/%s", ruleID, vpcID)
-	d.SetId(id)
+	d.SetId(fmt.Sprintf("%s/%s", resolverRuleId, vpcId))
 
-	log.Printf("[DEBUG] Waiting for DNS resolver rule associate (%s) to become available", d.Id())
+	log.Printf("[DEBUG] Waiting for DNS resolver rule (%s) associate VPC (%s) to complete", resolverRuleId, vpcId)
 	stateConf := &resource.StateChangeConf{
-		Target:       []string{"ACTIVE"},
 		Pending:      []string{"PENDING"},
-		Refresh:      waitForDNSResolverRuleAssociate(dnsClient, ruleID, body.RouterID),
+		Target:       []string{"COMPLETED"},
+		Refresh:      waitForResolverRuleAssociate(dnsClient, resolverRuleId, vpcId, false),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        5 * time.Second,
 		PollInterval: 5 * time.Second,
@@ -96,15 +94,24 @@ func resourceDNSResolverRuleAssociateCreate(ctx context.Context, d *schema.Resou
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf(
-			"error waiting for DNS resolver rule associate (%s) to become ACTIVE for creation: %s",
-			d.Id(), err)
+		return diag.Errorf("error waiting for DNS resolver rule (%s) associate VPC (%s) to complete: %s",
+			resolverRuleId, vpcId, err)
 	}
 
-	return resourceDNSResolverRuleAssociateRead(ctx, d, meta)
+	return resourceResolverRuleAssociateRead(ctx, d, meta)
 }
 
-func resourceDNSResolverRuleAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func getResolverRuleAndVpcId(resourceId string) (resolverRuleId string, vpcId string, err error) {
+	parts := strings.Split(resourceId, "/")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid resource ID format (%s), want '<resolver_rule_id>/<vpc_id>'", resourceId)
+	}
+	resolverRuleId = parts[0]
+	vpcId = parts[1]
+	return
+}
+
+func resourceResolverRuleAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	dnsClient, err := cfg.DNSV21Client(region)
@@ -112,33 +119,40 @@ func resourceDNSResolverRuleAssociateRead(_ context.Context, d *schema.ResourceD
 		return diag.Errorf("error creating DNS client: %s", err)
 	}
 
-	arr := strings.Split(d.Id(), "/")
-	if len(arr) != 2 {
-		return diag.Errorf("error getting resolver rule ID and VPC ID, DNS resolver rule associate ID: %s", d.Id())
-	}
-	ruleID := arr[0]
-	vpcID := arr[1]
-
-	rule, err := resolverrule.Get(dnsClient, ruleID).Extract()
+	resolverRuleId, vpcId, err := getResolverRuleAndVpcId(d.Id())
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving DNS resolver rule")
+		return diag.FromErr(err)
 	}
 
-	for _, r := range rule.Routers {
-		if r.RouterID == vpcID {
-			mErr := multierror.Append(nil,
-				d.Set("vpc_id", vpcID),
-				d.Set("resolver_rule_id", ruleID),
-				d.Set("status", r.Status),
-			)
-			return diag.FromErr(mErr.ErrorOrNil())
+	associatedVpc, err := GetAssociatedVpcById(dnsClient, resolverRuleId, vpcId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving associated VPC from resolver rule")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("vpc_id", associatedVpc.RouterID),
+		d.Set("resolver_rule_id", resolverRuleId),
+		d.Set("status", associatedVpc.Status),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func GetAssociatedVpcById(client *golangsdk.ServiceClient, resolverRuleId, vpcId string) (*resolverrule.Router, error) {
+	rule, err := resolverrule.Get(client, resolverRuleId).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, router := range rule.Routers {
+		if router.RouterID == vpcId {
+			return &router, nil
 		}
 	}
-
-	return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	return nil, golangsdk.ErrDefault404{}
 }
 
-func resourceDNSResolverRuleAssociateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceResolverRuleAssociateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	dnsClient, err := cfg.DNSV21Client(region)
@@ -146,29 +160,22 @@ func resourceDNSResolverRuleAssociateDelete(ctx context.Context, d *schema.Resou
 		return diag.Errorf("error creating DNS client: %s", err)
 	}
 
-	arr := strings.Split(d.Id(), "/")
-	if len(arr) != 2 {
-		return diag.Errorf("error getting resolver rule ID and VPC ID, DNS resolver rule associate resource ID: %s", d.Id())
-	}
-	ruleID := arr[0]
-	vpcID := arr[1]
-
+	resolverRuleId := d.Get("resolver_rule_id").(string)
+	vpcId := d.Get("vpc_id").(string)
 	opts := associate.RouterOpts{
-		RouterID: vpcID,
+		RouterID: vpcId,
 	}
-	body, err := associate.DisAssociate(dnsClient, ruleID, opts).Extract()
-
+	_, err = associate.DisAssociate(dnsClient, resolverRuleId, opts).Extract()
 	if err != nil {
-		return diag.Errorf("error deleting DNS resolver rule associate: %s", err)
+		return diag.Errorf("error disassociating VPC (%s) from DNS resolver rule (%s): %s", vpcId, resolverRuleId, err)
 	}
-
-	log.Printf("[DEBUG] Waiting for DNS resolver rule associate (%s) to become DELETED", d.Id())
+	log.Printf("[DEBUG] Waiting for disassociating VPC (%s) from DNS resolver rule (%s) to complete", vpcId, resolverRuleId)
 
 	stateConf := &resource.StateChangeConf{
-		Target: []string{"DELETED"},
 		// we allow to try to delete ERROR resolver rule associate
-		Pending:      []string{"ACTIVE", "PENDING", "ERROR"},
-		Refresh:      waitForDNSResolverRuleAssociate(dnsClient, ruleID, body.RouterID),
+		Pending:      []string{"PENDING"},
+		Target:       []string{"DELETED"},
+		Refresh:      waitForResolverRuleAssociate(dnsClient, resolverRuleId, vpcId, true),
 		Timeout:      d.Timeout(schema.TimeoutDelete),
 		Delay:        5 * time.Second,
 		PollInterval: 5 * time.Second,
@@ -176,31 +183,33 @@ func resourceDNSResolverRuleAssociateDelete(ctx context.Context, d *schema.Resou
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf(
-			"error waiting for DNS resolver rule associate (%s) to delete: %s",
-			d.Id(), err)
+		return diag.Errorf("error waiting for disassociating VPC (%s) from DNS resolver rule (%s) to complete: %s",
+			vpcId, resolverRuleId, err)
 	}
 
 	return nil
 }
 
-func waitForDNSResolverRuleAssociate(client *golangsdk.ServiceClient, resolverRuleID string, vpcID string) resource.StateRefreshFunc {
+func waitForResolverRuleAssociate(client *golangsdk.ServiceClient, resolverRuleId string, vpcId string, isDelete bool) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		rule, err := resolverrule.Get(client, resolverRuleID).Extract()
+		associatedVpc, err := GetAssociatedVpcById(client, resolverRuleId, vpcId)
 		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return nil, "DELETED", nil
+			if _, ok := err.(golangsdk.ErrDefault404); ok && isDelete {
+				return "Resource Not Found", "DELETED", nil
 			}
-			return nil, "", err
+			return nil, "ERROR", err
 		}
 
-		for _, router := range rule.Routers {
-			if router.RouterID == vpcID {
-				log.Printf("[DEBUG] DNS resolver rule associate (%s) current status: %s", resolverRuleID, router.Status)
-				return router, parseStatus(router.Status), nil
+		status := associatedVpc.Status
+		if !isDelete {
+			if status == "ACTIVE" {
+				return associatedVpc, "COMPLETED", nil
+			}
+
+			if status == "ERROR" {
+				return associatedVpc, "ERROR", fmt.Errorf("unexpect status (%s)", status)
 			}
 		}
-
-		return rule.Routers, "DELETED", nil
+		return associatedVpc, "PENDING", nil
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Adjust code and acceptance test of the **huaweicloud_dns_resolver_rule_associate**.
+ Remove redundant code.
+ The naming of the normalization methods.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove redundant codes.
2. the naming of normalization methods.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o dns -f TestAccResolverRuleAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccResolverRuleAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccResolverRuleAssociate_basic
=== PAUSE TestAccResolverRuleAssociate_basic
=== CONT  TestAccResolverRuleAssociate_basic
--- PASS: TestAccResolverRuleAssociate_basic (187.05s)
PASS
coverage: 12.5% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       187.103s        coverage: 12.5% of statements in ./huaweicloud/services/dns
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
   ![image](https://github.com/user-attachments/assets/3c4b7162-684e-499b-87f1-bb1dfeee61e0)

    ab. Related resources (parent resources) not found
  The resolve rule does not exist.
  ![image](https://github.com/user-attachments/assets/375aa6ac-1636-4c51-b762-ee7e984c7226)
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
