### PR TITLE
feat(cae/component): enhance component resource and new attributes

### DIFF
--- a/docs/resources/cae_component.md
+++ b/docs/resources/cae_component.md
@@ -116,6 +116,7 @@ The following arguments are supported:
   The valid values are as follows:
   + **deploy**: Deploy component. Only valid for undeployed component.
   + **configure**: Configurations of effesctive component. Only valid for deployed component.
+  + **upgrade**: Upgrade component. Only valid for deployed component.
 
 * `configurations` - (Optional, List) Specifies the list of configurations of the component.  
   The [configurations](#component_configurations) structure is documented below.  
@@ -230,6 +231,14 @@ The `configurations` block supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
+
+* `available_replica` - The number of available instances under the component.
+
+* `status` - The current status of the component.
+  + **running**
+  + **paused**
+  + **notReady**: The component deployed but not ready.
+  + **created**: The component was not deployed.
 
 * `created_at` - The creation time of the component.
 

--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_test.go
@@ -61,6 +61,10 @@ func TestAccComponent_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "spec.0.resource_limit.0.memory", "4Gi"),
 					resource.TestCheckResourceAttr(rName, "spec.0.source.0.type", "image"),
 					resource.TestCheckResourceAttr(rName, "spec.0.source.0.url", acceptance.HW_CAE_IMAGE_URL),
+					// Check attributes.
+					// When the component is not deployed, the number of available instances under it is 0.
+					resource.TestCheckResourceAttr(rName, "available_replica", "0"),
+					resource.TestCheckResourceAttr(rName, "status", "created"),
 					resource.TestCheckResourceAttrSet(rName, "created_at"),
 					resource.TestCheckResourceAttrSet(rName, "updated_at"),
 				),
@@ -205,7 +209,7 @@ func testAccComponentImportStateFunc(name string) resource.ImportStateIdFunc {
 	}
 }
 
