### PR TITLE
fix(cae/action): resource params do not include action

### DIFF
--- a/huaweicloud/services/cae/resource_huaweicloud_cae_component_action.go
+++ b/huaweicloud/services/cae/resource_huaweicloud_cae_component_action.go
@@ -161,7 +161,7 @@ func resourceComponentActionCreate(ctx context.Context, d *schema.ResourceData, 
 
 	err = doActionComponent(ctx, client, d, componentId, buildCreateComponentActionBodyParams(d), d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.Errorf("error operating (%s) the component (%s): %s", d.Get("action").(string), componentId, err)
+		return diag.Errorf("error operating the component (%s): %s", componentId, err)
 	}
 	d.SetId(componentId)
 
@@ -186,7 +186,7 @@ func resourceComponentActionUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	err = doActionComponent(ctx, client, d, componentId, buildCreateComponentActionBodyParams(d), d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
-		return diag.Errorf("unable to operate (%s) the component (%s): %s", d.Get("action").(string), componentId, err)
+		return diag.Errorf("unable to operate the component (%s): %s", componentId, err)
 	}
 
 	return resourceComponentActionRead(ctx, d, meta)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
No parameter names 'action', if we obtain it in the resource code and assert it as the string type, the panic will returned.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. no parameter names 'action'.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
