### PR TITLE
feat(workspace): add new resource desktop pool

### DIFF
--- a/docs/resources/workspace_desktop_pool.md
+++ b/docs/resources/workspace_desktop_pool.md
@@ -1,0 +1,310 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_desktop_pool"
+description: |-
+  Manages a Workspace desktop pool resource within HuaweiCloud.
+---
+
+# huaweicloud_workspace_desktop_pool
+
+Manages a Workspace desktop pool resource within HuaweiCloud.
+
+-> Before creating Workspace desktop, ensure that the Workspace service has been registered.
+
+## Example Usage
+
+```hcl
+variable "desktop_pool_name" {}
+variable "product_id" {}
+variable "image_id" {}
+variable "vpc_id" {}
+variable "subnet_ids"  {
+  type = list(string)
+}
+variable "security_group_ids"  {
+  type = list(string)
+}
+variable "data_volume_sizes"  {
+  type = list(number)
+}
+variable "authorized_object_list" {
+  type = list(object({
+    object_id   = string  
+    object_type = string
+    object_name = string
+    user_group  = string
+  }))
+}
+
+resource "huaweicloud_workspace_desktop_pool" "test" {
+  name                          = var.desktop_pool_name
+  type                          = "DYNAMIC"
+  size                          = 1
+  product_id                    = var.product_id
+  image_type                    = "gold"
+  image_id                      = var.image_id
+  vpc_id                        = var.vpc_id
+  subnet_ids                    = var.subnet_ids
+  disconnected_retention_period = 10
+
+  root_volume {
+    type = "SAS"
+    size = 80
+  }
+
+  dynamic "security_groups" {
+    for_each = var.security_group_ids
+  
+    content {
+      id = security_groups.value
+    }
+  }
+
+  dynamic "data_volumes" {
+    for_each = var.data_volume_sizes
+  
+    content {
+      type = "SAS"
+      size = data_volumes.value
+    }
+  }
+
+  dynamic "authorized_objects" {
+    for_each = var.authorized_object_list
+  
+    content {
+      object_id   = authorized_objects.value.object_id
+      object_type = authorized_objects.value.object_type
+      object_name = authorized_objects.value.object_name
+      user_group  = authorized_objects.value.user_group
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the desktop pool.  
+  The name valid length is limited from `1` to `15`, only Chinese and English characters, digits and hyphens (-) are allowed.
+
+* `type` - (Required, String, NonUpdatable) Specifies the type of the desktop pool.  
+  The valid values are as follows:
+  + **DYNAMIC**
+  + **STATIC**
+
+* `size` - (Required, Int, NonUpdatable) Specifies the number of the desktops under the desktop pool.  
+  The valid value ranges from `1` to `100`.
+
+  -> This parameter will be affected by `autoscale_policy` parameter and will appear when `terraform plan` or
+    `terraform apply`. If it is inconsistent with the script configuration, it can be ignored by `ignore_changes`
+    in non-change scenarios.
+
+* `product_id` - (Required, String, NonUpdatable) Specifies the specification ID of the desktop pool.
+
+* `image_type` - (Required, String, NonUpdatable) Specifies the image type of the desktop pool.  
+  The valid values are as follows:
+  + **private**
+  + **gold**
+
+* `image_id` - (Required, String, NonUpdatable) Specifies the image ID of the desktop pool.
+
+* `root_volume` - (Required, List, NonUpdatable) Specifies the system volume configuration of the desktop pool.  
+  The [root_volume](#desktop_pool_volume) structure is documented below.
+
+* `subnet_ids` - (Required, List, NonUpdatable) Specifies the list of the subnet IDs to which the desktop pool belongs.
+
+* `vpc_id` - (Optional, String) Specifies the ID of the VPC to which the desktop pool belongs.
+
+* `security_groups` - (Optional, List, NonUpdatable) Specifies the list of the security groups to which the
+  desktop pool belongs.  
+  The [security_groups](#desktop_pool_security_groups) structure is documented below.
+
+* `data_volumes` - (Optional, List, NonUpdatable) Specifies the list of the data volume configurations of
+  the desktop pool.  
+  The [data_volumes](#desktop_pool_volume) structure is documented below.
+  
+* `authorized_objects` - (Optional, List, NonUpdatable) Specifies the list of the users or user groups
+  to be authorized.  
+  The [authorized_objects](#desktop_pool_authorized_objects) structure is documented below.
+
+* `availability_zone` - (Optional, String) Specifies the availability zone to which the desktop pool belongs.
+
+* `disconnected_retention_period` - (Optional, Int) Specifies the desktops and users disconnection retention period
+  under desktop pool, in minutes.  
+  The valid value ranges from `10` to `43,200`.  
+  This parameter is available and required only when the `type` is set to **DYNAMIC**.
+
+* `enable_autoscale` - (Optional, Bool) Specifies whether to enable elastic scaling of the desktop pool.  
+  Defaults to **false**.
+
+* `autoscale_policy` - (Optional, List) Specifies the automatic scaling policy of the desktop pool.  
+  The [autoscale_policy](#desktop_pool_autoscale_policy) structure is documented below.  
+  This parameter is available only when the `enable_autoscale` is set to **true**.
+
+* `desktop_name_policy_id` - (Optional, String) Specifies the ID of the policy to generate the desktop name.
+
+* `ou_name` - (Optional, String) Specifies the OU name corresponding to the AD server.  
+  This parameter is available only when the AD server is connected.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the ID of the enterprise project to which
+  the desktop pool belongs.  
+  This parameter is only valid for enterprise users, if omitted, default enterprise project will be used.
+
+* `description` - (Optional, String) Specifies the description of the desktop pool.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the desktop pool.
+
+* `in_maintenance_mode` - (Optional, Bool) Specifies whether to enable maintenance mode of the desktop pool.  
+  Defaults to **false**.
+
+<a name="desktop_pool_volume"></a>
+The `root_volume` block supports:
+
+* `type` - (Required, String) Specifies the type of the volume.  
+  The valid values are as follows:
+  + **SAS**: High I/O disk type.
+  + **SSD**: Ultra-high I/O disk type.
+
+* `size` - (Required, Int) Specifies the size of the volume, in GB.
+  + For root volume, the valid value ranges from `80` to `1,020`.
+  + For data volume, the valid value ranges from `10` to `8,200`.
+
+<a name="desktop_pool_authorized_objects"></a>
+The `authorized_objects` block supports:
+
+* `object_id` - (Required, String) Specifies the ID of the object.
+
+* `object_type` - (Required, String) Specifies the type of the object.  
+  The valid values are as follows:
+  + **USER**
+  + **USER_GROUP**
+
+* `object_name` - (Required, String) Specifies the name of the object.
+
+* `user_group` - (Required, String) Specifies the permission group to which the user belongs.  
+  The valid values are as follows:
+  + **sudo**: Linux administrator group.
+  + **default**: Linux default user group.
+  + **administrators**: Windows administrator group.
+  + **users**: Windows standard user group.
+
+<a name="desktop_pool_autoscale_policy"></a>
+The `autoscale_policy` block supports:
+
+* `autoscale_type` - (Optional, String) Specifies the type of automatic scaling policy.  
+  The valid values are as follows:
+  + **ACCESS_CREATED**: Create desktops during accessing.
+  + **AUTO_CREATED**: Pre-creation desktops.
+
+* `max_auto_created` - (Optional, Int) Specifies the maximum number of automatically created desktops.  
+  The valid value ranges from `1` to `1,000`.
+
+* `min_idle` - (Optional, Int) Specifies the desktops will be automatically created when the number of idle desktops is
+  less than this value.  
+  The valid value ranges from `1` to `1,000`.
+
+* `once_auto_created` - (Optional, Int) Specifies the number of desktops automatically created at one time.  
+  The valid value ranges from `1` to `100`.
+
+<a name="desktop_pool_security_groups"></a>
+The `security_groups` block supports:
+
+* `id` - (Required, String, NonUpdatable) Specifies the ID of the security group.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also desktop pool ID.
+
+* `root_volume` - The system volume configuration of the desktop pool.  
+  The [root_volume](#attr_desktop_pool_volume) structure is documented below.
+  
+* `data_volumes` - The list of the data volume configurations of the desktop pool.  
+  The [data_volumes](#attr_desktop_pool_volume) structure is documented below.
+
+* `status` - The status of the desktop pool.
+  + **STEADY**
+  + **TEMPORARY**
+  + **EXIST_FROZEN**
+  + **UNKNOWN**
+  
+* `created_time` - The creation time of the desktop pool, in UTC format.
+
+* `desktop_used` - The number of desktops associated with the users under the desktop pool.
+
+* `product` - The product information of the desktop pool.  
+  The [product](#attr_desktop_pool_product) structure is documented below.
+  
+* `image_name` - The image name of the desktop pool.
+
+* `image_os_type` - The image OS type of the desktop pool.
+
+* `image_os_version` - The image OS version of the desktop pool.
+
+* `image_os_platform` - The image OS platform of the desktop pool.
+
+<a name="attr_desktop_pool_volume"></a>
+The `data_volumes` block supports:
+
+* `id` - The ID of the volume.
+
+<a name="attr_desktop_pool_product"></a>
+The `product` block supports:
+
+* `flavor_id` - The product specification ID of the desktop pool.
+
+* `type` - The product type of the desktop pool.
+  + **BASE**: Basic package of the product.
+
+* `memory` - The product memory of the desktop pool.
+
+* `cpu` - The product CPU of the desktop pool.
+
+* `descriptions` - The product description of the desktop pool.
+
+* `charging_mode` - The product charging mode of the desktop pool.
+  + **0**: The yearly/monthly billing mode.
+  + **1**: The pay-per-use billing mode.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.
+* `delete` - Default is 20 minutes.
+
+## Import
+
+The desktop pool can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_workspace_desktop_pool.test <id>
+```
+
+Please add the followings if some attributes are missing when importing the resource.
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes include: `vpc_id`, `image_type`, `tags`, `ou_name`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the instance. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_workspace_desktop_pool" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      vpc_id, image_type, tags, ou_name,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2340,6 +2340,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_access_policy":           workspace.ResourceAccessPolicy(),
 			"huaweicloud_workspace_desktop_name_rule":       workspace.ResourceDesktopNameRule(),
 			"huaweicloud_workspace_desktop":                 workspace.ResourceDesktop(),
