### PR TITLE
feat(servicestage/component): new gray releasing status append

### DIFF
--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_component.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_component.go
@@ -1358,10 +1358,16 @@ func componentStatusRefreshFunc(client *golangsdk.ServiceClient, appId, commpone
 }
 
 func waitV3ComponentUpdateCompleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	expectedStatuses := []string{
+		"PENDING",
+		"RUNNING",
+		"GRAYING", // Upgrade the component by gray release and waiting for manual continuation.
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"PENDING"},
 		Target:       []string{"COMPLETED"},
-		Refresh:      componentStatusRefreshFunc(client, d.Get("application_id").(string), d.Id(), []string{"PENDING", "RUNNING"}),
+		Refresh:      componentStatusRefreshFunc(client, d.Get("application_id").(string), d.Id(), expectedStatuses),
 		Timeout:      d.Timeout(schema.TimeoutUpdate),
 		PollInterval: 10 * time.Second,
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New status supported for the gray release: GRAYING.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. new gray releasing status append.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
