### PR TITLE
feat(ELB): add params to elb active standby pool resource

### DIFF
--- a/docs/resources/elb_active_standby_pool.md
+++ b/docs/resources/elb_active_standby_pool.md
@@ -69,6 +69,15 @@ The following arguments are supported:
 * `healthmonitor` - (Required, List, ForceNew) Specifies the health check configured for the active-standby pool.
   The [healthmonitor](#ELB_healthmonitor) structure is documented below. Changing this parameter will create a new resource.
 
+* `lb_algorithm` - (Required, String, ForceNew) Specifies the load balancing algorithm used by the load balancer to route
+  requests to backend servers in the associated backend server group. Value options:
+  + **ROUND_ROBIN**: weighted round robin.
+  + **LEAST_CONNECTIONS**: weighted least connections.
+  + **SOURCE_IP**: source IP hash.
+  + **QUIC_CID**: connection ID.
+
+  Defaults to **ROUND_ROBIN**.
+
 * `type` - (Optional, String, ForceNew) Specifies the type of the active-standby pool. Value options:
   + **instance**: Any type of backend servers can be added. `vpc_id` must be mandatory.
   + **ip**: Only IP as backend servers can be added. `vpc_id` cannot be specified.
@@ -235,6 +244,9 @@ In addition to all arguments above, the following attributes are exported:
 * `healthmonitor` - The health check configured for the active-standby pool.
   The [healthmonitor](#ELB_healthmonitorResp) structure is documented below.
 
+* `quic_cid_hash_strategy` - The multi-path distribution configuration based on destination connection IDs.
+  The [quic_cid_hash_strategy](#ELB_quiccidhashstrategyResp) structure is documented below.
+
 * `created_at` - The create time of the active-standby pool.
 
 * `updated_at` - The update time of the active-standby pool.
@@ -252,10 +264,67 @@ The `members` block supports:
 
 * `operating_status` - The health status of the member.
 
+* `reason` - Why health check fails.
+  The [reason](#ELB_member_reasonResp) structure is documented below.
+
+* `status` - The health status of the backend server if `listener_id` under status is specified. If `listener_id` under
+  status is not specified, operating_status of member takes precedence.
+  The [status](#ELB_member_statusResp) structure is documented below.
+
+<a name="ELB_member_reasonResp"></a>
+The `reason` block supports:
+
+* `reason_code` - The code of the health check failures. The value can be:
+  + **CONNECT_TIMEOUT**: The connection with the backend server times out during a health check.
+  + **CONNECT_REFUSED**: The load balancer rejects connections with the backend server during a health check.
+  + **CONNECT_FAILED**: The load balancer fails to establish connections with the backend server during a health check.
+  + **CONNECT_INTERRUPT**: The load balancer is disconnected from the backend server during a health check.
+  + **SSL_HANDSHAKE_ERROR**: The SSL handshakes with the backend server fail during a health check.
+  + **RECV_RESPONSE_FAILED**: The load balancer fails to receive responses from the backend server during a health check.
+  + **RECV_RESPONSE_TIMEOUT**: The load balancer does not receive responses from the backend server within the timeout
+    duration during a health check.
+  + **SEND_REQUEST_FAILED**: The load balancer fails to send a health check request to the backend server during a health
+    check.
+  + **SEND_REQUEST_TIMEOUT**: The load balancer fails to send a health check request to the backend server within the
+    timeout duration.
+  + **RESPONSE_FORMAT_ERROR**: The load balancer receives invalid responses from the backend server during a health check.
+  + **RESPONSE_MISMATCH**: The response code received from the backend server is different from the preset code.
+
+* `expected_response` - The expected HTTP status code. This parameter will take effect only when `type` is set to **HTTP**,
+  **HTTPS** or **GRPC**.
+  + A specific status code. If `type` is set to **GRPC**, the status code ranges from **0** to **99**. If `type` is set
+    to other values, the status code ranges from **200** to **599**.
+  + A list of status codes that are separated with commas (,). A maximum of five status codes are supported.
+  + A status code range. Different ranges are separated with commas (,). A maximum of five ranges are supported.
+
+* `healthcheck_response` - The returned HTTP status code in the response. This parameter will take effect only when `type`
+  is set to **HTTP**, **HTTPS** or **GRPC**.
+  + A specific status code. If type is set to **GRPC**, the status code ranges from **0** to **99**. If `type` is set to
+    other values, the status code ranges from **200** to **599**.
+
+<a name="ELB_member_statusResp"></a>
+The `status` block supports:
+
+* `listener_id` - The ID of the listener associated with the backend server.
+
+* `operating_status` - The health status of the backend server. The value can be:
+  + **ONLINE**: The backend server is running normally.
+  + **NO_MONITOR**: No health check is configured for the backend server group to which the backend server belongs.
+  + **OFFLINE**: The cloud server used as the backend server is stopped or does not exist.
+
 <a name="ELB_healthmonitorResp"></a>
 The `healthmonitor` block supports:
 
 * `id` - The health check ID.
+
+<a name="ELB_quiccidhashstrategyResp"></a>
+The `quic_cid_hash_strategy` block supports:
+
+* `len` - The length of the hash factor in the connection ID, in byte. This parameter is valid only when `lb_algorithm`
+  is **QUIC_CID**. Value range: **1** to **20**.
+
+* `offset` - The start position in the connection ID as the hash factor, in byte. This parameter is valid only when
+  `lb_algorithm` is **QUIC_CID**. Value range: **0** to **19**.
 
 ## Timeouts
 

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_active_standby_pool_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_active_standby_pool_test.go
@@ -66,6 +66,12 @@ func TestAccElbActiveStandbyPool_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "TCP"),
+					resource.TestCheckResourceAttr(resourceName, "lb_algorithm", "ROUND_ROBIN"),
+					resource.TestCheckResourceAttr(resourceName, "type", "instance"),
+					resource.TestCheckResourceAttrPair(resourceName, "loadbalancer_id",
+						"huaweicloud_elb_loadbalancer.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "listener_id",
+						"huaweicloud_elb_listener.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "type", "instance"),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id",
 						"huaweicloud_vpc.test", "id"),
@@ -85,6 +91,8 @@ func TestAccElbActiveStandbyPool_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "members.0.member_type"),
 					resource.TestCheckResourceAttrSet(resourceName, "members.0.operating_status"),
 					resource.TestCheckResourceAttrSet(resourceName, "members.0.ip_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "members.0.status.0.listener_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "members.0.status.0.operating_status"),
 					resource.TestCheckResourceAttrSet(resourceName, "healthmonitor.0.id"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
@@ -99,6 +107,72 @@ func TestAccElbActiveStandbyPool_basic(t *testing.T) {
 	})
 }
 
+func TestAccElbActiveStandbyPool_quic_protocol(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_elb_active_standby_pool.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getELBActiveStandbyPoolResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccElbActiveStandbyPoolConfig_quic_protocol(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "QUIC"),
+					resource.TestCheckResourceAttr(resourceName, "lb_algorithm", "QUIC_CID"),
+					resource.TestCheckResourceAttr(resourceName, "type", "instance"),
+					resource.TestCheckResourceAttr(resourceName, "type", "instance"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id",
+						"huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "quic_cid_hash_strategy.0.len"),
+					resource.TestCheckResourceAttrSet(resourceName, "quic_cid_hash_strategy.0.offset"),
+				),
+			},
+		},
+	})
+}
+
+func testAccElbActiveStandbyPoolConfig_base(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_elb_loadbalancer" "test" {
+  name              = "%[2]s"
+  cross_vpc_backend = true
+  ipv4_subnet_id    = huaweicloud_vpc_subnet.test.ipv4_subnet_id
+
+  availability_zone = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+
+  tags = {
+    key   = "value"
+    owner = "terraform"
+  }
+}
+
+resource "huaweicloud_elb_listener" "test" {
+  name            = "%[2]s"
+  description     = "test description"
+  protocol        = "TCP"
+  protocol_port   = 8080
+  loadbalancer_id = huaweicloud_elb_loadbalancer.test.id
+}
+`, common.TestVpc(rName), rName)
+}
+
 func testAccElbActiveStandbyPoolConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
@@ -107,6 +181,9 @@ resource "huaweicloud_elb_active_standby_pool" "test" {
   name                     = "%s"
   description              = "test"
   protocol                 = "TCP"
+  lb_algorithm             = "ROUND_ROBIN"
+  loadbalancer_id          = huaweicloud_elb_loadbalancer.test.id
+  listener_id              = huaweicloud_elb_listener.test.id
   vpc_id                   = huaweicloud_vpc.test.id
   type                     = "instance"
   any_port_enable          = false
@@ -135,7 +212,42 @@ resource "huaweicloud_elb_active_standby_pool" "test" {
     timeout          = 3
     type             = "HTTP"
   }
+}
+`, testAccElbActiveStandbyPoolConfig_base(rName), rName)
+}
 