-func TestAccComponent_configurations(t *testing.T) {
+func TestAccComponent_configurationsAndAction(t *testing.T) {
 	var (
 		obj interface{}
 
@@ -236,7 +240,7 @@ func TestAccComponent_configurations(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComponent_configurations_step1(name),
+				Config: testAccComponent_configurationsAndAction_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rcWithConfiguration.CheckResourceExists(),
 					resource.TestMatchResourceAttr(withConfiguration, "metadata.0.name", regexp.MustCompile(name)),
@@ -259,7 +263,7 @@ func TestAccComponent_configurations(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccComponent_configurations_step2(name),
+				Config: testAccComponent_configurationsAndAction_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rcWithConfiguration.CheckResourceExists(),
 					resource.TestCheckResourceAttr(withConfiguration, "configurations.#", "1"),
@@ -271,6 +275,51 @@ func TestAccComponent_configurations(t *testing.T) {
 					resource.TestCheckResourceAttr(withConfigurationUpdateDeploy, "configurations.#", "1"),
 					rcWithoutConfigurationUpdateDeploy.CheckResourceExists(),
 					resource.TestCheckResourceAttr(withoutConfigurationUpdateDeploy, "configurations.#", "0"),
+				),
+			},
+			// Upgrade the component.
+			{
+				Config: testAccComponent_configurationsAndAction_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rcWithConfiguration.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withConfiguration, "configurations.#", "1"),
+					resource.TestCheckResourceAttr(withConfiguration, "metadata.0.annotations.version", "2.0.0"),
+					resource.TestCheckResourceAttr(withConfiguration, "spec.0.resource_limit.0.memory", "1Gi"),
+					rcWithoutConfiguration.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withoutConfiguration, "configurations.#", "1"),
+					resource.TestCheckResourceAttr(withoutConfiguration, "metadata.0.annotations.version", "2.0.0"),
+					resource.TestCheckResourceAttr(withoutConfiguration, "spec.0.resource_limit.0.memory", "1Gi"),
+					rcWithConfigurationUpdateDeploy.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withConfigurationUpdateDeploy, "configurations.#", "1"),
+					resource.TestCheckResourceAttr(withConfigurationUpdateDeploy, "metadata.0.annotations.version", "2.0.0"),
+					resource.TestCheckResourceAttr(withConfigurationUpdateDeploy, "spec.0.resource_limit.0.memory", "2Gi"),
+					rcWithoutConfigurationUpdateDeploy.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withoutConfigurationUpdateDeploy, "configurations.#", "1"),
+					resource.TestCheckResourceAttr(withoutConfigurationUpdateDeploy, "metadata.0.annotations.version", "2.0.0"),
+					resource.TestCheckResourceAttr(withoutConfigurationUpdateDeploy, "spec.0.resource_limit.0.memory", "2Gi"),
+					resource.TestCheckResourceAttrSet(withoutConfigurationUpdateDeploy, "status"),
+					// In some cases, the component is deployed successfully but its instance is unavailable, so this property
+					// `available_replica` is not asserted.
+				),
+			},
+			// Upgrade the component again to verify that the action has not changed.
+			{
+				Config: testAccComponent_configurationsAndAction_step4(name),
+				Check: resource.ComposeTestCheckFunc(
+					rcWithConfiguration.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withConfiguration, "metadata.0.annotations.version", "2.0.0"),
+					resource.TestCheckResourceAttr(withConfiguration, "spec.0.resource_limit.0.memory", "2Gi"),
+					rcWithoutConfiguration.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withoutConfiguration, "metadata.0.annotations.version", "2.0.0"),
+					resource.TestCheckResourceAttr(withoutConfiguration, "spec.0.resource_limit.0.memory", "2Gi"),
+					rcWithConfigurationUpdateDeploy.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withConfigurationUpdateDeploy, "metadata.0.annotations.version", "3.0.0"),
+					resource.TestCheckResourceAttr(withConfigurationUpdateDeploy, "spec.0.resource_limit.0.memory", "2Gi"),
+					rcWithoutConfigurationUpdateDeploy.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withoutConfigurationUpdateDeploy, "configurations.#", "1"),
+					resource.TestCheckResourceAttr(withoutConfigurationUpdateDeploy, "metadata.0.annotations.version", "3.0.0"),
+					resource.TestCheckResourceAttr(withoutConfigurationUpdateDeploy, "spec.0.resource_limit.0.memory", "2Gi"),
+					resource.TestCheckResourceAttrSet(withoutConfigurationUpdateDeploy, "status"),
 				),
 			},
 			{
@@ -331,7 +380,7 @@ func testAccComponent_deploy_base() string {
 data "huaweicloud_swr_repositories" "test" {}
 
 locals {
-  swr_repositories = [for v in data.huaweicloud_swr_repositories.test.repositories : v if length(v.tags) > 0][0]
+  swr_repositories = [for v in data.huaweicloud_swr_repositories.test.repositories : v if length(v.tags) > 1][0]
 }
 
 locals {
@@ -382,10 +431,12 @@ locals {
 `
 }
 
-func testAccComponent_configurations_step1(name string) string {
+func testAccComponent_configurationsAndAction_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
+# Deploy components directly after creation, and the first component specifies 'configurations', the second component does not specify
+# 'configurations'.
 resource "huaweicloud_cae_component" "test" {
   count          = 2
   environment_id = "%[2]s"
@@ -425,6 +476,7 @@ resource "huaweicloud_cae_component" "test" {
   }
 }
 
+# The components are not deployed when created.
 resource "huaweicloud_cae_component" "deploy_after_update" {
   count          = 2
   environment_id = "%[2]s"
@@ -456,7 +508,7 @@ resource "huaweicloud_cae_component" "deploy_after_update" {
 `, testAccComponent_deploy_base(), acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID, name)
 }
 
-func testAccComponent_configurations_step2(name string) string {
+func testAccComponent_configurationsAndAction_step2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -468,6 +520,7 @@ locals {
   }]
 }
 
+# Modify the configurations of the component, and the action is 'configure'.
 resource "huaweicloud_cae_component" "test" {
   count          = 2
   environment_id = "%[2]s"
@@ -507,6 +560,7 @@ resource "huaweicloud_cae_component" "test" {
   }
 }
 
+# Modify the configurations of the component, and the action is 'deploy'.
 resource "huaweicloud_cae_component" "deploy_after_update" {
   count          = 2
   environment_id = "%[2]s"
@@ -539,6 +593,177 @@ resource "huaweicloud_cae_component" "deploy_after_update" {
 
   dynamic "configurations" {
     for_each = count.index == 0 ? local.configurations_update : []
+    content {
+      type = configurations.value.type
+      data = configurations.value.data
+    }
+  }
+}
+`, testAccComponent_deploy_base(), acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID, name)
+}
+
+// Upgrade the component, modify the configuration, version and other parameters, and the action is 'upgrade'.
+func testAccComponent_configurationsAndAction_step3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cae_component" "test" {
+  count          = 2
+  environment_id = "%[2]s"
+  application_id = "%[3]s"
+
+  metadata {
+    name = "%[4]s${count.index}"
+
+    annotations = {
+      version = "2.0.0"
+    }
+  }
+
+  spec {
+    replica = 1
+    runtime = "Docker"
+
+    source {
+      type = "image"
+      url  = format("%%s:%%s", local.swr_repositories.path, local.swr_repositories.tags[1])
+    }
+
+    resource_limit {
+      cpu    = "500m"
+      memory = "1Gi"
+    }
+  }
+
+  action = "upgrade"
+
+  dynamic "configurations" {
+    for_each = local.configurations_update
+    content {
+      type = configurations.value.type
+      data = configurations.value.data
+    }
+  }
+}
+
+resource "huaweicloud_cae_component" "deploy_after_update" {
+  count          = 2
+  environment_id = "%[2]s"
+  application_id = "%[3]s"
+
+  metadata {
+    name = "%[4]s-update-${count.index}"
+
+    annotations = {
+      version = "2.0.0"
+    }
+  }
+
+  spec {
+    replica = 1
+    runtime = "Docker"
+
+    source {
+      type = "image"
+      url  = format("%%s:%%s", local.swr_repositories.path, local.swr_repositories.tags[1])
+    }
+
+    resource_limit {
+      cpu    = "500m"
+      memory = "2Gi"
+    }
+  }
+
+  action = "upgrade"
+
+  dynamic "configurations" {
+    for_each = local.configurations_update
+    content {
+      type = configurations.value.type
+      data = configurations.value.data
+    }
+  }
+}
+`, testAccComponent_deploy_base(), acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID, name)
+}
+
+func testAccComponent_configurationsAndAction_step4(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Verify that only 'resource_limit' is changed.
+resource "huaweicloud_cae_component" "test" {
+  count          = 2
+  environment_id = "%[2]s"
+  application_id = "%[3]s"
+
+  metadata {
+    name = "%[4]s${count.index}"
+
+    annotations = {
+      version = "2.0.0"
+    }
+  }
+
+  spec {
+    replica = 1
+    runtime = "Docker"
+
+    source {
+      type = "image"
+      url  = format("%%s:%%s", local.swr_repositories.path, local.swr_repositories.tags[1])
+    }
+
+    resource_limit {
+      cpu    = "500m"
+      memory = "2Gi"
+    }
+  }
+
+  action = "upgrade"
+
+  dynamic "configurations" {
+    for_each = local.configurations_update
+    content {
+      type = configurations.value.type
+      data = configurations.value.data
+    }
+  }
+}
+
+# Verify that only the 'version' is changed and that 'resource_limit' is ignored in the request body.
+resource "huaweicloud_cae_component" "deploy_after_update" {
+  count          = 2
+  environment_id = "%[2]s"
+  application_id = "%[3]s"
+
+  metadata {
+    name = "%[4]s-update-${count.index}"
+
+    annotations = {
+      version = "3.0.0"
+    }
+  }
+
+  spec {
+    replica = 1
+    runtime = "Docker"
+
+    source {
+      type = "image"
+      url  = format("%%s:%%s", local.swr_repositories.path, local.swr_repositories.tags[1])
+    }
+
+    resource_limit {
+      cpu    = "500m"
+      memory = "2Gi"
+    }
+  }
+
+  action = "upgrade"
+
+  dynamic "configurations" {
+    for_each = local.configurations_update
     content {
       type = configurations.value.type
       data = configurations.value.data


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Enhance component resource and new attributes.
+ Support logic with action upgrade in update method.
+ New attributes: status and available_replica.
+ Added logic in delete method to determine that if the number available instances under the component is not 0, the component must be stopped before deletion.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cae -f TestAccComponent_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccComponent_ -timeout 360m -parallel 10
=== RUN   TestAccComponent_basic
=== PAUSE TestAccComponent_basic
=== RUN   TestAccComponent_configurationsAndAction
=== PAUSE TestAccComponent_configurationsAndAction
=== CONT  TestAccComponent_basic
=== CONT  TestAccComponent_configurationsAndAction
--- PASS: TestAccComponent_basic (60.75s)
--- PASS: TestAccComponent_configurationsAndAction (948.16s)
PASS
coverage: 16.8% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       948.265s        coverage: 16.8% of statements in ./huaweicloud/services/cae
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
