### PR TITLE
refactor(dns/resolver_rule): adjust the code and acceptance test

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1800,7 +1800,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_zone":                    dns.ResourceDNSZone(),
 			"huaweicloud_dns_endpoint_assignment":     dns.ResourceEndpointAssignment(),
 			"huaweicloud_dns_endpoint":                dns.ResourceDNSEndpoint(),
-			"huaweicloud_dns_resolver_rule":           dns.ResourceDNSResolverRule(),
+			"huaweicloud_dns_resolver_rule":           dns.ResourceResolverRule(),
 			"huaweicloud_dns_resolver_rule_associate": dns.ResourceResolverRuleAssociate(),
 			"huaweicloud_dns_line_group":              dns.ResourceLineGroup(),
 

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_resolver_rule_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_resolver_rule_test.go
@@ -7,35 +7,29 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/dns/v2/resolverrule"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dns"
 )
 
-func getDNSResolverRuleFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getResolverRule(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := conf.DNSV21Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating dns client: %s", err)
 	}
-	body, err := resolverrule.Get(client, state.Primary.ID).Extract()
-	if err == nil && body.Status == "DELETED" {
-		return nil, fmt.Errorf("DNS resolver rule does not found")
-	}
-	return body, err
+
+	return dns.GetResolverRuleById(client, state.Primary.ID)
 }
 
-func TestAccDNSResolverRule_basic(t *testing.T) {
+func TestAccResolverRule_basic(t *testing.T) {
 	var (
-		obj        interface{}
 		name       = acceptance.RandomAccResourceNameWithDash()
 		domainName = fmt.Sprintf("%s.", name)
-		rName      = "huaweicloud_dns_resolver_rule.test"
-	)
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getDNSResolverRuleFunc,
+
+		resolverRule interface{}
+		rName        = "huaweicloud_dns_resolver_rule.test"
+		rc           = acceptance.InitResourceCheck(rName, &resolverRule, getResolverRule)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -44,24 +38,25 @@ func TestAccDNSResolverRule_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testDNSResolverRule_basic(name),
+				Config: testAccResolverRule_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "domain_name", domainName),
 					resource.TestCheckResourceAttr(rName, "ip_addresses.#", "1"),
-					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
-					resource.TestCheckResourceAttrSet(rName, "rule_type"),
-					resource.TestCheckResourceAttrSet(rName, "created_at"),
-					resource.TestCheckResourceAttrSet(rName, "updated_at"),
 					resource.TestCheckResourceAttrPair(rName, "endpoint_id",
 						"huaweicloud_dns_endpoint.test", "id"),
 					resource.TestCheckResourceAttrPair(rName, "ip_addresses.0.ip",
 						"huaweicloud_dns_endpoint.test", "ip_addresses.0.ip"),
+					// Check attributtes.
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttrSet(rName, "rule_type"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
 				),
 			},
 			{
-				Config: testDNSResolverRule_basic_update(name),
+				Config: testAccResolverRule_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
@@ -69,12 +64,13 @@ func TestAccDNSResolverRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "ip_addresses.#", "2"),
 					resource.TestCheckResourceAttrSet(rName, "ip_addresses.0.ip"),
 					resource.TestCheckResourceAttrSet(rName, "ip_addresses.1.ip"),
+					resource.TestCheckResourceAttrPair(rName, "endpoint_id",
+						"huaweicloud_dns_endpoint.test", "id"),
+					// Check attributtes.
 					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
 					resource.TestCheckResourceAttrSet(rName, "rule_type"),
 					resource.TestCheckResourceAttrSet(rName, "created_at"),
 					resource.TestCheckResourceAttrSet(rName, "updated_at"),
-					resource.TestCheckResourceAttrPair(rName, "endpoint_id",
-						"huaweicloud_dns_endpoint.test", "id"),
 				),
 			},
 			{
@@ -86,33 +82,24 @@ func TestAccDNSResolverRule_basic(t *testing.T) {
 	})
 }
 
-func testDNSEndpoint(rName string) string {
+func testAccResolverRule_base(rName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_vpc" "test" {
-  name = "%[1]s"
-  cidr = "192.168.0.0/16"
-}
-
-resource "huaweicloud_vpc_subnet" "test" {
-  name       = "%[1]s"
-  cidr       = "192.168.0.0/24"
-  gateway_ip = "192.168.0.1"
-  vpc_id     = huaweicloud_vpc.test.id
-}
+%[1]s
 
 resource "huaweicloud_dns_endpoint" "test" {
-  name      = "%[1]s"
+  name      = "%[2]s"
   direction = "inbound"
+
   ip_addresses {
     subnet_id = huaweicloud_vpc_subnet.test.id
   }
   ip_addresses {
     subnet_id = huaweicloud_vpc_subnet.test.id
   }
-}`, rName)
+}`, common.TestVpc(rName), rName)
 }
 
-func testDNSResolverRule_basic(rName string) string {
+func testAccResolverRule_basic_step1(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -124,10 +111,10 @@ resource "huaweicloud_dns_resolver_rule" "test" {
   ip_addresses {
     ip = huaweicloud_dns_endpoint.test.ip_addresses[0].ip
   }
-}`, testDNSEndpoint(rName), rName)
+}`, testAccResolverRule_base(rName), rName)
 }
 
-func testDNSResolverRule_basic_update(rName string) string {
+func testAccResolverRule_basic_step2(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -142,5 +129,5 @@ resource "huaweicloud_dns_resolver_rule" "test" {
       ip = ip_addresses.value
     }
   }
-}`, testDNSEndpoint(rName), rName)
+}`, testAccResolverRule_base(rName), rName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 Adjust the code and acceptance test of the **huaweicloud_dns_resolver_rule** resource.
+ Follow a unified naming convention.
+ Simplify the code.

![image](https://github.com/user-attachments/assets/5c45cf55-3472-4318-84b2-f8800ffbe635)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
adjust the code and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccResolverRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccResolverRule_basic -timeout 360m -parallel 10
=== RUN   TestAccResolverRule_basic
=== PAUSE TestAccResolverRule_basic
=== CONT  TestAccResolverRule_basic
--- PASS: TestAccResolverRule_basic (193.14s)
PASS
coverage: 10.7% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       193.213s        coverage: 10.7% of statements in ./huaweicloud/services/dns
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
  ![image](https://github.com/user-attachments/assets/c595919a-2715-4e97-934d-430b88ee41e6)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
