### PR TITLE
chore(lts/waf_access): fixed issues related to enterprise project ID

### DIFF
--- a/docs/resources/lts_waf_access.md
+++ b/docs/resources/lts_waf_access.md
@@ -43,8 +43,9 @@ The following arguments are supported:
 
 -> The fields `lts_attack_stream_id` and `lts_access_stream_id` must be specified as different log streams.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID. If not specified, the
-  default enterprise project will be used. The default enterprise project ID is **0**.
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID.  
+  This parameter is only valid for enterprise users. If not specified, the default enterprise project will be used.
+  The default enterprise project ID is **0**.  
 
   Changing this parameter will create a new resource.
 
@@ -56,8 +57,14 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-The LTS access WAF logs configuration can be imported using the `enterprise_project_id`, e.g.
+For enterprise users, The resource can be imported using the `enterprise_project_id`, e.g.
 
 ```bash
 $ terraform import huaweicloud_lts_waf_access.test <enterprise_project_id>
+```
+
+For non-enterprise users, The resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_lts_waf_access.test <id>
 ```

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_waf_access_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_waf_access_test.go
@@ -83,6 +83,7 @@ func TestAccWAFAccess_basic(t *testing.T) {
 						"huaweicloud_lts_stream.streamA1", "id"),
 					resource.TestCheckResourceAttrPair(rName, "lts_access_stream_id",
 						"huaweicloud_lts_stream.streamA2", "id"),
+					resource.TestCheckNoResourceAttr(rName, "enterprise_project_id"),
 				),
 			},
 			{
@@ -108,10 +109,11 @@ func TestAccWAFAccess_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      rName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: testWAFAccessImportState(rName),
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       testWAFAccessImportState(rName),
+				ImportStateVerifyIgnore: []string{"enterprise_project_id"},
 			},
 		},
 	})
@@ -138,7 +140,7 @@ func TestAccWAFAccess_withEpsId(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testWAFAccess_withEpsId(name),
+				Config: testWAFAccess_withEpsId(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id",
@@ -283,7 +285,7 @@ resource "huaweicloud_lts_waf_access" "test" {
 `, testWAFAccess_base(name))
 }
 
-func testWAFAccess_withEpsId(name string) string {
+func testWAFAccess_withEpsId(name, epsId string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -297,7 +299,7 @@ resource "huaweicloud_lts_waf_access" "test" {
     huaweicloud_waf_dedicated_instance.test
   ]
 }
-`, testWAFAccess_epsId(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testWAFAccess_epsId(name, epsId), epsId)
 }
 
 func testWAFAccessImportState(name string) resource.ImportStateIdFunc {
@@ -314,4 +316,42 @@ func testWAFAccessImportState(name string) resource.ImportStateIdFunc {
 		}
 		return epsId, nil
 	}
+}
+
+// Only one LTS log access resource can be created under one enterprise project ID.
+func TestAccWAFAccess_withDefaultEpsId(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		wafAccess interface{}
+		rName     = "huaweicloud_lts_waf_access.test"
+		rc        = acceptance.InitResourceCheck(rName, &wafAccess, getWAFAccessResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testWAFAccess_withEpsId(name, "0"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "lts_group_id",
+						"huaweicloud_lts_group.groupA", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_attack_stream_id",
+						"huaweicloud_lts_stream.streamA1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_access_stream_id",
+						"huaweicloud_lts_stream.streamA2", "id"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFAccessImportState(rName),
+			},
+		},
+	})
 }

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_waf_access_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_waf_access_test.go
@@ -108,6 +108,13 @@ func TestAccWAFAccess_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "lts_access_stream_id", ""),
 				),
 			},
+			// Use resource ID to import.
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Use enterprise project ID to import.
 			{
 				ResourceName:            rName,
 				ImportState:             true,

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_waf_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_waf_access.go
@@ -59,6 +59,7 @@ func ResourceWAFAccess() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
+				Computed:    true,
 				Description: `Specifies the enterprise project ID.`,
 			},
 		},
@@ -246,12 +247,8 @@ func buildDeleteWAFAccessBodyParams() map[string]interface{} {
 	}
 	return bodyParams
 }
-
 func resourceWAFAccessImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
 	[]*schema.ResourceData, error) {
-	// `0` means default enterprise project.
-	if d.Id() == "0" {
-		return []*schema.ResourceData{d}, nil
-	}
-	return []*schema.ResourceData{d}, d.Set("enterprise_project_id", d.Id())
+	mErr := multierror.Append(d.Set("enterprise_project_id", d.Id()))
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
 }

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_waf_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_waf_access.go
@@ -247,8 +247,17 @@ func buildDeleteWAFAccessBodyParams() map[string]interface{} {
 	}
 	return bodyParams
 }
+
 func resourceWAFAccessImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
 	[]*schema.ResourceData, error) {
-	mErr := multierror.Append(d.Set("enterprise_project_id", d.Id()))
+	var mErr *multierror.Error
+	importId := d.Id()
+	// `0` means default enterprise project.
+	// The non-default enterprise project ID format is a 32-bit UUID with hyphens.
+	// The resource ID format is a 32-bit UUID without hyphens.
+	if utils.IsUUIDWithHyphens(importId) || importId == "0" {
+		mErr = multierror.Append(d.Set("enterprise_project_id", d.Id()))
+	}
+
 	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixed issues related to enterprise project ID.
+ Fixed resource changes after executing terraform plan after import when specifying the default enterprise project ID.
+ Added import scenarios for non-enterprise users.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fixed resource changes after executing terraform plan after import when specifying the default enterprise project ID.
2. added import scenarios for non-enterprise users.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lts -f TestAccWAFAccess_ -n 1
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccWAFAccess_ -timeout 360m -parallel 1
=== RUN   TestAccWAFAccess_basic
=== PAUSE TestAccWAFAccess_basic
=== RUN   TestAccWAFAccess_withEpsId
=== PAUSE TestAccWAFAccess_withEpsId
=== RUN   TestAccWAFAccess_withDefaultEpsId
=== PAUSE TestAccWAFAccess_withDefaultEpsId
=== CONT  TestAccWAFAccess_basic
--- PASS: TestAccWAFAccess_basic (762.23s)
=== CONT  TestAccWAFAccess_withDefaultEpsId
--- PASS: TestAccWAFAccess_withDefaultEpsId (601.53s)
=== CONT  TestAccWAFAccess_withEpsId
--- PASS: TestAccWAFAccess_withEpsId (600.08s)
PASS
coverage: 9.5% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       1963.955s       coverage: 9.5% of statements in ./huaweicloud/services/lts
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
