### PR TITLE
feat(dc): provide a new datasource to query global gateway peer links

### DIFF
--- a/docs/data-sources/dc_global_gateway_peer_links.md
+++ b/docs/data-sources/dc_global_gateway_peer_links.md
@@ -1,0 +1,112 @@
+---
+subcategory: "Direct Connect (DC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dc_global_gateway_peer_links"
+description: |-
+  Use this data source to get the list of DC global gateway peer links.
+---
+
+# huaweicloud_dc_global_gateway_peer_links
+
+Use this data source to get the list of DC global gateway peer links.
+
+## Example Usage
+
+```hcl
+variable "global_dc_gateway_id" {}
+
+data "huaweicloud_dc_global_gateway_peer_links" "test" {
+  global_dc_gateway_id = var.global_dc_gateway_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `global_dc_gateway_id` - (Required, String) Specifies the global DC gateway ID.
+
+* `fields` - (Optional, List) Specifies the list of fields to be displayed. If omitted, all fields will be queried.
+
+* `sort_key` - (Optional, String) Specifies the sorting field. Defaults to **id**.
+
+* `sort_dir` - (Optional, String) Specifies the sorting order of returned results.
+  There are two options: **asc** (default) and **desc**.
+
+* `peer_link_ids` - (Optional, List) Specifies the resource IDs for querying instances.
+
+* `names` - (Optional, List) Specifies the resource names for querying instances.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `peer_links` - The list of the peer links.
+
+  The [peer_links](#peer_links_struct) structure is documented below.
+
+<a name="peer_links_struct"></a>
+The `peer_links` block supports:
+
+* `id` - The peer link ID.
+
+* `name` - The name of the peer link.
+
+* `description` - The description of the peer link.
+
+* `reason` - The cause of the failure to add the peer link.
+
+* `global_dc_gateway_id` - The ID of the global DC gateway that the peer link is added for.
+
+* `bandwidth_info` - The bandwidth information.
+  The [bandwidth_info](#peer_link_bandwidth_info) structure is documented below.
+
+* `peer_site` - The bandwidth information.
+  The [peer_site](#peer_link_peer_site) structure is documented below.
+
+* `status` - The status of the peer link. This attribute values include:
+  + **PENDING_CREATE**: The peer link is being created.
+  + **PENDING_UPDATE**: The peer link is being updated.
+  + **ACTIVE**: The peer link is available.
+  + **ERROR**: An error occurred.
+
+* `created_time` - The time when the peer link was added.
+
+* `updated_time` - The time when the peer link was updated.
+
+* `create_owner` - The cloud service where the peer link is used. This attribute values include:
+  + **cc**: Cloud Connect.
+  + **dc**: Direct Connect.
+
+* `instance_id` - The ID of the instance associated with the peer link.
+
+<a name="peer_link_bandwidth_info"></a>
+The `bandwidth_info` block supports:
+
+* `bandwidth_size` - The bandwidth size.
+
+* `gcb_id` - The global connection bandwidth ID.
+
+<a name="peer_link_peer_site"></a>
+The `peer_site` block supports:
+
+* `gateway_id` - The ID of enterprise router that the global DC gateway is attached to.
+
+* `project_id` - The project ID of the enterprise router that the global DC gateway is attached to.
+
+* `region_id` - The region ID of the enterprise router that the global DC gateway is attached to.
+
+* `link_id` - The connection ID of the peer gateway at the peer site.
+  For example, if the peer gateway is an enterprise router, this attribute means attachment ID.
+  If the peer gateway is a global DC gateway, this attribute means the peer link ID.
+
+* `site_code` - The site information of the global DC gateway.
+
+* `type` - The type of the peer gateway. This attribute values include:
+  + **ER**: Enterprise router.
+  + **GDGW**: Global DC gateway.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -706,11 +706,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_dbss_operation_logs":            dbss.DataSourceOperationLogs(),
 			"huaweicloud_dbss_rds_databases":             dbss.DataSourceDbssRdsDatabases(),
 
-			"huaweicloud_dc_connections":        dc.DataSourceDcConnections(),
-			"huaweicloud_dc_quotas":             dc.DataSourceDcQuotas(),
-			"huaweicloud_dc_virtual_gateways":   dc.DataSourceDCVirtualGateways(),
-			"huaweicloud_dc_virtual_interfaces": dc.DataSourceDCVirtualInterfaces(),
-			"huaweicloud_dc_global_gateways":    dc.DataSourceDcGlobalGateways(),
+			"huaweicloud_dc_connections":               dc.DataSourceDcConnections(),
+			"huaweicloud_dc_quotas":                    dc.DataSourceDcQuotas(),
+			"huaweicloud_dc_virtual_gateways":          dc.DataSourceDCVirtualGateways(),
+			"huaweicloud_dc_virtual_interfaces":        dc.DataSourceDCVirtualInterfaces(),
+			"huaweicloud_dc_global_gateways":           dc.DataSourceDcGlobalGateways(),
+			"huaweicloud_dc_global_gateway_peer_links": dc.DataSourceDcGlobalGatewayPeerLinks(),
 
 			"huaweicloud_dcs_flavors":         dcs.DataSourceDcsFlavorsV2(),
 			"huaweicloud_dcs_maintainwindow":  dcs.DataSourceDcsMaintainWindow(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -277,13 +277,14 @@ var (
 	HW_RF_VARIABLES_ARCHIVE_URI = os.Getenv("HW_RF_VARIABLES_ARCHIVE_URI")
 
 	// The direct connection ID (provider does not support direct connection resource).
-	HW_DC_DIRECT_CONNECT_ID    = os.Getenv("HW_DC_DIRECT_CONNECT_ID")
-	HW_DC_RESOURCE_TENANT_ID   = os.Getenv("HW_DC_RESOURCE_TENANT_ID")
-	HW_DC_HOSTTING_ID          = os.Getenv("HW_DC_HOSTTING_ID")
-	HW_DC_TARGET_TENANT_VGW_ID = os.Getenv("HW_DC_TARGET_TENANT_VGW_ID")
-	HW_DC_VIRTUAL_INTERFACE_ID = os.Getenv("HW_DC_VIRTUAL_INTERFACE_ID")
-	HW_DC_ENABLE_FLAG          = os.Getenv("HW_DC_ENABLE_FLAG")
-	HW_DC_GLOBAL_GATEWAY_ID    = os.Getenv("HW_DC_GLOBAL_GATEWAY_ID")
+	HW_DC_DIRECT_CONNECT_ID               = os.Getenv("HW_DC_DIRECT_CONNECT_ID")
+	HW_DC_RESOURCE_TENANT_ID              = os.Getenv("HW_DC_RESOURCE_TENANT_ID")
+	HW_DC_HOSTTING_ID                     = os.Getenv("HW_DC_HOSTTING_ID")
+	HW_DC_TARGET_TENANT_VGW_ID            = os.Getenv("HW_DC_TARGET_TENANT_VGW_ID")
+	HW_DC_VIRTUAL_INTERFACE_ID            = os.Getenv("HW_DC_VIRTUAL_INTERFACE_ID")
+	HW_DC_ENABLE_FLAG                     = os.Getenv("HW_DC_ENABLE_FLAG")
+	HW_DC_GLOBAL_GATEWAY_ID               = os.Getenv("HW_DC_GLOBAL_GATEWAY_ID")
+	HW_DC_GLOBAL_GATEWAY_ID_HAS_PEER_LINK = os.Getenv("HW_DC_GLOBAL_GATEWAY_ID_HAS_PEER_LINK")
 
 	HW_DSC_INSTANCE_ID    = os.Getenv("HW_DSC_INSTANCE_ID")
 	HW_DSC_ALARM_TOPIC_ID = os.Getenv("HW_DSC_ALARM_TOPIC_ID")
@@ -1684,6 +1685,13 @@ func TestAccPreCheckDcHostedConnection(t *testing.T) {
 func TestAccPreCheckDcGlobalGatewayID(t *testing.T) {
 	if HW_DC_GLOBAL_GATEWAY_ID == "" {
 		t.Skip("HW_DC_GLOBAL_GATEWAY_ID must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDcGlobalGatewayIDHasPeerLink(t *testing.T) {
+	if HW_DC_GLOBAL_GATEWAY_ID_HAS_PEER_LINK == "" {
+		t.Skip("HW_DC_GLOBAL_GATEWAY_ID_HAS_PEER_LINK must be set for this acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dc/data_source_huaweicloud_dc_global_gateway_peer_links_test.go
+++ b/huaweicloud/services/acceptance/dc/data_source_huaweicloud_dc_global_gateway_peer_links_test.go
@@ -1,0 +1,143 @@
+package dc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceDcGlobalGatewayPeerLinks_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_dc_global_gateway_peer_links.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		bySort   = "data.huaweicloud_dc_global_gateway_peer_links.filter_by_sort"
+		dcBySort = acceptance.InitDataSourceCheck(bySort)
+
+		byFields   = "data.huaweicloud_dc_global_gateway_peer_links.filter_by_fields"
+		dcByFields = acceptance.InitDataSourceCheck(byFields)
+
+		byPeerLinkIDs   = "data.huaweicloud_dc_global_gateway_peer_links.filter_by_peer_link_ids"
+		dcByPeerLinkIDs = acceptance.InitDataSourceCheck(byPeerLinkIDs)
+
+		byNames   = "data.huaweicloud_dc_global_gateway_peer_links.filter_by_names"
+		dcByNames = acceptance.InitDataSourceCheck(byNames)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please configure the global gateway ID containing peer link.
+			acceptance.TestAccPreCheckDcGlobalGatewayIDHasPeerLink(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceDcGlobalGatewayPeerLinks_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_links.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_links.0.bandwidth_info.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_links.0.create_owner"),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_links.0.created_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_links.0.global_dc_gateway_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_links.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_links.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_links.0.peer_site.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_links.0.peer_site.0.gateway_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_links.0.peer_site.0.link_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_links.0.peer_site.0.project_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_links.0.peer_site.0.region_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_links.0.peer_site.0.site_code"),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_links.0.peer_site.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_links.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_links.0.updated_time"),
+
+					dcBySort.CheckResourceExists(),
+					resource.TestCheckOutput("filter_by_sort_is_useful", "true"),
+
+					dcByFields.CheckResourceExists(),
+					resource.TestCheckOutput("filter_by_fields_is_useful", "true"),
+
+					dcByPeerLinkIDs.CheckResourceExists(),
+					resource.TestCheckOutput("filter_by_peer_link_ids_is_useful", "true"),
+
+					dcByNames.CheckResourceExists(),
+					resource.TestCheckOutput("filter_by_names_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceDcGlobalGatewayPeerLinks_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dc_global_gateway_peer_links" "test" {
+  global_dc_gateway_id = "%[1]s"
+}
+
+# filter by sort (Just determine whether the data exists)
+data "huaweicloud_dc_global_gateway_peer_links" "filter_by_sort" {
+  global_dc_gateway_id = "%[1]s"
+  sort_key             = "id"
+  sort_dir             = "desc"
+}
+
+output "filter_by_sort_is_useful" {
+  value = length(data.huaweicloud_dc_global_gateway_peer_links.filter_by_sort.peer_links) > 0
+}
+
+# filter by fields (Just determine whether the data exists)
+data "huaweicloud_dc_global_gateway_peer_links" "filter_by_fields" {
+  global_dc_gateway_id = "%[1]s"
+  fields               = ["name", "id"]
+}
+
+output "filter_by_fields_is_useful" {
+  value = length(data.huaweicloud_dc_global_gateway_peer_links.filter_by_fields.peer_links) > 0
+}
+
+# filter by peer_link_ids
+locals {
+  id = data.huaweicloud_dc_global_gateway_peer_links.test.peer_links[0].id
+}
+
+data "huaweicloud_dc_global_gateway_peer_links" "filter_by_peer_link_ids" {
+  global_dc_gateway_id = "%[1]s"
+  peer_link_ids        = [local.id]
+}
+
+locals {
+  filter_by_peer_link_ids_result = [
+    for v in data.huaweicloud_dc_global_gateway_peer_links.filter_by_peer_link_ids.peer_links[*].id : v == local.id
+  ]
+}
+
+output "filter_by_peer_link_ids_is_useful" {
+  value = alltrue(local.filter_by_peer_link_ids_result) && length(local.filter_by_peer_link_ids_result) > 0
+}
+
+# filter by names
+locals {
+  name = data.huaweicloud_dc_global_gateway_peer_links.test.peer_links[0].name
+}
+
+data "huaweicloud_dc_global_gateway_peer_links" "filter_by_names" {
+  global_dc_gateway_id = "%[1]s"
+  names                = [local.name]
+}
+
+locals {
+  filter_by_names_result = [
+    for v in data.huaweicloud_dc_global_gateway_peer_links.filter_by_names.peer_links[*].name : v == local.name
+  ]
+}
+
+output "filter_by_names_is_useful" {
+  value = alltrue(local.filter_by_names_result) && length(local.filter_by_names_result) > 0
+}
+`, acceptance.HW_DC_GLOBAL_GATEWAY_ID_HAS_PEER_LINK)
+}

