### PR TITLE
fix(css): fixed css logstash cluster availability_zone loss error

### DIFF
--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_logstash_cluster_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_logstash_cluster_test.go
@@ -50,6 +50,7 @@ func TestAccLogstashCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
 					resource.TestCheckResourceAttr(resourceName, "is_period", "false"),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone", "data.huaweicloud_availability_zones.test", "names.0"),
 				),
 			},
 			{

--- a/huaweicloud/services/css/resource_huaweicloud_css_logstash_cluster.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_logstash_cluster.go
@@ -331,6 +331,7 @@ func buildlogstashClusterCreateParameters(d *schema.ResourceData, conf *config.C
 				"size":        d.Get("node_config.0.volume.0.size"),
 				"volume_type": d.Get("node_config.0.volume.0.volume_type"),
 			},
+			"availability_zone": utils.ValueIgnoreEmpty(d.Get("availability_zone")),
 		},
 		"instanceNum": d.Get("node_config.0.instance_number"),
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx
fixed css logstash cluster availability_zone loss error

**Special notes for your reviewer**:

**Release note**:

```
fixed css logstash cluster availability_zone loss error
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run TestAccLogstashCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccLogstashCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccLogstashCluster_basic
=== PAUSE TestAccLogstashCluster_basic
=== CONT  TestAccLogstashCluster_basic
--- PASS: TestAccLogstashCluster_basic (1675.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1675.897s
```

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
