### PR TITLE
feat(ELB): add params to lb certificate resource

### DIFF
--- a/docs/resources/lb_certificate.md
+++ b/docs/resources/lb_certificate.md
@@ -86,16 +86,26 @@ The following arguments are supported:
 
 * `type` - (Optional, String, ForceNew) Specifies the certificate type. The default value is "server". The value can be
   one of the following:
-  + server: indicates the server certificate.
-  + client: indicates the CA certificate.
+  + **server**: indicates the server certificate.
+  + **client**: indicates the CA certificate.
 
 * `certificate` - (Required, String) The public encrypted key of the Certificate, PEM format.
 
 * `private_key` - (Optional, String) The private encrypted key of the Certificate, PEM format. This parameter is valid
-  and mandatory only when `type` is set to "server".
+  and mandatory only when `type` is set to **server**.
 
 * `domain` - (Optional, String) The domain of the Certificate. The value contains a maximum of 100 characters. This
-  parameter is valid only when `type` is set to "server".
+  parameter is valid only when `type` is set to **server**.
+
+* `source` - (Optional, String) Specifies the source of the certificate.
+
+* `protection_status` - (Optional, String) Specifies the protection status. Value options:
+  + **nonProtection**: The load balancer is not protected.
+  + **consoleProtection**: Modification protection is enabled to avoid that resources are modified by accident on the console.
+
+  Defaults to **nonProtection**.
+
+* `protection_reason` - (Optional, String) Specifies why the modification protection is enabled.
 
 * `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project ID of the certificate. Changing this
   creates a new certificate.
@@ -119,10 +129,10 @@ This resource provides the following timeouts configuration options:
 
 ## Import
 
-ELB certificate can be imported using the certificate ID, e.g.
+ELB certificate can be imported using the `id` e.g.
 
 ```bash
-$ terraform import huaweicloud_lb_certificate.certificate_1 5c20fdad-7288-11eb-b817-0255ac10158b
+$ terraform import huaweicloud_lb_certificate.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
@@ -132,12 +142,12 @@ You can then decide if changes should be applied to the certificate, or the reso
 definition should be updated to align with the certificate. Also you can ignore changes as below.
 
 ```hcl
-resource "huaweicloud_lb_certificate" "certificate_1" {
+resource "huaweicloud_lb_certificate" "test" {
     ...
 
   lifecycle {
     ignore_changes = [
-      enterprise_project_id,
+      enterprise_project_id, private_key,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_certificate_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_certificate_test.go
@@ -2,32 +2,50 @@ package lb
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/elb/v2/certificates"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getCertificateResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	c, err := conf.LoadBalancerClient(acceptance.HW_REGION_NAME)
+func getCertificateResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/elb/certificates/{certificate_id}"
+		product = "elb"
+	)
+	client, err := cfg.NewServiceClient(product, acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating HuaweiCloud LB v2 client: %s", err)
+		return nil, err
 	}
-	resp, err := certificates.Get(c, state.Primary.ID).Extract()
-	if resp == nil && err == nil {
-		return resp, fmt.Errorf("Unable to find the certificate (%s)", state.Primary.ID)
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{certificate_id}", state.Primary.ID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
-	return resp, err
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(getResp)
 }
 
 func TestAccLBV2Certificate_basic(t *testing.T) {
 	var c certificates.Certificate
 	name := acceptance.RandomAccResourceNameWithDash()
+	updateName := acceptance.RandomAccResourceNameWithDash()
 	resourceName := "huaweicloud_lb_certificate.certificate_1"
 
 	rc := acceptance.InitResourceCheck(
@@ -49,20 +67,29 @@ func TestAccLBV2Certificate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "terraform test certificate"),
 					resource.TestCheckResourceAttr(resourceName, "domain", "www.elb.com"),
 					resource.TestCheckResourceAttr(resourceName, "type", "server"),
+					resource.TestCheckResourceAttr(resourceName, "protection_status", "consoleProtection"),
+					resource.TestCheckResourceAttr(resourceName, "protection_reason", "test protection"),
+					resource.TestCheckResourceAttr(resourceName, "source", "scm"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
 				),
 			},
 			{
-				Config: testAccLBV2CertificateConfig_update(name),
+				Config: testAccLBV2CertificateConfig_update(updateName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_updated", name)),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
 					resource.TestCheckResourceAttr(resourceName, "description", "terraform test certificate update"),
 					resource.TestCheckResourceAttr(resourceName, "domain", "www.elbUpdate.com"),
+					resource.TestCheckResourceAttr(resourceName, "protection_status", "nonProtection"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"enterprise_project_id",
+					"private_key",
+				},
 			},
 		},
 	})
@@ -96,41 +123,16 @@ func TestAccLBV2Certificate_client(t *testing.T) {
 	})
 }
 
-func TestAccLBV2Certificate_withEpsId(t *testing.T) {
-	var c certificates.Certificate
-	name := acceptance.RandomAccResourceNameWithDash()
-	resourceName := "huaweicloud_lb_certificate.certificate_1"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&c,
-		getCertificateResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheckEpsID(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccLBV2CertificateConfig_withEpsId(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "type", "server"),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
-				),
-			},
-		},
-	})
-}
-
 func testAccLBV2CertificateConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_lb_certificate" "certificate_1" {
-  name        = "%s"
-  description = "terraform test certificate"
-  domain      = "www.elb.com"
+  name                  = "%s"
+  description           = "terraform test certificate"
+  domain                = "www.elb.com"
+  protection_status     = "consoleProtection"
+  protection_reason     = "test protection"
+  source                = "scm"
+  enterprise_project_id = "0"
   private_key = <<EOT
 -----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
@@ -198,9 +200,12 @@ EOT
 func testAccLBV2CertificateConfig_update(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_lb_certificate" "certificate_1" {
-  name        = "%s_updated"
-  description = "terraform test certificate update"
-  domain      = "www.elbUpdate.com"
+  name                  = "%s"
+  description           = "terraform test certificate update"
+  domain                = "www.elbUpdate.com"
+  protection_status     = "nonProtection"
+  source                = "scm"
+  enterprise_project_id = "0"
   private_key = <<EOT
 -----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
@@ -298,69 +303,4 @@ i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
 EOT
 }
 `, name)
