### PR TITLE
fix(servicestage/component): adjust the parameter setting and new parameter supported

### DIFF
--- a/docs/resources/servicestagev3_component.md
+++ b/docs/resources/servicestagev3_component.md
@@ -239,6 +239,8 @@ The following arguments are supported:
 * `deploy_strategy` - (Optional, List) Specifies the configuration of the deploy strategy.  
   The [deploy_strategy](#servicestage_v3_component_deploy_strategy) structure is documented below.
 
+* `update_strategy` - (Optional, String) Specifies the configuration of the update strategy, in JSON format.
+
 * `command` - (Optional, String) Specifies the start commands of the component, in JSON format.  
   For the keys, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/api-servicestage/servicestage_06_0076.html#servicestage_06_0076__table856311795212).
 

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_component.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_component.go
@@ -280,7 +280,7 @@ func ResourceV3Component() *schema.Resource {
 				Description: `The configuration of the deploy strategy.`,
 			},
 			// Most of the strategy configuration inputs for component deployment and upgrades have been changed from
-			// deploy_strategy to update_strategy now, but for this parameter configuration, service does not return.
+			// deploy_strategy to update_strategy now.
 			"update_strategy": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -1229,6 +1229,12 @@ func flattenV3ExternalAccesses(accesses []interface{}) []map[string]interface{} 
 
 	result := make([]map[string]interface{}, 0, len(accesses))
 	for _, access := range accesses {
+		protocol := utils.PathSearch("protocol", access, "").(string)
+		lowercaseProtocol := strings.ToLower(protocol)
+		// Only external accesses of protocol http or https can be defined manually.
+		if lowercaseProtocol != "http" && lowercaseProtocol != "https" {
+			continue
+		}
 		result = append(result, map[string]interface{}{
 			"protocol":     utils.PathSearch("protocol", access, nil),
 			"address":      utils.PathSearch("address", access, nil),

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_component.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_component.go
@@ -279,6 +279,14 @@ func ResourceV3Component() *schema.Resource {
 				},
 				Description: `The configuration of the deploy strategy.`,
 			},
+			// Most of the strategy configuration inputs for component deployment and upgrades have been changed from
+			// deploy_strategy to update_strategy now, but for this parameter configuration, service does not return.
+			"update_strategy": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsJSON,
+				Description:  `The configuration of the update strategy, in JSON format.`,
+			},
 			"command": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -849,6 +857,7 @@ func buildV3ComponentCreateBodyParams(d *schema.ResourceData) map[string]interfa
 		"envs":              utils.ValueIgnoreEmpty(buildV3ComponentEnvVariables(d.Get("envs").(*schema.Set))),
 		"storages":          utils.ValueIgnoreEmpty(buildV3ComponentStorages(d.Get("storages").(*schema.Set))),
 		"deploy_strategy":   utils.ValueIgnoreEmpty(buildV3ComponentDeployStrategy(d.Get("deploy_strategy").([]interface{}))),
+		"update_strategy":   utils.StringToJson(d.Get("update_strategy").(string)),
 		"command":           utils.StringToJson(d.Get("command").(string)),
 		"post_start":        utils.ValueIgnoreEmpty(buildV3ComponentLifecycle(d.Get("post_start").([]interface{}))),
 		"pre_stop":          utils.ValueIgnoreEmpty(buildV3ComponentLifecycle(d.Get("pre_stop").([]interface{}))),
@@ -1267,6 +1276,7 @@ func resourceV3ComponentRead(_ context.Context, d *schema.ResourceData, meta int
 		d.Set("storages", flattenV3ComponentStorages(utils.PathSearch("storages", respBody, make([]interface{}, 0)).([]interface{}))),
 		d.Set("deploy_strategy", flattenV3ComponentDeployStrategy(utils.PathSearch("deploy_strategy", respBody,
 			make(map[string]interface{})).(map[string]interface{}))),
+		d.Set("update_strategy", utils.JsonToString(utils.PathSearch("update_strategy", respBody, nil))),
 		d.Set("command", utils.JsonToString(utils.PathSearch("command", respBody, nil))),
 		d.Set("post_start", flattenV3ComponentLifecycle(utils.PathSearch("post_start", respBody,
 			make(map[string]interface{})).(map[string]interface{}))),
@@ -1322,6 +1332,7 @@ func buildV3ComponentUpdteBodyParams(d *schema.ResourceData) map[string]interfac
 		"envs":              utils.ValueIgnoreEmpty(buildV3ComponentEnvVariables(d.Get("envs").(*schema.Set))),
 		"storages":          utils.ValueIgnoreEmpty(buildV3ComponentStorages(d.Get("storages").(*schema.Set))),
 		"deploy_strategy":   utils.ValueIgnoreEmpty(buildV3ComponentDeployStrategy(d.Get("deploy_strategy").([]interface{}))),
+		"update_strategy":   utils.StringToJson(d.Get("update_strategy").(string)),
 		"command":           utils.StringToJson(d.Get("command").(string)),
 		"post_start":        utils.ValueIgnoreEmpty(buildV3ComponentLifecycle(d.Get("post_start").([]interface{}))),
 		"pre_stop":          utils.ValueIgnoreEmpty(buildV3ComponentLifecycle(d.Get("pre_stop").([]interface{}))),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New update_strategy parameter supported, and ignore non-user config access rules without protocl HTTP(S).
The strategy configuration of the rolling release and gray release can not be configured with the deploy_strategy, the corresponding function are be replaced with the update_strategy parameter.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. build param should ignore ID return.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
