### PR TITLE
feat(EIP): support to insert ipv6 port to bandwidth

### DIFF
--- a/docs/resources/vpc_bandwidth_associate.md
+++ b/docs/resources/vpc_bandwidth_associate.md
@@ -7,7 +7,7 @@ description: ""
 
 # huaweicloud_vpc_bandwidth_associate
 
-Associates an EIP to a specified **shared** bandwidth.
+Associates an **EIP** or a fixed **IPv6** address to a specified **shared** bandwidth.
 
 -> Yearly/monthly EIPs cannot be added to a shared bandwidth. After an EIP is removed from a shared bandwidth,
   a dedicated bandwidth will be allocated to the EIP. By default, the dedicated bandwidth will be billed by bandwidth
@@ -82,6 +82,40 @@ resource "huaweicloud_vpc_bandwidth_associate" "test" {
 }
 ```
 
+### Associate with an IPv6 port by port ID
+
+```hcl
+variable "port_id" {}
+
+resource "huaweicloud_vpc_bandwidth" "test" {
+  name = "bandwidth_1"
+  size = 100
+}
+
+resource "huaweicloud_vpc_bandwidth_associate" "test" {
+  bandwidth_id = huaweicloud_vpc_bandwidth.test.id
+  port_id      = var.port_id
+}
+```
+
+### Associate with a fixed IPv6 address
+
+```hcl
+variable "network_id" {}
+variable "fixed_ip" {}
+
+resource "huaweicloud_vpc_bandwidth" "test" {
+  name = "bandwidth_1"
+  size = 100
+}
+
+resource "huaweicloud_vpc_bandwidth_associate" "test" {
+  bandwidth_id = huaweicloud_vpc_bandwidth.test.id
+  network_id   = var.network_id
+  fixed_ip     = var.fixed_ip
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -92,7 +126,9 @@ The following arguments are supported:
 * `bandwidth_id` - (Required, String, ForceNew) Specifies the shared bandwidth ID to associate.
   Changing this creates a new resource.
 
-* `eip_id` - (Required, String) Specifies the ID of the EIP that uses the bandwidth.
+* `eip_id` - (Optional, String) Specifies the ID of the EIP that uses the bandwidth.
+
+  -> Exactly one of `eip_id`, `port_id` and `fixed_ip` can be specified.
 
 * `bandwidth_charge_mode` - (Optional, String) Specifies the billing mode of the dedicated bandwidth used by the EIP that
   has been removed from a shared bandwidth. The value can be **bandwidth** or **traffic**. If not specified, the dedicated
@@ -101,18 +137,42 @@ The following arguments are supported:
 * `bandwidth_size` - (Optional, Int) Specifies the size (Mbit/s) of the dedicated bandwidth used by the EIP that
   has been removed from a shared bandwidth. The default bandwidth size is 5 Mbit/s.
 
+* `port_id` - (Optional, String) Specifies the ID of the **Ipv6** port that uses the bandwidth.
+
+* `fixed_ip` - (Optional, String) Specifies a fixed **Ipv6** address to associate with the bandwidth.
+
+* `network_id` - (Optional, String) Specifies the ID of the network to which the `fixed_ip` belongs.
+  It is mandatory when `fixed_ip` is set.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The resource ID in format of `<bandwidth_id>/<eip_id>`.
-* `public_ip` - The EIP address.
+* `id` - The resource ID in format of `<bandwidth_id>/<eip_id>` or `<bandwidth_id>/<port_id>`.
+
+* `ip_version` - The IP version.
+
+* `public_ip_type` - The public IP type.
+
+* `public_ip` - The public IP address.
+
+* `public_ipv6` - The public IPv6 address.
+
 * `bandwidth_name` - The shared bandwidth name.
 
 ## Import
 
-Bandwidth associations can be imported using the `bandwidth_id` and `eip_id` separated by a slash, e.g.:
+Bandwidth associations can be imported using the `bandwidth_id` and `eip_id` separated by a slash or the `bandwidth_id`
+and `port_id` separated by a slash, or `bandwidth_id`, `network_id` and `fixed_ip` separated by slashes, e.g.:
 
 ```bash
 $ terraform import huaweicloud_vpc_bandwidth_associate.eip <bandwidth_id>/<eip_id>
+```
+
+```bash
+$ terraform import huaweicloud_vpc_bandwidth_associate.port <bandwidth_id>/<port_id>
+```
+
+```bash
+$ terraform import huaweicloud_vpc_bandwidth_associate.fixed_ip_v6 <bandwidth_id>/<network_id>/<fixed_ip>
 ```

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_bandwidth_associate_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_bandwidth_associate_test.go
@@ -62,6 +62,78 @@ func TestAccBandWidthAssociate_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccBandWidthAssociate_ipv6Port(randName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "eip_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "ip_version", "6"),
+					resource.TestCheckResourceAttr(resourceName, "public_ip_type", "5_dualStack"),
+					resource.TestCheckResourceAttrPair(resourceName, "port_id", "huaweicloud_networking_vip.test.0", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "network_id", "huaweicloud_networking_vip.test.0", "network_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "fixed_ip", "huaweicloud_networking_vip.test.0", "ip_address"),
+					resource.TestCheckResourceAttrPair(resourceName, "public_ipv6", "huaweicloud_networking_vip.test.0", "ip_address"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBandWidthAssociate_basic(randName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth_name", randName),
+					resource.TestCheckResourceAttrPair(resourceName, "bandwidth_id", "huaweicloud_vpc_bandwidth.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "eip_id", "huaweicloud_vpc_eip.test.0", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "public_ip", "huaweicloud_vpc_eip.test.0", "address"),
+					resource.TestCheckResourceAttr(resourceName, "port_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "fixed_ip", ""),
+				),
+			},
+			{
+				Config: testAccBandWidthAssociate_ipv6Ip(randName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "eip_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "ip_version", "6"),
+					resource.TestCheckResourceAttr(resourceName, "public_ip_type", "5_dualStack"),
+					resource.TestCheckResourceAttrPair(resourceName, "port_id", "huaweicloud_networking_vip.test.0", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "network_id", "huaweicloud_networking_vip.test.0", "network_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "fixed_ip", "huaweicloud_networking_vip.test.0", "ip_address"),
+					resource.TestCheckResourceAttrPair(resourceName, "public_ipv6", "huaweicloud_networking_vip.test.0", "ip_address"),
+				),
+			},
+			{
+				Config: testAccBandWidthAssociate_ipv6Ip(randName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "eip_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "ip_version", "6"),
+					resource.TestCheckResourceAttr(resourceName, "public_ip_type", "5_dualStack"),
+					resource.TestCheckResourceAttrPair(resourceName, "port_id", "huaweicloud_networking_vip.test.1", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "network_id", "huaweicloud_networking_vip.test.1", "network_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "fixed_ip", "huaweicloud_networking_vip.test.1", "ip_address"),
+					resource.TestCheckResourceAttrPair(resourceName, "public_ipv6", "huaweicloud_networking_vip.test.1", "ip_address"),
+				),
+			},
+			{
+				Config: testAccBandWidthAssociate_ipv6Port(randName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "eip_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "ip_version", "6"),
+					resource.TestCheckResourceAttr(resourceName, "public_ip_type", "5_dualStack"),
+					resource.TestCheckResourceAttrPair(resourceName, "port_id", "huaweicloud_networking_vip.test.0", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "network_id", "huaweicloud_networking_vip.test.0", "network_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "fixed_ip", "huaweicloud_networking_vip.test.0", "ip_address"),
+					resource.TestCheckResourceAttrPair(resourceName, "public_ipv6", "huaweicloud_networking_vip.test.0", "ip_address"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccBandWidthAssociateIpv6ImportStateFunc(resourceName),
+			},
 		},
 	})
 }
@@ -106,8 +178,66 @@ func TestAccBandWidthAssociate_migrate(t *testing.T) {
 	})
 }
 
+func TestAccBandWidthAssociate_migrate_ipv6(t *testing.T) {
+	var bandwidth bandwidths.BandWidth
+
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_vpc_bandwidth_associate.test_1"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&bandwidth,
+		getBandwidthAssociateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBandWidthAssociate_ipv6Ip_migrate(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "bandwidth_id", "huaweicloud_vpc_bandwidth.test.1", "id"),
+					resource.TestCheckResourceAttr(resourceName, "eip_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "ip_version", "6"),
+					resource.TestCheckResourceAttr(resourceName, "public_ip_type", "5_dualStack"),
+					resource.TestCheckResourceAttrPair(resourceName, "port_id", "huaweicloud_networking_vip.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "network_id", "huaweicloud_networking_vip.test", "network_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "fixed_ip", "huaweicloud_networking_vip.test", "ip_address"),
+					resource.TestCheckResourceAttrPair(resourceName, "public_ipv6", "huaweicloud_networking_vip.test", "ip_address"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccBandWidthAssociate_base(rName string) string {
 	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id      = huaweicloud_vpc.test.id
+  name        = "%[1]s"
+  cidr        = "192.168.0.0/24"
+  gateway_ip  = "192.168.0.1"
+  ipv6_enable = true
+}
+
+resource "huaweicloud_networking_vip" "test" {
+  count = 2
+
+  name       = "%[1]s-${count.index}"
+  network_id = huaweicloud_vpc_subnet.test.id
+  ip_version = 6
+}
+
 resource "huaweicloud_vpc_bandwidth" "test" {
   name = "%[1]s"
   size = 5
@@ -142,6 +272,29 @@ func testAccBandWidthAssociate_basic(rName string, index int) string {
 resource "huaweicloud_vpc_bandwidth_associate" "test" {
   bandwidth_id = huaweicloud_vpc_bandwidth.test.id
   eip_id       = huaweicloud_vpc_eip.test.%d.id
+}
+`, testAccBandWidthAssociate_base(rName), index)
+}
+
+func testAccBandWidthAssociate_ipv6Port(rName string, index int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_vpc_bandwidth_associate" "test" {
+  bandwidth_id = huaweicloud_vpc_bandwidth.test.id
+  port_id      = huaweicloud_networking_vip.test.%d.id
+}
+`, testAccBandWidthAssociate_base(rName), index)
+}
+
+func testAccBandWidthAssociate_ipv6Ip(rName string, index int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_vpc_bandwidth_associate" "test" {
+  bandwidth_id = huaweicloud_vpc_bandwidth.test.id
+  fixed_ip     = huaweicloud_networking_vip.test.%d.ip_address
+  network_id   = huaweicloud_vpc_subnet.test.id
 }
 `, testAccBandWidthAssociate_base(rName), index)
 }
@@ -207,4 +360,66 @@ resource "huaweicloud_vpc_bandwidth_associate" "test" {
   eip_id       = huaweicloud_vpc_eip.test.id
 }
 `, rName)
+}
+
+func testAccBandWidthAssociate_ipv6Ip_migrate(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id      = huaweicloud_vpc.test.id
+  name        = "%[1]s"
+  cidr        = "192.168.0.0/24"
+  gateway_ip  = "192.168.0.1"
+  ipv6_enable = true
+}
+
+resource "huaweicloud_networking_vip" "test" {
+  name       = "%[1]s"
+  network_id = huaweicloud_vpc_subnet.test.id
+  ip_version = 6
+}
+
+resource "huaweicloud_vpc_bandwidth" "test" {
+  count = 2
+
+  name = "%[1]s"
+  size = 5
+}
+
+resource "huaweicloud_vpc_bandwidth_associate" "test_0" {
+  bandwidth_id = huaweicloud_vpc_bandwidth.test.0.id
+  fixed_ip     = huaweicloud_networking_vip.test.ip_address
+  network_id   = huaweicloud_vpc_subnet.test.id
+}
+
+resource "huaweicloud_vpc_bandwidth_associate" "test_1" {
+  depends_on = [huaweicloud_vpc_bandwidth_associate.test_0]
+
+  bandwidth_id = huaweicloud_vpc_bandwidth.test.1.id
+  fixed_ip     = huaweicloud_networking_vip.test.ip_address
+  network_id   = huaweicloud_vpc_subnet.test.id
+}
+`, rName)
+}
+
+func testAccBandWidthAssociateIpv6ImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+		bwID := rs.Primary.Attributes["bandwidth_id"]
+		networkID := rs.Primary.Attributes["network_id"]
+		fixedIP := rs.Primary.Attributes["fixed_ip"]
+		if bwID == "" || networkID == "" || fixedIP == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<bandwidth_id>/<network_id>/<fixed_ip>', but got '%s/%s/%s'",
+				bwID, networkID, fixedIP)
+		}
+
+		return fmt.Sprintf("%s/%s/%s", bwID, networkID, fixedIP), nil
+	}
 }

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_bandwidth_associate.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_bandwidth_associate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/chnsz/golangsdk"
 	bandwidthsv1 "github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths"
 	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
+	"github.com/chnsz/golangsdk/openstack/networking/v1/ports"
 	"github.com/chnsz/golangsdk/openstack/networking/v2/bandwidths"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
@@ -20,14 +21,17 @@ import (
 )
 
 const (
+	PublicIPv6Type             = "5_dualStack"
 	DefaultBandWidthChargeMode = "bandwidth"
 	DefaultBandWidthSize       = 5
 )
 
-// @API EIP POST /v1/{project_id}/bandwidths/{ID}/insert
-// @API EIP POST /v1/{project_id}/bandwidths/{ID}/remove
+// @API EIP POST /v2.0/{project_id}/bandwidths/{bandwidth_id}/insert
+// @API EIP POST /v2.0/{project_id}/bandwidths/{bandwidth_id}/remove
 // @API EIP GET /v1/{project_id}/bandwidths/{id}
 // @API EIP GET /v1/{project_id}/publicips/{id}
+// @API VPC GET /v1/{project_id}/ports
+// @API VPC GET /v1/{project_id}/ports/{portId}
 func ResourceBandWidthAssociate() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceBandWidthAssociateCreate,
@@ -52,8 +56,9 @@ func ResourceBandWidthAssociate() *schema.Resource {
 				ForceNew: true,
 			},
 			"eip_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"port_id", "eip_id", "fixed_ip"},
 			},
 			"bandwidth_charge_mode": {
 				Type:        schema.TypeString,
@@ -64,6 +69,34 @@ func ResourceBandWidthAssociate() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: `The size (Mbits/s) after removal bandwidth.`,
+			},
+			"port_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"fixed_ip": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				RequiredWith: []string{"network_id"},
+			},
+			"network_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"ip_version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"public_ip_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public_ipv6": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"public_ip": {
 				Type:     schema.TypeString,
@@ -88,17 +121,45 @@ func resourceBandWidthAssociateCreate(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		return diag.Errorf("error creating EIP client: %s", err)
 	}
+	vpcClient, err := cfg.NetworkingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
+	}
 
 	bwID := d.Get("bandwidth_id").(string)
 	eipID := d.Get("eip_id").(string)
 
-	err = insertEIPsToBandwidth(d, bwClient, eipClient, bwID, eipID)
-	if err != nil {
-		return diag.FromErr(err)
+	if eipID != "" {
+		err = insertEIPsToBandwidth(d, bwClient, eipClient, bwID, eipID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		resourceID := fmt.Sprintf("%s/%s", bwID, eipID)
+		d.SetId(resourceID)
+	} else {
+		portID := d.Get("port_id").(string)
+		if portID == "" {
+			networkID := d.Get("network_id").(string)
+			fixedIP := d.Get("fixed_ip").(string)
+			portID, err = getPortbyFixedIP(vpcClient, networkID, fixedIP)
+			if err != nil {
+				return diag.Errorf("unable to get port ID of %s: %s", fixedIP, err)
+			}
+		}
+
+		if err = insertPortToBandwidth(bwClient, vpcClient, bwID, portID); err != nil {
+			return diag.FromErr(err)
+		}
+
+		resourceID := fmt.Sprintf("%s/%s", bwID, portID)
+		d.SetId(resourceID)
+
+		if err := d.Set("port_id", portID); err != nil {
+			return diag.Errorf("error setting port_id: %s", err)
+		}
 	}
 
-	resourceID := fmt.Sprintf("%s/%s", bwID, eipID)
-	d.SetId(resourceID)
 	return resourceBandWidthAssociateRead(ctx, d, meta)
 }
 
@@ -109,25 +170,34 @@ func resourceBandWidthAssociateRead(_ context.Context, d *schema.ResourceData, m
 	if err != nil {
 		return diag.Errorf("error creating bandwidth v1 client: %s", err)
 	}
+	vpcClient, err := cfg.NetworkingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
+	}
 
 	bwID := d.Get("bandwidth_id").(string)
 	eipID := d.Get("eip_id").(string)
+	portID := d.Get("port_id").(string)
 
 	b, err := bandwidthsv1.Get(eipClient, bwID).Extract()
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "bandwidth associate")
 	}
 
-	var eipItem *bandwidthsv1.PublicIpinfo
-	allEIPs := b.PublicipInfo
-	for i := range allEIPs {
-		if allEIPs[i].PublicipId == eipID {
-			eipItem = &allEIPs[i]
+	associatedID := eipID
+	if eipID == "" {
+		associatedID = portID
+	}
+	var associatedItem *bandwidthsv1.PublicIpinfo
+	allAssociatedItems := b.PublicipInfo
+	for i := range allAssociatedItems {
+		if allAssociatedItems[i].PublicipId == associatedID {
+			associatedItem = &allAssociatedItems[i]
 			break
 		}
 	}
 
-	if eipItem == nil {
+	if associatedItem == nil {
 		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
 	}
 
@@ -135,9 +205,32 @@ func resourceBandWidthAssociateRead(_ context.Context, d *schema.ResourceData, m
 		d.Set("region", region),
 		d.Set("bandwidth_id", b.ID),
 		d.Set("bandwidth_name", b.Name),
-		d.Set("eip_id", eipItem.PublicipId),
-		d.Set("public_ip", eipItem.PublicipAddress),
+		d.Set("public_ip_type", associatedItem.PublicipType),
+		d.Set("ip_version", associatedItem.IPVersion),
+		d.Set("public_ip", associatedItem.PublicipAddress),
+		d.Set("public_ipv6", associatedItem.Publicipv6Address),
 	)
+
+	if eipID == "" {
+		associatedPort, err := ports.Get(vpcClient, portID)
+		if err != nil {
+			return common.CheckDeletedDiag(d, err, "error fetching port")
+		}
+		mErr = multierror.Append(mErr,
+			d.Set("port_id", associatedItem.PublicipId),
+			d.Set("fixed_ip", associatedItem.Publicipv6Address),
+			d.Set("network_id", associatedPort.NetworkId),
+			d.Set("eip_id", ""),
+		)
+	} else {
+		mErr = multierror.Append(mErr,
+			d.Set("eip_id", associatedItem.PublicipId),
+			d.Set("port_id", ""),
+			d.Set("fixed_ip", ""),
+			d.Set("network_id", ""),
+		)
+	}
+
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
@@ -152,24 +245,56 @@ func resourceBandWidthAssociateUpdate(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		return diag.Errorf("error creating EIP client: %s", err)
 	}
+	vpcClient, err := cfg.NetworkingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
+	}
 
-	if d.HasChange("eip_id") {
+	if d.HasChanges("eip_id", "port_id", "fixed_ip", "network_id") {
 		bwID := d.Get("bandwidth_id").(string)
-		oldVal, newVal := d.GetChange("eip_id")
+		oldEipId, newEipId := d.GetChange("eip_id")
+		oldPortId, newPortId := d.GetChange("port_id")
+		newNetworkId := d.Get("network_id").(string)
+		newFixedIp := d.Get("fixed_ip").(string)
 
-		err = removeEIPsFromBandwidth(d, bwClient, eipClient, bwID, oldVal.(string))
+		// remove old
+		if oldEipId.(string) != "" {
+			err = removeEIPsFromBandwidth(d, bwClient, eipClient, bwID, oldEipId.(string))
+		} else {
+			err = removePortFromBandwidth(bwClient, vpcClient, bwID, oldPortId.(string))
+		}
 		if err != nil {
 			return diag.FromErr(err)
 		}
 
-		err = insertEIPsToBandwidth(d, bwClient, eipClient, bwID, newVal.(string))
-		if err != nil {
-			return diag.FromErr(err)
-		}
+		// insert new
+		if newEipId.(string) != "" {
+			err = insertEIPsToBandwidth(d, bwClient, eipClient, bwID, newEipId.(string))
+			if err != nil {
+				return diag.FromErr(err)
+			}
 
-		// update the resource ID
-		resourceID := fmt.Sprintf("%s/%s", bwID, newVal.(string))
-		d.SetId(resourceID)
+			// update the resource ID
+			resourceID := fmt.Sprintf("%s/%s", bwID, newEipId.(string))
+			d.SetId(resourceID)
+		} else {
+			portID := newPortId.(string)
+			if !d.HasChange("port_id") {
+				portID, err = getPortbyFixedIP(vpcClient, newNetworkId, newFixedIp)
+				if err != nil {
+					return diag.Errorf("unable to get port ID of %s: %s", newFixedIp, err)
+				}
+			}
+
+			if err = insertPortToBandwidth(bwClient, vpcClient, bwID, portID); err != nil {
+				return diag.FromErr(err)
+			}
+
+			// update the resource ID and port ID
+			resourceID := fmt.Sprintf("%s/%s", bwID, portID)
+			d.SetId(resourceID)
+			d.Set("port_id", portID)
+		}
 	}
 
 	return resourceBandWidthAssociateRead(ctx, d, meta)
@@ -186,14 +311,95 @@ func resourceBandWidthAssociateDelete(_ context.Context, d *schema.ResourceData,
 	if err != nil {
 		return diag.Errorf("error creating EIP client: %s", err)
 	}
+	vpcClient, err := cfg.NetworkingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
+	}
 
 	bwID := d.Get("bandwidth_id").(string)
 	eipID := d.Get("eip_id").(string)
+	portID := d.Get("port_id").(string)
 
-	err = removeEIPsFromBandwidth(d, bwClient, eipClient, bwID, eipID)
-	if err != nil {
-		return diag.FromErr(err)
+	if eipID != "" {
+		err = removeEIPsFromBandwidth(d, bwClient, eipClient, bwID, eipID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		err = removePortFromBandwidth(bwClient, vpcClient, bwID, portID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
+
+	return nil
+}
+
+func insertPortToBandwidth(bwClient, vpcClient *golangsdk.ServiceClient, bwID, portID string) error {
+	associatedPort, err := ports.Get(vpcClient, portID)
+	if err != nil {
+		return fmt.Errorf("error fetching port %s: %s", portID, err)
+	}
+	if associatedPort.Ipv6BandwidthId != "" {
+		// the port is already associated to the shared bandwidth, return with success.
+		if associatedPort.Ipv6BandwidthId == bwID {
+			log.Printf("[DEBUG] port %s is already associated to shared bandwidth %s", portID, bwID)
+			return nil
+		}
+		// the port is associated to another shared bandwidth, we should remove it first.
+		if err := removePortFromBandwidth(bwClient, vpcClient, associatedPort.Ipv6BandwidthId, portID); err != nil {
+			return err
+		}
+	}
+
+	insertOpts := bandwidths.BandWidthInsertOpts{
+		PublicipInfo: []bandwidths.PublicIpInfoID{
+			{
+				PublicIPID:   portID,
+				PublicIPType: PublicIPv6Type,
+			},
+		},
+	}
+
+	log.Printf("[DEBUG] Insert port %s to bandwidth %s", portID, bwID)
+	_, err = bandwidths.Insert(bwClient, bwID, insertOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error inserting %s into bandwidth %s: %s", portID, bwID, err)
+	}
+
+	return nil
+}
+
+func removePortFromBandwidth(bwClient, vpcClient *golangsdk.ServiceClient, bwID, portID string) error {
+	if _, err := ports.Get(vpcClient, portID); err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			log.Printf("[WARN] unnecessary to remove the non-existent port %s from bandwidth %s", portID, bwID)
+			return nil
+		}
+		return fmt.Errorf("error fetching port %s: %s", portID, err)
+	}
+
+	// chargeMode and size are not required in actual, although they are required in docs
+	removalChargeMode := "bandwidth"
+	removalSize := 5
+
+	removeOpts := bandwidths.BandWidthRemoveOpts{
+		ChargeMode: removalChargeMode,
+		Size:       &removalSize,
+		PublicipInfo: []bandwidths.PublicIpInfoID{
+			{
+				PublicIPID:   portID,
+				PublicIPType: PublicIPv6Type,
+			},
+		},
+	}
+
+	log.Printf("[DEBUG] Remove port %s from bandwidth %s", portID, bwID)
+	err := bandwidths.Remove(bwClient, bwID, removeOpts).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("error removing %s from bandwidth: %s", portID, err)
+	}
+
 	return nil
 }
 
@@ -270,16 +476,59 @@ func removeEIPsFromBandwidth(d *schema.ResourceData, bwClient, eipClient *golang
 	return nil
 }
 
-func resourceBandWidthAssociationImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+func resourceBandWidthAssociationImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData,
 	error) {
-	parts := strings.SplitN(d.Id(), "/", 2)
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid format for import ID, want '<bandwidth_id>/<eip_id>', but '%s'", d.Id())
+	parts := strings.Split(d.Id(), "/")
+	length := len(parts)
+	if length != 2 && length != 3 {
+		return nil, fmt.Errorf("invalid format for import ID, want '<bandwidth_id>/<eip_id>' or '<bandwidth_id>/<port_id>',"+
+			" or '<bandwidth_id>/<network_id>/<fixed_ip>', but got '%s'", d.Id())
 	}
 
 	mErr := multierror.Append(nil,
 		d.Set("bandwidth_id", parts[0]),
-		d.Set("eip_id", parts[1]),
 	)
+
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	vpcClient, err := cfg.NetworkingV1Client(region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating VPC client: %s", err)
+	}
+	eipClient, err := cfg.NetworkingV1Client(region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating EIP client: %s", err)
+	}
+
+	if length == 3 {
+		networkID := parts[1]
+		fixedIP := parts[2]
+		portID, err := getPortbyFixedIP(vpcClient, networkID, fixedIP)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get port ID of %s: %s", fixedIP, err)
+		}
+
+		resourceID := fmt.Sprintf("%s/%s", parts[0], portID)
+		d.SetId(resourceID)
+		mErr = multierror.Append(mErr,
+			d.Set("network_id", parts[1]),
+			d.Set("fixed_ip", parts[2]),
+			d.Set("port_id", portID),
+		)
+	} else {
+		if _, err := eips.Get(eipClient, parts[1]).Extract(); err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); !ok {
+				return nil, fmt.Errorf("error getting eip(%s): %s", parts[1], err)
+			}
+			mErr = multierror.Append(mErr,
+				d.Set("port_id", parts[1]),
+			)
+		} else {
+			mErr = multierror.Append(mErr,
+				d.Set("eip_id", parts[1]),
+			)
+		}
+	}
+
 	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to insert ipv6 port to bandwidth
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support to insert ipv6 port to bandwidth
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
./scripts/acc-test.sh 

run acceptance tests of huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_bandwidth_associate_test.go:
=== RUN   TestAccBandWidthAssociate_basic
=== PAUSE TestAccBandWidthAssociate_basic
=== RUN   TestAccBandWidthAssociate_migrate
=== PAUSE TestAccBandWidthAssociate_migrate
=== RUN   TestAccBandWidthAssociate_migrate_ipv6
=== PAUSE TestAccBandWidthAssociate_migrate_ipv6
=== CONT  TestAccBandWidthAssociate_basic
=== CONT  TestAccBandWidthAssociate_migrate_ipv6
=== CONT  TestAccBandWidthAssociate_migrate
--- PASS: TestAccBandWidthAssociate_migrate (117.38s)
--- PASS: TestAccBandWidthAssociate_migrate_ipv6 (135.48s)
--- PASS: TestAccBandWidthAssociate_basic (355.42s)
PASS
coverage: 19.4% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       355.508s        coverage: 19.4% of statements in ./huaweicloud/services/eip

### coverage of files in huaweicloud/services:

- github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip/resource_huaweicloud_vpc_bandwidth_associate.go (80.1%)

### [summary] 0 failed in 1 resource acceptance tests
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
