### PR TITLE
feat(fgs/function): resource supports new peering_cidr param

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -465,6 +465,10 @@ The following arguments are supported:
 * `network_controller` - (Optional, List) Specifies the network configuration of the function.  
   The [network_controller](#function_network_controller) structure is documented below.
 
+* `peering_cidr` - (Optional, String) Specifies the VPC cidr blocks used in the function code to detect whether it
+  conflicts with the VPC cidr blocks used by the service.  
+  The cidr blocks are separated by semicolons and cannot exceed `5`.
+
 <a name="function_func_mounts"></a>
 The `func_mounts` block supports:
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The function resource of the FunctionGraph service supports the new parameter peering_cidr.
Note: Only update function metadata API supports it.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. resource supports new peering_cidr parameter.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFunction_network
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_network -timeout 360m -parallel 10
=== RUN   TestAccFunction_network
=== PAUSE TestAccFunction_network
=== CONT  TestAccFunction_network
--- PASS: TestAccFunction_network (159.49s)
PASS
coverage: 14.5% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       160.005s        coverage: 14.5% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
