### PR TITLE
feat(ELB): add attribute fingerprint to elb certificate resource

### DIFF
--- a/docs/resources/elb_certificate.md
+++ b/docs/resources/elb_certificate.md
@@ -116,6 +116,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - Indicates the resource ID.
 
+* `fingerprint` - Indicates the fingerprint of the certificate.
+
 * `subject_alternative_names` - Indicates all the domain names of the certificate.
 
 * `update_time` - Indicates the update time.

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_certificate_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_certificate_test.go
@@ -66,6 +66,8 @@ func TestAccElbV3Certificate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", "server"),
 					resource.TestCheckResourceAttr(resourceName, "domain", "www.elb.com"),
 					resource.TestCheckResourceAttr(resourceName, "description", "terraform test certificate"),
+					resource.TestCheckResourceAttrSet(resourceName, "fingerprint"),
+					resource.TestCheckResourceAttrSet(resourceName, "subject_alternative_names.#"),
 				),
 			},
 			{

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_certificate.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_certificate.go
@@ -85,6 +85,10 @@ func ResourceCertificateV3() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+			"fingerprint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"subject_alternative_names": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -211,6 +215,7 @@ func resourceCertificateV3Read(_ context.Context, d *schema.ResourceData, meta i
 		d.Set("enc_certificate", utils.PathSearch("certificate.enc_certificate", getRespBody, nil)),
 		d.Set("scm_certificate_id", utils.PathSearch("certificate.scm_certificate_id", getRespBody, nil)),
 		d.Set("enterprise_project_id", utils.PathSearch("certificate.enterprise_project_id", getRespBody, nil)),
+		d.Set("fingerprint", utils.PathSearch("certificate.fingerprint", getRespBody, nil)),
 		d.Set("subject_alternative_names", utils.PathSearch("certificate.subject_alternative_names",
 			getRespBody, nil)),
 	)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add attribute fingerprint to elb certificate resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add attribute fingerprint to elb certificate resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/elb/ TESTARGS='-run TestAccElbV3Certificate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v -run TestAccElbV3Certificate_ -timeout 360m -parallel 4
=== RUN   TestAccElbV3Certificate_basic
=== PAUSE TestAccElbV3Certificate_basic
=== RUN   TestAccElbV3Certificate_client
=== PAUSE TestAccElbV3Certificate_client
=== RUN   TestAccElbV3Certificate_serverSm
=== PAUSE TestAccElbV3Certificate_serverSm
=== CONT  TestAccElbV3Certificate_basic
=== CONT  TestAccElbV3Certificate_client
=== CONT  TestAccElbV3Certificate_serverSm
--- PASS: TestAccElbV3Certificate_serverSm (21.42s)
--- PASS: TestAccElbV3Certificate_client (21.70s)
--- PASS: TestAccElbV3Certificate_basic (35.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       35.187s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
