### PR TITLE
feat(nat): the NAT gateway resource supports new fields and attributes

### DIFF
--- a/docs/resources/nat_gateway.md
+++ b/docs/resources/nat_gateway.md
@@ -2,7 +2,8 @@
 subcategory: "NAT Gateway (NAT)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_nat_gateway"
-description: ""
+description: |-
+  Manages a gateway resource of the **public** NAT within HuaweiCloud.
 ---
 
 # huaweicloud_nat_gateway
@@ -98,7 +99,7 @@ The following arguments are supported:
 * `auto_renew` - (Optional, String) Specifies whether auto-renew is enabled. This parameter is only valid when
   `charging_mode` is set to **prePaid**. Valid values are **true** and **false**. Defaults to **false**.
 
-* `ngport_ip_address` - (Optional, String, ForceNew) Specifies the private IP address of the NAT gateway.
+* `ngport_ip_address` - (Optional, String, ForceNew) Specifies the IP address used for the NG port of the NAT gateway.
   The IP address must be one of the IP addresses of the VPC subnet associated with the NAT gateway.
   If not spacified, it will be automatically allocated.
   Changing this will creates a new resource.
@@ -108,6 +109,24 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the NAT gateway.
 
+* `session_conf` - (Optional, List) Specifies the session configuration of the NAT gateway.
+  The [session_conf](#nat_session_conf) structure is documented below.
+
+<a name="nat_session_conf"></a>
+The `session_conf` block supports:
+
+* `tcp_session_expire_time` - (Optional, Int) Specifies the TCP session expiration time, in seconds.
+  The valid value from `40` to `7,200`, default value is `900`.
+
+* `udp_session_expire_time` - (Optional, Int) Specifies the UDP session expiration time, in seconds.
+  The valid value from `40` to `7,200`, default value is `300`.
+
+* `icmp_session_expire_time` - (Optional, Int) Specifies the ICMP session expiration time, in seconds.
+  The valid value from `10` to `7,200`, default value is `10`.
+
+* `tcp_time_wait_time` - (Optional, Int) Specifies the duration of TIME_WAIT state when TCP connection is closed,
+  in seconds. The valid value from `0` to `1,800`, default value is `5`.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -115,6 +134,19 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The resource ID in UUID format.
 
 * `status` - The current status of the NAT gateway.
+
+* `created_at` - The creation time of the NAT gateway.
+
+* `billing_info` - The order information of the NAT gateway.
+  When the `charging_mode` is set to **prePaid**, this parameter is available.
+
+* `dnat_rules_limit` - The maximum number of DNAT rules on the NAT gateway. Defaults to `200`.
+
+* `snat_rule_public_ip_limit` - The maximum number of SNAT rules on the NAT gateway. Defaults to `20`.
+
+* `pps_max` - The number of packets that the NAT gateway can receive or send per second.
+
+* `bps_max` - The bandwidth that the NAT gateway can receive or send per second, unit is MB.
 
 ## Timeouts
 

--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_gateway_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_gateway_test.go
@@ -52,8 +52,15 @@ func TestAccPublicGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "spec", string(nat.PublicSpecTypeSmall)),
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
 					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.tcp_session_expire_time", "1000"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.udp_session_expire_time", "400"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.icmp_session_expire_time", "20"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.tcp_time_wait_time", "10"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "dnat_rules_limit"),
+					resource.TestCheckResourceAttrSet(rName, "snat_rule_public_ip_limit"),
 				),
 			},
 			{
@@ -64,6 +71,10 @@ func TestAccPublicGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "spec", string(nat.PublicSpecTypeMedium)),
 					resource.TestCheckResourceAttr(rName, "description", ""),
 					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.tcp_session_expire_time", "900"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.udp_session_expire_time", "300"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.icmp_session_expire_time", "10"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.tcp_time_wait_time", "5"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "baaar"),
 					resource.TestCheckResourceAttr(rName, "tags.newkey", "value"),
 				),
@@ -89,6 +100,13 @@ resource "huaweicloud_nat_gateway" "test" {
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
 
+  session_conf {
+    tcp_session_expire_time  = 1000
+    udp_session_expire_time  = 400
+    icmp_session_expire_time = 20
+    tcp_time_wait_time       = 10
+  }
+
   tags = {
     foo = "bar"
     key = "value"
@@ -107,6 +125,13 @@ resource "huaweicloud_nat_gateway" "test" {
   ngport_ip_address = "192.168.0.101"
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
+
+  session_conf {
+    tcp_session_expire_time  = 900
+    udp_session_expire_time  = 300
+    icmp_session_expire_time = 10
+    tcp_time_wait_time       = 5
+  }
 
   tags = {
     foo    = "baaar"
@@ -147,8 +172,15 @@ func TestAccPublicGateway_prepaid(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
 					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.tcp_session_expire_time", "800"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.udp_session_expire_time", "200"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.icmp_session_expire_time", "100"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.tcp_time_wait_time", "50"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttrSet(rName, "billing_info"),
+					resource.TestCheckResourceAttrSet(rName, "pps_max"),
+					resource.TestCheckResourceAttrSet(rName, "bps_max"),
 				),
 			},
 			{
@@ -160,6 +192,10 @@ func TestAccPublicGateway_prepaid(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
 					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.tcp_session_expire_time", "900"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.udp_session_expire_time", "400"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.icmp_session_expire_time", "30"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.tcp_time_wait_time", "0"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "baaar"),
 					resource.TestCheckResourceAttr(rName, "tags.newkey", "value"),
 				),
@@ -192,6 +228,13 @@ resource "huaweicloud_nat_gateway" "test" {
   subnet_id             = huaweicloud_vpc_subnet.test.id
   enterprise_project_id = "0"
 
+  session_conf {
+    tcp_session_expire_time  = 800
+    udp_session_expire_time  = 200
+    icmp_session_expire_time = 100
+    tcp_time_wait_time       = 50
+  }
+
   charging_mode = "prePaid"
   period_unit   = "month"
   period        = "1"
@@ -217,6 +260,13 @@ resource "huaweicloud_nat_gateway" "test" {
   vpc_id                = huaweicloud_vpc.test.id
   subnet_id             = huaweicloud_vpc_subnet.test.id
   enterprise_project_id = "0"
+
+  session_conf {
+    tcp_session_expire_time  = 900
+    udp_session_expire_time  = 400
+    icmp_session_expire_time = 30
+    tcp_time_wait_time       = 0
+  }
 
   charging_mode = "prePaid"
   period_unit   = "month"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The NAT gateway resource supports new fields and attributes.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPublicGateway_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccPublicGateway_basic
=== PAUSE TestAccPublicGateway_basic
=== CONT  TestAccPublicGateway_basic
--- PASS: TestAccPublicGateway_basic (160.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       160.279s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPublicGateway_prepaid"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicGateway_prepaid -timeout 360m -parallel 4
=== RUN   TestAccPublicGateway_prepaid
=== PAUSE TestAccPublicGateway_prepaid
=== CONT  TestAccPublicGateway_prepaid
--- PASS: TestAccPublicGateway_prepaid (187.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       187.916s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