--- a/huaweicloud/services/dc/data_source_huaweicloud_dc_global_gateway_peer_links.go
+++ b/huaweicloud/services/dc/data_source_huaweicloud_dc_global_gateway_peer_links.go
@@ -1,0 +1,342 @@
+package dc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DC GET /v3/{project_id}/dcaas/global-dc-gateways/{global_dc_gateway_id}/peer-links
+func DataSourceDcGlobalGatewayPeerLinks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDcGlobalGatewayPeerLinksRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"global_dc_gateway_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the global DC gateway ID.`,
+			},
+			"fields": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Specifies the list of fields to be displayed.`,
+			},
+			"sort_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the sorting field.`,
+			},
+			"sort_dir": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the sorting order of returned results.`,
+			},
+			"peer_link_ids": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Specifies the resource IDs for querying instances.`,
+			},
+			"names": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Specifies the resource names for querying instances.`,
+			},
+			"peer_links": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the peer links.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The peer link ID.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the peer link.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the peer link.`,
+						},
+						"reason": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The cause of the failure to add the peer link.`,
+						},
+						"global_dc_gateway_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the global DC gateway that the peer link is added for.`,
+						},
+						"bandwidth_info": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The bandwidth information.`,
+							Elem:        datasourceBandwidthInfoSchema(),
+						},
+						"peer_site": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The site of the peer link.`,
+							Elem:        datasourcePeerSiteSchema(),
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the peer link.`,
+						},
+						"created_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time when the peer link was added.`,
+						},
+						"updated_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time when the peer link was updated.`,
+						},
+						"create_owner": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The cloud service where the peer link is used.`,
+						},
+						"instance_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the instance associated with the peer link.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func datasourceBandwidthInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"bandwidth_size": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The bandwidth size.`,
+			},
+			"gcb_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The global connection bandwidth ID.`,
+			},
+		},
+	}
+}
+
+func datasourcePeerSiteSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"gateway_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of enterprise router that the global DC gateway is attached to.`,
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The project ID of the enterprise router that the global DC gateway is attached to.`,
+			},
+			"region_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The region ID of the enterprise router that the global DC gateway is attached to.`,
+			},
+			"link_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The connection ID of the peer gateway at the peer site.`,
+			},
+			"site_code": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The site information of the global DC gateway.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the peer gateway.`,
+			},
+		},
+	}
+}
+
+func buildDcGlobalGatewayPeerLinksQueryParams(d *schema.ResourceData) string {
+	rst := "?limit=2000"
+	if v, ok := d.GetOk("fields"); ok {
+		rst += buildQueryStringParams("fields", v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		rst += fmt.Sprintf("&sort_key=%v", v)
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%v", v)
+	}
+
+	if v, ok := d.GetOk("peer_link_ids"); ok {
+		rst += buildQueryStringParams("id", v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("names"); ok {
+		rst += buildQueryStringParams("name", v.([]interface{}))
+	}
+
+	return rst
+}
+
+func buildPeerLinksQueryParamsWithMarker(requestPath, marker string) string {
+	if marker == "" {
+		return requestPath
+	}
+
+	return fmt.Sprintf("%s&marker=%s", requestPath, marker)
+}
+
+func dataSourceDcGlobalGatewayPeerLinksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		httpUrl   = "v3/{project_id}/dcaas/global-dc-gateways/{global_dc_gateway_id}/peer-links"
+		product   = "dc"
+		marker    = ""
+		allValues []interface{}
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{global_dc_gateway_id}", d.Get("global_dc_gateway_id").(string))
+	requestPath += buildDcGlobalGatewayPeerLinksQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithMarker := buildPeerLinksQueryParamsWithMarker(requestPath, marker)
+		resp, err := client.Request("GET", requestPathWithMarker, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DC global gateway peer links: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		peerLinks := utils.PathSearch("peer_links", respBody, make([]interface{}, 0)).([]interface{})
+		if len(peerLinks) == 0 {
+			break
+		}
+
+		allValues = append(allValues, peerLinks...)
+
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	uuId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(uuId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("peer_links", flattenDcGlobalGatewayPeerLinksAttribute(allValues)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDcGlobalGatewayPeerLinksAttribute(allValues []interface{}) []interface{} {
+	if len(allValues) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(allValues))
+	for _, v := range allValues {
+		rst = append(rst, map[string]interface{}{
+			"id":                   utils.PathSearch("id", v, nil),
+			"name":                 utils.PathSearch("name", v, nil),
+			"description":          utils.PathSearch("description", v, nil),
+			"reason":               utils.PathSearch("reason", v, nil),
+			"global_dc_gateway_id": utils.PathSearch("global_dc_gateway_id", v, nil),
+			"bandwidth_info":       flattenDatasourceBandwidthInfoAttribute(v),
+			"peer_site":            flattenDatasourcePeerSiteAttribute(v),
+			"status":               utils.PathSearch("status", v, nil),
+			"created_time":         utils.PathSearch("created_time", v, nil),
+			"updated_time":         utils.PathSearch("updated_time", v, nil),
+			"create_owner":         utils.PathSearch("create_owner", v, nil),
+			"instance_id":          utils.PathSearch("instance_id", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenDatasourceBandwidthInfoAttribute(respBody interface{}) []interface{} {
+	bandwidthInfo := utils.PathSearch("bandwidth_info", respBody, nil)
+	if bandwidthInfo == nil {
+		return nil
+	}
+
+	rawMap := map[string]interface{}{
+		"bandwidth_size": utils.PathSearch("bandwidth_size", bandwidthInfo, nil),
+		"gcb_id":         utils.PathSearch("gcb_id", bandwidthInfo, nil),
+	}
+	return []interface{}{rawMap}
+}
+
+func flattenDatasourcePeerSiteAttribute(respBody interface{}) []interface{} {
+	peerSite := utils.PathSearch("peer_site", respBody, nil)
+	if peerSite == nil {
+		return nil
+	}
+
+	rawMap := map[string]interface{}{
+		"gateway_id": utils.PathSearch("gateway_id", peerSite, nil),
+		"project_id": utils.PathSearch("project_id", peerSite, nil),
+		"region_id":  utils.PathSearch("region_id", peerSite, nil),
+		"link_id":    utils.PathSearch("link_id", peerSite, nil),
+		"site_code":  utils.PathSearch("site_code", peerSite, nil),
+		"type":       utils.PathSearch("type", peerSite, nil),
+	}
+	return []interface{}{rawMap}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

provide a new datasource to query global gateway peer links.

![image](https://github.com/user-attachments/assets/4b37e340-3d52-4da2-bf87-ae96896c3c92)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/dc' TESTARGS='-run TestAccDatasourceDcGlobalGatewayPeerLinks_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dc -v -run TestAccDatasourceDcGlobalGatewayPeerLinks_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceDcGlobalGatewayPeerLinks_basic
=== PAUSE TestAccDatasourceDcGlobalGatewayPeerLinks_basic
=== CONT  TestAccDatasourceDcGlobalGatewayPeerLinks_basic
--- PASS: TestAccDatasourceDcGlobalGatewayPeerLinks_basic (7.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dc        7.825s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
