### PR TITLE
feat(cts): notification supports some attributes

### DIFF
--- a/docs/data-sources/cts_notifications.md
+++ b/docs/data-sources/cts_notifications.md
@@ -75,6 +75,8 @@ The `notifications` block supports:
 
 * `created_at` - The creation time of the CTS key event notification.
 
+* `agency_name` - The cloud service agency name.
+
 <a name="Notifications_Operations"></a>
 The `operations` block supports:
 

--- a/docs/resources/cts_notification.md
+++ b/docs/resources/cts_notification.md
@@ -135,6 +135,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - The notification status, the value can be **enabled** or **disabled**.
 
+* `created_at` - The creation time of the notification.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:

--- a/huaweicloud/services/acceptance/cts/data_source_huaweicloud_cts_notifications_test.go
+++ b/huaweicloud/services/acceptance/cts/data_source_huaweicloud_cts_notifications_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccDatasourceCTSNotifications_basic(t *testing.T) {
-	defaultDataSourceName := "data.huaweicloud_cts_notifications.test"
+	defaultDataSourceName := "data.huaweicloud_cts_notifications.filter_by_name"
 	dc := acceptance.InitDataSourceCheck(defaultDataSourceName)
 	name := acceptance.RandomAccResourceName()
 	baseConfig := testAccDatasourceCTSNotifications_base(name)
@@ -23,6 +23,7 @@ func TestAccDatasourceCTSNotifications_basic(t *testing.T) {
 				Config: testAccDatasourceCTSNotifications_basic(baseConfig),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(defaultDataSourceName, "notifications.0.agency_name", "cts_admin_trust"),
 					resource.TestCheckResourceAttrSet(defaultDataSourceName, "notifications.0.name"),
 					resource.TestCheckResourceAttrSet(defaultDataSourceName, "notifications.0.operation_type"),
 					resource.TestCheckResourceAttrSet(defaultDataSourceName, "notifications.0.status"),
@@ -49,6 +50,7 @@ resource "huaweicloud_cts_notification" "notify" {
   name           = "%[1]s_1"
   operation_type = "complete"
   smn_topic      = huaweicloud_smn_topic.topic_1.id
+  agency_name    = "cts_admin_trust"
   
   filter {
     condition = "AND"

--- a/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_notification_test.go
+++ b/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_notification_test.go
@@ -78,6 +78,7 @@ func TestAccCTSNotification_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "agency_name", "cts_admin_trust"),
 					resource.TestCheckResourceAttrPair(resourceName, "smn_topic",
 						"huaweicloud_smn_topic.topic_1", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 				),
 			},
 			{

--- a/huaweicloud/services/cts/data_source_huaweicloud_cts_notifications.go
+++ b/huaweicloud/services/cts/data_source_huaweicloud_cts_notifications.go
@@ -161,6 +161,11 @@ func DataSourceNotifications() *schema.Resource {
 							Computed:    true,
 							Description: "The creation time of the CTS key event notification.",
 						},
+						"agency_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The cloud service agency name.",
+						},
 					},
 				},
 				Description: "All CTS key event notifications that match the filter parameters.",
@@ -265,11 +270,12 @@ func flattenAllNotifications(d *schema.ResourceData, notifications []interface{}
 		createTime := utils.PathSearch("create_time", notification, float64(0)).(float64)
 
 		notificationMap := map[string]interface{}{
-			"id":         actualNotificationId,
-			"name":       name,
-			"topic_id":   actualTopicId,
-			"filter":     flattenNotificationFilter(filter),
-			"created_at": utils.FormatTimeStampRFC3339(int64(createTime)/1000, false),
+			"id":          actualNotificationId,
+			"name":        name,
+			"topic_id":    actualTopicId,
+			"filter":      flattenNotificationFilter(filter),
+			"created_at":  utils.FormatTimeStampRFC3339(int64(createTime)/1000, false),
+			"agency_name": utils.PathSearch("agency_name", notification, nil),
 		}
 
 		operations := utils.PathSearch("operations", notification, make([]interface{}, 0)).([]interface{})

--- a/huaweicloud/services/cts/resource_huaweicloud_cts_notification.go
+++ b/huaweicloud/services/cts/resource_huaweicloud_cts_notification.go
@@ -140,6 +140,10 @@ func ResourceCTSNotification() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -332,6 +336,7 @@ func resourceCTSNotificationRead(_ context.Context, d *schema.ResourceData, meta
 	operations := utils.PathSearch("operations", notification, make([]interface{}, 0)).([]interface{})
 	notifyUserList := utils.PathSearch("notify_user_list", notification, make([]interface{}, 0)).([]interface{})
 	status := utils.PathSearch("status", notification, "").(string)
+	createTime := utils.PathSearch("create_time", notification, float64(0)).(float64)
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
 		d.Set("name", name),
@@ -344,6 +349,7 @@ func resourceCTSNotificationRead(_ context.Context, d *schema.ResourceData, meta
 		d.Set("operation_type", utils.PathSearch("operation_type", notification, nil)),
 		d.Set("status", status),
 		d.Set("enabled", status == "enabled"),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(createTime)/1000, false)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
notification supports some attributes
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. cts notification supports create_time attribute
2. cts notifications supports agency_name attribute
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 make testacc TEST="./huaweicloud/services/acceptance/cts" s_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccDatasourceCTSNotifications_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCTSNotifications_basic
=== PAUSE TestAccDatasourceCTSNotifications_basic
=== CONT  TestAccDatasourceCTSNotifications_basic
--- PASS: TestAccDatasourceCTSNotifications_basic (106.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       106.594s

 make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccCTSNotification_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSNotification_basic -timeout 360m -parallel 4
=== RUN   TestAccCTSNotification_basic
=== PAUSE TestAccCTSNotification_basic
=== CONT  TestAccCTSNotification_basic
--- PASS: TestAccCTSNotification_basic (75.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       75.280s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
