### PR TITLE
chore(nat): remove the NAT gateway resource 'spec' paramater ValidateFunc

### DIFF
--- a/huaweicloud/services/nat/resource_huaweicloud_nat_gateway.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_gateway.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -82,14 +81,8 @@ func ResourcePublicGateway() *schema.Resource {
 				Description: "The NAT gateway name.",
 			},
 			"spec": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(PublicSpecTypeSmall),
-					string(PublicSpecTypeMedium),
-					string(PublicSpecTypeLarge),
-					string(PublicSpecTypeExtraLarge),
-				}, false),
+				Type:        schema.TypeString,
+				Required:    true,
 				Description: "The specification of the NAT gateway.",
 			},
 			"charging_mode": common.SchemaChargingMode(nil),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove the NAT gateway resource 'spec' paramater ValidateFunc.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPublicGateway_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccPublicGateway_basic
=== PAUSE TestAccPublicGateway_basic
=== CONT  TestAccPublicGateway_basic
--- PASS: TestAccPublicGateway_basic (161.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       161.279s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPublicGateway_prepaid"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicGateway_prepaid -timeout 360m -parallel 4
=== RUN   TestAccPublicGateway_prepaid
=== PAUSE TestAccPublicGateway_prepaid
=== CONT  TestAccPublicGateway_prepaid
--- PASS: TestAccPublicGateway_prepaid (222.69s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       222.760s
```

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
