### PR TITLE
test(lts/group): adjust and add scenarios about enterprise project ID

### DIFF
--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_group_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_group_test.go
@@ -46,14 +46,7 @@ func getLtsGroupResourceFunc(cfg *config.Config, state *terraform.ResourceState)
 	return groupResult, nil
 }
 
-func getAcceptanceEpsId() string {
-	if acceptance.HW_ENTERPRISE_PROJECT_ID_TEST == "" {
-		return "0"
-	}
-	return acceptance.HW_ENTERPRISE_PROJECT_ID_TEST
-}
-
-func TestAccLtsGroup_basic(t *testing.T) {
+func TestAccGroup_basic(t *testing.T) {
 	var (
 		group        interface{}
 		resourceName = "huaweicloud_lts_group.test"
@@ -76,7 +69,7 @@ func TestAccLtsGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ttl_in_days", "30"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", getAcceptanceEpsId()),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
 				),
 			},
 			{
@@ -114,21 +107,15 @@ func TestAccLtsGroup_basic(t *testing.T) {
 
 func testAccLtsGroup_basic(name string, ttl int) string {
 	return fmt.Sprintf(`
-variable "enterprise_project_id" {
-  default = "%[1]s"
-}
-
 resource "huaweicloud_lts_group" "test" {
-  group_name  = "%[2]s"
-  ttl_in_days = %d
+  group_name  = "%[1]s"
+  ttl_in_days = %[2]d
 
   tags = {
     owner = "terraform"
   }
-
-  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 }
-`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name, ttl)
+`, name, ttl)
 }
 
 func testAccLtsGroup_step3(name string, ttl int) string {
@@ -153,4 +140,62 @@ resource "huaweicloud_lts_group" "test" {
   ttl_in_days = %d
 }
 `, name, ttl)
+}
+
+func TestAccGroup_withEpsId(t *testing.T) {
+	var (
+		group interface{}
+
+		resourceName = "huaweicloud_lts_group.test"
+		rName        = acceptance.RandomAccResourceName()
+		rc           = acceptance.InitResourceCheck(resourceName, &group, getLtsGroupResourceFunc)
+		epsId        = acceptance.HW_ENTERPRISE_PROJECT_ID_TEST
+		updateEpsId  = acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMigrateEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGroup_withEpsId_step1(rName, epsId),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "group_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "ttl_in_days", "30"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", epsId),
+				),
+			},
+			{
+				Config: testAccGroup_withEpsId_step2(rName, updateEpsId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "group_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", updateEpsId),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccGroup_withEpsId_step1(name, epsId string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lts_group" "test" {
+  group_name            = "%[1]s"
+  ttl_in_days           = 30
+  enterprise_project_id = "%[2]s"
+}
+`, name, epsId)
+}
+
+func testAccGroup_withEpsId_step2(name, epsId string) string {
+	return testAccGroup_withEpsId_step1(name, epsId)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Verify that the `enterprise_project_id ` value is `0 `when the test does not specify an enterprise project ID.
Verify scenarios the non-default enterprise project ID is specified.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. verify that the `enterprise_project_id ` value is `0 `when the test does not specify an enterprise project ID.
2. verify scenarios the non-default enterprise project ID is specified.

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lts -f TestAccGroup_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccGroup_ -timeout 360m -parallel 10
=== RUN   TestAccGroup_basic
=== PAUSE TestAccGroup_basic
=== RUN   TestAccGroup_withEpsId
=== PAUSE TestAccGroup_withEpsId
=== CONT  TestAccGroup_basic
=== CONT  TestAccGroup_withEpsId
--- PASS: TestAccGroup_withEpsId (59.79s)
--- PASS: TestAccGroup_basic (100.59s)
PASS
coverage: 6.6% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       100.659s        coverage: 6.6% of statements in ./huaweicloud/services/lts
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
