### PR TITLE
feat(iotda): add a new resource to manage IoTDA custom authentication

### DIFF
--- a/docs/resources/iotda_custom_authentication.md
+++ b/docs/resources/iotda_custom_authentication.md
@@ -1,0 +1,108 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_iotda_custom_authentication"
+description: |-
+  Manages an IoTDA custom authentication resource within HuaweiCloud.
+---
+
+# huaweicloud_iotda_custom_authentication
+
+Manages an IoTDA custom authentication resource within HuaweiCloud.
+
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+  endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  **9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "name" {}
+variable "func_urn" {}
+variable "signing_token" {}
+variable "signing_public_key" {}
+
+resource "huaweicloud_iotda_custom_authentication" "test" {
+  authorizer_name    = var.name
+  func_urn           = var.func_urn
+  signing_token      = var.signing_token
+  signing_public_key = var.signing_public_key
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the custom authentication resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `authorizer_name` - (Required, String) Specifies the name of the custom authentication.
+  The name contains a maximum of `128` characters, and only letters, digits, underscores (_), and hyphens (-)
+  are allowed. The name must be unique.
+
+* `func_urn` - (Required, String) Specifies the URN of the function associated with the custom authentication.
+
+* `signing_enable` - (Optional, Bool) Specifies whether to enable signature authentication. Defaults to **true**.
+  You are advised to enable this function. If this function is enabled, authentication information that does not
+  meet signature requirements will be rejected to reduce invalid function calls.
+
+* `signing_token` - (Optional, String) Specifies the private key for signature authentication.
+  The key contains a maximum of `128` characters, and only letters, digits, underscores (_), and hyphens (-)
+  are allowed.
+
+* `signing_public_key` - (Optional, String) Specifies the public key for signature authentication.
+  Used to check whether the signature information carried by the device is correct.
+
+  -> 1. The parameters `signing_token` and `signing_public_key` are mandatory when `signing_enable` is set to **true**.
+  <br/>2. The parameter `signing_public_key` must be RSA encryption public key.
+
+* `default_authorizer` - (Optional, Bool) Specifies whether the custom authentication is the default
+  authentication mode. Defaults to **false**.
+  If this parameter is set to **true**, the current authentication policy is used fo authentication on all devices that
+  support SNI unless otherwise specified.
+
+* `status` - (Optional, String) Specifies whether to enable the custom authentication mode. Defaults to **INACTIVE**.
+  The valid values are as follows:
+  + **ACTIVE**: The authentication is enabled.
+  + **INACTIVE**: The authentication is disabled.
+
+* `cache_enable` - (Optional, Bool) Specifies whether to enable the cache function. Defaults to **false**.
+  If this parameter is set to **true** and the device input parameters (username, client ID, password, certificate
+  information, and function URN) remain unchanged, the cache result is directly used when the cache result exists.
+  Yor are advised to set this parameter to **false** during debugging, set this parameter to **true** during production
+  to avoid frequent function invoking.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `func_name` - The name of the function associated with the custom authentication.
+
+* `create_time` - The creation time of the custom authentication.
+  The format is **yyyyMMdd'T'HHmmss'Z'**. e.g. **20151212T121212Z**.
+
+* `update_time` - The latest update time of the custom authentication.
+  The format is **yyyyMMdd'T'HHmmss'Z'**. e.g. **20151212T121212Z**.
+
+## Import
+
+The custom authentication can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_iotda_custom_authentication.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1998,6 +1998,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_access_credential":        iotda.ResourceAccessCredential(),
 			"huaweicloud_iotda_amqp":                     iotda.ResourceAmqp(),
 			"huaweicloud_iotda_batchtask":                iotda.ResourceBatchTask(),
+			"huaweicloud_iotda_custom_authentication":    iotda.ResourceCustomAuthentication(),
 			"huaweicloud_iotda_dataforwarding_rule":      iotda.ResourceDataForwardingRule(),
 			"huaweicloud_iotda_data_flow_control_policy": iotda.ResourceDataFlowControlPolicy(),
 			"huaweicloud_iotda_data_backlog_policy":      iotda.ResourceDataBacklogPolicy(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -473,6 +473,8 @@ var (
 
 	HW_IOTDA_ACCESS_ADDRESS      = os.Getenv("HW_IOTDA_ACCESS_ADDRESS")
 	HW_IOTDA_BATCHTASK_FILE_PATH = os.Getenv("HW_IOTDA_BATCHTASK_FILE_PATH")
+	HW_IOTDA_SIGNING_PUBLIC_KEY  = os.Getenv("HW_IOTDA_SIGNING_PUBLIC_KEY")
+	HW_IOTDA_SIGNING_TOKEN       = os.Getenv("HW_IOTDA_SIGNING_TOKEN")
 
 	HW_DWS_MUTIL_AZS               = os.Getenv("HW_DWS_MUTIL_AZS")
 	HW_DWS_CLUSTER_ID              = os.Getenv("HW_DWS_CLUSTER_ID")
@@ -2476,6 +2478,20 @@ func TestAccPreCheckHWIOTDAAccessAddress(t *testing.T) {
 func TestAccPreCheckIOTDABatchTaskFilePath(t *testing.T) {
 	if HW_IOTDA_BATCHTASK_FILE_PATH == "" {
 		t.Skip("HW_IOTDA_BATCHTASK_FILE_PATH must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckIOTDASigningPublicKey(t *testing.T) {
+	if HW_IOTDA_SIGNING_PUBLIC_KEY == "" {
+		t.Skip("HW_IOTDA_SIGNING_PUBLIC_KEY must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckIOTDASigningToken(t *testing.T) {
+	if HW_IOTDA_SIGNING_TOKEN == "" {
+		t.Skip("HW_IOTDA_SIGNING_TOKEN must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_custom_authentication_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_custom_authentication_test.go
@@ -1,0 +1,184 @@
+package iotda
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iotda"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getCustomAuthenticationFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region    = acceptance.HW_REGION_NAME
+		isDerived = iotda.WithDerivedAuth(cfg, region)
+		httpUrl   = "v5/iot/{project_id}/device-authorizers/{authorizer_id}"
+	)
+
+	client, err := cfg.NewServiceClientWithDerivedAuth("iotda", region, isDerived)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IoTDA client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{authorizer_id}", state.Primary.ID)
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving IoTDA custom authentication: %s", err)
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+func TestAccCustomAuthentication_basic(t *testing.T) {
+	var (
+		authObj    interface{}
+		rName      = "huaweicloud_iotda_custom_authentication.test"
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&authObj,
+		getCustomAuthenticationFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+			acceptance.TestAccPreCheckIOTDASigningPublicKey(t)
+			acceptance.TestAccPreCheckIOTDASigningToken(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomAuthentication_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "authorizer_name", name),
+					resource.TestCheckResourceAttrPair(rName, "func_urn", "huaweicloud_fgs_function.test1", "urn"),
+					resource.TestCheckResourceAttr(rName, "signing_enable", "true"),
+					resource.TestCheckResourceAttr(rName, "signing_token", acceptance.HW_IOTDA_SIGNING_TOKEN),
+					resource.TestCheckResourceAttr(rName, "signing_public_key", acceptance.HW_IOTDA_SIGNING_PUBLIC_KEY),
+					resource.TestCheckResourceAttr(rName, "default_authorizer", "true"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(rName, "cache_enable", "true"),
+					resource.TestCheckResourceAttrSet(rName, "func_name"),
+					resource.TestCheckResourceAttrSet(rName, "create_time"),
+					resource.TestCheckResourceAttrSet(rName, "update_time"),
+				),
+			},
+			{
+				Config: testAccCustomAuthentication_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "authorizer_name", updateName),
+					resource.TestCheckResourceAttrPair(rName, "func_urn", "huaweicloud_fgs_function.test2", "urn"),
+					resource.TestCheckResourceAttr(rName, "signing_enable", "false"),
+					resource.TestCheckResourceAttr(rName, "default_authorizer", "false"),
+					resource.TestCheckResourceAttr(rName, "status", "INACTIVE"),
+					resource.TestCheckResourceAttr(rName, "cache_enable", "false"),
+					resource.TestCheckResourceAttrSet(rName, "func_name"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+const functionScriptVariableDefinition = `
+variable "script_content" {
+  type    = string
+  default = <<EOT
+def main():
+    print("Hello, World!")
+
+if __name__ == "__main__":
+    main()
+EOT
+}
+`
+
+func testAccCustomAuthentication_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_fgs_function" "test1" {
+  name        = "%[2]s-func1"
+  memory_size = 128
+  runtime     = "Python2.7"
+  timeout     = 3
+  app         = "default"
+  handler     = "index.handler"
+  code_type   = "inline"
+  func_code   = base64encode(var.script_content)
+}
+
+resource "huaweicloud_fgs_function" "test2" {
+  name        = "%[2]s-fun2"
+  memory_size = 128
+  runtime     = "Python3.6"
+  timeout     = 3
+  app         = "default"
+  handler     = "index.handler"
+  code_type   = "inline"
+  func_code   = base64encode(var.script_content)
+}
+`, functionScriptVariableDefinition, name)
+}
+
+func testAccCustomAuthentication_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
+resource "huaweicloud_iotda_custom_authentication" "test" {
+  authorizer_name    = "%[3]s"
+  func_urn           = huaweicloud_fgs_function.test1.urn
+  signing_enable     = true
+  signing_token      = "%[4]s"
+  signing_public_key = "%[5]s"
+  default_authorizer = true
+  status             = "ACTIVE"
+  cache_enable       = true
+}
+`, buildIoTDAEndpoint(), testAccCustomAuthentication_base(name), name, acceptance.HW_IOTDA_SIGNING_TOKEN, acceptance.HW_IOTDA_SIGNING_PUBLIC_KEY)
+}
+
+func testAccCustomAuthentication_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
+resource "huaweicloud_iotda_custom_authentication" "test" {
+  authorizer_name    = "%[3]s"
+  func_urn           = huaweicloud_fgs_function.test2.urn
+  signing_enable     = false
+  signing_token      = "%[4]s"
+  signing_public_key = "%[5]s"
+  default_authorizer = false
+  status             = "INACTIVE"
+  cache_enable       = false
+}
+`, buildIoTDAEndpoint(), testAccCustomAuthentication_base(name), name, acceptance.HW_IOTDA_SIGNING_TOKEN, acceptance.HW_IOTDA_SIGNING_PUBLIC_KEY)
+}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_custom_authentication.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_custom_authentication.go
@@ -1,0 +1,254 @@
+package iotda
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IoTDA POST /v5/iot/{project_id}/device-authorizers
+// @API IoTDA GET /v5/iot/{project_id}/device-authorizers/{authorizer_id}
+// @API IoTDA PUT /v5/iot/{project_id}/device-authorizers/{authorizer_id}
+// @API IoTDA DELETE /v5/iot/{project_id}/device-authorizers/{authorizer_id}
+func ResourceCustomAuthentication() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCustomAuthenticationCreate,
+		ReadContext:   resourceCustomAuthenticationRead,
+		UpdateContext: resourceCustomAuthenticationUpdate,
+		DeleteContext: resourceCustomAuthenticationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"authorizer_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"func_urn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"signing_enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"signing_token": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+				Computed:  true,
+			},
+			"signing_public_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"default_authorizer": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cache_enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"func_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCustomAuthenticationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	authenticationParams := map[string]interface{}{
+		"authorizer_name":    d.Get("authorizer_name"),
+		"func_urn":           d.Get("func_urn"),
+		"signing_enable":     d.Get("signing_enable"),
+		"signing_token":      utils.ValueIgnoreEmpty(d.Get("signing_token")),
+		"signing_public_key": utils.ValueIgnoreEmpty(d.Get("signing_public_key")),
+		"default_authorizer": d.Get("default_authorizer"),
+		"status":             utils.ValueIgnoreEmpty(d.Get("status")),
+		"cache_enable":       d.Get("cache_enable"),
+	}
+
+	return authenticationParams
+}
+
+func resourceCustomAuthenticationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+		httpUrl   = "v5/iot/{project_id}/device-authorizers"
+	)
+
+	client, err := cfg.NewServiceClientWithDerivedAuth("iotda", region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCustomAuthenticationBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA custom authentication: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	authorizerId := utils.PathSearch("authorizer_id", respBody, "").(string)
+	if authorizerId == "" {
+		return diag.Errorf("error creating IoTDA custom authentication: ID is not found in API response")
+	}
+
+	d.SetId(authorizerId)
+
+	return resourceCustomAuthenticationRead(ctx, d, meta)
+}
+
+func resourceCustomAuthenticationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+		httpUrl   = "v5/iot/{project_id}/device-authorizers/{authorizer_id}"
+	)
+
+	client, err := cfg.NewServiceClientWithDerivedAuth("iotda", region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{authorizer_id}", d.Id())
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		// When the resource does not exist, query API will return `404`.
+		return common.CheckDeletedDiag(d, err, "error retrieving IoTDA custom authentication")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("authorizer_name", utils.PathSearch("authorizer_name", getRespBody, nil)),
+		d.Set("func_name", utils.PathSearch("func_name", getRespBody, nil)),
+		d.Set("func_urn", utils.PathSearch("func_urn", getRespBody, nil)),
+		d.Set("signing_enable", utils.PathSearch("signing_enable", getRespBody, nil)),
+		d.Set("signing_token", utils.PathSearch("signing_token", getRespBody, nil)),
+		d.Set("signing_public_key", utils.PathSearch("signing_public_key", getRespBody, nil)),
+		d.Set("default_authorizer", utils.PathSearch("default_authorizer", getRespBody, nil)),
+		d.Set("status", utils.PathSearch("status", getRespBody, nil)),
+		d.Set("cache_enable", utils.PathSearch("cache_enable", getRespBody, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", getRespBody, nil)),
+		d.Set("update_time", utils.PathSearch("update_time", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceCustomAuthenticationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+		httpUrl   = "v5/iot/{project_id}/device-authorizers/{authorizer_id}"
+	)
+
+	client, err := cfg.NewServiceClientWithDerivedAuth("iotda", region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{authorizer_id}", d.Id())
+	updateOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCustomAuthenticationBodyParams(d)),
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpts)
+	if err != nil {
+		return diag.Errorf("error updating IoTDA custom authentication: %s", err)
+	}
+
+	return resourceCustomAuthenticationRead(ctx, d, meta)
+}
+
+func resourceCustomAuthenticationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+		httpUrl   = "v5/iot/{project_id}/device-authorizers/{authorizer_id}"
+	)
+
+	client, err := cfg.NewServiceClientWithDerivedAuth("iotda", region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{authorizer_id}", d.Id())
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpts)
+	if err != nil {
+		// When the resource does not exist, delete API will return `404`.
+		return common.CheckDeletedDiag(d, err, "error deleting IoTDA custom authentication")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new resource to manage IoTDA custom authentication.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new resource to manage custom authentication.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccCustomAuthentication_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccCustomAuthentication_basic -timeout 360m -parallel 4
=== RUN   TestAccCustomAuthentication_basic
--- PASS: TestAccCustomAuthentication_basic (66.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     66.957s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/5cd46c9f-4d14-468c-a0e5-e45aeff960e3)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/f9ffcfed-0a6a-498e-bc33-c911817c9bea)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
