### PR TITLE
fix(lts/search_criteria): fix error creating resource of type 'VISUALIZATION'

### DIFF
--- a/huaweicloud/services/lts/resource_huaweicloud_lts_search_criteria.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_search_criteria.go
@@ -143,6 +143,8 @@ func resourceSearchCriteriaRead(_ context.Context, d *schema.ResourceData, meta 
 	getSearchCriteriaPath = strings.ReplaceAll(getSearchCriteriaPath, "{project_id}", getSearchCriteriaClient.ProjectID)
 	getSearchCriteriaPath = strings.ReplaceAll(getSearchCriteriaPath, "{group_id}", d.Get("log_group_id").(string))
 	getSearchCriteriaPath = strings.ReplaceAll(getSearchCriteriaPath, "{topic_id}", d.Get("log_stream_id").(string))
+	// If `type` parameter is not specified, the default query is "ORIGINALLOG" type, and the "VISUALIZATION" type cannot be queried.
+	getSearchCriteriaPath = fmt.Sprintf("%s?search_type=%s", getSearchCriteriaPath, d.Get("type").(string))
 
 	getSearchCriteriaOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixed the issue that an error occurred when creating the resource of type "VISUALIZATION".
![image](https://github.com/user-attachments/assets/21951f42-a88f-49dc-93f9-8ed55344c72b)


Error reason:  If `type` parameter is not specified, the default query is "ORIGINALLOG" type, and the "VISUALIZATION" type cannot be queried.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fixed the issue that an error occurred when creating the resource of type "VISUALIZATION".
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lts -f TestAccSearchCriteria_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccSearchCriteria_basic -timeout 360m -parallel 10
=== RUN   TestAccSearchCriteria_basic
=== PAUSE TestAccSearchCriteria_basic
=== CONT  TestAccSearchCriteria_basic
--- PASS: TestAccSearchCriteria_basic (63.32s)
PASS
coverage: 9.4% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       63.401s coverage: 9.4% of statements in ./huaweicloud/services/lts
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
