### PR TITLE
chore(GEIP): modify test and docs for bandwidth

### DIFF
--- a/docs/resources/global_internet_bandwidth.md
+++ b/docs/resources/global_internet_bandwidth.md
@@ -40,7 +40,14 @@ The following arguments are supported:
 * `access_site` - (Required, String, ForceNew) Specifies the access site name.
   Changing this creates a new resource.
 
-* `charge_mode` - (Required, String) Specifies the charge mode, for example, **95peak_guar**.
+* `charge_mode` - (Required, String) Specifies the charge mode.
+  Value can be as follows:
+  + **bandwidth**: billed by bandwidth
+  + **traffic**: billed by traffic
+  + **95peak_plus_1000**: billed by enhanced 95
+  + **95peak_bidirection**: billed by bidirectional traditional 95
+  + **95peak_guar**: billed by traditional 95 with guaranteed minimum
+  + **95peak_avr**: 95 peak average billing
 
 * `isp` - (Required, String, ForceNew) Specifies the internet service provider of the global internet bandwidth.
   Changing this creates a new resource.

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_internet_bandwidth_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_internet_bandwidth_test.go
@@ -93,6 +93,7 @@ func testAccInternetBandwidth_basic(name string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_global_eip_pools" "all" {
   access_site = "cn-north-beijing"
+  ip_version  = 4
 }
 
 resource "huaweicloud_global_internet_bandwidth" "test" {
@@ -114,6 +115,7 @@ func testAccInternetBandwidth_update(name string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_global_eip_pools" "all" {
   access_site = "cn-north-beijing"
+  ip_version  = 4
 }
 
 resource "huaweicloud_global_internet_bandwidth" "test" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/eip' TESTARGS='-run TestAccInternetBandwidth_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccInternetBandwidth_basic -timeout 360m -parallel 4
=== RUN   TestAccInternetBandwidth_basic
=== PAUSE TestAccInternetBandwidth_basic
=== CONT  TestAccInternetBandwidth_basic
--- PASS: TestAccInternetBandwidth_basic (67.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       67.735s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
