### PR TITLE
feat(cts): CTS traces supports read_only、operation_id attributes

### DIFF
--- a/docs/data-sources/cts_traces.md
+++ b/docs/data-sources/cts_traces.md
@@ -129,6 +129,10 @@ The `traces` block supports:
 
 * `trace_name` - The trace name.
 
+* `read_only` - Whether a user request is read-only.
+
+* `operation_id` - The operation ID of the trace.
+
 <a name="traces_user_struct"></a>
 The `user` block supports:
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -1575,13 +1575,6 @@ func TestAccPreCheckCCConnectionRouteRegionName(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckCtsTimeRange(t *testing.T) {
-	if HW_CTS_START_TIME == "" || HW_CTS_END_TIME == "" {
-		t.Skip("HW_CTS_START_TIME and HW_CTS_END_TIME must be set for CTS acceptance tests")
-	}
-}
-
-// lintignore:AT003
 func TestAccPreCheckWorkspaceADDomainNames(t *testing.T) {
 	if len(strings.Split(HW_WORKSPACE_AD_DOMAIN_NAMES, ",")) != 2 {
 		t.Skip(`The Workspace AD service need domain name configurations for both master and standby servers, plesse config them in the

--- a/huaweicloud/services/cts/data_source_huaweicloud_cts_traces.go
+++ b/huaweicloud/services/cts/data_source_huaweicloud_cts_traces.go
@@ -218,6 +218,16 @@ func DataSourceCtsTraces() *schema.Resource {
 							Computed:    true,
 							Description: `The trace name.`,
 						},
+						"read_only": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether a user request is read-only.`,
+						},
+						"operation_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The operation ID of the trace`,
+						},
 					},
 				},
 			},
@@ -357,6 +367,8 @@ func (w *TracesDSWrapper) listTracesToSchema(body *gjson.Result) error {
 					"service_type":  traces.Get("service_type").Value(),
 					"location_info": traces.Get("location_info").Value(),
 					"trace_name":    traces.Get("trace_name").Value(),
+					"read_only":     traces.Get("read_only").Value(),
+					"operation_id":  traces.Get("operation_id").Value(),
 				}
 			},
 		)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
CTS traces supports read_only、operation_id attributes
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. CTS traces supports read_only、operation_id attributes
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccDataSourceCtsTraces_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccDataSourceCtsTraces_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCtsTraces_basic
=== PAUSE TestAccDataSourceCtsTraces_basic
=== CONT  TestAccDataSourceCtsTraces_basic
--- PASS: TestAccDataSourceCtsTraces_basic (96.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       96.369s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