+			"huaweicloud_workspace_desktop_pool":            workspace.ResourceDesktopPool(),
 			"huaweicloud_workspace_policy_group":            workspace.ResourcePolicyGroup(),
 			"huaweicloud_workspace_service":                 workspace.ResourceService(),
 			"huaweicloud_workspace_terminal_binding":        workspace.ResourceTerminalBinding(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -236,6 +236,7 @@ var (
 	HW_WORKSPACE_OU_NAME                           = os.Getenv("HW_WORKSPACE_OU_NAME")
 	HW_WORKSPACE_APP_FILE_NAME                     = os.Getenv("HW_WORKSPACE_APP_FILE_NAME")
 	HW_WORKSPACE_USER_NAMES                        = os.Getenv("HW_WORKSPACE_USER_NAMES")
+	HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID             = os.Getenv("HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID")
 
 	HW_FGS_AGENCY_NAME         = os.Getenv("HW_FGS_AGENCY_NAME")
 	HW_FGS_APP_AGENCY_NAME     = os.Getenv("HW_FGS_APP_AGENCY_NAME")
@@ -1631,6 +1632,13 @@ func TestAccPrecheckWorkspaceUserNames(t *testing.T) {
 func TestAccPreCheckWorkspaceOUName(t *testing.T) {
 	if HW_WORKSPACE_OU_NAME == "" {
 		t.Skip("HW_WORKSPACE_OU_NAME must be set for Workspace service acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckWorkspaceDesktopPoolImageId(t *testing.T) {
+	if HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID == "" {
+		t.Skip("HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID must be set for Workspace desktop pool acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_desktop_pool_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_desktop_pool_test.go
@@ -1,0 +1,441 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/workspace"
+)
+
+func getDesktopPoolFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("workspace", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating Workspace client: %s", err)
+	}
+	return workspace.GetDesktopPoolById(client, state.Primary.ID)
+}
+
+func TestAccDesktopPool_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceNameWithDash()
+		updateName = acceptance.RandomAccResourceNameWithDash()
+
+		desktopPool  interface{}
+		resourceName = "huaweicloud_workspace_desktop_pool.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &desktopPool, getDesktopPoolFunc)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceDesktopPoolImageId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDesktopPool_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "type", "DYNAMIC"),
+					resource.TestCheckResourceAttr(resourceName, "size", "2"),
+					resource.TestCheckResourceAttrPair(resourceName, "product_id",
+						"data.huaweicloud_workspace_flavors.test", "flavors.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "image_id", acceptance.HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID),
+					resource.TestCheckResourceAttr(resourceName, "root_volume.0.type", "SAS"),
+					resource.TestCheckResourceAttr(resourceName, "root_volume.0.size", "80"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_ids.0",
+						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "security_groups.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "data_volumes.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "authorized_objects.#", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "authorized_objects.0.object_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "authorized_objects.0.object_name"),
+					resource.TestCheckResourceAttr(resourceName, "authorized_objects.0.object_type", "USER"),
+					resource.TestCheckResourceAttr(resourceName, "authorized_objects.0.user_group", "administrators"),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName, "disconnected_retention_period", "10"),
+					resource.TestCheckResourceAttr(resourceName, "enable_autoscale", "true"),
+					resource.TestCheckResourceAttr(resourceName, "autoscale_policy.0.autoscale_type", "AUTO_CREATED"),
+					resource.TestCheckResourceAttr(resourceName, "autoscale_policy.0.min_idle", "1"),
+					resource.TestCheckResourceAttr(resourceName, "autoscale_policy.0.max_auto_created", "2"),
+					resource.TestCheckResourceAttr(resourceName, "autoscale_policy.0.once_auto_created", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "desktop_name_policy_id",
+						"huaweicloud_workspace_desktop_name_rule.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "in_maintenance_mode", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Create a dynamic desktop pool"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
+			},
+			{
+				Config: testAccDesktopPool_basic_step2(name, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "availability_zone", ""),
+					resource.TestCheckResourceAttr(resourceName, "disconnected_retention_period", "43200"),
+					resource.TestCheckResourceAttr(resourceName, "enable_autoscale", "false"),
+					resource.TestCheckResourceAttr(resourceName, "autoscale_policy.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "desktop_name_policy_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "in_maintenance_mode", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					// Check attributes.
+					resource.TestCheckResourceAttrSet(resourceName, "root_volume.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "data_volumes.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "status", "STEADY"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "desktop_used"),
+					resource.TestCheckResourceAttrSet(resourceName, "product.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "product.0.type"),
+					resource.TestCheckResourceAttrSet(resourceName, "product.0.cpu"),
+					resource.TestCheckResourceAttrSet(resourceName, "product.0.memory"),
+					resource.TestCheckResourceAttrSet(resourceName, "product.0.descriptions"),
+					resource.TestCheckResourceAttrSet(resourceName, "product.0.charging_mode"),
+					resource.TestCheckResourceAttrSet(resourceName, "image_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "image_os_type"),
+					resource.TestCheckResourceAttrSet(resourceName, "image_os_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "image_os_platform"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"image_type",
+					"vpc_id",
+					"tags",
+				},
+			},
+		},
+	})
+}
+
+func testAccDesktopPool_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  os_type           = "Windows"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_workspace_desktop_name_rule" "test" {
+  name                         = replace("%[1]s", "-", "_")
+  name_prefix                  = "pool"
+  digit_number                 = 1
+  start_number                 = 1
+  single_domain_user_increment = 0
+}
+`, name)
+}
+
+func testAccDesktopPool_basic_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "huaweicloud_workspace_service" "test" {
+  access_mode = "INTERNET"
+  vpc_id      = huaweicloud_vpc.test.id
+  network_ids = [
+    huaweicloud_vpc_subnet.test.id
+  ]
+}
+
+resource "huaweicloud_workspace_user" "test" {
+  count = 2
+  name  = "%[3]s${count.index}"
+  email = "user@test.com"
+
+  depends_on = [huaweicloud_workspace_service.test]
+}
+`, common.TestBaseNetwork(name), testAccDesktopPool_base(name), name)
+}
+
+func testAccDesktopPool_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+locals {
+  data_volume_sizes = [50, 70]
+}
+
+resource "huaweicloud_workspace_desktop_pool" "test" {
+  name                          = "%[2]s"
+  type                          = "DYNAMIC"
+  size                          = 2
+  product_id                    = try(data.huaweicloud_workspace_flavors.test.flavors[0].id, "")
+  image_type                    = "gold"
+  image_id                      = "%[3]s"
+  subnet_ids                    = [huaweicloud_vpc_subnet.test.id]
+  vpc_id                        = huaweicloud_vpc.test.id
+  availability_zone             = data.huaweicloud_availability_zones.test.names[0]
+  disconnected_retention_period = 10
+  enable_autoscale              = true
+  desktop_name_policy_id        = huaweicloud_workspace_desktop_name_rule.test.id
+  description                   = "Create a dynamic desktop pool"
+  in_maintenance_mode           = true
+
+  root_volume {
+    type = "SAS"
+    size = 80
+  }
+
+  security_groups {
+    id = huaweicloud_workspace_service.test.desktop_security_group.0.id
+  }
+  security_groups {
+    id = huaweicloud_networking_secgroup.test.id
+  }
+
+  dynamic "data_volumes" {
+    for_each = local.data_volume_sizes
+
+    content {
+      type = "SAS"
+      size = data_volumes.value
+    }
+  }
+
+  dynamic "authorized_objects" {
+    for_each = huaweicloud_workspace_user.test[*]
+
+    content {
+      object_id   = authorized_objects.value.id
+      object_type = "USER"
+      object_name = authorized_objects.value.name
+      user_group  = "administrators"
+    }
+  }
+
+  autoscale_policy {
+    autoscale_type    = "AUTO_CREATED"
+    min_idle          = 1
+    max_auto_created  = 2
+    once_auto_created = 1
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, testAccDesktopPool_basic_base(name), name, acceptance.HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID)
+}
+
+func testAccDesktopPool_basic_step2(name, updateName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+locals {
+  data_volume_sizes = [50, 70]
+}
+
+resource "huaweicloud_workspace_desktop_pool" "test" {
+  name                          = "%[2]s"
+  type                          = "DYNAMIC"
+  size                          = 2
+  product_id                    = try(data.huaweicloud_workspace_flavors.test.flavors[0].id, "")
+  image_type                    = "gold"
+  image_id                      = "%[3]s"
+  subnet_ids                    = [huaweicloud_vpc_subnet.test.id]
+  vpc_id                        = huaweicloud_vpc.test.id
+  disconnected_retention_period = 43200
+
+  root_volume {
+    type = "SAS"
+    size = 80
+  }
+
+
+  security_groups {
+    id = huaweicloud_workspace_service.test.desktop_security_group.0.id
+  }
+  security_groups {
+    id = huaweicloud_networking_secgroup.test.id
+  }
+
+  dynamic "data_volumes" {
+    for_each = local.data_volume_sizes
+
+    content {
+      type = "SAS"
+      size = data_volumes.value
+    }
+  }
+
+  dynamic "authorized_objects" {
+    for_each = huaweicloud_workspace_user.test[*]
+
+    content {
+      object_id   = authorized_objects.value.id
+      object_type = "USER"
+      object_name = authorized_objects.value.name
+      user_group  = "administrators"
+    }
+  }
+}
+`, testAccDesktopPool_basic_base(name), updateName, acceptance.HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID)
+}
+
+// Before running this use case, you must add the OU on the AD server to the Workspace.
+func TestAccDesktopPool_localAD(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		desktopPool  interface{}
+		resourceName = "huaweicloud_workspace_desktop_pool.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &desktopPool, getDesktopPoolFunc)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceDesktopPoolImageId(t)
+			acceptance.TestAccPreCheckWorkspaceOUName(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDesktopPool_localAD_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "type", "STATIC"),
+					resource.TestCheckResourceAttr(resourceName, "size", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "product_id",
+						"data.huaweicloud_workspace_flavors.test", "flavors.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "image_id", acceptance.HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID),
+					resource.TestCheckResourceAttr(resourceName, "root_volume.0.type", "SAS"),
+					resource.TestCheckResourceAttr(resourceName, "root_volume.0.size", "80"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_ids.0",
+						"data.huaweicloud_workspace_service.test", "network_ids.0"),
+					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "data_volumes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "authorized_objects.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "availability_zone", ""),
+					resource.TestCheckResourceAttr(resourceName, "disconnected_retention_period", "0"),
+					resource.TestCheckResourceAttr(resourceName, "enable_autoscale", "false"),
+					resource.TestCheckResourceAttr(resourceName, "autoscale_policy.0.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "desktop_name_policy_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "ou_name", acceptance.HW_WORKSPACE_OU_NAME),
+					resource.TestCheckResourceAttr(resourceName, "in_maintenance_mode", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				Config: testAccDesktopPool_localAD_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName, "enable_autoscale", "true"),
+					resource.TestCheckResourceAttr(resourceName, "autoscale_policy.0.autoscale_type", "ACCESS_CREATED"),
+					resource.TestCheckResourceAttr(resourceName, "autoscale_policy.0.max_auto_created", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "desktop_name_policy_id",
+						"huaweicloud_workspace_desktop_name_rule.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "ou_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "in_maintenance_mode", "true"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated desktop pool"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "update"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"image_type",
+					"tags",
+					"ou_name",
+				},
+			},
+		},
+	})
+}
+
+func testAccDesktopPool_localAD_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_workspace_service" "test" {}
+
+resource "huaweicloud_workspace_desktop_pool" "test" {
+  name                  = "%[2]s"
+  type                  = "STATIC"
+  size                  = 1
+  product_id            = try(data.huaweicloud_workspace_flavors.test.flavors[0].id, "")
+  image_type            = "gold"
+  image_id              = "%[3]s"
+  subnet_ids            = try(slice(data.huaweicloud_workspace_service.test.network_ids, 0, 1), [])
+  enterprise_project_id = "%[4]s"
+  ou_name               = "%[5]s"
+
+  root_volume {
+    type = "SAS"
+    size = 80
+  }
+}
+`, testAccDesktopPool_base(name),
+		name,
+		acceptance.HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID,
+		acceptance.HW_ENTERPRISE_PROJECT_ID_TEST,
+		acceptance.HW_WORKSPACE_OU_NAME)
+}
+
+func testAccDesktopPool_localAD_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_workspace_service" "test" {}
+
+resource "huaweicloud_workspace_desktop_pool" "test" {
+  name                   = "%[2]s"
+  type                   = "STATIC"
+  size                   = 1
+  product_id             = try(data.huaweicloud_workspace_flavors.test.flavors[0].id, "")
+  image_type             = "gold"
+  image_id               = "%[3]s"
+  subnet_ids             = try(slice(data.huaweicloud_workspace_service.test.network_ids, 0, 1), [])
+  availability_zone      = data.huaweicloud_availability_zones.test.names[0]
+  enable_autoscale       = true
+  desktop_name_policy_id = huaweicloud_workspace_desktop_name_rule.test.id
+  description            = "Updated desktop pool"
+  in_maintenance_mode    = true
+  enterprise_project_id  = "%[4]s"
+  
+  root_volume {
+    type = "SAS"
+    size = 80
+  }
+
+  autoscale_policy {
+    autoscale_type   = "ACCESS_CREATED"
+    max_auto_created = 1
+  }
+
+  tags = {
+    foo = "update"
+  }
+}
+`, testAccDesktopPool_base(name),
+		name,
+		acceptance.HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID,
+		acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop_pool.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop_pool.go
@@ -1,0 +1,942 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace POST /v2/{project_id}/desktop-pools
+// @API Workspace GET /v2/{project_id}/workspace-sub-jobs
+// @API Workspace GET /v2/{project_id}/desktop-pools/{pool_id}
+// @API Workspace GET /v2/{project_id}/desktop-pools/{pool_id}/users
+// @API Workspace PUT /v2/{project_id}/desktop-pools/{pool_id}
+// @API Workspace GET /v2/{project_id}/desktops
+// @API Workspace POST /v2/{project_id}/desktops/batch-delete
+// @API Workspace DELETE /v2/{project_id}/desktop-pools/{pool_id}
+var nonUpdatableParams = []string{"type", "size", "product_id", "image_type", "image_id", "root_volume",
+	"root_volume.*.type", "root_volume.*.size", "subnet_ids",
+	"vpc_id", "security_groups", "data_volumes", "authorized_objects", "enterprise_project_id"}
+
+func ResourceDesktopPool() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDesktopPoolCreate,
+		ReadContext:   resourceDesktopPoolRead,
+		UpdateContext: resourceDesktopPoolUpdate,
+		DeleteContext: resourceDesktopPoolDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the desktop pool.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the desktop pool.`,
+			},
+			"size": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The number of the desktops under the desktop pool.`,
+			},
+			"product_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The specification ID of the desktop pool.`,
+			},
+			"image_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The image type of the desktop pool.`,
+			},
+			"image_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The image ID of the desktop pool.`,
+			},
+			"root_volume": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Elem:        desktopPoolVolumeSchema(),
+				Description: `The system volume configuration of the desktop pool.`,
+			},
+			"subnet_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of the subnet IDs to which the desktop pool belongs.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the VPC to which the desktop pool belongs.`,
+			},
+			"security_groups": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The ID of the security group.`,
+						},
+					},
+				},
+				Description: `The list of the security groups to which the desktop pool belongs.`,
+			},
+			"data_volumes": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem:        desktopPoolVolumeSchema(),
+				Description: `The list of the data volume configurations of the desktop pool.`,
+			},
+			"authorized_objects": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"object_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The ID of the object.`,
+						},
+						"object_type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The type of the object.`,
+						},
+						"object_name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The name of the object.`,
+						},
+						"user_group": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The permission group to which the user belongs.`,
+						},
+					},
+				},
+				Description: `The list of the users or user groups to be authorized.`,
+			},
+			"availability_zone": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The availability zone to which the desktop pool belongs.`,
+			},
+			"disconnected_retention_period": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The desktops and users disconnection retention period under desktop pool, in minutes.`,
+			},
+			"enable_autoscale": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to enable elastic scaling of the desktop pool.`,
+			},
+			"autoscale_policy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"autoscale_type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The type of automatic scaling policy.`,
+						},
+						"max_auto_created": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: `The maximum number of automatically created desktops.`,
+						},
+						"min_idle": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Description: `The desktops will be automatically created when the number of idle desktops is less than
+							the specified value.`,
+						},
+						"once_auto_created": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: `The number of desktops automatically created at one time.`,
+						},
+					},
+				},
+				Description: `The automatic scaling policy of the desktop pool.`,
+			},
+			"desktop_name_policy_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the policy to generate the desktop name.`,
+			},
+			"ou_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The OU name corresponding to the AD server.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The ID of the enterprise project to which the desktop pool belongs.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the desktop pool.`,
+			},
+			"tags": common.TagsSchema(`The key/value pairs to associate with the desktop pool.`),
+			"in_maintenance_mode": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to enable maintenance mode of the desktop pool.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the desktop pool.`,
+			},
+			"created_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the desktop pool, in UTC format.`,
+			},
+			"desktop_used": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of desktops associated with the users under the desktop pool.`,
+			},
+			"product": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"flavor_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The product specification ID of the desktop pool.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The product type of the desktop pool.`,
+						},
+						"cpu": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The product CPU of the desktop pool.`,
+						},
+						"memory": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The product memory of the desktop pool.`,
+						},
+						"descriptions": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The product description of the desktop pool.`,
+						},
+						"charging_mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The product charging mode of the desktop pool.`,
+						},
+					},
+				},
+				Description: `The product information of the desktop pool.`,
+			},
+			"image_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The image name of the desktop pool.`,
+			},
+			"image_os_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The image OS type of the desktop pool.`,
+			},
+			"image_os_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The image OS version of the desktop pool.`,
+			},
+			"image_os_platform": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The image OS platform of the desktop pool.`,
+			},
+		},
+	}
+}
+
+func desktopPoolVolumeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the volume.`,
+			},
+			"size": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The size of the volume, in GB.`,
+			},
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the volume.`,
+			},
+		},
+	}
+}
+
+func buildCreateDesktopPoolBodyParam(epsId string, d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		// Required.
+		"name":        d.Get("name"),
+		"type":        d.Get("type"),
+		"size":        d.Get("size"),
+		"product_id":  d.Get("product_id"),
+		"image_type":  d.Get("image_type"),
+		"image_id":    d.Get("image_id"),
+		"root_volume": buildDesktopPoolRootVolume(d.Get("root_volume.0")),
+		"subnet_ids":  d.Get("subnet_ids"),
+		// Optional.
+		"vpc_id":                        utils.ValueIgnoreEmpty(d.Get("vpc_id")),
+		"security_groups":               buildDesktopPoolSecurityGroups(d.Get("security_groups").(*schema.Set)),
+		"availability_zone":             utils.ValueIgnoreEmpty(d.Get("availability_zone")),
+		"data_volumes":                  buildDesktopPoolDataVolumes(d.Get("data_volumes").(*schema.Set)),
+		"authorized_objects":            buildDesktopPoolAuthorizedObjects(d.Get("authorized_objects").(*schema.Set)),
+		"disconnected_retention_period": utils.ValueIgnoreEmpty(d.Get("disconnected_retention_period")),
+		"enable_autoscale":              d.Get("enable_autoscale"),
+		"autoscale_policy":              buildDesktopPoolAutoScalePolicy(d.Get("autoscale_policy").([]interface{})),
+		"desktop_name_policy_id":        utils.ValueIgnoreEmpty(d.Get("desktop_name_policy_id")),
+		"ou_name":                       utils.ValueIgnoreEmpty(d.Get("ou_name")),
+		"tags":                          utils.ValueIgnoreEmpty(utils.ExpandResourceTags(d.Get("tags").(map[string]interface{}))),
+		"enterprise_project_id":         utils.ValueIgnoreEmpty(epsId),
+		"description":                   utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+}
+
+func buildDesktopPoolRootVolume(rootVolume interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"type": utils.PathSearch("type", rootVolume, nil),
+		"size": utils.PathSearch("size", rootVolume, nil),
+	}
+}
+
+func buildDesktopPoolDataVolumes(dataVolumes *schema.Set) []map[string]interface{} {
+	if dataVolumes.Len() == 0 {
+		return nil
+	}
+
+	rest := make([]map[string]interface{}, dataVolumes.Len())
+	for i, v := range dataVolumes.List() {
+		rest[i] = map[string]interface{}{
+			"type": utils.PathSearch("type", v, nil),
+			"size": utils.PathSearch("size", v, nil),
+		}
+	}
+	return rest
+}
+
+func buildDesktopPoolSecurityGroups(secutityGroups *schema.Set) []map[string]interface{} {
+	if secutityGroups.Len() == 0 {
+		return nil
+	}
+	rest := make([]map[string]interface{}, secutityGroups.Len())
+	for i, v := range secutityGroups.List() {
+		rest[i] = map[string]interface{}{
+			"id": utils.PathSearch("id", v, nil),
+		}
+	}
+	return rest
+}
+
+func buildDesktopPoolAuthorizedObjects(authorizedObject *schema.Set) []map[string]interface{} {
+	if authorizedObject.Len() == 0 {
+		return nil
+	}
+
+	rest := make([]map[string]interface{}, authorizedObject.Len())
+	for i, v := range authorizedObject.List() {
+		rest[i] = map[string]interface{}{
+			"object_id":   utils.PathSearch("object_id", v, nil),
+			"object_type": utils.PathSearch("object_type", v, nil),
+			"object_name": utils.PathSearch("object_name", v, nil),
+			"user_group":  utils.PathSearch("user_group", v, nil),
+		}
+	}
+	return rest
+}
+
+func buildDesktopPoolAutoScalePolicy(autoScalePolicy []interface{}) map[string]interface{} {
+	if len(autoScalePolicy) == 0 || autoScalePolicy[0] == nil {
+		return map[string]interface{}{}
+	}
+	policy := autoScalePolicy[0]
+	return map[string]interface{}{
+		"autoscale_type":    utils.ValueIgnoreEmpty(utils.PathSearch("autoscale_type", policy, nil)),
+		"max_auto_created":  utils.ValueIgnoreEmpty(utils.PathSearch("max_auto_created", policy, nil)),
+		"min_idle":          utils.ValueIgnoreEmpty(utils.PathSearch("min_idle", policy, nil)),
+		"once_auto_created": utils.ValueIgnoreEmpty(utils.PathSearch("once_auto_created", policy, nil)),
+	}
+}
+
+func resourceDesktopPoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg             = meta.(*config.Config)
+		httpUrl         = "v2/{project_id}/desktop-pools"
+		desktopPoolName = d.Get("name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("workspace", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateDesktopPoolBodyParam(cfg.GetEnterpriseProjectID(d), d)),
+	}
+
+	resp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating desktop pool: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to job ID from API response")
+	}
+	// 1. To prevent residual resources on the cloud, first determine whether the resource pool has been created,
+	//    and then determine whether the desktop under it has been created.
+	// 2. If you use the job_id obtained from the creation interface to call the query job interface, you can only determine whether
+	//    the desktop under the desktop pool is created successfully, but you cannot obtain the ID of the desktop pool, resulting in
+	//    the inability to set the resource ID. Therefore, the query desktop pool list interface is called here in a loop to determine
+	//    whether the desktop pool is created successfully.
+	desktopPoolId, err := waitForWorkspacePoolStatusCompleted(ctx, client, desktopPoolName, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for the creation desktop pool (%s) to complete: %s", desktopPoolName, err)
+	}
+
+	if desktopPoolId == "" {
+		return diag.Errorf("unable to find desktop pool ID from API response")
+	}
+
+	d.SetId(desktopPoolId)
+
+	// The successful creation of a desktop pool does not mean that all desktops under it are successfully created.
+	_, err = waitForWorkspaceJobCompleted(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for the job (%s) completed: %s", jobId, err)
+	}
+
+	if v, ok := d.GetOk("in_maintenance_mode"); ok {
+		updateOpt := map[string]interface{}{
+			"in_maintenance_mode": v,
+		}
+		err = updateDesktopPool(client, desktopPoolId, updateOpt)
+		if err != nil {
+			return diag.Errorf("error enabling maintenance mode of the desktop pool (%s): %s", desktopPoolId, err)
+		}
+	}
+	return resourceDesktopPoolRead(ctx, d, meta)
+}
+
+func waitForWorkspacePoolStatusCompleted(ctx context.Context, client *golangsdk.ServiceClient, desktopPoolName string,
+	timeout time.Duration) (string, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshWorkspacePoolJobStatus(client, desktopPoolName),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 15 * time.Second,
+	}
+
+	desktopPool, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return utils.PathSearch("id", desktopPool, "").(string), nil
+}
+
+func getDesktopPoolbyName(client *golangsdk.ServiceClient, desktopPoolName string) (interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/desktop-pools"
+		offset  = 0
+		opt     = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	// The 'name' parameter is fuzzy search.
+	listPath = fmt.Sprintf("%s?name=%s", listPath, desktopPoolName)
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving desktop pools: %s", err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		desktopPools := utils.PathSearch("desktop_pools", respBody, make([]interface{}, 0)).([]interface{})
+		if len(desktopPools) < 1 {
+			break
+		}
+
+		desktopPool := utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0]", desktopPoolName), desktopPools, nil)
+		if desktopPool != nil {
+			return desktopPool, nil
+		}
+
+		offset += len(desktopPools)
+	}
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func refreshWorkspacePoolJobStatus(client *golangsdk.ServiceClient, desktopPoolName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		desktopPool, err := getDesktopPoolbyName(client, desktopPoolName)
+		if err != nil {
+			return desktopPool, "ERROR", err
+		}
+
+		status := utils.PathSearch("status", desktopPool, "").(string)
+		if status == "STEADY" {
+			return desktopPool, "COMPLETED", nil
+		}
+
+		if status == "ERROR" {
+			return desktopPool, "ERROR", fmt.Errorf("unexpect status (%s)", status)
+		}
+
+		return desktopPool, "PENDING", nil
+	}
+}
+
+func GetDesktopPoolById(client *golangsdk.ServiceClient, desktopPoolId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/desktop-pools/{pool_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{pool_id}", desktopPoolId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	respBody, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		// WKS.0001: The desktop pool does not exist.
+		return nil, common.ConvertExpected400ErrInto404Err(err, "error_code", "WKS.0001")
+	}
+
+	desktopPool, err := utils.FlattenResponse(respBody)
+	if err != nil {
+		return nil, err
+	}
+	return desktopPool, nil
+}
+
+func getAssociatedObjectsById(client *golangsdk.ServiceClient, desktopPoolId string) ([]interface{}, error) {
+	var (
+		// The 'limit' default value is 10.
+		httpUrl = "v2/{project_id}/desktop-pools/{pool_id}/users?limit=100"
+		offset  = 0
+		result  = make([]interface{}, 0)
+		opt     = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{pool_id}", desktopPoolId)
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+		objects := utils.PathSearch("objects", respBody, make([]interface{}, 0)).([]interface{})
+		if len(objects) < 1 {
+			break
+		}
+
+		result = append(result, objects...)
+		offset += len(objects)
+	}
+	return result, nil
+}
+
+func resourceDesktopPoolRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		desktopPoolId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	desktopPool, err := GetDesktopPoolById(client, desktopPoolId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error retrieving desktop pool (%s)", desktopPoolId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", desktopPool, nil)),
+		d.Set("type", utils.PathSearch("type", desktopPool, nil)),
+		d.Set("size", utils.PathSearch("desktop_count", desktopPool, nil)),
+		d.Set("product_id", utils.PathSearch("product.product_id", desktopPool, nil)),
+		d.Set("image_id", utils.PathSearch("image_id", desktopPool, nil)),
+		d.Set("root_volume", flattenDesktopPoolRootVolume(utils.PathSearch("root_volume", desktopPool, nil))),
+		d.Set("subnet_ids", flattenDesktopPoolSubnet(utils.PathSearch("subnet_id", desktopPool, nil))),
+		d.Set("security_groups", utils.PathSearch("security_groups", desktopPool, nil)),
+		d.Set("availability_zone", utils.PathSearch("availability_zone", desktopPool, nil)),
+		d.Set("data_volumes", flattenDesktopPoolDataVolume(utils.PathSearch("data_volumes", desktopPool, make([]interface{}, 0)).([]interface{}))),
+		d.Set("disconnected_retention_period", utils.PathSearch("disconnected_retention_period", desktopPool, nil)),
+		d.Set("enable_autoscale", utils.PathSearch("enable_autoscale", desktopPool, nil)),
+		d.Set("autoscale_policy", flattenDesktopPoolAutoScalePolicy(utils.PathSearch("autoscale_policy", desktopPool, nil))),
+		d.Set("desktop_name_policy_id", utils.PathSearch("desktop_name_policy_id", desktopPool, nil)),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", desktopPool, nil)),
+		d.Set("description", utils.PathSearch("description", desktopPool, nil)),
+		d.Set("in_maintenance_mode", utils.PathSearch("in_maintenance_mode", desktopPool, nil)),
+		// Attributes.
+		d.Set("status", utils.PathSearch("status", desktopPool, nil)),
+		d.Set("created_time", utils.PathSearch("created_time", desktopPool, nil)),
+		d.Set("desktop_used", utils.PathSearch("desktop_used", desktopPool, nil)),
+		d.Set("product", flattenDesktopPoolProduct(utils.PathSearch("product", desktopPool, nil))),
+		d.Set("image_name", utils.PathSearch("image_name", desktopPool, nil)),
+		d.Set("image_os_type", utils.PathSearch("image_os_type", desktopPool, nil)),
+		d.Set("image_os_version", utils.PathSearch("image_os_version", desktopPool, nil)),
+		d.Set("image_os_platform", utils.PathSearch("image_os_platform", desktopPool, nil)),
+	)
+
+	authorizedObjects, err := getAssociatedObjectsById(client, desktopPoolId)
+	if err != nil {
+		// To prevent resource errors caused by the interface not being online in some regions, use log to record the error.
+		log.Printf("[WARN] error retrieving associated users under specified desktop pool (%s): %s", desktopPoolId, err)
+	}
+	mErr = multierror.Append(mErr,
+		d.Set("authorized_objects", flattenDesktopPoolAuthorizedObjects(authorizedObjects)))
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDesktopPoolRootVolume(volume interface{}) []map[string]interface{} {
+	if volume == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"type": utils.PathSearch("type", volume, nil),
+			"size": utils.PathSearch("size", volume, nil),
+			"id":   utils.PathSearch("id", volume, nil),
+		},
+	}
+}
+
+func flattenDesktopPoolSubnet(subnetId interface{}) []interface{} {
+	if subnetId == nil {
+		return nil
+	}
+	return []interface{}{subnetId}
+}
+
+func flattenDesktopPoolDataVolume(volumes []interface{}) []map[string]interface{} {
+	if len(volumes) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(volumes))
+	for i, volume := range volumes {
+		result[i] = map[string]interface{}{
+			"type": utils.PathSearch("type", volume, nil),
+			"size": utils.PathSearch("size", volume, nil),
+			"id":   utils.PathSearch("id", volume, nil),
+		}
+	}
+	return result
+}
+
+func flattenDesktopPoolAuthorizedObjects(authorizedObjects []interface{}) []map[string]interface{} {
+	if len(authorizedObjects) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(authorizedObjects))
+	for i, object := range authorizedObjects {
+		result[i] = map[string]interface{}{
+			"object_id":   utils.PathSearch("object_id", object, nil),
+			"object_type": utils.PathSearch("object_type", object, nil),
+			"object_name": utils.PathSearch("object_name", object, nil),
+			"user_group":  utils.PathSearch("user_group", object, nil),
+		}
+	}
+	return result
+}
+
+func flattenDesktopPoolAutoScalePolicy(autoScalePolicy interface{}) []map[string]interface{} {
+	if autoScalePolicy == nil || len(autoScalePolicy.(map[string]interface{})) == 0 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"autoscale_type":    utils.PathSearch("autoscale_type", autoScalePolicy, nil),
+			"max_auto_created":  utils.PathSearch("max_auto_created", autoScalePolicy, nil),
+			"min_idle":          utils.PathSearch("min_idle", autoScalePolicy, nil),
+			"once_auto_created": utils.PathSearch("once_auto_created", autoScalePolicy, nil),
+		},
+	}
+}
+
+func flattenDesktopPoolProduct(product interface{}) []map[string]interface{} {
+	if product == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"flavor_id":     utils.PathSearch("flavor_id", product, nil),
+			"type":          utils.PathSearch("type", product, nil),
+			"cpu":           utils.PathSearch("cpu", product, nil),
+			"memory":        utils.PathSearch("memory", product, nil),
+			"descriptions":  utils.PathSearch("descriptions", product, nil),
+			"charging_mode": utils.PathSearch("charge_mode", product, nil),
+		},
+	}
+}
+
+func buildUpdateDesktopPoolBodyParam(d *schema.ResourceData) map[string]interface{} {
+	// availability_zone, ou_name, desktop_name_policy_id, description must be set to an empty string to be changed to an empty value.
+	param := map[string]interface{}{
+		"availability_zone":             d.Get("availability_zone"),
+		"disconnected_retention_period": utils.ValueIgnoreEmpty(d.Get("disconnected_retention_period")),
+		"enable_autoscale":              d.Get("enable_autoscale"),
+		"ou_name":                       d.Get("ou_name"),
+		"desktop_name_policy_id":        d.Get("desktop_name_policy_id"),
+		"tags":                          utils.ValueIgnoreEmpty(utils.ExpandResourceTags(d.Get("tags").(map[string]interface{}))),
+		"description":                   d.Get("description"),
+		"in_maintenance_mode":           d.Get("in_maintenance_mode"),
+	}
+	params := utils.RemoveNil(param)
+	params["autoscale_policy"] = buildDesktopPoolAutoScalePolicy(d.Get("autoscale_policy").([]interface{}))
+	return params
+}
+
+func updateDesktopPool(client *golangsdk.ServiceClient, desktopPoolId string, params map[string]interface{}) error {
+	httpUrl := "v2/{project_id}/desktop-pools/{pool_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{pool_id}", desktopPoolId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         params,
+	}
+	_, err := client.Request("PUT", updatePath, &opt)
+	return err
+}
+
+func resourceDesktopPoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("workspace", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	if d.HasChanges("name", "availability_zone", "disconnected_retention_period", "enable_autoscale", "autoscale_policy",
+		"ou_name", "desktop_name_policy_id", "tags", "description", "in_maintenance_mode") {
+		updateOpt := buildUpdateDesktopPoolBodyParam(d)
+		if d.HasChange("name") {
+			updateOpt["name"] = d.Get("name")
+		}
+
+		if err := updateDesktopPool(client, d.Id(), updateOpt); err != nil {
+			return diag.Errorf("error updating desktop pool: %s", err)
+		}
+	}
+
+	return resourceDesktopPoolRead(ctx, d, meta)
+}
+
+func resourceDesktopPoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("workspace", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	// Before deleting the desktop pool, you must disable the automatic creation function under it.
+	desktopPoolId := d.Id()
+	desktopPool, err := GetDesktopPoolById(client, desktopPoolId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving desktop pool")
+	}
+
+	if utils.PathSearch("enable_autoscale", desktopPool, false).(bool) {
+		updateOpt := map[string]interface{}{
+			"enable_autoscale": false,
+		}
+		if err := updateDesktopPool(client, desktopPoolId, updateOpt); err != nil {
+			return diag.Errorf("error disabling the automatic creation function of the desktop pool (%s): %s", desktopPoolId, err)
+		}
+	}
+
+	// Before deleting the desktop pool, you must delete all desktops under it.
+	desktopIds, err := getDesktopIdsUnderDesktopPoolById(client, desktopPoolId)
+	if err != nil {
+		return diag.Errorf("error retrieving desktop IDs under specified desktop pool (%s): %s", desktopPoolId, err)
+	}
+
+	if len(desktopIds) != 0 {
+		jobId, err := deleteDesktopsUnderDesktopPool(client, desktopIds)
+		if err != nil {
+			return diag.Errorf("error deleting desktops under specified desktop pool (%s): %s", desktopPoolId, err)
+		}
+
+		_, err = waitForWorkspaceJobCompleted(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return diag.Errorf("error waiting for the job (%s) completed: %s", jobId, err)
+		}
+	}
+
+	err = deleteDesktopPoolById(client, desktopPoolId)
+	if err != nil {
+		return diag.Errorf("error deleting desktop pool (%s): %s", desktopPoolId, err)
+	}
+	return nil
+}
+
+func getDesktopIdsUnderDesktopPoolById(client *golangsdk.ServiceClient, desktopPoolId string) ([]interface{}, error) {
+	var (
+		// The 'limit' default value is 1000.
+		httpUrl = "v2/{project_id}/desktops"
+		offset  = 0
+		result  = make([]interface{}, 0)
+		opt     = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+		}
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = fmt.Sprintf("%s?pool_id=%s", listPath, desktopPoolId)
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+		desktops := utils.PathSearch("desktops", respBody, make([]interface{}, 0)).([]interface{})
+		if len(desktops) < 1 {
+			break
+		}
+
+		result = append(result, desktops...)
+		offset += len(desktops)
+	}
+	return utils.PathSearch("[*].desktop_id", result, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func deleteDesktopsUnderDesktopPool(client *golangsdk.ServiceClient, desktopIds interface{}) (string, error) {
+	httpUrl := "v2/{project_id}/desktops/batch-delete"
+	deleteDesktopsPath := client.Endpoint + httpUrl
+	deleteDesktopsPath = strings.ReplaceAll(deleteDesktopsPath, "{project_id}", client.ProjectID)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"desktop_ids": desktopIds,
+		},
+	}
+	resp, err := client.Request("POST", deleteDesktopsPath, &opt)
+	if err != nil {
+		return "", err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return "", err
+	}
+
+	return utils.PathSearch("job_id", respBody, "").(string), nil
+}
+
+func deleteDesktopPoolById(client *golangsdk.ServiceClient, desktopPoolId string) error {
+	httpUrl := "v2/{project_id}/desktop-pools/{pool_id}"
+	deleteDesktopsPath := client.Endpoint + httpUrl
+	deleteDesktopsPath = strings.ReplaceAll(deleteDesktopsPath, "{project_id}", client.ProjectID)
+	deleteDesktopsPath = strings.ReplaceAll(deleteDesktopsPath, "{pool_id}", desktopPoolId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	_, err := client.Request("DELETE", deleteDesktopsPath, &opt)
+	return err
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource **huaweicloud_workspace_desktop_pool**.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDesktopPool_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDesktopPool_basic -timeout 360m -parallel 10
=== RUN   TestAccDesktopPool_basic
--- PASS: TestAccDesktopPool_basic (1308.46s)
PASS
coverage: 16.6% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 1308.556s       coverage: 16.6% of statements in ./huaweicloud/services/workspace

./scripts/coverage.sh -o workspace -f TestAccDesktopPool_localD
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huweicloud/services/workspace" -run TestAccDesktopPool_localAD -timeout 360m -parallel 10
=== RUN   TestAccDesktopPool_localAD
--- PASS: TestAccDesktopPool_localAD (485.31s)
PASS
coverage: 13.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 485.377s        coverage: 13.0% of statements in ./huaweiclod/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/f73862ca-bc59-4044-8fac-1bf15a968098)


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found  
![image](https://github.com/user-attachments/assets/43db5518-160b-45eb-bff6-5031a4d0e709)



    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
