### PR TITLE
feat(nat): the DNAT rule datasource supports new fields

### DIFF
--- a/docs/data-sources/nat_dnat_rules.md
+++ b/docs/data-sources/nat_dnat_rules.md
@@ -2,7 +2,8 @@
 subcategory: "NAT Gateway (NAT)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_nat_dnat_rules"
-description: ""
+description: |-
+  Use this data source to get the list of DNAT rules.
 ---
 
 # huaweicloud_nat_dnat_rules
@@ -59,6 +60,11 @@ The following arguments are supported:
 * `global_eip_id` - (Optional, String) Specifies the ID of the global EIP associated with the DNAT rule.
 
 * `global_eip_address` - (Optional, String) Specifies the IP address of the global EIP associated with the DNAT rule.
+
+* `description` - (Optional, String) Specifies the description of the DNAT rule.
+
+* `created_at` - (Optional, String) Specifies the creation time of the DNAT rule.
+  The format is **yyyy-mm-dd hh:mm:ss.SSSSSS**. e.g. **2024-12-20 15:03:04.000000**.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/nat/data_source_huaweiclolud_nat_dnat_rules_test.go
+++ b/huaweicloud/services/acceptance/nat/data_source_huaweiclolud_nat_dnat_rules_test.go
@@ -40,6 +40,12 @@ func TestAccDatasourceDnatRules_basic(t *testing.T) {
 
 		byFloatingIpAddress   = "data.huaweicloud_nat_dnat_rules.filter_by_floating_ip_address"
 		dcByFloatingIpAddress = acceptance.InitDataSourceCheck(byFloatingIpAddress)
+
+		byDescription   = "data.huaweicloud_nat_dnat_rules.filter_by_description"
+		dcByDescription = acceptance.InitDataSourceCheck(byDescription)
+
+		byCreatedAt   = "data.huaweicloud_nat_dnat_rules.filter_by_created_at"
+		dcByCreatedAt = acceptance.InitDataSourceCheck(byCreatedAt)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -50,6 +56,15 @@ func TestAccDatasourceDnatRules_basic(t *testing.T) {
 				Config: testAccDatasourceDnatRules_basic(baseConfig),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.protocol"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.description"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.floating_ip_address"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.internal_service_port"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.created_at"),
+
 					dcByRuleId.CheckResourceExists(),
 					resource.TestCheckOutput("rule_id_filter_is_useful", "true"),
 
@@ -73,6 +88,12 @@ func TestAccDatasourceDnatRules_basic(t *testing.T) {
 
 					dcByFloatingIpAddress.CheckResourceExists(),
 					resource.TestCheckOutput("floating_ip_address_filter_is_useful", "true"),
+
+					dcByDescription.CheckResourceExists(),
+					resource.TestCheckOutput("description_filter_is_useful", "true"),
+
+					dcByCreatedAt.CheckResourceExists(),
+					resource.TestCheckOutput("created_at_filter_is_useful", "true"),
 				),
 			},
 		},
@@ -284,6 +305,42 @@ locals {
 
 output "floating_ip_address_filter_is_useful" {
   value = alltrue(local.floating_ip_address_filter_result) && length(local.floating_ip_address_filter_result) > 0
+}
+
+locals {
+  description = data.huaweicloud_nat_dnat_rules.test.rules[0].description
+}
+
+data "huaweicloud_nat_dnat_rules" "filter_by_description" {
+  description = local.description
+}
+
+locals {
+  description_filter_result = [
+    for v in data.huaweicloud_nat_dnat_rules.filter_by_description.rules[*].description : v == local.description
+  ]
+}
+
+output "description_filter_is_useful" {
+  value = alltrue(local.description_filter_result) && length(local.description_filter_result) > 0
+}
+
+locals {
+  created_at = data.huaweicloud_nat_dnat_rules.test.rules[0].created_at
+}
+
+data "huaweicloud_nat_dnat_rules" "filter_by_created_at" {
+  created_at = local.created_at
+}
+
+locals {
+  created_at_filter_result = [
+    for v in data.huaweicloud_nat_dnat_rules.filter_by_created_at.rules[*].created_at : v == local.created_at
+  ]
+}
+
+output "created_at_filter_is_useful" {
+  value = alltrue(local.created_at_filter_result) && length(local.created_at_filter_result) > 0
 }
 `, baseConfig)
 }

--- a/huaweicloud/services/nat/data_source_huaweicloud_nat_dnat_rules.go
+++ b/huaweicloud/services/nat/data_source_huaweicloud_nat_dnat_rules.go
@@ -87,6 +87,16 @@ func DataSourceDnatRules() *schema.Resource {
 				Optional:    true,
 				Description: "The IP address of the global EIP associated with the DNAT rule.",
 			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of the DNAT rule.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The creation time of the DNAT rule.",
+			},
 			"rules": {
 				Type:        schema.TypeList,
 				Elem:        dnatRuleSchema(),
@@ -322,6 +332,12 @@ func buildListDnatRuleQueryParams(d *schema.ResourceData) string {
 	}
 	if v, ok := d.GetOk("external_service_port"); ok {
 		res = fmt.Sprintf("%s&external_service_port=%v", res, v)
+	}
+	if v, ok := d.GetOk("description"); ok {
+		res = fmt.Sprintf("%s&description=%v", res, v)
+	}
+	if v, ok := d.GetOk("created_at"); ok {
+		res = fmt.Sprintf("%s&created_at=%v", res, v)
 	}
 	if res != "" {
 		res = "?" + res[1:]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The DNAT rule datasource supports new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccDatasourceDnatRules_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccDatasourceDnatRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceDnatRules_basic
=== PAUSE TestAccDatasourceDnatRules_basic
=== CONT  TestAccDatasourceDnatRules_basic
--- PASS: TestAccDatasourceDnatRules_basic (345.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       345.634s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
