### PR TITLE
fix(cdn): fix the error when closing cdn domain http2 status

### DIFF
--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -2244,7 +2244,7 @@ func buildCdnDomainHTTPSOpts(rawHTTPS []interface{}) map[string]interface{} {
 	}
 
 	https := rawHTTPS[0].(map[string]interface{})
-	return map[string]interface{}{
+	rst := map[string]interface{}{
 		"https_status":         buildCdnDomainHTTPSStatusOpts(https["https_enabled"].(bool)),
 		"certificate_name":     utils.ValueIgnoreEmpty(https["certificate_name"]),
 		"certificate_value":    utils.ValueIgnoreEmpty(https["certificate_body"]),
@@ -2252,10 +2252,16 @@ func buildCdnDomainHTTPSOpts(rawHTTPS []interface{}) map[string]interface{} {
 		"certificate_source":   https["certificate_source"],
 		"scm_certificate_id":   utils.ValueIgnoreEmpty(https["scm_certificate_id"]),
 		"certificate_type":     utils.ValueIgnoreEmpty(https["certificate_type"]),
-		"http2_status":         utils.ValueIgnoreEmpty(buildCdnDomainHTTP2StatusOpts(https["http2_enabled"].(bool))),
 		"tls_version":          utils.ValueIgnoreEmpty(https["tls_version"]),
 		"ocsp_stapling_status": utils.ValueIgnoreEmpty(https["ocsp_stapling_status"]),
 	}
+
+	// The API restriction field "http2_status" is only configurable if HTTPS is enabled.
+	if https["https_enabled"].(bool) {
+		rst["http2_status"] = utils.ValueIgnoreEmpty(buildCdnDomainHTTP2StatusOpts(https["http2_enabled"].(bool)))
+	}
+
+	return rst
 }
 
 func buildCdnDomainOriginRequestHeaderOpts(rawOriginRequestHeader []interface{}) []interface{} {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix the error when closing cdn domain http2 status:  The API restriction field "http2_status" is only configurable if HTTPS is enabled.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configHttpSettings'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configHttpSettings -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configHttpSettings
=== PAUSE TestAccCdnDomain_configHttpSettings
=== CONT  TestAccCdnDomain_configHttpSettings
--- PASS: TestAccCdnDomain_configHttpSettings (1293.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       1293.367s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
