### PR TITLE
feat(iotda): add a new datasource to get list of custom authentications

### DIFF
--- a/docs/data-sources/iotda_custom_authentications.md
+++ b/docs/data-sources/iotda_custom_authentications.md
@@ -1,0 +1,75 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_iotda_custom_authentications"
+description: |-
+  Use this data source to get the list of IoTDA custom authentications.
+---
+
+# huaweicloud_iotda_custom_authentications
+
+Use this data source to get the list of IoTDA custom authentications.
+
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+  endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  **9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+data "huaweicloud_iotda_custom_authentications" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `authorizer_name` - (Optional, String) Specifies the name of the custom authentication.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `authorizers` - The list of the custom authentications.
+  The [authorizers](#iotda_authorizers) structure is documented below.
+
+<a name="iotda_authorizers"></a>
+The `authorizers` block supports:
+
+* `authorizer_id` - The ID of the custom authentication.
+
+* `authorizer_name` - The name of the custom authentication.
+
+* `func_name` - The name of the function associated with the custom authentication.
+
+* `func_urn` -  The URN of the function associated with the custom authentication.
+
+* `signing_enable` - Whether to enable signature authentication.
+
+* `default_authorizer` - Whether the custom authentication is the default authentication mode.
+
+* `status` - Whether to enable the custom authentication mode.
+
+* `cache_enable` - Whether to enable the cache function.
+
+* `create_time` - The creation time of the custom authentication.
+  The format is **yyyyMMdd'T'HHmmss'Z'**. e.g. **20151212T121212Z**.
+
+* `update_time` - The latest update time of the custom authentication.
+  The format is **yyyyMMdd'T'HHmmss'Z'**. e.g. **20151212T121212Z**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -999,6 +999,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_device_binding_groups":      iotda.DataSourceDeviceBindingGroups(),
 			"huaweicloud_iotda_amqps":                      iotda.DataSourceAMQPQueues(),
 			"huaweicloud_iotda_batchtasks":                 iotda.DataSourceBatchTasks(),
+			"huaweicloud_iotda_custom_authentications":     iotda.DataSourceCustomAuthentications(),
 			"huaweicloud_iotda_dataforwarding_rules":       iotda.DataSourceDataForwardingRules(),
 			"huaweicloud_iotda_data_flow_control_policies": iotda.DataSourceDataFlowControlPolicies(),
 			"huaweicloud_iotda_data_backlog_policies":      iotda.DataSourceDataBacklogPolicies(),

--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_custom_authentications_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_custom_authentications_test.go
@@ -1,0 +1,83 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCustomAuthentications_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_custom_authentications.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		name           = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCustomAuthentications_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "authorizers.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "authorizers.0.authorizer_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "authorizers.0.authorizer_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "authorizers.0.func_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "authorizers.0.func_urn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "authorizers.0.signing_enable"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "authorizers.0.default_authorizer"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "authorizers.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "authorizers.0.cache_enable"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "authorizers.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "authorizers.0.update_time"),
+
+					resource.TestCheckOutput("authorizer_name_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceCustomAuthentications_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_iotda_custom_authentications" "test" {
+  depends_on = [huaweicloud_iotda_custom_authentication.test]
+}
+
+locals {
+  authorizer_name = data.huaweicloud_iotda_custom_authentications.test.authorizers[0].authorizer_name
+}
+
+data "huaweicloud_iotda_custom_authentications" "authorizer_name_filter" {
+  authorizer_name = local.authorizer_name
+}
+
+output "authorizer_name_filter_useful" {
+  value = length(data.huaweicloud_iotda_custom_authentications.authorizer_name_filter.authorizers) > 0 && alltrue(
+    [
+      for v in data.huaweicloud_iotda_custom_authentications.authorizer_name_filter.authorizers[*].authorizer_name :
+      v == local.authorizer_name
+    ]
+  )
+}
+
+data "huaweicloud_iotda_custom_authentications" "not_found" {
+  authorizer_name = "resource_not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_iotda_custom_authentications.not_found.authorizers) == 0
+}
+`, testAccCustomAuthentication_basic(name))
+}

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_custom_authentications.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_custom_authentications.go
@@ -1,0 +1,175 @@
+package iotda
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IoTDA GET /v5/iot/{project_id}/device-authorizers
+func DataSourceCustomAuthentications() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCustomAuthenticationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"authorizer_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"authorizers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"authorizer_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"authorizer_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"func_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"func_urn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"signing_enable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"default_authorizer": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cache_enable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildCustomAuthenticationsQueryParams(d *schema.ResourceData) string {
+	queryParams := ""
+
+	if v, ok := d.GetOk("authorizer_name"); ok {
+		queryParams = fmt.Sprintf("%s&authorizer_name=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceCustomAuthenticationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		isDerived      = WithDerivedAuth(cfg, region)
+		httpUrl        = "v5/iot/{project_id}/device-authorizers?limit=50"
+		allAuthorizers []interface{}
+		offset         = 0
+	)
+
+	client, err := cfg.NewServiceClientWithDerivedAuth("iotda", region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildCustomAuthenticationsQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		listResp, err := client.Request("GET", requestPathWithOffset, &listOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving IoTDA custom authentications: %s", err)
+		}
+
+		listRespBody, err := utils.FlattenResponse(listResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		authorizers := utils.PathSearch("authorizers", listRespBody, make([]interface{}, 0)).([]interface{})
+		if len(authorizers) == 0 {
+			break
+		}
+
+		allAuthorizers = append(allAuthorizers, authorizers...)
+		offset += len(authorizers)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("authorizers", flattenListCustomAuthentications(allAuthorizers)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListCustomAuthentications(authorizers []interface{}) []interface{} {
+	if len(authorizers) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(authorizers))
+	for _, v := range authorizers {
+		result = append(result, map[string]interface{}{
+			"authorizer_id":      utils.PathSearch("authorizer_id", v, nil),
+			"authorizer_name":    utils.PathSearch("authorizer_name", v, nil),
+			"func_name":          utils.PathSearch("func_name", v, nil),
+			"func_urn":           utils.PathSearch("func_urn", v, nil),
+			"signing_enable":     utils.PathSearch("signing_enable", v, nil),
+			"default_authorizer": utils.PathSearch("default_authorizer", v, nil),
+			"status":             utils.PathSearch("status", v, nil),
+			"cache_enable":       utils.PathSearch("cache_enable", v, nil),
+			"create_time":        utils.PathSearch("create_time", v, nil),
+			"update_time":        utils.PathSearch("update_time", v, nil),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new datasource to get list of custom authentications.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceCustomAuthentications_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceCustomAuthentications_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCustomAuthentications_basic
=== PAUSE TestAccDataSourceCustomAuthentications_basic
=== CONT  TestAccDataSourceCustomAuthentications_basic
--- PASS: TestAccDataSourceCustomAuthentications_basic (62.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     62.473s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
