### PR TITLE
feat(apig/group): new resource to associate the URL domain

### DIFF
--- a/docs/resources/apig_group.md
+++ b/docs/resources/apig_group.md
@@ -57,12 +57,6 @@ The following arguments are supported:
 
  -> The `environment` paramater is conflict with `huaweicloud_apig_environment_variable` resource.
 
-* `url_domains` - (Optional, List) Specifies independent domain names of the associated with group.  
-  The [url_domains](#group_url_domains) structure is documented below.
-
-  -> Different groups under the same dedicated instance cannot be bound to the same independent domain name.
-     Each API group can be associated with up to `5` domain names.
-
 * `domain_access_enabled` - (Optional, Bool) Specifies whether to use the debugging domain name to access the APIs
   within the group. The default value is `false`.
 
@@ -95,24 +89,6 @@ The `variable` block supports:
 
   -> **NOTE:** The variable value will be displayed in plain text on the console.
 
-<a name="group_url_domains"></a>
-The `url_domains` block supports:
-
-* `name` - (Required, String) Specifies the domain name. The valid must comply with the domian name specifications.
-
-* `min_ssl_version` - (Optional, String) Specifies the minimum TLS version that can be used to access the domain name,
-  the default value is `TLSv1.2`.
-  The valid values are as follows:
-  + **TLSv1.1**
-  + **TLSv1.2**
-
-  -> This parameter applies only to `HTTPS` and does not take effect for `HTTP` and other access modes.
-     Configure `HTTPS` cipher suites using the `ssl_ciphers` parameter on the parameters tab,
-     please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/usermanual-apig/apig_03_0039.html).
-
-* `is_http_redirect_to_https` - (Optional, Bool) Specifies whether to enable redirection from `HTTP` to `HTTPS`.
-  The default value is `false`.
-
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -126,6 +102,9 @@ In addition to all arguments above, the following attributes are exported:
 * `environment` - The array of one or more environments of the associated group.  
   The [object](#group_environment_attr) structure is documented below.
 
+* `url_domains` - The associated domain information of the group.  
+  The [url_domains](#group_url_domains_attr) structure is documented below.
+
 <a name="group_environment_attr"></a>
 The `environment` block supports:
 
@@ -136,6 +115,17 @@ The `environment` block supports:
 The `variable` block supports:
 
 * `id` - The variable ID.
+
+<a name="group_url_domains_attr"></a>
+The `url_domains` block supports:
+
+* `name` - The associated domain name.
+
+* `min_ssl_version` - The minimum SSL protocol version.
+  + **TLSv1.1**
+  + **TLSv1.2**
+
+* `is_http_redirect_to_https` - Whether to enable redirection from `HTTP` to `HTTPS`.
 
 ## Import
 

--- a/docs/resources/apig_group_domain_associate.md
+++ b/docs/resources/apig_group_domain_associate.md
@@ -20,21 +20,12 @@ Use this resource to associate a domain name with an API group.
 
 ```hcl
 variable "instance_id" {}
+variable "group_id" {}
 variable "domain_name" {}
-
-resource "huaweicloud_apig_group" "test" {
-  ...
-
-  lifecycle {
-    ignore_changes = [
-      url_domains,
-    ]
-  }
-}
 
 resource "huaweicloud_apig_group_domain_associate" "test" {
   instance_id = var.instance_id
-  group_id    = huaweicloud_apig_group.test.id
+  group_id    = var.group_id
   url_domain  = var.domain_name
 
   min_ssl_version           = "TLSv1.1"

--- a/docs/resources/apig_group_domain_associate.md
+++ b/docs/resources/apig_group_domain_associate.md
@@ -1,0 +1,116 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_group_domain_associate"
+description: |-
+  Use this resource to associate a domain name with an API group.
+---
+
+# huaweicloud_apig_group_domain_associate
+
+Use this resource to associate a domain name with an API group.
+
+~> This resource cannot be used simultaneously with the domain name management parameter (`url_domains`) of the group
+   resource.<br>Using `lifecycle.ignore_changes` to ignore changes for the corresponding group when using this resource.
+
+-> Different groups under the same dedicated instance cannot be bound to the same independent domain name.
+   Each API group can be associated with up to `5` domain names.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "domain_name" {}
+
+resource "huaweicloud_apig_group" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      url_domains,
+    ]
+  }
+}
+
+resource "huaweicloud_apig_group_domain_associate" "test" {
+  instance_id = var.instance_id
+  group_id    = huaweicloud_apig_group.test.id
+  url_domain  = var.domain_name
+
+  min_ssl_version           = "TLSv1.1"
+  ingress_http_port         = 80
+  ingress_https_port        = -1
+  is_http_redirect_to_https = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the APIG (API) group is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the dedicated instance to which the group belongs.
+
+* `group_id` - (Required, String, NonUpdatable) Specifies the ID of the group to associate with the domain name.
+
+* `url_domain` - (Required, String, NonUpdatable) Specifies the associated domain name.
+  The maximum valid length is `255` characters and the value must conform to the domain name specifications (the regular
+  expression **^(a-zA-Z0-9?\.){1,7}\[a-zA-Z\]{2,64}\.?$** or the regular expression
+  **^*{1,6}\.\[a-zA-Z\]{2,64}.?$**).
+
+* `min_ssl_version` - (Optional, String) Specifies the minimum SSL protocol version.  
+  The valid values are as follows:
+  + **TLSv1.1**
+  + **TLSv1.2**
+
+  The default value is different in different regions. For the specific default value, please consult the corresponding
+  service OnCall through the [service ticket](https://support.huaweicloud.com/intl/en-us/usermanual-ticket/topic_0065264094.html).
+
+* `ingress_http_port` - (Optional, Int) Specifies the HTTP protocol inbound access port bound to the domain name.  
+  The valid value is `-1` (disable), `80` or custom HTTP inbound access port (must be opened by the instance, ranges
+  from `1,024` to `49,151`).
+
+* `ingress_https_port` - (Optional, Int) Specifies the HTTPS protocol inbound access port bound to the domain name.  
+  The valid value is `-1` (disable), `443` or custom HTTPS inbound access port (must be opened by the instance, ranges
+  from `1,024` to `49,151`).
+
+-> `ingress_http_port` and `ingress_https_port` cannot be disabled at the same time.
+
+* `is_http_redirect_to_https` - (Optional, Bool) Specifies whether to enable redirection from `HTTP` to `HTTPS`.
+  Defaults to `false`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, the format is `<instance_id>/<group_id>/<url_domain>`.
+
+## Import
+
+Associated information for the specified domain and group can be imported using resource `id` (consists of
+`instance_id`, `group_id` and `url_domain`, separated by the slashes (/)), e.g.
+
+```bash
+$ terraform import huaweicloud_apig_group_domain_associate.test <instance_id>/<group_id>/<url_domain>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response.
+The missing attributes includes: `is_http_redirect_to_https`.
+It is generally recommended running `terraform plan` after importing this resource.
+You can then decide if changes should be applied to the resource, or the definition should be updated to align with the
+resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_apig_group_domain_associate" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      is_http_redirect_to_https,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1499,6 +1499,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_environment":                    apig.ResourceApigEnvironmentV2(),
 			"huaweicloud_apig_environment_variable":           apig.ResourceEnvironmentVariable(),
 			"huaweicloud_apig_group":                          apig.ResourceApigGroupV2(),
+			"huaweicloud_apig_group_domain_associate":         apig.ResourceGroupDomainAssociate(),
 			"huaweicloud_apig_instance_feature":               apig.ResourceInstanceFeature(),
 			"huaweicloud_apig_instance_routes":                apig.ResourceInstanceRoutes(),
 			"huaweicloud_apig_instance":                       apig.ResourceApigInstanceV2(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_group_domain_associate_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_group_domain_associate_test.go
@@ -1,0 +1,215 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
+)
+
+func getAssociatedDomainInfoFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ApigV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	return apig.GetGroupAssociatedDomainByUrl(client, state.Primary.Attributes["instance_id"],
+		state.Primary.Attributes["group_id"], state.Primary.Attributes["url_domain"])
+}
+
+func TestAccGroupDomainAssociate_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		resourceName = "huaweicloud_apig_group_domain_associate.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getAssociatedDomainInfoFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGroupDomainAssociate_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttrPair(resourceName, "group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "url_domain", "huaweicloud_dns_zone.test", "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "min_ssl_version"),
+					resource.TestCheckResourceAttr(resourceName, "ingress_http_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "ingress_https_port", "443"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_id"),
+				),
+			},
+			{
+				Config: testAccGroupDomainAssociate_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttrPair(resourceName, "group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "url_domain", "huaweicloud_dns_zone.test", "name"),
+					resource.TestCheckResourceAttr(resourceName, "min_ssl_version", "TLSv1.2"),
+					resource.TestCheckResourceAttr(resourceName, "ingress_http_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "ingress_https_port", "-1"),
+					resource.TestCheckResourceAttr(resourceName, "is_http_redirect_to_https", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_id"),
+				),
+			},
+			{
+				Config: testAccGroupDomainAssociate_basic_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttrPair(resourceName, "group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "url_domain", "huaweicloud_dns_zone.test", "name"),
+					resource.TestCheckResourceAttr(resourceName, "min_ssl_version", "TLSv1.1"),
+					resource.TestCheckResourceAttr(resourceName, "ingress_http_port", "-1"),
+					resource.TestCheckResourceAttr(resourceName, "ingress_https_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "is_http_redirect_to_https", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_id"),
+				),
+			},
+			{
+				Config: testAccGroupDomainAssociate_basic_step4(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttrPair(resourceName, "group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "url_domain", "huaweicloud_dns_zone.test", "name"),
+					resource.TestCheckResourceAttr(resourceName, "min_ssl_version", "TLSv1.1"),
+					resource.TestCheckResourceAttr(resourceName, "ingress_http_port", "1024"),
+					resource.TestCheckResourceAttr(resourceName, "ingress_https_port", "1025"),
+					resource.TestCheckResourceAttr(resourceName, "is_http_redirect_to_https", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"is_http_redirect_to_https",
+				},
+			},
+		},
+	})
+}
+
+func testAccGroupDomainAssociate_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dns_zone" "test" {
+  name        = "script-test-%[1]s.com."
+  description = "a zone"
+  ttl         = 300
+  status      = "DISABLE"
+
+  tags = {
+    zone_type = "public"
+    owner     = "terraform"
+  }
+}
+
+resource "huaweicloud_apig_group" "test" {
+  instance_id = "%[2]s"
+  name        = "%[1]s"
+
+  force_destroy = true
+
+  lifecycle {
+    ignore_changes = [
+      url_domains,
+    ]
+  }
+}
+`, name, acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
+}
+
+func testAccGroupDomainAssociate_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_group_domain_associate" "test" {
+  instance_id = huaweicloud_apig_group.test.instance_id
+  group_id    = huaweicloud_apig_group.test.id
+  url_domain  = huaweicloud_dns_zone.test.name
+
+  depends_on = [
+    huaweicloud_dns_zone.test,
+  ]
+}
+`, testAccGroupDomainAssociate_base(name))
+}
+
+func testAccGroupDomainAssociate_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_group_domain_associate" "test" {
+  instance_id = huaweicloud_apig_group.test.instance_id
+  group_id    = huaweicloud_apig_group.test.id
+  url_domain  = huaweicloud_dns_zone.test.name
+
+  min_ssl_version           = "TLSv1.2"
+  ingress_http_port         = 80
+  ingress_https_port        = -1
+  is_http_redirect_to_https = true
+
+  depends_on = [
+    huaweicloud_dns_zone.test,
+  ]
+}
+`, testAccGroupDomainAssociate_base(name))
+}
+
+func testAccGroupDomainAssociate_basic_step3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_group_domain_associate" "test" {
+  instance_id = huaweicloud_apig_group.test.instance_id
+  group_id    = huaweicloud_apig_group.test.id
+  url_domain  = huaweicloud_dns_zone.test.name
+
+  min_ssl_version           = "TLSv1.1"
+  ingress_http_port         = -1
+  ingress_https_port        = 443
+  is_http_redirect_to_https = false
+
+  depends_on = [
+    huaweicloud_dns_zone.test,
+  ]
+}
+`, testAccGroupDomainAssociate_base(name))
+}
+
+func testAccGroupDomainAssociate_basic_step4(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_group_domain_associate" "test" {
+  instance_id = huaweicloud_apig_group.test.instance_id
+  group_id    = huaweicloud_apig_group.test.id
+  url_domain  = huaweicloud_dns_zone.test.name
+
+  ingress_http_port         = 1024 # Make sure this custom inbound access port is opened.
+  ingress_https_port        = 1025 # Make sure this custom inbound access port is opened.
+  is_http_redirect_to_https = false
+
+  depends_on = [
+    huaweicloud_dns_zone.test,
+  ]
+}
+`, testAccGroupDomainAssociate_base(name))
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_group.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_group.go
@@ -114,25 +114,50 @@ func ResourceApigGroupV2() *schema.Resource {
 			"url_domains": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				MaxItems: 5,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
 							Type:     schema.TypeString,
 							Required: true,
+							Description: utils.SchemaDesc(
+								`The associated domain name.`,
+								utils.SchemaDescInput{
+									Computed: true,
+								},
+							),
 						},
 						"min_ssl_version": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
+							Description: utils.SchemaDesc(
+								`The minimum SSL protocol version.`,
+								utils.SchemaDescInput{
+									Computed: true,
+								},
+							),
 						},
 						"is_http_redirect_to_https": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Computed: true,
+							Description: utils.SchemaDesc(
+								`Whether to enable redirection from HTTP to HTTPS.`,
+								utils.SchemaDescInput{
+									Computed: true,
+								},
+							),
 						},
 					},
 				},
+				Description: utils.SchemaDesc(
+					`The associated domain information of the group.`,
+					utils.SchemaDescInput{
+						Computed: true,
+					},
+				),
 			},
 			"domain_access_enabled": {
 				Type:        schema.TypeBool,

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_group_domain_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_group_domain_associate.go
@@ -1,0 +1,354 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var domainAssociateNonUpdatableParams = []string{
+	"instance_id",
+	"group_id",
+	"url_domain",
+}
+
+// @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/api-groups/{group_id}/domains
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/api-groups/{group_id}
+// @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}/api-groups/{group_id}/domains/{domain_id}
+// @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/api-groups/{group_id}/domains/{domain_id}
+func ResourceGroupDomainAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGroupDomainAssociateCreate,
+		ReadContext:   resourceGroupDomainAssociateRead,
+		UpdateContext: resourceGroupDomainAssociateUpdate,
+		DeleteContext: resourceGroupDomainAssociateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceGroupDomainAssociateImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(domainAssociateNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the APIG group and domain are located.",
+			},
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the dedicated instance to which the group belongs.",
+			},
+			"group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the group to associate with the domain name.",
+			},
+			"url_domain": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The associated domain name.",
+			},
+			// Optional parameters.
+			"min_ssl_version": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The minimum SSL protocol version.",
+			},
+			"ingress_http_port": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "The HTTP protocol inbound access port bound to the domain name.",
+			},
+			"ingress_https_port": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "The HTTPS protocol inbound access port bound to the domain name.",
+			},
+			"is_http_redirect_to_https": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to enable redirection from HTTP to HTTPS.`,
+			},
+			// Internal parameters/attributes.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`The associated domain ID.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func resourceGroupDomainAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/api-groups/{group_id}/domains"
+		instanceId = d.Get("instance_id").(string)
+		groupId    = d.Get("group_id").(string)
+		urlDomain  = d.Get("url_domain").(string)
+	)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createPath = strings.ReplaceAll(createPath, "{group_id}", groupId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(map[string]interface{}{
+			"url_domain":                utils.ValueIgnoreEmpty(urlDomain),
+			"min_ssl_version":           utils.ValueIgnoreEmpty(d.Get("min_ssl_version")),
+			"is_http_redirect_to_https": d.Get("is_http_redirect_to_https"),
+			"ingress_http_port":         utils.ValueIgnoreEmpty(d.Get("ingress_http_port")),
+			"ingress_https_port":        utils.ValueIgnoreEmpty(d.Get("ingress_https_port")),
+		}),
+	}
+
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error associating the domain name with the group (%s): %s", groupId, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s/%s", instanceId, groupId, urlDomain))
+
+	return resourceGroupDomainAssociateRead(ctx, d, meta)
+}
+
+func getGroupAssociatedDomains(client *golangsdk.ServiceClient, instanceId, groupId string) ([]interface{}, error) {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/api-groups/{group_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getPath = strings.ReplaceAll(getPath, "{group_id}", groupId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("url_domains", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func GetGroupAssociatedDomainByUrl(client *golangsdk.ServiceClient, instanceId, groupId, urlDomain string) (interface{}, error) {
+	urlDomains, err := getGroupAssociatedDomains(client, instanceId, groupId)
+	if err != nil {
+		return nil, err
+	}
+
+	result := utils.PathSearch(fmt.Sprintf("[?domain=='%s']|[0]", urlDomain), urlDomains, nil)
+	if result == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v2/{project_id}/apigw/instances/{instance_id}/api-groups/{group_id}",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the domain (%s) does not bound to the API group (%s)", urlDomain, groupId)),
+			},
+		}
+	}
+	return result, nil
+}
+
+func resourceGroupDomainAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+		groupId    = d.Get("group_id").(string)
+		urlDomain  = d.Get("url_domain").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+	resp, err := GetGroupAssociatedDomainByUrl(client, instanceId, groupId, urlDomain)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error querying domain associate info for the API group")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", cfg.GetRegion(d)),
+		d.Set("min_ssl_version", utils.PathSearch("min_ssl_version", resp, nil)),
+		d.Set("ingress_http_port", utils.PathSearch("ingress_http_port", resp, nil)),
+		d.Set("ingress_https_port", utils.PathSearch("ingress_https_port", resp, nil)),
+		d.Set("url_domain", utils.PathSearch("domain", resp, nil)),
+		// Attributes
+		d.Set("domain_id", utils.PathSearch("id", resp, nil)),
+	)
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving associate resource for the domain and API group: %s", err)
+	}
+	return nil
+}
+
+func buildDomainAssociateUpdateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"min_ssl_version":           utils.ValueIgnoreEmpty(d.Get("min_ssl_version")),
+		"is_http_redirect_to_https": d.Get("is_http_redirect_to_https"),
+		"ingress_http_port":         utils.ValueIgnoreEmpty(d.Get("ingress_http_port")),
+		"ingress_https_port":        utils.ValueIgnoreEmpty(d.Get("ingress_https_port")),
+	}
+}
+
+func resourceGroupDomainAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/api-groups/{group_id}/domains/{domain_id}"
+		instanceId = d.Get("instance_id").(string)
+		groupId    = d.Get("group_id").(string)
+		domainId   = d.Get("domain_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	// Get domain ID if the value of attribute 'domain_id' is empty.
+	if domainId == "" {
+		urlDomain := d.Get("url_domain").(string)
+		associateInfo, err := GetGroupAssociatedDomainByUrl(client, instanceId, groupId, urlDomain)
+		if err != nil {
+			return common.CheckDeletedDiag(d, err, fmt.Sprintf("error querying the associated domain information (%s)", urlDomain))
+		}
+		domainId = utils.PathSearch("id", associateInfo, "").(string)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", instanceId)
+	updatePath = strings.ReplaceAll(updatePath, "{group_id}", groupId)
+	updatePath = strings.ReplaceAll(updatePath, "{domain_id}", domainId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildDomainAssociateUpdateBodyParams(d)),
+	}
+
+	_, err = client.Request("PUT", updatePath, &opt)
+	if err != nil {
+		return diag.Errorf("error updating associate configuration for the domain (%s) and the API group (%s): %s",
+			domainId, groupId, err)
+	}
+	return resourceGroupDomainAssociateRead(ctx, d, meta)
+}
+
+func resourceGroupDomainAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/api-groups/{group_id}/domains/{domain_id}"
+		instanceId = d.Get("instance_id").(string)
+		groupId    = d.Get("group_id").(string)
+		domainId   = d.Get("domain_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	// Get domain ID if the value of attribute 'domain_id' is empty.
+	if domainId == "" {
+		urlDomain := d.Get("url_domain").(string)
+		associateInfo, err := GetGroupAssociatedDomainByUrl(client, instanceId, groupId, urlDomain)
+		if err != nil {
+			return common.CheckDeletedDiag(d, err, fmt.Sprintf("error querying the associated domain information (%s)", urlDomain))
+		}
+		domainId = utils.PathSearch("id", associateInfo, "").(string)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceId)
+	deletePath = strings.ReplaceAll(deletePath, "{group_id}", groupId)
+	deletePath = strings.ReplaceAll(deletePath, "{domain_id}", domainId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &opt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error dissociate the domain name with the group (%s)", groupId))
+	}
+	return nil
+}
+
+func resourceGroupDomainAssociateImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid resource ID format, want '<instance_id>/<group_id>/<url_domain>', but got '%s'",
+			importedId)
+	}
+
+	instanceId := parts[0]
+	groupId := parts[1]
+	urlDomain := parts[2]
+
+	mrr := multierror.Append(nil,
+		d.Set("instance_id", instanceId),
+		d.Set("group_id", groupId),
+		d.Set("url_domain", urlDomain),
+	)
+	return []*schema.ResourceData{d}, mrr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New resource support that used to associate a DNS domain with a API group.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. new associate resource supported.
2. related document and acceptance test supported.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccGroupDomainAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccGroupDomainAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccGroupDomainAssociate_basic
=== PAUSE TestAccGroupDomainAssociate_basic
=== CONT  TestAccGroupDomainAssociate_basic
--- PASS: TestAccGroupDomainAssociate_basic (65.62s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      65.678s coverage: 4.6% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/ce3de7e5-4581-4a9c-b890-1670f0d5f30a)

    ab. Related resources (parent resources) not found
    ![image](https://github.com/user-attachments/assets/913914cc-3fc5-4148-8548-ade8b532528a)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![image](https://github.com/user-attachments/assets/a095a43b-66ac-467c-affe-e79423ffdb27)

    bb. Related resources (parent resources) not found
    ![image](https://github.com/user-attachments/assets/a07566e9-e488-4639-b984-8fb7359fe5e8)

