### PR TITLE
feat(as): the AS bandwidth policy resource supports new API

### DIFF
--- a/docs/resources/as_bandwidth_policy.md
+++ b/docs/resources/as_bandwidth_policy.md
@@ -2,7 +2,8 @@
 subcategory: "Auto Scaling"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_as_bandwidth_policy"
-description: ""
+description: |-
+  Manages an AS bandwidth scaling policy resource within HuaweiCloud.
 ---
 
 # huaweicloud_as_bandwidth_policy
@@ -105,6 +106,12 @@ The following arguments are supported:
 * `description` - (Optional, String) Specifies the description of the AS policy.
   The value can contain 0 to 256 characters.
 
+* `action` - (Optional, String) Specifies identification of operation the AS bandwidth policy.
+  After the AS bandwidth policy created, the status is inservice, indicates the AS bandwidth policy is enabled.
+  The valid values are as follows:
+  - **resume**: Indicates enable the AS bandwidth policy.
+  - **pause**: Indicates disable the AS bandwidth policy.
+
 * `scaling_policy_action` - (Optional, List) Specifies the scaling action of the AS policy.
   The [object](#ASBandWidthPolicy_ScalingPolicyAction) structure is documented below.
 
@@ -170,10 +177,36 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - The AS policy status. The value can be **INSERVICE**, **PAUSED** and **EXECUTING**.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 2 minutes.
+* `update` - Default is 2 minutes.
+
 ## Import
 
 The bandwidth scaling policies can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_as_bandwidth_policy.test 0ce123456a00f2591fabc00385ff1234
+$ terraform import huaweicloud_as_bandwidth_policy.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes include: `action`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_as_bandwidth_policy" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      action,
+    ]
+  }
+}
 ```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The AS bandwidth policy resource supports new API.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASBandWidthPolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASBandWidthPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccASBandWidthPolicy_basic
=== PAUSE TestAccASBandWidthPolicy_basic
=== CONT  TestAccASBandWidthPolicy_basic
--- PASS: TestAccASBandWidthPolicy_basic (131.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        131.793s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASBandWidthPolicy_alarm"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASBandWidthPolicy_alarm -timeout 360m -parallel 4
=== RUN   TestAccASBandWidthPolicy_alarm
=== PAUSE TestAccASBandWidthPolicy_alarm
=== CONT  TestAccASBandWidthPolicy_alarm
--- PASS: TestAccASBandWidthPolicy_alarm (62.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        62.073s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
