### PR TITLE
feat(utils): add a new method to check whether a string is in uuid with hyphens

### DIFF
--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -562,8 +562,16 @@ func ConvertMemoryUnit(memory interface{}, diffLevel int) int {
 
 // IsUUID is a method used to determine whether a string is in UUID format.
 func IsUUID(uuid string) bool {
-	// Using regular expressions to match UUID formats, with or without underscores.
+	// Using regular expressions to match UUID formats, with or without hyphens.
 	pattern := "[0-9a-fA-F]{8}(-?[0-9a-fA-F]{4}){3}-?[0-9a-fA-F]{12}"
+	match, _ := regexp.MatchString(pattern, uuid)
+	return match
+}
+
+// IsUUIDWithHyphens is a method used to determine whether a string is in UUID format with hyphens.
+func IsUUIDWithHyphens(uuid string) bool {
+	// Use regular expression to match UUID format with hyphens.
+	pattern := "[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}"
 	match, _ := regexp.MatchString(pattern, uuid)
 	return match
 }

--- a/huaweicloud/utils/utils_test.go
+++ b/huaweicloud/utils/utils_test.go
@@ -116,6 +116,20 @@ func TestAccFunction_IsUUID(t *testing.T) {
 		t.Logf("The processing result of IsUUID method meets expectation: %s", Green(expected[i]))
 	}
 }
+func TestAccFunction_IsUUIDWithHyphens(t *testing.T) {
+	var (
+		ids      = []string{"550e8400-e29b-41d4-a716-446655440000", "550e8400e29b41d4a716446655440000", "abc123", ""}
+		expected = []bool{true, false, false, false}
+	)
+
+	for i, idInput := range ids {
+		if isValid := IsUUIDWithHyphens(idInput); isValid != expected[i] {
+			t.Fatalf("The processing result of IsUUIDWithHyphens method is not as expected, want %s, but %s, the ID is %s",
+				Green(expected[i]), Yellow(isValid), idInput)
+		}
+		t.Logf("The processing result of IsUUIDWithHyphens method meets expectation: %s", Green(expected[i]))
+	}
+}
 
 func TestAccFunction_FilterMapWithSameKey(t *testing.T) {
 	var (


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 make testacc TEST='./huaweicloud/utils' TESTARGS='-run TestAccFunction_IsUUIDWithHyphens'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/utils -v -run TestAccFunction_IsUUIDWithHyphens -timeout 360m -parallel 4
=== RUN   TestAccFunction_IsUUIDWithHyphens
    utils_test.go:131: The processing result of IsUUIDWithHyphens method meets expectation: true
    utils_test.go:131: The processing result of IsUUIDWithHyphens method meets expectation: false
    utils_test.go:131: The processing result of IsUUIDWithHyphens method meets expectation: false
    utils_test.go:131: The processing result of IsUUIDWithHyphens method meets expectation: false
--- PASS: TestAccFunction_IsUUIDWithHyphens (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils 0.014s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
