### PR TITLE
fix(lts/cce_access|host_access): modify the type of some parameters type to set

### DIFF
--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_cce_access_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_cce_access_test.go
@@ -265,8 +265,8 @@ func TestAccCceAccessConfig_hostFile(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "access_type", "K8S_CCE"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.paths.0", "/var"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.black_paths.0", "/var/a.log"),
+					resource.TestCheckResourceAttr(rName, "access_config.0.paths.#", "2"),
+					resource.TestCheckResourceAttr(rName, "access_config.0.black_paths.#", "2"),
 					resource.TestCheckResourceAttr(rName, "access_config.0.path_type", "host_file"),
 				),
 			},
@@ -278,8 +278,9 @@ func TestAccCceAccessConfig_hostFile(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "tags.key", "value-updated"),
 					resource.TestCheckResourceAttr(rName, "tags.owner", "terraform"),
 					resource.TestCheckResourceAttr(rName, "access_type", "K8S_CCE"),
+					resource.TestCheckResourceAttr(rName, "access_config.0.paths.#", "1"),
 					resource.TestCheckResourceAttr(rName, "access_config.0.paths.0", "/var/logs"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.black_paths.0", "/var/logs/a.log"),
+					resource.TestCheckResourceAttr(rName, "access_config.0.black_paths.#", "0"),
 				),
 			},
 			{
@@ -508,8 +509,8 @@ resource "huaweicloud_lts_cce_access" "host_file" {
 
   access_config {
     path_type   = "host_file"
-    paths       = ["/var"]
-    black_paths = ["/var/a.log"]
+    paths       = ["/var", "/temp"]
+    black_paths = ["/var/temp.log", "/var/a.log"]
 
     single_log_format {
       mode = "system"
@@ -536,9 +537,8 @@ resource "huaweicloud_lts_cce_access" "host_file" {
   cluster_id     = "%[3]s"
 
   access_config {
-    path_type   = "host_file"
-    paths       = ["/var/logs"]
-    black_paths = ["/var/logs/a.log"]
+    path_type = "host_file"
+    paths     = ["/var/logs"]
 
     single_log_format {
       mode = "system"

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_host_access_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_host_access_test.go
@@ -76,7 +76,8 @@ func TestAccHostAccessConfig_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "access_config.0.paths.0", "/var/log/*"),
+					resource.TestCheckResourceAttr(rName, "access_config.0.paths.#", "2"),
+					resource.TestCheckResourceAttr(rName, "access_config.0.black_paths.#", "2"),
 					resource.TestCheckResourceAttr(rName, "host_group_ids.#", "0"),
 					resource.TestCheckResourceAttr(rName, "access_type", "AGENT"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
@@ -93,6 +94,7 @@ func TestAccHostAccessConfig_basic(t *testing.T) {
 			{
 				Config: testHostAccessConfig_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "access_config.0.paths.#", "1"),
 					resource.TestCheckResourceAttr(rName, "access_config.0.paths.0", "/var/log/*/*.log"),
 					resource.TestCheckResourceAttr(rName, "access_config.0.black_paths.0", "/var/log/*/a.log"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value-updated"),
@@ -208,7 +210,8 @@ resource "huaweicloud_lts_host_access" "test" {
   log_stream_id = huaweicloud_lts_stream.test.id
 
   access_config {
-    paths = ["/var/log/*"]
+    paths       = ["/var/temp", "/var/log/*"]
+    black_paths = ["/var/temp", "/var/log/*/a.log"]
 
     single_log_format {
       mode = "system"

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_cce_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_cce_access.go
@@ -122,13 +122,13 @@ func cceAccessConfigDeatilSchema() *schema.Resource {
 				Description: `The type of the CCE access.`,
 			},
 			"paths": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,
 				Description: `The collection paths.`,
 			},
 			"black_paths": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,
 				Description: `The collection path blacklist.`,
@@ -314,8 +314,8 @@ func buildCceAccessConfigDeatilRequestBody(rawParams interface{}) map[string]int
 
 	params := map[string]interface{}{
 		"pathType":           raw["path_type"],
-		"paths":              utils.ValueIgnoreEmpty(raw["paths"]),
-		"black_paths":        utils.ValueIgnoreEmpty(raw["black_paths"]),
+		"paths":              utils.ValueIgnoreEmpty(raw["paths"].(*schema.Set).List()),
+		"black_paths":        utils.ValueIgnoreEmpty(raw["black_paths"].(*schema.Set).List()),
 		"format":             buildHostAccessConfigFormatRequestBody(raw),
 		"windows_log_info":   buildHostAccessConfigWindowsLogInfoRequestBody(raw["windows_log_info"]),
 		"stdout":             utils.ValueIgnoreEmpty(raw["stdout"]),

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_host_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_host_access.go
@@ -145,12 +145,12 @@ func hostAccessConfigDeatilSchema(parent string) *schema.Resource {
 	sc := schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"paths": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Required: true,
 			},
 			"black_paths": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 				Computed: true,
@@ -323,8 +323,8 @@ func buildHostAccessConfigDeatilRequestBody(rawParams interface{}) map[string]in
 		}
 
 		params := map[string]interface{}{
-			"paths":            utils.ValueIgnoreEmpty(raw["paths"]),
-			"black_paths":      utils.ValueIgnoreEmpty(raw["black_paths"]),
+			"paths":            utils.ValueIgnoreEmpty(raw["paths"].(*schema.Set).List()),
+			"black_paths":      utils.ValueIgnoreEmpty(raw["black_paths"].(*schema.Set).List()),
 			"format":           buildHostAccessConfigFormatRequestBody(raw),
 			"windows_log_info": buildHostAccessConfigWindowsLogInfoRequestBody(raw["windows_log_info"]),
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Because the order of the specified parameters is inconsistent with the order returned by the query interface, causing the resource to change.

Change the type of the following parameters to set:
+ access_config.paths
+ access_config.black_paths

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
modify the type of some parameters type to Set.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lts -f TestAccCceAccessConfig_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccCceAccessConfig_ -timeout 360m -parallel 10
=== RUN   TestAccCceAccessConfig_containerFile
=== PAUSE TestAccCceAccessConfig_containerFile
=== RUN   TestAccCceAccessConfig_containerStdout
=== PAUSE TestAccCceAccessConfig_containerStdout
=== RUN   TestAccCceAccessConfig_hostFile
=== PAUSE TestAccCceAccessConfig_hostFile
=== CONT  TestAccCceAccessConfig_containerFile
=== CONT  TestAccCceAccessConfig_hostFile
=== CONT  TestAccCceAccessConfig_containerStdout
--- PASS: TestAccCceAccessConfig_containerStdout (165.12s)
--- PASS: TestAccCceAccessConfig_containerFile (166.70s)
--- PASS: TestAccCceAccessConfig_hostFile (167.22s)
PASS
coverage: 13.5% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       167.284s        coverage: 13.5% of statements in ./huaweicloud/services/lts
```
```
./scripts/coverage.sh -o lts -f TestAccHostAccessConfig_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccHostAccessConfig_ -timeout 360m -parallel 10
=== RUN   TestAccHostAccessConfig_basic
=== PAUSE TestAccHostAccessConfig_basic
=== RUN   TestAccHostAccessConfig_windows
=== PAUSE TestAccHostAccessConfig_windows
=== CONT  TestAccHostAccessConfig_basic
=== CONT  TestAccHostAccessConfig_windows
--- PASS: TestAccHostAccessConfig_windows (76.45s)
--- PASS: TestAccHostAccessConfig_basic (112.60s)
PASS
coverage: 14.1% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       112.666s        coverage: 14.1% of statements in ./huaweicloud/services/lts
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
