### PR TITLE
chore(iotda): fix device async commond resource 'paras' parameter request loss error

### DIFF
--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_async_command_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_async_command_test.go
@@ -78,6 +78,16 @@ func TestAccDeviceAsyncCommand_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "created_at"),
 				),
 			},
+			{
+				Config: testAccDeviceAsyncCommand_custom(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "device_id", "huaweicloud_iotda_device.test", "id"),
+					resource.TestCheckResourceAttr(rName, "send_strategy", "immediately"),
+					resource.TestCheckResourceAttrSet(rName, "sent_time"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+				),
+			},
 		},
 	})
 }
@@ -144,6 +154,17 @@ resource "huaweicloud_iotda_device_async_command" "test" {
   paras = {
     (huaweicloud_iotda_product.test.services.0.commands.0.paras.0.name) = "tf-acc"
   }
+}
+`, testAccDeviceAsyncCommand_base(name))
+}
+
+func testAccDeviceAsyncCommand_custom(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_iotda_device_async_command" "test" {
+  device_id     = huaweicloud_iotda_device.test.id
+  send_strategy = "immediately"
 }
 `, testAccDeviceAsyncCommand_base(name))
 }

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_async_command.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_async_command.go
@@ -94,13 +94,17 @@ func ResourceDeviceAsyncCommand() *schema.Resource {
 }
 
 func buildDeviceAsyncCommandBodyParams(d *schema.ResourceData) map[string]interface{} {
-	return map[string]interface{}{
+	asyncCommandParams := map[string]interface{}{
 		"service_id":    utils.ValueIgnoreEmpty(d.Get("service_id")),
 		"command_name":  utils.ValueIgnoreEmpty(d.Get("name")),
-		"paras":         utils.ValueIgnoreEmpty(d.Get("paras")),
 		"expire_time":   utils.ValueIgnoreEmpty(d.Get("expire_time")),
 		"send_strategy": d.Get("send_strategy"),
 	}
+
+	asyncCommandParams = utils.RemoveNil(asyncCommandParams)
+	asyncCommandParams["paras"] = d.Get("paras")
+
+	return asyncCommandParams
 }
 
 func resourceDeviceAsyncCommandCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -123,7 +127,7 @@ func resourceDeviceAsyncCommandCreate(ctx context.Context, d *schema.ResourceDat
 
 	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildDeviceAsyncCommandBodyParams(d)),
+		JSONBody:         buildDeviceAsyncCommandBodyParams(d),
 	}
 
 	resp, err := client.Request("POST", createPath, &createOpt)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix device async commond resource 'paras' parameter request loss error.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDeviceAsyncCommand_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceAsyncCommand_basic -timeout 360m -parallel 4
=== RUN   TestAccDeviceAsyncCommand_basic
--- PASS: TestAccDeviceAsyncCommand_basic (96.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     96.957s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
