### PR TITLE
feat(dc): provide a new resource to manage global gateway peer link

### DIFF
--- a/docs/resources/dc_global_gateway_peer_link.md
+++ b/docs/resources/dc_global_gateway_peer_link.md
@@ -1,0 +1,125 @@
+---
+subcategory: "Direct Connect (DC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dc_global_gateway_peer_link"
+description: |-
+  Manages a DC global gateway peer link resource within HuaweiCloud.
+---
+
+# huaweicloud_dc_global_gateway_peer_link
+
+Manages a DC global gateway peer link resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "name" {}
+variable "global_dc_gateway_id" {}
+variable "gateway_id" {}
+variable "project_id" {}
+variable "region_id" {}
+
+resource "huaweicloud_dc_global_gateway_peer_link" "test" {
+  name                 = var.name
+  global_dc_gateway_id = var.global_dc_gateway_id
+  description          = "test description"
+
+  peer_site {
+    gateway_id = var.gateway_id
+    project_id = var.project_id
+    region_id  = var.region_id
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create new resource.
+
+* `name` - (Required, String) Specifies the name of the global DC gateway peer link.
+
+* `global_dc_gateway_id` - (Required, String, NonUpdatable) Specifies the global DC gateway ID.
+
+  -> It is required that the gateway has created a virtual interface.
+
+* `peer_site` - (Required, List, NonUpdatable) Specifies the site of the peer link.
+  Currently, only one site information can be configured.
+  The [peer_site](#peer_link_peer_site) structure is documented below.
+
+* `description` - (Optional, String) Specifies the description of the global DC gateway peer link.
+
+<a name="peer_link_peer_site"></a>
+The `peer_site` block supports:
+
+* `gateway_id` - (Required, String, NonUpdatable) Specifies the ID of enterprise router (ER) that the global DC gateway
+  is attached to.
+
+* `project_id` - (Required, String, NonUpdatable) Specifies the project ID of the enterprise router (ER) that the global
+  DC gateway is attached to.
+
+* `region_id` - (Required, String, NonUpdatable) Specifies the region ID of the enterprise router (ER) that the global
+  DC gateway is attached to.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `reason` - The cause of the failure to add the peer link.
+
+* `bandwidth_info` - The bandwidth information.
+  The [bandwidth_info](#peer_link_bandwidth_info) structure is documented below.
+
+* `peer_site/link_id` - The connection ID of the peer gateway at the peer site.
+  For example, if the peer gateway is an enterprise router, this attribute means attachment ID.
+  If the peer gateway is a global DC gateway, this attribute means the peer link ID.
+
+* `peer_site/site_code` - The site information of the global DC gateway.
+
+* `peer_site/type` - The type of the peer gateway. This attribute values include:
+  + **ER**: Enterprise router.
+  + **GDGW**: Global DC gateway.
+
+* `status` - The status of the peer link. This attribute values include:
+  + **PENDING_CREATE**: The peer link is being created.
+  + **PENDING_UPDATE**: The peer link is being updated.
+  + **ACTIVE**: The peer link is available.
+  + **ERROR**: An error occurred.
+
+* `created_time` - The time when the peer link was added.
+
+* `updated_time` - The time when the peer link was updated.
+
+* `create_owner` - The cloud service where the peer link is used. This attribute values include:
+  + **cc**: Cloud Connect.
+  + **dc**: Direct Connect.
+
+* `instance_id` - The ID of the instance associated with the peer link.
+
+<a name="peer_link_bandwidth_info"></a>
+The `bandwidth_info` block supports:
+
+* `bandwidth_size` - The bandwidth size.
+
+* `gcb_id` - The global connection bandwidth ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Defaults to 10 minutes.
+* `update` - Defaults to 10 minutes.
+* `delete` - Defaults to 10 minutes.
+
+## Import
+
+The DC global gateway peer link resource can be imported using the `global_dc_gateway_id` and `id`,
+separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_dc_global_gateway_peer_link.test <global_dc_gateway_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1669,6 +1669,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dc_virtual_interface_accepter": dc.ResourceInterfaceAccepter(),
 			"huaweicloud_dc_hosted_connect":             dc.ResourceHostedConnect(),
 			"huaweicloud_dc_global_gateway":             dc.ResourceDcGlobalGateway(),
+			"huaweicloud_dc_global_gateway_peer_link":   dc.ResourceDcGlobalGatewayPeerLink(),
 
 			"huaweicloud_dcs_instance":         dcs.ResourceDcsInstance(),
 			"huaweicloud_dcs_backup":           dcs.ResourceDcsBackup(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -266,7 +266,8 @@ var (
 	HW_IDENTITY_CENTER_IDENTITY_POLICY_ID        = os.Getenv("HW_IDENTITY_CENTER_IDENTITY_POLICY_ID")
 	HW_IDENTITY_CENTER_IDENTITY_POLICY_ID_UPDATE = os.Getenv("HW_IDENTITY_CENTER_IDENTITY_POLICY_ID_UPDATE")
 
-	HW_ER_TEST_ON = os.Getenv("HW_ER_TEST_ON") // Whether to run the ER related tests.
+	HW_ER_TEST_ON     = os.Getenv("HW_ER_TEST_ON")     // Whether to run the ER related tests.
+	HW_ER_INSTANCE_ID = os.Getenv("HW_ER_INSTANCE_ID") // Whether to run the ER related tests.
 
 	// The OBS address where the HCL/JSON template archive (No variables) is located.
 	HW_RF_TEMPLATE_ARCHIVE_NO_VARS_URI = os.Getenv("HW_RF_TEMPLATE_ARCHIVE_NO_VARS_URI")
@@ -282,6 +283,7 @@ var (
 	HW_DC_TARGET_TENANT_VGW_ID = os.Getenv("HW_DC_TARGET_TENANT_VGW_ID")
 	HW_DC_VIRTUAL_INTERFACE_ID = os.Getenv("HW_DC_VIRTUAL_INTERFACE_ID")
 	HW_DC_ENABLE_FLAG          = os.Getenv("HW_DC_ENABLE_FLAG")
+	HW_DC_GLOBAL_GATEWAY_ID    = os.Getenv("HW_DC_GLOBAL_GATEWAY_ID")
 
 	HW_DSC_INSTANCE_ID    = os.Getenv("HW_DSC_INSTANCE_ID")
 	HW_DSC_ALARM_TOPIC_ID = os.Getenv("HW_DSC_ALARM_TOPIC_ID")
@@ -1650,6 +1652,13 @@ func TestAccPreCheckER(t *testing.T) {
 }
 
 // lintignore:AT003
+func TestAccPreCheckERInstanceID(t *testing.T) {
+	if HW_ER_INSTANCE_ID == "" {
+		t.Skip("HW_ER_INSTANCE_ID must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
 func TestAccPreCheckRfArchives(t *testing.T) {
 	if HW_RF_TEMPLATE_ARCHIVE_NO_VARS_URI == "" || HW_RF_TEMPLATE_ARCHIVE_URI == "" ||
 		HW_RF_VARIABLES_ARCHIVE_URI == "" {
@@ -1668,6 +1677,13 @@ func TestAccPreCheckDcDirectConnection(t *testing.T) {
 func TestAccPreCheckDcHostedConnection(t *testing.T) {
 	if HW_DC_RESOURCE_TENANT_ID == "" || HW_DC_HOSTTING_ID == "" {
 		t.Skip("HW_DC_RESOURCE_TENANT_ID, HW_DC_HOSTTING_ID must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDcGlobalGatewayID(t *testing.T) {
+	if HW_DC_GLOBAL_GATEWAY_ID == "" {
+		t.Skip("HW_DC_GLOBAL_GATEWAY_ID must be set for this acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_global_gateway_peer_link_test.go
+++ b/huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_global_gateway_peer_link_test.go
@@ -1,0 +1,170 @@
+package dc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dc"
+)
+
+func getResourceDcGlobalGatewayPeerLinkFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dc", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DC client: %s", err)
+	}
+
+	return dc.GetPeerLinkDetail(client, state.Primary.Attributes["global_dc_gateway_id"], state.Primary.ID)
+}
+
+func TestAccResourceDcGlobalGatewayPeerLink_basic(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_dc_global_gateway_peer_link.test"
+		randName     = acceptance.RandomAccResourceName()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getResourceDcGlobalGatewayPeerLinkFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckProjectID(t)
+			// Please configure a global gateway containing virtual interface, and there are no peer links below it.
+			acceptance.TestAccPreCheckDcGlobalGatewayID(t)
+			acceptance.TestAccPreCheckERInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceDcGlobalGatewayPeerLink_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "global_dc_gateway_id", acceptance.HW_DC_GLOBAL_GATEWAY_ID),
+					resource.TestCheckResourceAttr(resourceName, "peer_site.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "peer_site.0.gateway_id", acceptance.HW_ER_INSTANCE_ID),
+					resource.TestCheckResourceAttr(resourceName, "peer_site.0.project_id", acceptance.HW_PROJECT_ID),
+					resource.TestCheckResourceAttr(resourceName, "peer_site.0.region_id", acceptance.HW_REGION_NAME),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth_info.#", "1"),
+
+					resource.TestCheckResourceAttrSet(resourceName, "peer_site.0.link_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "peer_site.0.site_code"),
+					resource.TestCheckResourceAttrSet(resourceName, "peer_site.0.type"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "create_owner"),
+				),
+			},
+			{
+				Config: testResourceDcGlobalGatewayPeerLink_update1(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", randName)),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description update"),
+					resource.TestCheckResourceAttrSet(resourceName, "peer_site.0.link_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "peer_site.0.site_code"),
+					resource.TestCheckResourceAttrSet(resourceName, "peer_site.0.type"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "create_owner"),
+				),
+			},
+			{
+				Config: testResourceDcGlobalGatewayPeerLink_update2(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "peer_site.0.link_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "peer_site.0.site_code"),
+					resource.TestCheckResourceAttrSet(resourceName, "peer_site.0.type"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "create_owner"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testDcGlobalGatewayPeerLinkImportState(resourceName),
+			},
+		},
+	})
+}
+
+func testResourceDcGlobalGatewayPeerLink_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dc_global_gateway_peer_link" "test" {
+  name                 = "%[1]s"
+  global_dc_gateway_id = "%[2]s"
+  description          = "test description"
+
+  peer_site {
+    gateway_id = "%[3]s"
+    project_id = "%[4]s"
+    region_id  = "%[5]s"
+  }
+}
+`, name, acceptance.HW_DC_GLOBAL_GATEWAY_ID, acceptance.HW_ER_INSTANCE_ID, acceptance.HW_PROJECT_ID, acceptance.HW_REGION_NAME)
+}
+
+func testResourceDcGlobalGatewayPeerLink_update1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dc_global_gateway_peer_link" "test" {
+  name                 = "%[1]s_update"
+  global_dc_gateway_id = "%[2]s"
+  description          = "test description update"
+
+  peer_site {
+    gateway_id = "%[3]s"
+    project_id = "%[4]s"
+    region_id  = "%[5]s"
+  }
+}
+`, name, acceptance.HW_DC_GLOBAL_GATEWAY_ID, acceptance.HW_ER_INSTANCE_ID, acceptance.HW_PROJECT_ID, acceptance.HW_REGION_NAME)
+}
+
+func testResourceDcGlobalGatewayPeerLink_update2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dc_global_gateway_peer_link" "test" {
+  name                 = "%[1]s_update"
+  global_dc_gateway_id = "%[2]s"
+
+  peer_site {
+    gateway_id = "%[3]s"
+    project_id = "%[4]s"
+    region_id  = "%[5]s"
+  }
+}
+`, name, acceptance.HW_DC_GLOBAL_GATEWAY_ID, acceptance.HW_ER_INSTANCE_ID, acceptance.HW_PROJECT_ID, acceptance.HW_REGION_NAME)
+}
+
+func testDcGlobalGatewayPeerLinkImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+
+		gatewayID := rs.Primary.Attributes["global_dc_gateway_id"]
+		if gatewayID == "" {
+			return "", fmt.Errorf("attribute (global_dc_gateway_id) of resource (%s) not found", name)
+		}
+
+		return fmt.Sprintf("%s/%s", gatewayID, rs.Primary.ID), nil
+	}
+}

--- a/huaweicloud/services/dc/resource_huaweicloud_dc_global_gateway_peer_link.go
+++ b/huaweicloud/services/dc/resource_huaweicloud_dc_global_gateway_peer_link.go
@@ -1,0 +1,488 @@
+package dc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var peerLinkNonUpdatableParams = []string{"global_dc_gateway_id", "peer_site", "peer_site.*.gateway_id",
+	"peer_site.*.project_id", "peer_site.*.region_id"}
+
+// @API DC POST /v3/{project_id}/dcaas/global-dc-gateways/{global_dc_gateway_id}/peer-links
+// @API DC GET /v3/{project_id}/dcaas/global-dc-gateways/{global_dc_gateway_id}/peer-links/{peer_link_id}
+// @API DC PUT /v3/{project_id}/dcaas/global-dc-gateways/{global_dc_gateway_id}/peer-links/{peer_link_id}
+// @API DC DELETE /v3/{project_id}/dcaas/global-dc-gateways/{global_dc_gateway_id}/peer-links/{peer_link_id}
+func ResourceDcGlobalGatewayPeerLink() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDcGlobalGatewayPeerLinkCreate,
+		ReadContext:   resourceDcGlobalGatewayPeerLinkRead,
+		UpdateContext: resourceDcGlobalGatewayPeerLinkUpdate,
+		DeleteContext: resourceDcGlobalGatewayPeerLinkDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDcGlobalGatewayPeerLinkImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(peerLinkNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the name of the global DC gateway peer link.`,
+			},
+			// Fields `global_dc_gateway_id` and `peer_site` do not support editing.
+			"global_dc_gateway_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the global DC gateway ID.`,
+			},
+			"peer_site": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Description: `Specifies the site of the peer link.`,
+				Elem:        peerSiteSchema(),
+			},
+			// Field `description` can be edited to be empty, so the Computed attribute is not added.
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the description of global DC gateway peer link.`,
+			},
+			// Field `enable_force_new` is used internally to control forceNew.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"reason": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The cause of the failure to add the peer link.`,
+			},
+			"bandwidth_info": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The bandwidth information.`,
+				Elem:        bandwidthInfoSchema(),
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the peer link.`,
+			},
+			"created_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the peer link was added.`,
+			},
+			"updated_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the peer link was updated.`,
+			},
+			"create_owner": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The cloud service where the peer link is used.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the instance associated with the peer link.`,
+			},
+		},
+	}
+}
+
+func peerSiteSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"gateway_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of enterprise router that the global DC gateway is attached to.`,
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the project ID of the enterprise router that the global DC gateway is attached to.`,
+			},
+			"region_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the region ID of the enterprise router that the global DC gateway is attached to.`,
+			},
+			"link_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The connection ID of the peer gateway at the peer site.`,
+			},
+			"site_code": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The site information of the global DC gateway.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the peer gateway.`,
+			},
+		},
+	}
+}
+
+func bandwidthInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"bandwidth_size": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The bandwidth size.`,
+			},
+			"gcb_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The global connection bandwidth ID.`,
+			},
+		},
+	}
+}
+
+func buildPeerLinkPeerSiteBodyParams(d *schema.ResourceData) map[string]interface{} {
+	rawArray := d.Get("peer_site").([]interface{})
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap := rawArray[0].(map[string]interface{})
+	return map[string]interface{}{
+		"gateway_id": rawMap["gateway_id"],
+		"project_id": rawMap["project_id"],
+		"region_id":  rawMap["region_id"],
+	}
+}
+
+func buildCreateDcGlobalGatewayPeerLinkBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":        d.Get("name"),
+		"peer_site":   buildPeerLinkPeerSiteBodyParams(d),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+
+	return map[string]interface{}{
+		"peer_link": bodyParams,
+	}
+}
+
+func GetPeerLinkDetail(client *golangsdk.ServiceClient, gatewayID, id string) (interface{}, error) {
+	requestPath := client.Endpoint + "v3/{project_id}/dcaas/global-dc-gateways/{global_dc_gateway_id}/peer-links/{peer_link_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{global_dc_gateway_id}", gatewayID)
+	requestPath = strings.ReplaceAll(requestPath, "{peer_link_id}", id)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func waitingForPeerLinkActive(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			respBody, err := GetPeerLinkDetail(client, d.Get("global_dc_gateway_id").(string), d.Id())
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			status := utils.PathSearch("peer_link.status", respBody, "").(string)
+			if status == "" {
+				return nil, "ERROR", errors.New("the status in detail API response is empty")
+			}
+
+			if status == "ACTIVE" {
+				return respBody, "COMPLETED", nil
+			}
+
+			if status == "ERROR" {
+				reason := utils.PathSearch("peer_link.reason", respBody, "").(string)
+				return nil, "ERROR", fmt.Errorf("the status in detail API response is ERROR, cause: %s", reason)
+			}
+
+			return respBody, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceDcGlobalGatewayPeerLinkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		httpUrl   = "v3/{project_id}/dcaas/global-dc-gateways/{global_dc_gateway_id}/peer-links"
+		product   = "dc"
+		gatewayID = d.Get("global_dc_gateway_id").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{global_dc_gateway_id}", gatewayID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateDcGlobalGatewayPeerLinkBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating DC global gateway peer link: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("peer_link.id", respBody, "").(string)
+	if id == "" {
+		return diag.Errorf("error creating DC global gateway peer link: ID is not found in API response")
+	}
+	d.SetId(id)
+	if err := waitingForPeerLinkActive(ctx, client, d, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("error waiting for DC global gateway peer link (%s) creation to active: %s", id, err)
+	}
+
+	return resourceDcGlobalGatewayPeerLinkRead(ctx, d, meta)
+}
+
+func resourceDcGlobalGatewayPeerLinkRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		product   = "dc"
+		gatewayID = d.Get("global_dc_gateway_id").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DC client: %s", err)
+	}
+
+	respBody, err := GetPeerLinkDetail(client, gatewayID, d.Id())
+	// When the resource does not exist, the query API returns status code `404`.
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DC global gateway peer link")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("peer_link.name", respBody, nil)),
+		d.Set("global_dc_gateway_id", utils.PathSearch("peer_link.global_dc_gateway_id", respBody, nil)),
+		d.Set("peer_site", flattenPeerSiteAttribute(respBody)),
+		d.Set("description", utils.PathSearch("peer_link.description", respBody, nil)),
+		d.Set("reason", utils.PathSearch("peer_link.reason", respBody, nil)),
+		d.Set("bandwidth_info", flattenBandwidthInfoAttribute(respBody)),
+		d.Set("status", utils.PathSearch("peer_link.status", respBody, nil)),
+		d.Set("created_time", utils.PathSearch("peer_link.created_time", respBody, nil)),
+		d.Set("updated_time", utils.PathSearch("peer_link.updated_time", respBody, nil)),
+		d.Set("create_owner", utils.PathSearch("peer_link.create_owner", respBody, nil)),
+		d.Set("instance_id", utils.PathSearch("peer_link.instance_id", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenBandwidthInfoAttribute(respBody interface{}) []interface{} {
+	bandwidthInfo := utils.PathSearch("peer_link.bandwidth_info", respBody, nil)
+	if bandwidthInfo == nil {
+		return nil
+	}
+
+	rawMap := map[string]interface{}{
+		"bandwidth_size": utils.PathSearch("bandwidth_size", bandwidthInfo, nil),
+		"gcb_id":         utils.PathSearch("gcb_id", bandwidthInfo, nil),
+	}
+	return []interface{}{rawMap}
+}
+
+func flattenPeerSiteAttribute(respBody interface{}) []interface{} {
+	peerSite := utils.PathSearch("peer_link.peer_site", respBody, nil)
+	if peerSite == nil {
+		return nil
+	}
+
+	rawMap := map[string]interface{}{
+		"gateway_id": utils.PathSearch("gateway_id", peerSite, nil),
+		"project_id": utils.PathSearch("project_id", peerSite, nil),
+		"region_id":  utils.PathSearch("region_id", peerSite, nil),
+		"link_id":    utils.PathSearch("link_id", peerSite, nil),
+		"site_code":  utils.PathSearch("site_code", peerSite, nil),
+		"type":       utils.PathSearch("type", peerSite, nil),
+	}
+	return []interface{}{rawMap}
+}
+
+func buildUpdateDcGlobalGatewayPeerLinkBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":        d.Get("name"),
+		"description": d.Get("description"),
+	}
+
+	return map[string]interface{}{
+		"peer_link": bodyParams,
+	}
+}
+
+func updateDcGlobalGatewayPeerLink(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v3/{project_id}/dcaas/global-dc-gateways/{global_dc_gateway_id}/peer-links/{peer_link_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{global_dc_gateway_id}", d.Get("global_dc_gateway_id").(string))
+	requestPath = strings.ReplaceAll(requestPath, "{peer_link_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildUpdateDcGlobalGatewayPeerLinkBodyParams(d),
+	}
+
+	_, err := client.Request("PUT", requestPath, &requestOpt)
+	return err
+}
+
+func resourceDcGlobalGatewayPeerLinkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dc"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DC client: %s", err)
+	}
+
+	if d.HasChanges("name", "description") {
+		if err := updateDcGlobalGatewayPeerLink(client, d); err != nil {
+			return diag.Errorf("error updating DC global gateway peer link: %s", err)
+		}
+
+		if err := waitingForPeerLinkActive(ctx, client, d, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return diag.Errorf("error waiting for DC global gateway peer link (%s) update to active: %s", d.Id(), err)
+		}
+	}
+
+	return resourceDcGlobalGatewayPeerLinkRead(ctx, d, meta)
+}
+
+func waitingForPeerLinkDelete(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			respBody, err := GetPeerLinkDetail(client, d.Get("global_dc_gateway_id").(string), d.Id())
+			if err != nil {
+				var errDefault404 golangsdk.ErrDefault404
+				if errors.As(err, &errDefault404) {
+					return "success deleted", "COMPLETED", nil
+				}
+
+				return nil, "ERROR", err
+			}
+
+			return respBody, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceDcGlobalGatewayPeerLinkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		httpUrl   = "v3/{project_id}/dcaas/global-dc-gateways/{global_dc_gateway_id}/peer-links/{peer_link_id}"
+		product   = "dc"
+		gatewayID = d.Get("global_dc_gateway_id").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{global_dc_gateway_id}", gatewayID)
+	requestPath = strings.ReplaceAll(requestPath, "{peer_link_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DC global gateway peer link: %s", err)
+	}
+
+	if err := waitingForPeerLinkDelete(ctx, client, d, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.Errorf("error waiting for DC global gateway peer link (%s) to be deleted: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceDcGlobalGatewayPeerLinkImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<global_dc_gateway_id>/<id>',"+
+			" but got '%s'", d.Id())
+	}
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, d.Set("global_dc_gateway_id", parts[0])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Provide a new resource to manage global gateway peer link.
![image](https://github.com/user-attachments/assets/63587a05-0a5b-4369-8ed7-bce77ad01f27)



**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/dc' TESTARGS='-run TestAccResourceDcGlobalGatewayPeerLink_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dc -v -run TestAccResourceDcGlobalGatewayPeerLink_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDcGlobalGatewayPeerLink_basic
=== PAUSE TestAccResourceDcGlobalGatewayPeerLink_basic
=== CONT  TestAccResourceDcGlobalGatewayPeerLink_basic
--- PASS: TestAccResourceDcGlobalGatewayPeerLink_basic (80.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dc        80.102s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/e37075d0-6ffe-445c-bbd2-5af2ac04ff10)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
