### PR TITLE
feat(RDS): rds pg database privilege resource support delete users

### DIFF
--- a/docs/resources/rds_pg_database_privilege.md
+++ b/docs/resources/rds_pg_database_privilege.md
@@ -75,3 +75,4 @@ This resource provides the following timeouts configuration options:
 
 * `create` - Default is 30 minutes.
 * `update` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_database_privilege_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_database_privilege_test.go
@@ -53,19 +53,14 @@ resource "huaweicloud_rds_instance" "test" {
 }
 
 resource "huaweicloud_rds_pg_account" "test" {
-  count = 2
+  count = 4
 
   instance_id = huaweicloud_rds_instance.test.id
   name        = "%[2]s_${count.index}"
-  password    = "Test@123456789"
+  password    = "Test@159357"
 }
 
 resource "huaweicloud_rds_pg_database" "test" {
-  depends_on = [
-    huaweicloud_rds_pg_account.test[0],
-    huaweicloud_rds_pg_account.test[1],
-  ]
-
   instance_id   = huaweicloud_rds_instance.test.id
   name          = "%[2]s"
   owner         = "root"
@@ -120,12 +115,12 @@ resource "huaweicloud_rds_pg_database_privilege" "test" {
   db_name     = huaweicloud_rds_pg_database.test.name
 
   users {
-    name        = huaweicloud_rds_pg_account.test[0].name
+    name        = huaweicloud_rds_pg_account.test[2].name
     readonly    = false
     schema_name = "public"
   }
   users {
-    name        = huaweicloud_rds_pg_account.test[1].name
+    name        = huaweicloud_rds_pg_account.test[3].name
     readonly    = true
     schema_name = "public"
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds pg database privilege resource support delete users
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds pg database privilege resource support delete users
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccPgDatabasePrivilege_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccPgDatabasePrivilege_basic -timeout 360m -parallel 4
=== RUN   TestAccPgDatabasePrivilege_basic
=== PAUSE TestAccPgDatabasePrivilege_basic
=== CONT  TestAccPgDatabasePrivilege_basic
--- PASS: TestAccPgDatabasePrivilege_basic (729.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       729.528s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
