### PR TITLE
feat(fgs/function): enterprise project ID supports update now

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -381,9 +381,8 @@ The following arguments are supported:
 * `initializer_timeout` - (Optional, Int) Specifies the maximum duration the function can be initialized, in seconds.  
   The valid value is range from `1` to `300`.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project to which the
-  function belongs.  
-  Changing this will create a new resource.
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the
+  function belongs.
 
 * `vpc_id` - (Optional, String) Specifies the ID of the VPC to which the function belongs.
 

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -821,13 +821,20 @@ func TestAccFunction_withEpsId(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFunction_withEpsId(name),
+				Config: testAccFunction_withEpsId(name, "0"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
+					// Default value is v2. Some regions support only v1, the default value is v1.
+					resource.TestMatchResourceAttr(resourceName, "functiongraph_version", regexp.MustCompile(`v1|v2`)),
+				),
+			},
+			{
+				Config: testAccFunction_withEpsId(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id",
 						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
-					// Default value is v2. Some regions support only v1, the default value is v1.
-					resource.TestMatchResourceAttr(resourceName, "functiongraph_version", regexp.MustCompile(`v1|v2`)),
 				),
 			},
 			{
@@ -842,8 +849,7 @@ func TestAccFunction_withEpsId(t *testing.T) {
 	})
 }
 
-func testAccFunction_withEpsId(name string) string {
-	//nolint:revive
+func testAccFunction_withEpsId(name, epsId string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -859,8 +865,7 @@ resource "huaweicloud_fgs_function" "test" {
   enterprise_project_id = "%[3]s"
   description           = "Created by terraform script"
 }
-`, functionScriptVariableDefinition,
-		name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, functionScriptVariableDefinition, name, epsId)
 }
 
 func TestAccFunction_logConfig(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The update API supports change enterprise project ID now.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. the enterprise project ID can be updated
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFunction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_basic -timeout 360m -parallel 10
=== RUN   TestAccFunction_basic
=== PAUSE TestAccFunction_basic
=== CONT  TestAccFunction_basic
--- PASS: TestAccFunction_basic (85.73s)
PASS
coverage: 22.7% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       85.785s coverage: 22.7% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_withEpsId
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_withEpsId -timeout 360m -parallel 10
=== RUN   TestAccFunction_withEpsId
=== PAUSE TestAccFunction_withEpsId
=== CONT  TestAccFunction_withEpsId
--- PASS: TestAccFunction_withEpsId (25.97s)
PASS
coverage: 14.3% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       26.034s coverage: 14.3% of statements in ./huaweicloud/services/fgs
```
![image](https://github.com/user-attachments/assets/ab3b08b2-e6ee-4ee1-8fa2-6fd0069b57d1)

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