+func testAccElbActiveStandbyPoolConfig_quic_protocol(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_elb_active_standby_pool" "test" {
+  name            = "%[2]s"
+  protocol        = "QUIC"
+  lb_algorithm    = "QUIC_CID"
+  type            = "instance"
+  vpc_id          = huaweicloud_vpc.test.id
+  any_port_enable = false
+
+  members {
+    address       = "1.1.1.1"
+    protocol_port = 45
+    role          = "slave"
+    name          = "slave_name"
+  }
+
+  members {
+    address       = "2.2.2.2"
+    protocol_port = 36
+    role          = "master"
+    name          = "master_name"
+  }
+
+  healthmonitor {
+    delay       = 5
+    max_retries = 3
+    timeout     = 3
+    type        = "UDP_CONNECT"
+  }
 }
 `, common.TestVpc(rName), rName)
 }

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_active_standby_pool.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_active_standby_pool.go
@@ -61,6 +61,13 @@ func ResourceActiveStandbyPool() *schema.Resource {
 				MaxItems: 1,
 				Elem:     activeStandbyHealthMonitorRefSchema(),
 			},
+			"lb_algorithm": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     "ROUND_ROBIN",
+				Description: "schema: Required",
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -123,6 +130,11 @@ func ResourceActiveStandbyPool() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"quic_cid_hash_strategy": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     activeStandbyQuicCidHashStrategyRefSchema(),
+			},
 			"created_at": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -183,6 +195,50 @@ func activeStandbyMemberRefSchema() *schema.Resource {
 				Computed: true,
 			},
 			"ip_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     activeStandbyMemberStatusRefSchema(),
+			},
+			"reason": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     activeStandbyMemberReasonRefSchema(),
+			},
+		},
+	}
+}
+
+func activeStandbyMemberStatusRefSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"listener_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"operating_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func activeStandbyMemberReasonRefSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"reason_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expected_response": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"healthcheck_response": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -257,6 +313,21 @@ func activeStandbyHealthMonitorRefSchema() *schema.Resource {
 			},
 			"id": {
 				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func activeStandbyQuicCidHashStrategyRefSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"len": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"offset": {
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 		},
@@ -346,6 +417,7 @@ func resourceActiveStandbyPoolRead(_ context.Context, d *schema.ResourceData, me
 		d.Set("protocol", utils.PathSearch("pool.protocol", getActiveStandbyPoolBody, nil)),
 		d.Set("description", utils.PathSearch("pool.description", getActiveStandbyPoolBody, nil)),
 		d.Set("name", utils.PathSearch("pool.name", getActiveStandbyPoolBody, nil)),
+		d.Set("lb_algorithm", utils.PathSearch("pool.lb_algorithm", getActiveStandbyPoolBody, nil)),
 		d.Set("loadbalancer_id", utils.PathSearch("pool.loadbalancers|[0].id", getActiveStandbyPoolBody, nil)),
 		d.Set("listener_id", utils.PathSearch("pool.listeners|[0].id", getActiveStandbyPoolBody, nil)),
 		d.Set("type", utils.PathSearch("pool.type", getActiveStandbyPoolBody, nil)),
@@ -356,6 +428,7 @@ func resourceActiveStandbyPoolRead(_ context.Context, d *schema.ResourceData, me
 		d.Set("ip_version", utils.PathSearch("pool.ip_version", getActiveStandbyPoolBody, nil)),
 		d.Set("connection_drain_enabled", utils.PathSearch("pool.connection_drain.enable", getActiveStandbyPoolBody, nil)),
 		d.Set("connection_drain_timeout", utils.PathSearch("pool.connection_drain.timeout", getActiveStandbyPoolBody, nil)),
+		d.Set("quic_cid_hash_strategy", flattenActiveStandbyQuicCidHashStrategy(getActiveStandbyPoolBody)),
 		d.Set("created_at", utils.PathSearch("pool.created_at", getActiveStandbyPoolBody, nil)),
 		d.Set("updated_at", utils.PathSearch("pool.updated_at", getActiveStandbyPoolBody, nil)),
 	)
@@ -418,8 +491,48 @@ func flattenActiveStandbyPoolMembers(resp interface{}) []interface{} {
 			"instance_id":      utils.PathSearch("instance_id", v, nil),
 			"operating_status": utils.PathSearch("operating_status", v, nil),
 			"ip_version":       utils.PathSearch("ip_version", v, nil),
+			"status":           flattenActiveStandbyPoolMemberStatus(v),
+			"reason":           flattenActiveStandbyPoolMemberReason(v),
 		})
 	}
+	return rst
+}
+
+func flattenActiveStandbyPoolMemberStatus(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("status", resp, make([]interface{}, 0))
+	if curJson == nil {
+		return nil
+	}
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"listener_id":      utils.PathSearch("listener_id", v, nil),
+			"operating_status": utils.PathSearch("operating_status", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenActiveStandbyPoolMemberReason(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	curJson := utils.PathSearch("reason", resp, nil)
+	if curJson == nil {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, 1)
+	rst = append(rst, map[string]interface{}{
+		"reason_code":          utils.PathSearch("reason_code", curJson, nil),
+		"expected_response":    utils.PathSearch("expected_response", curJson, nil),
+		"healthcheck_response": utils.PathSearch("healthcheck_response", curJson, nil),
+	})
 	return rst
 }
 
@@ -444,6 +557,21 @@ func flattenActiveStandbyPoolHealthMonitor(resp interface{}) []interface{} {
 			"timeout":          utils.PathSearch("timeout", curJson, nil),
 			"delay":            utils.PathSearch("delay", curJson, nil),
 			"id":               utils.PathSearch("id", curJson, nil),
+		},
+	}
+	return rst
+}
+
+func flattenActiveStandbyQuicCidHashStrategy(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("pool.quic_cid_hash_strategy", resp, nil)
+	if curJson == nil {
+		return nil
+	}
+
+	rst := []interface{}{
+		map[string]interface{}{
+			"len":    utils.PathSearch("len", curJson, nil),
+			"offset": utils.PathSearch("offset", curJson, nil),
 		},
 	}
 	return rst
@@ -505,7 +633,7 @@ func resourceElbPoolRefreshFunc(elbClient *golangsdk.ServiceClient, poolID strin
 
 func buildCreateActiveStandbyPoolBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
-		"lb_algorithm":     "ROUND_ROBIN",
+		"lb_algorithm":     d.Get("lb_algorithm"),
 		"protocol":         d.Get("protocol"),
 		"name":             utils.ValueIgnoreEmpty(d.Get("name")),
 		"loadbalancer_id":  utils.ValueIgnoreEmpty(d.Get("loadbalancer_id")),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add params to elb active standby pool resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add params to elb active standby pool resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/elb/ TESTARGS='-run TestAccElbActiveStandbyPool_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v -run TestAccElbActiveStandbyPool_ -timeout 360m -parallel 4
=== RUN   TestAccElbActiveStandbyPool_basic
=== PAUSE TestAccElbActiveStandbyPool_basic
=== RUN   TestAccElbActiveStandbyPool_quic_protocol
=== PAUSE TestAccElbActiveStandbyPool_quic_protocol
=== CONT  TestAccElbActiveStandbyPool_basic
=== CONT  TestAccElbActiveStandbyPool_quic_protocol
--- PASS: TestAccElbActiveStandbyPool_quic_protocol (64.98s)
--- PASS: TestAccElbActiveStandbyPool_basic (154.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       154.580s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
