### PR TITLE
feat(nat): the SNAT rule datasource supports new fields

### DIFF
--- a/docs/data-sources/nat_snat_rules.md
+++ b/docs/data-sources/nat_snat_rules.md
@@ -2,7 +2,8 @@
 subcategory: "NAT Gateway (NAT)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_nat_snat_rules"
-description: ""
+description: |-
+  Use this data source to get the list of SNAT rules.
 ---
 
 # huaweicloud_nat_snat_rules
@@ -52,6 +53,11 @@ The following arguments are supported:
 * `global_eip_id` - (Optional, String) Specifies the ID of the global EIP associated with SNAT rule.
 
 * `global_eip_address` - (Optional, String) Specifies the IP of the global EIP associated with SNAT rule.
+
+* `description` - (Optional, String) Specifies the description of the SNAT rule.
+
+* `created_at` - (Optional, String) Specifies the creation time of the SNAT rule.
+  The format is **yyyy-mm-dd hh:mm:ss.SSSSSS**. e.g. **2024-12-20 15:03:04.000000**.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/nat/data_source_huaweicloud_nat_snat_rules.go
+++ b/huaweicloud/services/nat/data_source_huaweicloud_nat_snat_rules.go
@@ -77,6 +77,16 @@ func DataSourceSnatRules() *schema.Resource {
 				Optional:    true,
 				Description: "The IPs of the global EIP associated with SNAT rule.",
 			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of the SNAT rule.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The creation time of the SNAT rule.",
+			},
 			"rules": {
 				Type:        schema.TypeList,
 				Elem:        snatRuleSchema(),
@@ -288,6 +298,12 @@ func buildListSnatRuleQueryParams(d *schema.ResourceData) string {
 	}
 	if v, ok := d.GetOk("status"); ok {
 		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+	if v, ok := d.GetOk("description"); ok {
+		res = fmt.Sprintf("%s&description=%v", res, v)
+	}
+	if v, ok := d.GetOk("created_at"); ok {
+		res = fmt.Sprintf("%s&created_at=%v", res, v)
 	}
 	if res != "" {
 		res = "?" + res[1:]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The SNAT rule datasource supports new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccDatasourceSnatRules_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccDatasourceSnatRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceSnatRules_basic
=== PAUSE TestAccDatasourceSnatRules_basic
=== CONT  TestAccDatasourceSnatRules_basic
--- PASS: TestAccDatasourceSnatRules_basic (198.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       198.841s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccDatasourceSnatRules_direct"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccDatasourceSnatRules_direct -timeout 360m -parallel 4
=== RUN   TestAccDatasourceSnatRules_direct
=== PAUSE TestAccDatasourceSnatRules_direct
=== CONT  TestAccDatasourceSnatRules_direct
--- PASS: TestAccDatasourceSnatRules_direct (161.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       161.687s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
