### PR TITLE
feat(fgs/function): new metadata parameters supplement

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -10,11 +10,14 @@ description: |-
 
 Manages the function resource within HuaweiCloud.
 
-~> Since version `1.73.1`, the requests of the function resource will send these parameters:
-   <br>`enable_dynamic_memory`
-   <br>`is_stateful_function`
-   <br>`network_controller`
-   <br>For the regions that do not support this parameter, please use the lower version to deploy this resource.
+~> Since version `1.73.1`, the requests of the function resource will send these parameters:<br>
+   `enable_dynamic_memory`<br>
+   `is_stateful_function`<br>
+   `network_controller`<br>
+   Since version `1.74.0`, the requests of the function resource will send these parameters:<br>
+   `enable_auth_in_header`<br>
+   `enable_class_isolation`<br>
+   For the regions that do not support this parameter, please use the lower version to deploy this resource.
 
 ## Example Usage
 
@@ -279,6 +282,31 @@ resource "huaweicloud_fgs_function" "test" {
 }
 ```
 
+### Create function with Java runtime and corresponding configuration
+
+```hcl
+variable "function_name" {}
+variable "agency_name" {}
+
+resource "huaweicloud_fgs_function" "test" {
+  name          = var.function_name
+  memory_size   = 128
+  runtime       = "Java11"
+  timeout       = 15
+  app           = "default"
+  handler       = "com.huawei.demo.TriggerTests.apigTest"
+  code_type     = "zip"
+  code_filename = "java-demo.zip"
+  agency        = var.agency_name
+
+  enable_class_isolation = true
+  ephemeral_storage      = 512
+  heartbeat_handler      = "com.huawei.demo.TriggerTests.heartBeat"
+  restore_hook_handler   = "com.huawei.demo.TriggerTests.restoreHook"
+  restore_hook_timeout   = 10
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -468,6 +496,35 @@ The following arguments are supported:
 * `peering_cidr` - (Optional, String) Specifies the VPC cidr blocks used in the function code to detect whether it
   conflicts with the VPC cidr blocks used by the service.  
   The cidr blocks are separated by semicolons and cannot exceed `5`.
+
+* `enable_auth_in_header` - (Optional, Bool) Specifies whether the authentication in the request header is enabled.  
+  Defaults to **false**.
+
+* `enable_class_isolation` - (Optional, Bool) Specifies whether the class isolation is enabled for the JAVA runtime
+  functions.  
+  Defaults to **false**.
+
+  ~> Enabes class isolation can support Kafka dumping and improve class loading efficiency, but it may also cause some
+     compatibility issues.
+
+* `ephemeral_storage` - (Optional, Int) Specifies the size of the function ephemeral storage.  
+  The valid values are as follows:
+  + **512**
+  + **10240**
+
+  Defaults to `512`. Only custom image or http runtime supported.
+
+* `heartbeat_handler` - (Optional, String) Specifies the heartbeat handler of the function.  
+  The rule is **xx.xx**, such as **com.huawei.demo.TriggerTests.heartBeat**, it must contain periods (.).
+  The heartbeat function entry must be in the same file as the function execution entry.
+
+* `restore_hook_handler` - (Optional, String) Specifies the restore hook handler of the function.
+
+* `restore_hook_timeout` - (Optional, Int) Specifies the timeout of the function restore hook.  
+  The function will be forcibly stopped if the time is end.
+  The valid value is range from `1` to `300`, the unit is seconds (s).
+
+  -> Only Java runtime supports the configurations of the heartbeat and restore hook.
 
 <a name="function_func_mounts"></a>
 The `func_mounts` block supports:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New parameters are supported:
+ **enable_auth_in_header**
+ **enable_class_isolation**
+ **ephemeral_storage**
+ **heartbeat_handler**
+ **restore_hook_handler**
+ **restore_hook_timeout**

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. new metadata parameters supplement
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFunction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_basic -timeout 360m -parallel 10
=== RUN   TestAccFunction_basic
=== PAUSE TestAccFunction_basic
=== CONT  TestAccFunction_basic
--- PASS: TestAccFunction_basic (77.69s)
PASS
coverage: 22.7% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       77.741s coverage: 22.7% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_java
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_java -timeout 360m -parallel 10
=== RUN   TestAccFunction_java
=== PAUSE TestAccFunction_java
=== CONT  TestAccFunction_java
--- PASS: TestAccFunction_java (18.54s)
PASS
coverage: 14.4% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       18.598s coverage: 14.4% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
