### PR TITLE
fix(common/error): return error directly if error code key not found

### DIFF
--- a/huaweicloud/common/errors.go
+++ b/huaweicloud/common/errors.go
@@ -42,13 +42,9 @@ func ConvertExpected400ErrInto404Err(err error, errCodeKey string, specErrCodes 
 
 	errCode := utils.PathSearch(errCodeKey, apiError, nil)
 	if errCode == nil {
-		// 4xx means the client parsing was failed.
-		return golangsdk.ErrDefault400{
-			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("Unable to find the error code from the error body using given error code key (%s), the error is: %#v",
-					errCodeKey, apiError)),
-			},
-		}
+		log.Printf("[WARN] Unable to find the error code from the error body using given error code key (%s), the error is: %#v",
+			errCodeKey, apiError)
+		return err
 	}
 
 	if len(specErrCodes) < 1 {
@@ -89,13 +85,9 @@ func ConvertExpected401ErrInto404Err(err error, errCodeKey string, specErrCodes 
 
 	errCode := utils.PathSearch(errCodeKey, apiError, nil)
 	if errCode == nil {
-		// 4xx means the client parsing was failed.
-		return golangsdk.ErrDefault400{
-			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("Unable to find the error code from the error body using given error code key (%s), the error is: %#v",
-					errCodeKey, apiError)),
-			},
-		}
+		log.Printf("[WARN] Unable to find the error code from the error body using given error code key (%s), the error is: %#v",
+			errCodeKey, apiError)
+		return err
 	}
 
 	if len(specErrCodes) < 1 {
@@ -136,13 +128,9 @@ func ConvertExpected403ErrInto404Err(err error, errCodeKey string, specErrCodes 
 
 	errCode := utils.PathSearch(errCodeKey, apiError, nil)
 	if errCode == nil {
-		// 4xx means the client parsing was failed.
-		return golangsdk.ErrDefault400{
-			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("Unable to find the error code from the error body using given error code key (%s), the error is: %#v",
-					errCodeKey, apiError)),
-			},
-		}
+		log.Printf("[WARN] Unable to find the error code from the error body using given error code key (%s), the error is: %#v",
+			errCodeKey, apiError)
+		return err
 	}
 
 	if len(specErrCodes) < 1 {
@@ -183,13 +171,9 @@ func ConvertExpected500ErrInto404Err(err error, errCodeKey string, specErrCodes 
 
 	errCode := utils.PathSearch(errCodeKey, apiError, nil)
 	if errCode == nil {
-		// 4xx means the client parsing was failed.
-		return golangsdk.ErrDefault400{
-			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("Unable to find the error code from the error body using given error code key (%s), the error is: %#v",
-					errCodeKey, apiError)),
-			},
-		}
+		log.Printf("[WARN] Unable to find the error code from the error body using given error code key (%s), the error is: %#v",
+			errCodeKey, apiError)
+		return err
 	}
 
 	if len(specErrCodes) < 1 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The error should be packaged if the error code key is not found, just return directly.
![image](https://github.com/user-attachments/assets/ce838fe1-311d-4069-8b5e-033faed827ab)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. return error directly if error code key not found
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
go test -v -run TestErrorFunc_ConvertExpected
=== RUN   TestErrorFunc_ConvertExpected400ErrInto404Err
2025/03/06 15:18:24 [INFO] Identified 400 error with code 'TESTERR.0002' and parsed it as 404 error
2025/03/06 15:18:24 [WARN] Unable to recognize expected error type, want 'golangsdk.ErrDefault400', but got 'golangsdk.ErrDefault403'
2025/03/06 15:18:24 [WARN] Unable to find the error code from the error body using given error code key (err_code), the error is: map[string]interface {}{"error_code":"TESTERR.0002", "error_msg":"Resource not found"}
2025/03/06 15:18:24 [INFO] Identified 400 error with code 'TESTERR.0002' and parsed it as 404 error
2025/03/06 15:18:24 [WARN] Unable to recognize expected error code (TESTERR.0002), want [TESTERR.0001 TESTERR.0003]
--- PASS: TestErrorFunc_ConvertExpected400ErrInto404Err (0.00s)
=== RUN   TestErrorFunc_ConvertExpected401ErrInto404Err
2025/03/06 15:18:24 [INFO] Identified 401 error with code 'TESTERR.0002' and parsed it as 404 error
2025/03/06 15:18:24 [WARN] Unable to recognize expected error type, want 'golangsdk.ErrDefault401', but got 'golangsdk.ErrDefault403'
2025/03/06 15:18:24 [WARN] Unable to find the error code from the error body using given error code key (err_code), the error is: map[string]interface {}{"error_code":"TESTERR.0002", "error_msg":"Resource not found"}
2025/03/06 15:18:24 [INFO] Identified 401 error with code 'TESTERR.0002' and parsed it as 404 error
2025/03/06 15:18:24 [WARN] Unable to recognize expected error code (TESTERR.0002), want [TESTERR.0001 TESTERR.0003]
--- PASS: TestErrorFunc_ConvertExpected401ErrInto404Err (0.00s)
=== RUN   TestErrorFunc_ConvertExpected403ErrInto404Err
2025/03/06 15:18:24 [INFO] Identified 403 error with code 'TESTERR.0002' and parsed it as 404 error
2025/03/06 15:18:24 [WARN] Unable to recognize expected error type, want 'golangsdk.ErrDefault403', but got 'golangsdk.ErrDefault400'
2025/03/06 15:18:24 [WARN] Unable to find the error code from the error body using given error code key (err_code), the error is: map[string]interface {}{"error_code":"TESTERR.0002", "error_msg":"Resource not found"}
2025/03/06 15:18:24 [INFO] Identified 403 error with code 'TESTERR.0002' and parsed it as 404 error
2025/03/06 15:18:24 [WARN] Unable to recognize expected error code (TESTERR.0002), want [TESTERR.0001 TESTERR.0003]
--- PASS: TestErrorFunc_ConvertExpected403ErrInto404Err (0.00s)
=== RUN   TestErrorFunc_ConvertExpected500ErrInto404Err
2025/03/06 15:18:24 [INFO] Identified 500 error with code 'TESTERR.0002' and parsed it as 404 error
2025/03/06 15:18:24 [WARN] Unable to recognize expected error type, want 'golangsdk.ErrDefault500', but got 'golangsdk.ErrDefault400'
2025/03/06 15:18:24 [WARN] Unable to find the error code from the error body using given error code key (err_code), the error is: map[string]interface {}{"error_code":"TESTERR.0002", "error_msg":"Resource not found"}
2025/03/06 15:18:24 [INFO] Identified 500 error with code 'TESTERR.0002' and parsed it as 404 error
2025/03/06 15:18:24 [WARN] Unable to recognize expected error code (TESTERR.0002), want [TESTERR.0001 TESTERR.0003]
--- PASS: TestErrorFunc_ConvertExpected500ErrInto404Err (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common        0.022s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