-}
-
-func testAccLBV2CertificateConfig_withEpsId(name string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_lb_certificate" "certificate_1" {
-  name                  = "%s"
-  description           = "terraform test certificate"
-  domain                = "www.elb.com"
-  enterprise_project_id = "%s"
-  private_key           = <<EOT
------BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
-qEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYldiE6Vp8HH5BSKaCWKVg8lGWg1
-UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb3iyNBmiZ8aZhGw2pI1YwR+15
-MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dzQ8z1JXWdg8/9Zx7Ktvgwu5PQ
-M3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5mf2DPkVgM08XAgaLJcLigwD5
-13koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwIDAQABAoIBACU9S5fjD9/jTMXA
-DRs08A+gGgZUxLn0xk+NAPX3LyB1tfdkCaFB8BccLzO6h3KZuwQOBPv6jkdvEDbx
-Nwyw3eA/9GJsIvKiHc0rejdvyPymaw9I8MA7NbXHaJrY7KpqDQyk6sx+aUTcy5jg
-iMXLWdwXYHhJ/1HVOo603oZyiS6HZeYU089NDUcX+1SJi3e5Ke0gPVXEqCq1O11/
-rh24bMxnwZo4PKBWdcMBN5Zf/4ij9vrZE+fFzW7vGBO48A5lvZxWU2U5t/OZQRtN
-1uLOHmMFa0FIF2aWbTVfwdUWAFsvAOkHj9VV8BXOUwKOUuEktdkfAlvrxmsFrO/H
-yDeYYPkCgYEA/S55CBbR0sMXpSZ56uRn8JHApZJhgkgvYr+FqDlJq/e92nAzf01P
-RoEBUajwrnf1ycevN/SDfbtWzq2XJGqhWdJmtpO16b7KBsC6BdRcH6dnOYh31jgA
-vABMIP3wzI4zSVTyxRE8LDuboytF1mSCeV5tHYPQTZNwrplDnLQhywcCgYEAw8Yc
-Uk/eiFr3hfH/ZohMfV5p82Qp7DNIGRzw8YtVG/3+vNXrAXW1VhugNhQY6L+zLtJC
-aKn84ooup0m3YCg0hvINqJuvzfsuzQgtjTXyaE0cEwsjUusOmiuj09vVx/3U7siK
-Hdjd2ICPCvQ6Q8tdi8jV320gMs05AtaBkZdsiWUCgYEAtLw4Kk4f+xTKDFsrLUNf
-75wcqhWVBiwBp7yQ7UX4EYsJPKZcHMRTk0EEcAbpyaJZE3I44vjp5ReXIHNLMfPs
-uvI34J4Rfot0LN3n7cFrAi2+wpNo+MOBwrNzpRmijGP2uKKrq4JiMjFbKV/6utGF
-Up7VxfwS904JYpqGaZctiIECgYA1A6nZtF0riY6ry/uAdXpZHL8ONNqRZtWoT0kD
-79otSVu5ISiRbaGcXsDExC52oKrSDAgFtbqQUiEOFg09UcXfoR6HwRkba2CiDwve
-yHQLQI5Qrdxz8Mk0gIrNrSM4FAmcW9vi9z4kCbQyoC5C+4gqeUlJRpDIkQBWP2Y4
-2ct/bQKBgHv8qCsQTZphOxc31BJPa2xVhuv18cEU3XLUrVfUZ/1f43JhLp7gynS2
-ep++LKUi9D0VGXY8bqvfJjbECoCeu85vl8NpCXwe/LoVoIn+7KaVIZMwqoGMfgNl
-nEqm7HWkNxHhf8A6En/IjleuddS1sf9e/x+TJN1Xhnt9W6pe7Fk1
------END RSA PRIVATE KEY-----
-EOT
-
-  certificate = <<EOT
------BEGIN CERTIFICATE-----
-MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
-BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
-CQYDVQQLDAJ4eDELMAkGA1UEAwwCeHgxGTAXBgkqhkiG9w0BCQEWCnh4QDE2My5j
-b20wHhcNMTcxMjA0MDM0MjQ5WhcNMjAxMjAzMDM0MjQ5WjBpMQswCQYDVQQGEwJ4
-eDELMAkGA1UECAwCeHgxCzAJBgNVBAcMAnh4MQswCQYDVQQKDAJ4eDELMAkGA1UE
-CwwCeHgxCzAJBgNVBAMMAnh4MRkwFwYJKoZIhvcNAQkBFgp4eEAxNjMuY29tMIIB
-IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN
-2s8tZ/6LC3X82fajpVsYqF1xqEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYld
-iE6Vp8HH5BSKaCWKVg8lGWg1UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb
-3iyNBmiZ8aZhGw2pI1YwR+15MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dz
-Q8z1JXWdg8/9Zx7Ktvgwu5PQM3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5
-mf2DPkVgM08XAgaLJcLigwD513koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwID
-AQABo1AwTjAdBgNVHQ4EFgQUo5A2tIu+bcUfvGTD7wmEkhXKFjcwHwYDVR0jBBgw
-FoAUo5A2tIu+bcUfvGTD7wmEkhXKFjcwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
-AQsFAAOCAQEAWJ2rS6Mvlqk3GfEpboezx2J3X7l1z8Sxoqg6ntwB+rezvK3mc9H0
-83qcVeUcoH+0A0lSHyFN4FvRQL6X1hEheHarYwJK4agb231vb5erasuGO463eYEG
-r4SfTuOm7SyiV2xxbaBKrXJtpBp4WLL/s+LF+nklKjaOxkmxUX0sM4CTA7uFJypY
-c8Tdr8lDDNqoUtMD8BrUCJi+7lmMXRcC3Qi3oZJW76ja+kZA5mKVFPd1ATih8TbA
-i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
-i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
------END CERTIFICATE-----
-EOT
-}
-`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_certificate.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_certificate.go
@@ -287,7 +287,7 @@ func resourceCertificateV3Delete(_ context.Context, d *schema.ResourceData, meta
 	}
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return diag.Errorf("error deleting ELB certificate: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting ELB certificate")
 	}
 
 	return nil

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_certificate.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_certificate.go
@@ -2,20 +2,18 @@ package lb
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/chnsz/golangsdk/openstack/elb/v2/certificates"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 // @API ELB POST /v2/{project_id}/elb/certificates
@@ -45,60 +43,64 @@ func ResourceCertificateV2() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
-
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
 			"type": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
-				Default:  "server",
 			},
-
 			"domain": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
 			"private_key": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				DiffSuppressFunc: utils.SuppressNewLineDiffs,
 				Sensitive:        true,
 			},
-
 			"certificate": {
 				Type:             schema.TypeString,
 				Required:         true,
 				DiffSuppressFunc: utils.SuppressNewLineDiffs,
 				Sensitive:        true,
 			},
-
+			"protection_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"protection_reason": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"source": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
-
 			"update_time": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"create_time": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"expire_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -109,135 +111,178 @@ func ResourceCertificateV2() *schema.Resource {
 
 func resourceCertificateV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	elbClient, err := cfg.LoadBalancerClient(cfg.GetRegion(d))
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v2/{project_id}/elb/certificates"
+		product = "elb"
+	)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
-	createOpts := certificates.CreateOpts{
-		Name:                d.Get("name").(string),
-		Description:         d.Get("description").(string),
-		Type:                d.Get("type").(string),
-		Domain:              d.Get("domain").(string),
-		EnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
-
-	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
-
-	// Add certificate and private_key here so they wouldn't go in the above log entry
-	createOpts.Certificate = d.Get("certificate").(string)
-	createOpts.PrivateKey = d.Get("private_key").(string)
-
-	c, err := certificates.Create(elbClient, createOpts).Extract()
+	createOpt.JSONBody = utils.RemoveNil(buildCreateCertificateBodyParams(d, cfg))
+	createResp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating Certificate: %s", err)
+		return diag.Errorf("error creating ELB certificate: %s", err)
 	}
 
-	// If all has been successful, set the ID on the resource
-	d.SetId(c.Id)
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.Errorf("error retrieving ELB certificate: %s", err)
+	}
+	certificateId := utils.PathSearch("id", createRespBody, "").(string)
+	if certificateId == "" {
+		return diag.Errorf("error creating ELB certificate: ID is not found in API response")
+	}
+
+	d.SetId(certificateId)
 
 	return resourceCertificateV2Read(ctx, d, meta)
+}
+
+func buildCreateCertificateBodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":                  utils.ValueIgnoreEmpty(d.Get("name")),
+		"description":           utils.ValueIgnoreEmpty(d.Get("description")),
+		"type":                  utils.ValueIgnoreEmpty(d.Get("type")),
+		"domain":                utils.ValueIgnoreEmpty(d.Get("domain")),
+		"private_key":           utils.ValueIgnoreEmpty(d.Get("private_key")),
+		"certificate":           utils.ValueIgnoreEmpty(d.Get("certificate")),
+		"protection_reason":     utils.ValueIgnoreEmpty(d.Get("protection_reason")),
+		"protection_status":     utils.ValueIgnoreEmpty(d.Get("protection_status")),
+		"source":                utils.ValueIgnoreEmpty(d.Get("source")),
+		"enterprise_project_id": cfg.GetEnterpriseProjectID(d),
+	}
+	return bodyParams
 }
 
 func resourceCertificateV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	elbClient, err := config.LoadBalancerClient(config.GetRegion(d))
-	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud elb client: %s", err)
-	}
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
-	c, err := certificates.Get(elbClient, d.Id()).Extract()
-	if err != nil {
-		return common.CheckDeletedDiag(d, err, "Error retrieving certificate")
-	}
-	logp.Printf("[DEBUG] Retrieved certificate %s: %#v", d.Id(), c)
+	var mErr *multierror.Error
 
-	mErr := multierror.Append(nil,
-		d.Set("region", config.GetRegion(d)),
-		d.Set("name", c.Name),
-		d.Set("description", c.Description),
-		d.Set("type", c.Type),
-		d.Set("domain", c.Domain),
-		d.Set("certificate", c.Certificate),
-		d.Set("private_key", c.PrivateKey),
-		d.Set("create_time", c.CreateTime),
-		d.Set("update_time", c.UpdateTime),
-		d.Set("expire_time", c.ExpireTime),
+	var (
+		httpUrl = "v2/{project_id}/elb/certificates/{certificate_id}"
+		product = "elb"
 	)
-	if err = mErr.ErrorOrNil(); err != nil {
-		return fmtp.DiagErrorf("Error setting certificate fields: %s", err)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
-	return nil
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{certificate_id}", d.Id())
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving ELB certificate")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", getRespBody, nil)),
+		d.Set("description", utils.PathSearch("description", getRespBody, nil)),
+		d.Set("type", utils.PathSearch("type", getRespBody, nil)),
+		d.Set("domain", utils.PathSearch("domain", getRespBody, nil)),
+		d.Set("certificate", utils.PathSearch("certificate", getRespBody, nil)),
+		d.Set("protection_reason", utils.PathSearch("protection_reason", getRespBody, nil)),
+		d.Set("protection_status", utils.PathSearch("protection_status", getRespBody, nil)),
+		d.Set("source", utils.PathSearch("source", getRespBody, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", getRespBody, nil)),
+		d.Set("update_time", utils.PathSearch("update_time", getRespBody, nil)),
+		d.Set("expire_time", utils.PathSearch("expire_time", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func resourceCertificateV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	elbClient, err := config.LoadBalancerClient(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v2/{project_id}/elb/certificates/{certificate_id}"
+		product = "elb"
+	)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
-	var updateOpts certificates.UpdateOpts
-	if d.HasChange("name") {
-		updateOpts.Name = d.Get("name").(string)
-	}
-	if d.HasChange("description") {
-		updateOpts.Description = d.Get("description").(string)
-	}
-	if d.HasChange("domain") {
-		updateOpts.Domain = d.Get("domain").(string)
-	}
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{certificate_id}", d.Id())
 
-	logp.Printf("[DEBUG] Updating certificate %s with options: %#v", d.Id(), updateOpts)
-
-	// Add certificate and private_key here so they wouldn't go in the above log entry
-	if d.HasChange("private_key") {
-		updateOpts.PrivateKey = d.Get("private_key").(string)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
-	if d.HasChange("certificate") {
-		updateOpts.Certificate = d.Get("certificate").(string)
-	}
-
-	timeout := d.Timeout(schema.TimeoutUpdate)
-	//lintignore:R006
-	err = resource.RetryContext(ctx, timeout, func() *resource.RetryError {
-		_, err := certificates.Update(elbClient, d.Id(), updateOpts).Extract()
-		if err != nil {
-			return common.CheckForRetryableError(err)
-		}
-		return nil
-	})
+	updateOpt.JSONBody = utils.RemoveNil(buildUpdateCertificateBodyParams(d))
+	_, err = client.Request("PUT", updatePath, &updateOpt)
 	if err != nil {
-		return fmtp.DiagErrorf("Error updating certificate %s: %s", d.Id(), err)
+		return diag.Errorf("error updating ELB certificate: %s", err)
 	}
 
 	return resourceCertificateV2Read(ctx, d, meta)
 }
 
+func buildUpdateCertificateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":              d.Get("name"),
+		"description":       d.Get("description"),
+		"domain":            d.Get("domain"),
+		"private_key":       d.Get("private_key"),
+		"certificate":       d.Get("certificate"),
+		"protection_reason": d.Get("protection_reason"),
+		"protection_status": d.Get("protection_status"),
+		"source":            d.Get("source"),
+	}
+	return bodyParams
+}
+
 func resourceCertificateV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	elbClient, err := config.LoadBalancerClient(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v2/{project_id}/elb/certificates/{certificate_id}"
+		product = "elb"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
-	logp.Printf("[DEBUG] Deleting certificate %s", d.Id())
-	timeout := d.Timeout(schema.TimeoutDelete)
-	//lintignore:R006
-	err = resource.RetryContext(ctx, timeout, func() *resource.RetryError {
-		err := certificates.Delete(elbClient, d.Id()).ExtractErr()
-		if err != nil {
-			return common.CheckForRetryableError(err)
-		}
-		return nil
-	})
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{certificate_id}", d.Id())
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		if utils.IsResourceNotFound(err) {
-			logp.Printf("[INFO] deleting an unavailable certificate: %s", d.Id())
-			return nil
-		}
-		return fmtp.DiagErrorf("Error deleting certificate %s: %s", d.Id(), err)
+		return common.CheckDeletedDiag(d, err, "error deleting ELB certificate")
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add params to lb certificate resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add params to lb certificate resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/lb/ TESTARGS='-run TestAccLBV2Certificate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb/ -v -run TestAccLBV2Certificate_ -timeout 360m -parallel 4
=== RUN   TestAccLBV2Certificate_basic
=== PAUSE TestAccLBV2Certificate_basic
=== RUN   TestAccLBV2Certificate_client
=== PAUSE TestAccLBV2Certificate_client
=== CONT  TestAccLBV2Certificate_basic
=== CONT  TestAccLBV2Certificate_client
--- PASS: TestAccLBV2Certificate_client (15.48s)
--- PASS: TestAccLBV2Certificate_basic (28.70s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        28.745s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
