### PR TITLE
feat(cts): system tracker and data tracker support some attributes

### DIFF
--- a/docs/resources/cts_data_tracker.md
+++ b/docs/resources/cts_data_tracker.md
@@ -73,6 +73,14 @@ In addition to all arguments above, the following attributes are exported:
 * `transfer_enabled` - Whether traces will be transferred.
 * `status` - The tracker status, the value can be **enabled**, **disabled** or **error**.
 * `agency_name` - The cloud service delegation name.
+* `create_time` - The creation time of the tracker.
+* `detail` - It indicates the cause of the abnormal status.
+* `domain_id` - The Account ID.
+* `group_id` - The LTS log group ID.
+* `stream_id` - The LTS log stream ID.
+* `log_group_name` - The name of the log group that CTS creates in LTS.
+* `log_topic_name` - The name of the log topic that CTS creates in LTS.
+* `is_authorized_bucket` - Whether CTS has been granted permissions to perform operations on the OBS bucket.
 
 ## Timeouts
 

--- a/docs/resources/cts_tracker.md
+++ b/docs/resources/cts_tracker.md
@@ -73,6 +73,14 @@ In addition to all arguments above, the following attributes are exported:
 * `transfer_enabled` - Whether traces will be transferred.
 * `status` - The tracker status, the value can be **enabled**, **disabled** or **error**.
 * `agency_name` - The cloud service delegation name.
+* `create_time` - The creation time of the tracker.
+* `detail` - It indicates the cause of the abnormal status.
+* `domain_id` - The Account ID.
+* `group_id` - The LTS log group ID.
+* `stream_id` - The LTS log stream ID.
+* `log_group_name` - The name of the log group that CTS creates in LTS.
+* `log_topic_name` - The name of the log topic that CTS creates in LTS.
+* `is_authorized_bucket` - Whether CTS has been granted permissions to perform operations on the OBS bucket.
 
 ## Timeouts
 

--- a/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_data_tracker_test.go
+++ b/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_data_tracker_test.go
@@ -79,6 +79,12 @@ func TestAccCTSDataTracker_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "data_bucket",
 						"huaweicloud_obs_bucket.data_bucket", "bucket"),
 					resource.TestCheckResourceAttrSet(resourceName, "agency_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "create_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "group_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "stream_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "log_group_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "log_topic_name"),
 				),
 			},
 			{

--- a/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_tracker_test.go
+++ b/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_tracker_test.go
@@ -36,6 +36,12 @@ func TestAccCTSTracker_keepTracker(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "is_sort_by_service", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttrSet(resourceName, "agency_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "create_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "group_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "stream_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "log_group_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "log_topic_name"),
 				),
 			},
 			{

--- a/huaweicloud/services/cts/resource_huaweicloud_cts_data_tracker.go
+++ b/huaweicloud/services/cts/resource_huaweicloud_cts_data_tracker.go
@@ -126,6 +126,38 @@ func ResourceCTSDataTracker() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"detail": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"stream_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"log_group_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"log_topic_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_authorized_bucket": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -415,6 +447,14 @@ func resourceCTSDataTrackerRead(_ context.Context, d *schema.ResourceData, meta 
 		d.Set("type", utils.PathSearch("tracker_type", tracker, nil)),
 		d.Set("status", status),
 		d.Set("enabled", status == "enabled"),
+		d.Set("create_time", utils.PathSearch("create_time", tracker, nil)),
+		d.Set("detail", utils.PathSearch("detail", tracker, nil)),
+		d.Set("domain_id", utils.PathSearch("domain_id", tracker, nil)),
+		d.Set("group_id", utils.PathSearch("group_id", tracker, nil)),
+		d.Set("stream_id", utils.PathSearch("stream_id", tracker, nil)),
+		d.Set("log_group_name", utils.PathSearch("lts.log_group_name", tracker, nil)),
+		d.Set("log_topic_name", utils.PathSearch("lts.log_topic_name", tracker, nil)),
+		d.Set("is_authorized_bucket", utils.PathSearch("obs_info.is_authorized_bucket", tracker, false)),
 	)
 
 	if bucketName != "" {

--- a/huaweicloud/services/cts/resource_huaweicloud_cts_tracker.go
+++ b/huaweicloud/services/cts/resource_huaweicloud_cts_tracker.go
@@ -124,6 +124,38 @@ func ResourceCTSTracker() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"detail": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"stream_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"log_group_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"log_topic_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_authorized_bucket": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -304,6 +336,14 @@ func resourceCTSTrackerRead(_ context.Context, d *schema.ResourceData, meta inte
 		d.Set("type", utils.PathSearch("tracker_type", ctsTracker, nil)),
 		d.Set("status", status),
 		d.Set("enabled", status == "enabled"),
+		d.Set("create_time", utils.PathSearch("create_time", ctsTracker, nil)),
+		d.Set("detail", utils.PathSearch("detail", ctsTracker, nil)),
+		d.Set("domain_id", utils.PathSearch("domain_id", ctsTracker, nil)),
+		d.Set("group_id", utils.PathSearch("group_id", ctsTracker, nil)),
+		d.Set("stream_id", utils.PathSearch("stream_id", ctsTracker, nil)),
+		d.Set("log_group_name", utils.PathSearch("lts.log_group_name", ctsTracker, nil)),
+		d.Set("log_topic_name", utils.PathSearch("lts.log_topic_name", ctsTracker, nil)),
+		d.Set("is_authorized_bucket", utils.PathSearch("obs_info.is_authorized_bucket", ctsTracker, false)),
 	)
 
 	if bucketName != "" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
system tracker and data tracker support some attributes
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. system tracker supports create_time、detail、domain_id、group_id、stream_id、log_group_name、log_topic_name、 is_authorized_bucket.
2. data tracker supports create_time、detail、domain_id、group_id、stream_id、log_group_name、log_topic_name、 is_authorized_bucket.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccCTSTracker_keepTracker"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSTracker_keepTracker -timeout 360m -parallel 4
=== RUN   TestAccCTSTracker_keepTracker
=== PAUSE TestAccCTSTracker_keepTracker
=== CONT  TestAccCTSTracker_keepTracker
--- PASS: TestAccCTSTracker_keepTracker (67.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       67.983s

make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccCTSDataTracker_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSDataTracker_basic -timeout 360m -parallel 4
=== RUN   TestAccCTSDataTracker_basic
=== PAUSE TestAccCTSDataTracker_basic
=== CONT  TestAccCTSDataTracker_basic
--- PASS: TestAccCTSDataTracker_basic (118.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       118.147s

make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccCTSTracker_deleteTracker"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSTracker_deleteTracker -timeout 360m -parallel 4
=== RUN   TestAccCTSTracker_deleteTracker
=== PAUSE TestAccCTSTracker_deleteTracker
=== CONT  TestAccCTSTracker_deleteTracker
--- PASS: TestAccCTSTracker_deleteTracker (38.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       38.409s


```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
