### PR TITLE
feat(lts): add new resource supports kafka instance register to LTS

### DIFF
--- a/docs/resources/lts_register_kafka_instance.md
+++ b/docs/resources/lts_register_kafka_instance.md
@@ -1,0 +1,66 @@
+---
+subcategory: "Log Tank Service (LTS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_lts_register_kafka_instance"
+description: |-
+  Use this resource to register the Kafka instance to LTS within HuaweiCloud.
+---
+
+
+# huaweicloud_lts_register_kafka_instance
+
+Use this resource to register the Kafka instance to LTS within HuaweiCloud.
+
+-> 1. Before registering a Kafka instance, please configure the inbound rules of the security group to which the Kafka
+  instance belongs. Please refer to the [document](https://support.huaweicloud.com/intl/en-us/usermanual-lts/lts_04_0043.html).
+  <br>2. The same Kafka instance can only be registered once.
+  <br>3. This resource is only a one-time action resource for registering the Kafka instance to LTS. Deleting this resource
+  will not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "kafka_instance_id" {}
+variable "kafka_instance_name" {}
+variable "kafka_instance_access_user" {}
+variable "kafka_instance_access_password" {}
+
+resource "huaweicloud_lts_register_kafka_instance" "test" {
+  instance_id = var.kafka_instance_id
+  kafka_name  = var.kafka_instance_name
+
+  connect_info {
+    user_name = var.kafka_instance_access_user
+    pwd       = var.kafka_instance_access_password
+  } 
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the Kafka instance to be registered to the LTS.
+
+* `kafka_name` - (Required, String, NonUpdatable) Specifies the name of the Kafka instance to be registered to the LTS.
+
+* `connect_info` - (Optional, List, NonUpdatable) Specifies the connection information of the Kafka instance to be
+  registered to the LTS.  
+  The [connect_info](#register_kafka_to_lts_connect_info) structure is documented below.  
+  This parameter is available and required only when the registered Kafka instance is encrypted access.
+
+<a name="register_kafka_to_lts_connect_info"></a>
+The `connect_info` block supports:
+
+* `user_name` - (Optional, String, NonUpdatable) Specifies the name of the SASL_SSL user of the Kafka instance.
+
+* `pwd` - (Optional, String, NonUpdatable) Specifies the password of the SASL_SSL user of the Kafka instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2072,6 +2072,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_lts_log_converge":                     lts.ResourceLogConverge(),
 			"huaweicloud_lts_log_converge_switch":              lts.ResourceLogConvergeSwitch(),
 			"huaweicloud_lts_metric_rule":                      lts.ResourceMetricRule(),
+			"huaweicloud_lts_register_kafka_instance":          lts.ResourceRegisterKafkaInstance(),
 			"huaweicloud_lts_stream":                           lts.ResourceLTSStream(),
 			"huaweicloud_lts_structing_template":               lts.ResourceStructConfig(),
 			"huaweicloud_lts_structuring_custom_configuration": lts.ResourceStructCustomConfig(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -200,6 +200,10 @@ var (
 	HW_LTS_ENABLE_FLAG                 = os.Getenv("HW_LTS_ENABLE_FLAG")
 	HW_LTS_STRUCT_CONFIG_TEMPLATE_ID   = os.Getenv("HW_LTS_STRUCT_CONFIG_TEMPLATE_ID")
 	HW_LTS_STRUCT_CONFIG_TEMPLATE_NAME = os.Getenv("HW_LTS_STRUCT_CONFIG_TEMPLATE_NAME")
+	// Two Kafka instance IDs must be set, separated by a comma (,).
+	// It consists of the Kafka instance ID connected via encrypted and the Kafka instance ID connected via plain text
+	HW_LTS_KAFKA_INSTANCE_IDS      = os.Getenv("HW_LTS_KAFKA_INSTANCE_IDS")
+	HW_LTS_KAFKA_INSTANCE_PASSWORD = os.Getenv("HW_LTS_KAFKA_INSTANCE_PASSWORD")
 
 	HW_LIVE_STREAMING_DOMAIN_NAME          = os.Getenv("HW_LIVE_STREAMING_DOMAIN_NAME")
 	HW_LIVE_INGEST_RTMP_DOMAIN_NAME        = os.Getenv("HW_LIVE_INGEST_RTMP_DOMAIN_NAME")
@@ -2075,6 +2079,22 @@ func TestAccPreCheckLtsStructConfigCustom(t *testing.T) {
 	if HW_LTS_STRUCT_CONFIG_TEMPLATE_ID == "" || HW_LTS_STRUCT_CONFIG_TEMPLATE_NAME == "" {
 		t.Skip("HW_LTS_STRUCT_CONFIG_TEMPLATE_ID and HW_LTS_STRUCT_CONFIG_TEMPLATE_NAME must be" +
 			" set for LTS struct config custom acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckLtsKafkaInstanceIds(t *testing.T) {
+	if len(strings.Split(HW_LTS_KAFKA_INSTANCE_IDS, ",")) != 2 {
+		t.Skip(`The Kafka instance is registered to LTS acceptance tests must set the Kafka instance IDs, plesse config them
+in the HW_LTS_KAFKA_INSTANCE_IDS environment variable, and IDs consist of encrypted instance ID and plaintext instance ID,
+separated by a commas (,)`)
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckLtsKafkaInstancePsw(t *testing.T) {
+	if HW_LTS_KAFKA_INSTANCE_PASSWORD == "" {
+		t.Skip("HW_LTS_KAFKA_INSTANCE_PASSWORD must be set for the encrypted access Kafka instance to be registered to the LTS acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_register_kafka_instance_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_register_kafka_instance_test.go
@@ -1,0 +1,150 @@
+package lts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccRegisterKafkaInstance_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLtsKafkaInstanceIds(t)
+			acceptance.TestAccPreCheckLtsKafkaInstancePsw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceRegisterKafkaInstance_basic(name),
+			},
+		},
+	})
+}
+
+func resourceRegisterKafkaInstance_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lts_group" "test" {
+  group_name  = "%[1]s"
+  ttl_in_days = 30
+}
+
+resource "huaweicloud_lts_stream" "test" {
+  group_id    = huaweicloud_lts_group.test.id
+  stream_name = "%[1]s"
+}
+`, name)
+}
+
+func resourceRegisterKafkaInstance_verity(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id = local.kafka_instance.id
+  name        = "%[1]s"
+  partitions  = 3
+}
+
+resource "huaweicloud_lts_transfer" "test" {
+  log_group_id = huaweicloud_lts_group.test.id
+
+  log_streams {
+    log_stream_id = huaweicloud_lts_stream.test.id
+  }
+
+  log_transfer_info {
+    log_transfer_type   = "DMS"
+    log_transfer_mode   = "realTime"
+    log_storage_format  = "RAW"
+    log_transfer_status = "ENABLE"
+
+    log_transfer_detail {
+      kafka_id    = local.kafka_instance.id
+      kafka_topic = huaweicloud_dms_kafka_topic.test.id
+    }
+  }
+
+  depends_on = [huaweicloud_lts_register_kafka_instance.test]
+}
+`, name)
+}
+
+func resourceRegisterKafkaInstance_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_dms_kafka_instances" test {
+  instance_id = element(split(",", "%[2]s"), 0)
+}
+
+locals {
+  kafka_instance = data.huaweicloud_dms_kafka_instances.test.instances[0]
+}
+
+resource "huaweicloud_lts_register_kafka_instance" "test" {
+  instance_id = local.kafka_instance.id
+  kafka_name  = local.kafka_instance.name
+
+  connect_info {
+    user_name = local.kafka_instance.access_user
+    pwd       = "%[3]s"
+  }
+}
+
+# Verify that the Kafka instance accessed by the encrypted data has been successfully registered to LTS.
+%[4]s
+`, resourceRegisterKafkaInstance_base(name),
+		acceptance.HW_LTS_KAFKA_INSTANCE_IDS,
+		acceptance.HW_LTS_KAFKA_INSTANCE_PASSWORD,
+		resourceRegisterKafkaInstance_verity(name))
+}
+
+func TestAccRegisterKafkaInstance_notSSL(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLtsKafkaInstanceIds(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceRegisterKafkaInstance_notSSL(name),
+			},
+		},
+	})
+}
+
+func resourceRegisterKafkaInstance_notSSL(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_dms_kafka_instances" test {
+  instance_id = element(split(",", "%[2]s"), 1)
+}
+
+locals {
+  kafka_instance = data.huaweicloud_dms_kafka_instances.test.instances[0]
+}
+
+resource "huaweicloud_lts_register_kafka_instance" "test" {
+  instance_id = local.kafka_instance.id
+  kafka_name  = local.kafka_instance.name
+}
+
+# Verify that the Kafka instance by plaintext access has been successfully registered to LTS.
+%[3]s
+`, resourceRegisterKafkaInstance_base(name),
+		acceptance.HW_LTS_KAFKA_INSTANCE_IDS,
+		resourceRegisterKafkaInstance_verity(name))
+}

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_register_kafka_instance.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_register_kafka_instance.go
@@ -1,0 +1,152 @@
+package lts
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var registerKafkaNonUpdatableParams = []string{"instance_id", "kafka_name", "connect_info", "connect_info.*.user_name", "connect_info.*.pwd"}
+
+// @API LTS POST /v2/{project_id}/lts/dms/kafka-instance
+func ResourceRegisterKafkaInstance() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRegisterKafkaInstanceCreate,
+		ReadContext:   resourceRegisterKafkaInstanceRead,
+		UpdateContext: resourceRegisterKafkaInstanceUpdate,
+		DeleteContext: resourceRegisterKafkaInstanceDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(registerKafkaNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the Kafka instance to be registered to the LTS.`,
+			},
+			"kafka_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the Kafka instance to be registered to the LTS.`,
+			},
+			"connect_info": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"user_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The name of the SASL_SSL user of the Kafka instance.`,
+						},
+						"pwd": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The password of the SASL_SSL user of the Kafka instance.`,
+						},
+					},
+				},
+				Description: `The connection information of the Kafka instance to be registered to the LTS.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceRegisterKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/lts/dms/kafka-instance"
+	)
+
+	client, err := cfg.NewServiceClient("lts", region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+		JSONBody:         buildCreateRegisterKafkaInstancemBodyParams(d),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return diag.Errorf("unable to register Kafka instance (%s) to LTS: %s", d.Get("instance_id").(string), err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	instanceId := utils.PathSearch("instance_id", respBody, "").(string)
+	if instanceId == "" {
+		return diag.Errorf("unable to find the ID from the API response")
+	}
+
+	d.SetId(instanceId)
+
+	return resourceRegisterKafkaInstanceRead(ctx, d, meta)
+}
+
+func buildCreateRegisterKafkaInstancemBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"instance_id": d.Get("instance_id"),
+		"kafka_name":  d.Get("kafka_name"),
+		// For non-authenticated Kafka, this parameter must be specified as an empty object, otherwise the interface will report an error.
+		"connect_info": buildConnectInfo(d.Get("connect_info").([]interface{})),
+	}
+}
+
+func buildConnectInfo(connectInfo []interface{}) map[string]interface{} {
+	if len(connectInfo) == 0 || connectInfo[0] == nil {
+		return map[string]interface{}{}
+	}
+
+	return map[string]interface{}{
+		"user_name": utils.PathSearch("user_name", connectInfo[0], nil),
+		"pwd":       utils.PathSearch("pwd", connectInfo[0], nil),
+	}
+}
+
+func resourceRegisterKafkaInstanceRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceRegisterKafkaInstanceUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceRegisterKafkaInstanceDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for registering the Kafka instance to LTS. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource supports kafka instance register to LTS.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Add new resource supports kafka instance register to LTS. This is a one-time action resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o lts -f TestAccRegistKafkaInstance_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccRegistKafkaInstance_ -timeout 360m -parallel 10
=== RUN   TestAccRegistKafkaInstance_basic
=== PAUSE TestAccRegistKafkaInstance_basic
=== RUN   TestAccRegistKafkaInstance_notSSL
=== PAUSE TestAccRegistKafkaInstance_notSSL
=== CONT  TestAccRegistKafkaInstance_basic
=== CONT  TestAccRegistKafkaInstance_notSSL
--- PASS: TestAccRegistKafkaInstance_notSSL (116.33s)
--- PASS: TestAccRegistKafkaInstance_basic (119.40s)
PASS
coverage: 11.0% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       119.485s        coverage: 11.0% of statements in ./huaweicloud/services/lts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
