### PR TITLE
feat(cci): add datasource cci v2 namespaces

### DIFF
--- a/docs/incubating/cciv2_namespaces.md
+++ b/docs/incubating/cciv2_namespaces.md
@@ -1,0 +1,60 @@
+---
+subcategory: "Cloud Container Instance (CCI)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cciv2_namespaces"
+description: |-
+  Use this data source to get the list of CCI namespaces within HuaweiCloud.
+---
+
+# huaweicloud_cciv2_namespaces
+
+Use this data source to get the list of CCI namespaces within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "namespace_name" {}
+
+data "huaweicloud_cciv2_namespaces" "test" {
+  name = var.namespace_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the namespace.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `namespaces` - The CCI namespaces.
+  The [namespaces](#attrblock_namespaces) structure is documented below.
+
+<a name="attrblock_namespaces"></a>
+The `namespaces` block supports:
+
+* `annotations` - The annotations of the namespace.
+
+* `api_version` - The API version of the namespace.
+
+* `creation_timestamp` - The creation timestamp of the namespace.
+
+* `finalizers` - The finalizers of the namespace.
+
+* `kind` - The kind of the namespace.
+
+* `labels` - The labels of the namespace.
+
+* `resource_version` - The resource version of the namespace.
+
+* `status` - The status of the namespace.
+
+* `uid` - The uid of the namespace.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -557,7 +557,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_cce_cluster_configurations": cce.DataSourceClusterConfigurations(),
 			"huaweicloud_cce_addons":                 cce.DataSourceCceAddons(),
 
-			"huaweicloud_cci_namespaces": cci.DataSourceCciNamespaces(),
+			"huaweicloud_cci_namespaces":   cci.DataSourceCciNamespaces(),
+			"huaweicloud_cciv2_namespaces": cci.DataSourceV2Namespaces(),
 
 			"huaweicloud_ccm_certificates":               ccm.DataSourceCertificates(),
 			"huaweicloud_ccm_certificate_export":         ccm.DataSourceCertificateExport(),

--- a/huaweicloud/services/acceptance/cci/data_source_huaweicloud_cciv2_namespaces_test.go
+++ b/huaweicloud/services/acceptance/cci/data_source_huaweicloud_cciv2_namespaces_test.go
@@ -1,0 +1,50 @@
+package cci
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceV2Namespaces_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_cciv2_namespaces.test"
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceV2Namespaces_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "namespaces.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "namespaces.0.name", rName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "namespaces.0.api_version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "namespaces.0.kind"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "namespaces.0.annotations.%"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "namespaces.0.labels.%"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "namespaces.0.creation_timestamp"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "namespaces.0.resource_version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "namespaces.0.uid"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "namespaces.0.finalizers.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "namespaces.0.status"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceV2Namespaces_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_cciv2_namespaces" "test" {
+  depends_on = [huaweicloud_cciv2_namespace.test]
+
+  name = "%[2]s"
+}
+`, testAccV2Namespace_basic(rName), rName)
+}

--- a/huaweicloud/services/cci/data_source_huaweicloud_cciv2_namespaces.go
+++ b/huaweicloud/services/cci/data_source_huaweicloud_cciv2_namespaces.go
@@ -1,0 +1,173 @@
+package cci
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CCI GET /apis/cci/v2/namespaces
+// @API CCI GET /apis/cci/v2/namespaces/{name}
+func DataSourceV2Namespaces() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV2NamespacesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"namespaces": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the namespace.`,
+						},
+						"api_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The API version of the namespace.`,
+						},
+						"kind": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The kind of the namespace.`,
+						},
+						"annotations": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The annotations of the namespace.`,
+						},
+						"labels": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The labels of the namespace.`,
+						},
+						"creation_timestamp": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation timestamp of the namespace.`,
+						},
+						"finalizers": {
+							Type:        schema.TypeList,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Computed:    true,
+							Description: `The finalizers of the namespace.`,
+						},
+						"resource_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The resource version of the namespace.`,
+						},
+						"uid": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The uid of the namespace.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the namespace.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceV2NamespacesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("cci", region)
+	if err != nil {
+		return diag.Errorf("error creating CCI client: %s", err)
+	}
+
+	nsList := make([]interface{}, 0)
+	if ns, ok := d.GetOk("name"); ok {
+		resp, err := GetNamespaceDetail(client, ns.(string))
+		if err != nil {
+			return diag.Errorf("error getting the namespace (%s) from the server: %s", ns.(string), err)
+		}
+		nsList = append(nsList, resp)
+	} else {
+		resp, err := listNamespaces(client)
+		if err != nil {
+			return diag.Errorf("error finding the namespace list from the server: %s", err)
+		}
+		nsList = utils.PathSearch("items", resp, make([]interface{}, 0)).([]interface{})
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("namespaces", flattenNamespace(nsList)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenNamespace(nsList []interface{}) []interface{} {
+	if len(nsList) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(nsList))
+	for _, v := range nsList {
+		rst = append(rst, map[string]interface{}{
+			"name":               utils.PathSearch("metadata.name", v, nil),
+			"api_version":        utils.PathSearch("apiVersion", v, nil),
+			"kind":               utils.PathSearch("kind", v, nil),
+			"annotations":        utils.PathSearch("metadata.annotations", v, nil),
+			"labels":             utils.PathSearch("metadata.labels", v, nil),
+			"creation_timestamp": utils.PathSearch("metadata.creationTimestamp", v, nil),
+			"resource_version":   utils.PathSearch("metadata.resourceVersion", v, nil),
+			"uid":                utils.PathSearch("metadata.uid", v, nil),
+			"finalizers":         utils.PathSearch("spec.finalizers", v, nil),
+			"status":             utils.PathSearch("status.phase", v, nil),
+		})
+	}
+	return rst
+}
+
+func listNamespaces(client *golangsdk.ServiceClient) (interface{}, error) {
+	listNamespaceHttpUrl := "apis/cci/v2/namespaces"
+	listNamespacePath := client.Endpoint + listNamespaceHttpUrl
+	listNamespaceOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	listNamespacesResp, err := client.Request("GET", listNamespacePath, &listNamespaceOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error querying CCI namespaces: %s", err)
+	}
+
+	return utils.FlattenResponse(listNamespacesResp)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
add datasource cci v2 namespaces

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
add datasource cci v2 namespaces
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/cci" TESTARGS="-run TestAccDataSourceV2Namespaces_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cci -v -run TestAccDataSourceV2Namespaces_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceV2Namespaces_basic
=== PAUSE TestAccDataSourceV2Namespaces_basic
=== CONT  TestAccDataSourceV2Namespaces_basic
--- PASS: TestAccDataSourceV2Namespaces_basic(81.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cci       82.430s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
