### PR TITLE
feat(ces): add resource notification mask

### DIFF
--- a/docs/resources/ces_notification_mask.md
+++ b/docs/resources/ces_notification_mask.md
@@ -1,0 +1,206 @@
+---
+subcategory: "Cloud Eye (CES)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ces_notification_mask"
+description: |-
+  Manages a CES notification mask resource within HuaweiCloud.
+---
+
+# huaweicloud_ces_notification_mask
+
+Manages a CES notification mask resource within HuaweiCloud.
+
+## Example Usage
+
+### Masked By Resource
+
+```hcl
+variable "mask_name" {}
+
+resource "huaweicloud_ces_notification_mask" "test" {
+  relation_type = "RESOURCE"
+  mask_name     = var.mask_name
+  
+  resources {
+    namespace = "SYS.OBS"
+
+    dimensions {
+      name  = "bucket_name"
+      value = "bucket-one"
+    }
+  }
+
+  resources {
+    namespace = "SYS.OBS"
+    
+    dimensions {
+      name  = "bucket_name"
+      value = "bucket-two"
+    }
+  }
+
+  mask_type  = "START_END_TIME"
+  start_date = "2025-03-27"
+  start_time = "09:12:09"
+  end_date   = "2025-03-27"
+  end_time   = "20:12:09"
+}
+```
+
+### Masked By Policy
+
+```hcl
+variable "mask_name" {}
+variable "alarm_policy_id" {}
+
+resource "huaweicloud_ces_notification_mask" "test" {
+  relation_type = "RESOURCE_POLICY_NOTIFICATION"
+  mask_name     = var.mask_name
+  relation_ids  = [var.alarm_policy_id]
+  
+  resources {
+    namespace = "SYS.OBS"
+
+    dimensions {
+      name = "bucket_name"
+      value = "*"
+    }
+  }
+
+  mask_type  = "FOREVER_TIME"
+}
+```
+
+### Masked By Rule
+
+```hcl
+variable "alarm_rule" {}
+
+resource "huaweicloud_ces_notification_mask" "test" {
+  relation_type = "ALARM_RULE"
+  relation_id   = var.alarm_rule
+
+  mask_type  = "START_END_TIME"
+  start_date = "2025-03-27"
+  start_time = "09:12:09"
+  end_date   = "2025-03-27"
+  end_time   = "20:12:10"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `relation_type` - (Required, String, NonUpdatable) Specifies the type of a resource that is associated with an alarm notification
+  masking rule.
+  The valid values are as follows:
+  + **ALARM_RULE**: alarm rules;
+  + **RESOURCE**: resources;
+  + **RESOURCE_POLICY_NOTIFICATION**: alarm policies for the resource;
+
+* `mask_type` - (Required, String) Specifies the alarm notification masking type.
+
+* `relation_ids` - (Optional, List) Specifies the alarm policy IDs.
+
+* `relation_id` - (Optional, String) Specifies the alarm rule ID.
+
+* `mask_name` - (Optional, String) Specifies the masking rule name.
+
+* `start_date` - (Optional, String) Specifies the masking start date, in **yyyy-MM-dd** format.
+
+* `start_time` - (Optional, String) Specifies the masking start time, in **HH:mm:ss** format.
+
+* `end_date` - (Optional, String) Specifies the masking end date, in **yyyy-MM-dd** format.
+
+* `end_time` - (Optional, String) Specifies the masking end time, in **HH:mm:ss** format.
+
+* `resources` - (Optional, List) Specifies the resource for which alarm notifications will be masked.
+  The [resources](#Resources) structure is documented below.
+
+<a name="Resources"></a>
+The `resources` block supports:
+
+* `namespace` - (Required, String) Specifies the resource namespace in **service.item** format.
+
+* `dimensions` - (Required, List) Specifies the resource dimension information.
+  The [dimensions](#ResourcesDimensions) structure is documented below.
+
+<a name="ResourcesDimensions"></a>
+The `dimensions` block supports:
+
+* `name` - (Required, String) Specifies the dimension of a resource.
+
+* `value` - (Required, String) Specifies the value of a resource dimension.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `mask_status` - Specifies the alarm notification masking status.
+
+* `policies` - The alarm policy list.
+  The [policies](#Policies) structure is documented below.
+
+<a name="Policies"></a>
+The `policies` block supports:
+
+* `alarm_policy_id` - The alarm policy ID.
+
+* `metric_name` - The metric name of a resource.
+
+* `extra_info` - The extended metric information.
+  The [extra_info](#PoliciesExtraInfo) structure is documented below.
+
+* `period` - The period for determining whether to generate an alarm, in seconds.
+
+* `filter` - The data rollup method.
+
+* `comparison_operator` - The operator.
+
+* `value` - The alarm threshold.
+
+* `unit` - The data unit.
+
+* `count` - The number of consecutive times that alarm conditions are met.
+
+* `type` - The alarm policy type.
+
+* `suppress_duration` - The interval for triggering alarms.
+
+* `alarm_level` - The alarm severity.
+
+* `selected_unit` - The unit you selected, which is used for subsequent metric data display and calculation.
+
+<a name="PoliciesExtraInfo"></a>
+The `extra_info` block supports:
+
+* `origin_metric_name` - The original metric name.
+
+* `metric_prefix` - The metric name prefix.
+
+* `custom_proc_name` - The name of a user process.
+
+* `metric_type` - The metric type.
+
+## Import
+
+When `relation_type` value is `RESOURCE` or `RESOURCE_POLICY_NOTIFICATION`, the notification mask can be imported
+using `relation_type` and `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_ces_notification_mask.test <relation_type>/<id>
+```
+
+When `relation_type` value is `ALARM_RULE`, the notification mask can be imported using `relation_type` and
+`relation_id`, e.g.
+
+```bash
+$ terraform import huaweicloud_ces_notification_mask.test <relation_type>/<relation_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1610,6 +1610,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ces_dashboard_widget":       ces.ResourceDashboardWidget(),
 			"huaweicloud_ces_event_report":           ces.ResourceCesEventReport(),
 			"huaweicloud_ces_metric_data_add":        ces.ResourceMetricDataAdd(),
+			"huaweicloud_ces_notification_mask":      ces.ResourceNotificationMask(),
 			"huaweicloud_ces_one_click_alarm":        ces.ResourceOneClickAlarm(),
 			"huaweicloud_ces_resource_group":         ces.ResourceResourceGroup(),
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -297,6 +297,8 @@ var (
 	HW_CES_START_TIME        = os.Getenv("HW_CES_START_TIME")
 	HW_CES_END_TIME          = os.Getenv("HW_CES_END_TIME")
 	HW_CES_ALARM_RULE        = os.Getenv("HW_CES_ALARM_RULE")
+	HW_CES_ALARM_POLICY_1    = os.Getenv("HW_CES_ALARM_POLICY_1")
+	HW_CES_ALARM_POLICY_2    = os.Getenv("HW_CES_ALARM_POLICY_2")
 
 	// The CFW instance ID
 	HW_CFW_INSTANCE_ID               = os.Getenv("HW_CFW_INSTANCE_ID")
@@ -1728,6 +1730,13 @@ func TestAccPreCheckDCVirtualInterfaceID(t *testing.T) {
 func TestAccPreCheckCesTimeRange(t *testing.T) {
 	if HW_CES_START_TIME == "" || HW_CES_END_TIME == "" {
 		t.Skip("HW_CES_START_TIME and HW_CES_END_TIME must be set for CES acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCesAlarmPolicies(t *testing.T) {
+	if HW_CES_ALARM_POLICY_1 == "" || HW_CES_ALARM_POLICY_2 == "" {
+		t.Skip("HW_CES_ALARM_POLICY_1 and HW_CES_ALARM_POLICY_2 must be set for CES acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_notification_mask_test.go
+++ b/huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_notification_mask_test.go
@@ -1,0 +1,426 @@
+package ces
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ces"
+)
+
+func getResourceNotificationMaskFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("ces", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CES client: %s", err)
+	}
+
+	return ces.GetNotificationMask(client, state.Primary.Attributes["relation_type"],
+		state.Primary.Attributes["relation_id"], state.Primary.ID,
+	)
+}
+
+func TestAccResourceNotificationMask_resource(t *testing.T) {
+	var obj interface{}
+
+	rName := "huaweicloud_ces_notification_mask.test"
+	name := acceptance.RandomAccResourceNameWithDash()
+	baseConfig := testResourceNotificationMask_base(name)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getResourceNotificationMaskFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceNotificationMask_resource(baseConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "mask_name", name),
+					resource.TestCheckResourceAttr(rName, "relation_type", "RESOURCE"),
+					resource.TestCheckResourceAttr(rName, "mask_type", "FOREVER_TIME"),
+					resource.TestCheckResourceAttr(rName, "resources.#", "1"),
+				),
+			},
+			{
+				Config: testResourceNotificationMask_resource_update(baseConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "mask_name", name+"-update"),
+					resource.TestCheckResourceAttr(rName, "relation_type", "RESOURCE"),
+					resource.TestCheckResourceAttr(rName, "mask_type", "FOREVER_TIME"),
+					resource.TestCheckResourceAttr(rName, "resources.#", "2"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testNotificationMaskImportState(rName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNotificationMask_policy(t *testing.T) {
+	var obj interface{}
+
+	rName := "huaweicloud_ces_notification_mask.test"
+	name := acceptance.RandomAccResourceNameWithDash()
+	baseConfig := testResourceNotificationMask_base(name)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getResourceNotificationMaskFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCesAlarmPolicies(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceNotificationMask_policy(baseConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "mask_name", name),
+					resource.TestCheckResourceAttr(rName, "relation_type", "RESOURCE_POLICY_NOTIFICATION"),
+					resource.TestCheckResourceAttr(rName, "mask_type", "FOREVER_TIME"),
+					resource.TestCheckResourceAttr(rName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(rName, "relation_ids.#", "2"),
+				),
+			},
+			{
+				Config: testResourceNotificationMask_policy_update(baseConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "mask_name", name+"-update"),
+					resource.TestCheckResourceAttr(rName, "relation_type", "RESOURCE_POLICY_NOTIFICATION"),
+					resource.TestCheckResourceAttr(rName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(rName, "relation_ids.#", "1"),
+					resource.TestCheckResourceAttr(rName, "mask_type", "START_END_TIME"),
+					resource.TestCheckResourceAttr(rName, "start_date", "2025-03-25"),
+					resource.TestCheckResourceAttr(rName, "end_date", "2027-03-26"),
+					resource.TestCheckResourceAttr(rName, "start_time", "12:00:00"),
+					resource.TestCheckResourceAttr(rName, "end_time", "20:00:00"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testNotificationMaskImportState(rName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNotificationMask_alarmRule(t *testing.T) {
+	var obj interface{}
+
+	rName := "huaweicloud_ces_notification_mask.test"
+	name := acceptance.RandomAccResourceNameWithDash()
+	baseConfig := testResourceNotificationMask_base(name)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getResourceNotificationMaskFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceNotificationMask_alarmRule(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "relation_type", "ALARM_RULE"),
+					resource.TestCheckResourceAttr(rName, "mask_type", "FOREVER_TIME"),
+					resource.TestCheckResourceAttrPair(rName, "relation_id", "huaweicloud_ces_alarmrule.test", "id"),
+				),
+			},
+			{
+				Config: testResourceNotificationMask_alarmRule_update(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "relation_type", "ALARM_RULE"),
+					resource.TestCheckResourceAttr(rName, "mask_type", "START_END_TIME"),
+					resource.TestCheckResourceAttr(rName, "start_date", "2025-03-25"),
+					resource.TestCheckResourceAttr(rName, "end_date", "2027-03-26"),
+					resource.TestCheckResourceAttr(rName, "start_time", "12:00:00"),
+					resource.TestCheckResourceAttr(rName, "end_time", "20:00:00"),
+					resource.TestCheckResourceAttrPair(rName, "relation_id", "huaweicloud_ces_alarmrule.test", "id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testNotificationMaskImportStateForAlarmRule(rName),
+			},
+		},
+	})
+}
+
+func testResourceNotificationMask_resource(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ces_notification_mask" "test" {
+  relation_type = "RESOURCE"
+  mask_name     = "%[2]s"
+  
+  resources {
+    namespace = "SYS.OBS"
+
+    dimensions {
+      name  = "bucket_name"
+      value = huaweicloud_obs_bucket.bucket[0].bucket
+    }
+  }
+
+  mask_type = "FOREVER_TIME"
+
+  depends_on = [huaweicloud_ces_alarmrule.test]
+}
+`, baseConfig, name)
+}
+
+func testResourceNotificationMask_resource_update(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ces_notification_mask" "test" {
+  relation_type = "RESOURCE"
+  mask_name     = "%[2]s-update"
+  
+  resources {
+    namespace = "SYS.OBS"
+
+    dimensions {
+      name  = "bucket_name"
+      value = huaweicloud_obs_bucket.bucket[0].bucket
+    }
+  }
+
+  resources {
+    namespace = "SYS.OBS"
+
+    dimensions {
+      name  = "bucket_name"
+      value = huaweicloud_obs_bucket.bucket[1].bucket
+    }
+  }
+
+  mask_type = "FOREVER_TIME"
+
+  depends_on = [huaweicloud_ces_alarmrule.test]
+}
+`, baseConfig, name)
+}
+
+func testResourceNotificationMask_policy(baseConfig, name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ces_notification_mask" "test" {
+  relation_type = "RESOURCE_POLICY_NOTIFICATION"
+  mask_name     = "%[2]s"
+  relation_ids  = [
+    "%[3]s",
+    "%[4]s",
+  ]
+  
+  resources {
+    namespace = "SYS.OBS"
+
+    dimensions {
+      name  = "bucket_name"
+      value = "*"
+    }
+  }
+
+  mask_type = "FOREVER_TIME"
+}
+`, baseConfig, name, acceptance.HW_CES_ALARM_POLICY_1, acceptance.HW_CES_ALARM_POLICY_2)
+}
+
+func testResourceNotificationMask_policy_update(baseConfig, name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ces_notification_mask" "test" {
+  relation_type = "RESOURCE_POLICY_NOTIFICATION"
+  mask_name     = "%[2]s-update"
+  relation_ids  = ["%[3]s"]
+  
+  resources {
+    namespace = "SYS.OBS"
+
+    dimensions {
+      name  = "bucket_name"
+      value = "*"
+    }
+  }
+
+  mask_type  = "START_END_TIME"
+  start_date = "2025-03-25"
+  end_date   = "2027-03-26"
+  start_time = "12:00:00"
+  end_time   = "20:00:00"
+}
+`, baseConfig, name, acceptance.HW_CES_ALARM_POLICY_1)
+}
+
+func testResourceNotificationMask_alarmRule(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ces_notification_mask" "test" {
+  relation_type = "ALARM_RULE"
+  relation_id   = huaweicloud_ces_alarmrule.test.id
+  mask_type     = "FOREVER_TIME"
+
+  depends_on = [huaweicloud_ces_alarmrule.test]
+}
+`, baseConfig)
+}
+
+func testResourceNotificationMask_alarmRule_update(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ces_notification_mask" "test" {
+  relation_type = "ALARM_RULE"
+  relation_id   = huaweicloud_ces_alarmrule.test.id
+
+  mask_type  = "START_END_TIME"
+  start_date = "2025-03-25"
+  end_date   = "2027-03-26"
+  start_time = "12:00:00"
+  end_time   = "20:00:00"
+
+  depends_on = [huaweicloud_ces_alarmrule.test]
+}
+`, baseConfig)
+}
+
+func testResourceNotificationMask_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test" {
+  name         = "smn-%[1]s"
+  display_name = "The display name of smn topic"
+}
+
+resource "huaweicloud_obs_bucket" "bucket" {
+  count         = 2
+  bucket        = "%[1]s-${count.index}"
+  storage_class = "STANDARD"
+  acl           = "private"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+resource "huaweicloud_ces_alarmrule" "test" {
+  alarm_name           = "rule-%[1]s"
+  alarm_action_enabled = true
+  alarm_type           = "ALL_INSTANCE"
+
+  metric {
+    namespace = "SYS.OBS"
+  }
+
+  resources {
+    dimensions {
+      name = "bucket_name"
+    }
+  }
+
+  condition  {
+    period              = 1
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 300
+    unit                = "B/s"
+    count               = 1
+    suppress_duration   = 86400
+    metric_name         = "request_count_monitor_2XX"
+    alarm_level         = 1
+  }
+
+  condition  {
+    period              = 1
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 50
+    unit                = "B/s"
+    count               = 1
+    suppress_duration   = 86400
+    metric_name         = "request_count_4xx"
+    alarm_level         = 3
+  }
+
+  alarm_actions {
+    type              = "notification"
+    notification_list = [
+      huaweicloud_smn_topic.test.topic_urn
+    ]
+  }
+
+  depends_on = [huaweicloud_obs_bucket.bucket]
+}
+`, name)
+}
+
+func testNotificationMaskImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.Attributes["relation_type"] == "" {
+			return "", fmt.Errorf("Attribute (relation_type) of Resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.ID == "" {
+			return "", fmt.Errorf("Attribute (ID) of Resource (%s) not found: %s", name, rs)
+		}
+
+		return rs.Primary.Attributes["relation_type"] + "/" + rs.Primary.ID, nil
+	}
+}
+
+func testNotificationMaskImportStateForAlarmRule(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.Attributes["relation_type"] == "" {
+			return "", fmt.Errorf("Attribute (relation_type) of Resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.Attributes["relation_id"] == "" {
+			return "", fmt.Errorf("Attribute (relation_id) of Resource (%s) not found: %s", name, rs)
+		}
+
+		return rs.Primary.Attributes["relation_type"] + "/" + rs.Primary.Attributes["relation_id"], nil
+	}
+}

--- a/huaweicloud/services/ces/resource_huaweicloud_ces_notification_mask.go
+++ b/huaweicloud/services/ces/resource_huaweicloud_ces_notification_mask.go
@@ -1,0 +1,591 @@
+package ces
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var notificationMaskNonUpdatableParams = []string{"relation_type"}
+
+// @API CES PUT /v2/{project_id}/notification-masks
+// @API CES PUT /v2/{project_id}/notification-masks/{notification_mask_id}
+// @API CES POST /v2/{project_id}/notification-masks/batch-delete
+// @API CES POST /v2/{project_id}/notification-masks/batch-query
+// @API CES GET /v2/{project_id}/notification-masks/{notification_mask_id}/resources
+func ResourceNotificationMask() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNotificationMaskCreate,
+		ReadContext:   resourceNotificationMaskRead,
+		UpdateContext: resourceNotificationMaskUpdate,
+		DeleteContext: resourceNotificationMaskDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceNotificationMaskImportState,
+		},
+		CustomizeDiff: config.FlexibleForceNew(notificationMaskNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"relation_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the type of a resource that is associated with an alarm notification masking rule.`,
+			},
+			"mask_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the alarm notification masking type.`,
+			},
+			"relation_ids": {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Description:   `Specifies the alarm policy ID.`,
+				ConflictsWith: []string{"relation_id"},
+			},
+			"relation_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				Description:   `Specifies the alarm rule ID.`,
+				ConflictsWith: []string{"relation_ids"},
+			},
+			"mask_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the masking rule name.`,
+			},
+			"start_date": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the masking start date.`,
+			},
+			"start_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the masking start time.`,
+			},
+			"end_date": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the masking end date.`,
+			},
+			"end_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the masking end time.`,
+			},
+			"resources": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: `Specifies the resource for which alarm notifications will be masked.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"namespace": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `Specifies the resource namespace in **service.item** format.`,
+						},
+						"dimensions": {
+							Type:        schema.TypeSet,
+							Required:    true,
+							Description: `Specifies the resource dimension information.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: `Specifies the dimension of a resource.`,
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: `Specifies the value of a resource dimension.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"mask_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Specifies the alarm notification masking status.`,
+			},
+			"policies": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The alarm policy list.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"alarm_policy_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The alarm policy ID.`,
+						},
+						"metric_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The metric name of a resource.`,
+						},
+						"extra_info": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The extended metric information.`,
+							Elem:        notificationMaskPolicyExtendedInfo(),
+						},
+						"period": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The period for determining whether to generate an alarm, in seconds.`,
+						},
+						"filter": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The data rollup method.`,
+						},
+						"comparison_operator": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The operator.`,
+						},
+						"value": {
+							Type:        schema.TypeFloat,
+							Computed:    true,
+							Description: `The alarm threshold.`,
+						},
+						"unit": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The data unit.`,
+						},
+						"count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The number of consecutive times that alarm conditions are met.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The alarm policy type.`,
+						},
+						"suppress_duration": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The interval for triggering alarms.`,
+						},
+						"alarm_level": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The alarm severity.`,
+						},
+						"selected_unit": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The unit you selected, which is used for subsequent metric data display and calculation.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func notificationMaskPolicyExtendedInfo() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"origin_metric_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The original metric name.`,
+			},
+			"metric_prefix": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The metric name prefix.`,
+			},
+			"custom_proc_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of a user process.`,
+			},
+			"metric_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The metric type.`,
+			},
+		},
+	}
+}
+
+func resourceNotificationMaskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		createNotificationMaskHttpUrl = "v2/{project_id}/notification-masks"
+		createNotificationMaskProduct = "ces"
+	)
+	createNotificationMaskClient, err := cfg.NewServiceClient(createNotificationMaskProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CES client: %s", err)
+	}
+
+	createNotificationMaskPath := createNotificationMaskClient.Endpoint + createNotificationMaskHttpUrl
+	createNotificationMaskPath = strings.ReplaceAll(createNotificationMaskPath, "{project_id}", createNotificationMaskClient.ProjectID)
+
+	createNotificationMaskOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createNotificationMaskOpt.JSONBody = utils.RemoveNil(buildNotificationMaskBodyParams(d))
+	createNotificationMaskResp, err := createNotificationMaskClient.Request("PUT", createNotificationMaskPath, &createNotificationMaskOpt)
+	if err != nil {
+		return diag.Errorf("error creating CES notification mask: %s", err)
+	}
+
+	createNotificationMaskRespBody, err := utils.FlattenResponse(createNotificationMaskResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("notification_mask_id", createNotificationMaskRespBody, "").(string)
+	// When relation_type is ALARM_RULE, no ID is returned
+	if id != "" {
+		d.SetId(id)
+	}
+
+	return resourceNotificationMaskRead(ctx, d, meta)
+}
+
+func buildNotificationMaskBodyParams(d *schema.ResourceData) map[string]interface{} {
+	relationType := d.Get("relation_type").(string)
+	param := map[string]interface{}{
+		"mask_name":     utils.ValueIgnoreEmpty(d.Get("mask_name")),
+		"relation_type": relationType,
+		"resources":     buildResourcesParams(d.Get("resources").(*schema.Set).List()),
+		"mask_type":     d.Get("mask_type").(string),
+		"start_date":    utils.ValueIgnoreEmpty(d.Get("start_date")),
+		"start_time":    utils.ValueIgnoreEmpty(d.Get("start_time")),
+		"end_date":      utils.ValueIgnoreEmpty(d.Get("end_date")),
+		"end_time":      utils.ValueIgnoreEmpty(d.Get("end_time")),
+	}
+	if relationType == "ALARM_RULE" {
+		param["relation_ids"] = []string{d.Get("relation_id").(string)}
+	} else {
+		param["relation_ids"] = d.Get("relation_ids").(*schema.Set).List()
+	}
+
+	return param
+}
+
+func buildResourcesParams(resources []interface{}) []map[string]interface{} {
+	var resourcesParams []map[string]interface{}
+	for _, resource := range resources {
+		resourceParams := map[string]interface{}{
+			"namespace":  resource.(map[string]interface{})["namespace"].(string),
+			"dimensions": buildDimensionsParams(resource.(map[string]interface{})["dimensions"].(*schema.Set).List()),
+		}
+		resourcesParams = append(resourcesParams, resourceParams)
+	}
+
+	return resourcesParams
+}
+
+func buildDimensionsParams(dimensions []interface{}) []map[string]interface{} {
+	var dimensionsParams []map[string]interface{}
+	for _, dimension := range dimensions {
+		dimensionParams := map[string]interface{}{
+			"name":  dimension.(map[string]interface{})["name"].(string),
+			"value": dimension.(map[string]interface{})["value"].(string),
+		}
+		dimensionsParams = append(dimensionsParams, dimensionParams)
+	}
+
+	return dimensionsParams
+}
+
+func resourceNotificationMaskRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	readNotificationMaskClient, err := cfg.NewServiceClient("ces", region)
+	if err != nil {
+		return diag.Errorf("error creating CES client: %s", err)
+	}
+
+	relationType := d.Get("relation_type").(string)
+	relationId := d.Get("relation_id").(string)
+	id := d.Id()
+	mask, err := GetNotificationMask(readNotificationMaskClient, relationType, relationId, id)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CES notification mask")
+	}
+
+	maskId := utils.PathSearch("notification_mask_id", mask, "").(string)
+	if relationType == "ALARM_RULE" {
+		d.SetId(maskId)
+	}
+
+	resources, err := getNotificationMaskResources(readNotificationMaskClient, maskId)
+	if err != nil {
+		return diag.Errorf("error retrieving CES notification mask resources: %s", err)
+	}
+
+	rawPolicies := utils.PathSearch("policies", mask, make([]interface{}, 0)).([]interface{})
+	policies := flattenNotificationMaskPolicies(rawPolicies)
+	relationIds := utils.PathSearch("policies[*].alarm_policy_id", mask, make([]interface{}, 0)).([]interface{})
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("relation_type", utils.PathSearch("relation_type", mask, nil)),
+		d.Set("mask_type", utils.PathSearch("mask_type", mask, nil)),
+		d.Set("relation_ids", relationIds),
+		d.Set("relation_id", utils.PathSearch("relation_id", mask, nil)),
+		d.Set("mask_name", utils.PathSearch("mask_name", mask, nil)),
+		d.Set("start_date", utils.PathSearch("start_date", mask, nil)),
+		d.Set("start_time", utils.PathSearch("start_time", mask, nil)),
+		d.Set("end_date", utils.PathSearch("end_date", mask, nil)),
+		d.Set("end_time", utils.PathSearch("end_time", mask, nil)),
+		d.Set("resources", resources),
+		d.Set("mask_status", utils.PathSearch("mask_status", mask, nil)),
+		d.Set("policies", policies),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func GetNotificationMask(client *golangsdk.ServiceClient, relationType, relationId, id string) (interface{}, error) {
+	getNotificationMaskHttpUrl := "v2/{project_id}/notification-masks/batch-query"
+	getNotificationMaskPath := client.Endpoint + getNotificationMaskHttpUrl
+	getNotificationMaskPath = strings.ReplaceAll(getNotificationMaskPath, "{project_id}", client.ProjectID)
+
+	getNotificationMaskOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	param := map[string]interface{}{
+		"relation_type": relationType,
+	}
+
+	if relationType == "ALARM_RULE" {
+		param["relation_ids"] = []string{relationId}
+	} else {
+		param["relation_ids"] = []interface{}{}
+		param["mask_id"] = id
+	}
+
+	getNotificationMaskOpt.JSONBody = param
+
+	resp, err := client.Request("POST", getNotificationMaskPath, &getNotificationMaskOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var mask interface{}
+	if relationType == "ALARM_RULE" {
+		mask = utils.PathSearch("[0]", respBody, nil)
+	} else {
+		mask = utils.PathSearch("notification_masks|[0]", respBody, nil)
+	}
+
+	if mask == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	maskId := utils.PathSearch("notification_mask_id", mask, "").(string)
+	if maskId == "" {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return mask, nil
+}
+
+func getNotificationMaskResources(client *golangsdk.ServiceClient, id string) ([]interface{}, error) {
+	httpUrl := "v2/{project_id}/notification-masks/{notification_mask_id}/resources"
+	basePath := client.Endpoint + httpUrl
+	basePath = strings.ReplaceAll(basePath, "{project_id}", client.ProjectID)
+	basePath = strings.ReplaceAll(basePath, "{notification_mask_id}", id)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+	rst := make([]interface{}, 0)
+
+	offset := 0
+	for {
+		path := fmt.Sprintf("%s?limit=100&offset=%d", basePath, offset)
+		resp, err := client.Request("GET", path, &opt)
+
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		resources := utils.PathSearch("resources", respBody, make([]interface{}, 0)).([]interface{})
+		if len(resources) == 0 {
+			return rst, nil
+		}
+
+		rst = append(rst, resources...)
+		offset += 100
+		total := utils.PathSearch("count", respBody, float64(0))
+		if int(total.(float64)) <= offset {
+			break
+		}
+	}
+	return rst, nil
+}
+
+func flattenNotificationMaskPolicies(policies []interface{}) []interface{} {
+	rst := make([]interface{}, len(policies))
+	for i, policy := range policies {
+		rst[i] = map[string]interface{}{
+			"alarm_policy_id":     utils.PathSearch("alarm_policy_id", policy, nil),
+			"metric_name":         utils.PathSearch("metric_name", policy, nil),
+			"extra_info":          flattenNotificationMaskExtInfo(utils.PathSearch("extra_info", policy, nil)),
+			"period":              utils.PathSearch("period", policy, nil),
+			"filter":              utils.PathSearch("filter", policy, nil),
+			"comparison_operator": utils.PathSearch("comparison_operator", policy, nil),
+			"value":               utils.PathSearch("value", policy, nil),
+			"unit":                utils.PathSearch("unit", policy, nil),
+			"count":               utils.PathSearch("count", policy, nil),
+			"type":                utils.PathSearch("type", policy, nil),
+			"suppress_duration":   utils.PathSearch("suppress_duration", policy, nil),
+			"alarm_level":         utils.PathSearch("alarm_level", policy, nil),
+			"selected_unit":       utils.PathSearch("selected_unit", policy, nil),
+		}
+	}
+	return rst
+}
+
+func flattenNotificationMaskExtInfo(extInfo interface{}) []interface{} {
+	if extInfo == nil {
+		return nil
+	}
+	rst := map[string]interface{}{
+		"origin_metric_name": utils.PathSearch("origin_metric_name", extInfo, nil),
+		"metric_prefix":      utils.PathSearch("metric_prefix", extInfo, nil),
+		"custom_proc_name":   utils.PathSearch("custom_proc_name", extInfo, nil),
+		"metric_type":        utils.PathSearch("metric_type", extInfo, nil),
+	}
+	return []interface{}{rst}
+}
+
+func resourceNotificationMaskUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updateNotificationMaskClient, err := cfg.NewServiceClient("ces", region)
+	if err != nil {
+		return diag.Errorf("error creating CES client: %s", err)
+	}
+
+	relationType := d.Get("relation_type").(string)
+	var updateNotificationMaskPath string
+
+	updateNotificationMaskOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	if relationType == "ALARM_RULE" {
+		updateNotificationMaskHttpUrl := "v2/{project_id}/notification-masks"
+		updateNotificationMaskPath = updateNotificationMaskClient.Endpoint + updateNotificationMaskHttpUrl
+		updateNotificationMaskPath = strings.ReplaceAll(updateNotificationMaskPath, "{project_id}", updateNotificationMaskClient.ProjectID)
+	} else {
+		updateNotificationMaskHttpUrl := "v2/{project_id}/notification-masks/{notification_mask_id}"
+		updateNotificationMaskPath = updateNotificationMaskClient.Endpoint + updateNotificationMaskHttpUrl
+		updateNotificationMaskPath = strings.ReplaceAll(updateNotificationMaskPath, "{project_id}", updateNotificationMaskClient.ProjectID)
+		updateNotificationMaskPath = strings.ReplaceAll(updateNotificationMaskPath, "{notification_mask_id}", d.Id())
+		updateNotificationMaskOpt.OkCodes = []int{204}
+	}
+
+	updateNotificationMaskOpt.JSONBody = utils.RemoveNil(buildNotificationMaskBodyParams(d))
+
+	_, err = updateNotificationMaskClient.Request("PUT", updateNotificationMaskPath, &updateNotificationMaskOpt)
+	if err != nil {
+		return diag.Errorf("error updating CES notification mask: %s", err)
+	}
+
+	return resourceNotificationMaskRead(ctx, d, meta)
+}
+
+func resourceNotificationMaskDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	deleteNotificationMaskClient, err := cfg.NewServiceClient("ces", region)
+	if err != nil {
+		return diag.Errorf("error creating CES client: %s", err)
+	}
+
+	deleteNotificationMaskHttpUrl := "v2/{project_id}/notification-masks/batch-delete"
+	deleteNotificationMaskPath := deleteNotificationMaskClient.Endpoint + deleteNotificationMaskHttpUrl
+	deleteNotificationMaskPath = strings.ReplaceAll(deleteNotificationMaskPath, "{project_id}", deleteNotificationMaskClient.ProjectID)
+
+	deleteNotificationMaskOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	deleteNotificationMaskOpt.JSONBody = map[string]interface{}{
+		"notification_mask_ids": []string{d.Id()},
+	}
+
+	_, err = deleteNotificationMaskClient.Request("POST", deleteNotificationMaskPath, &deleteNotificationMaskOpt)
+	if err != nil {
+		return diag.Errorf("error deleting CES notification mask: %s", err)
+	}
+
+	return nil
+}
+
+func resourceNotificationMaskImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, errors.New("invalid format specified for import id, " +
+			"must be <relation_type>/<relation_id> or <relation_type>/<notification_mask_id>")
+	}
+	relationType := parts[0]
+	d.Set("relation_type", relationType)
+	if relationType == "ALARM_RULE" {
+		d.Set("relation_id", parts[1])
+	} else {
+		d.SetId(parts[1])
+	}
+
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add resource notification mask
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add resource notification mask
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/ces" TESTARGS="-run TestAccResourceNotificationMask"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ces -v -run TestAccResourceNotificationMask -timeout 360m -parallel 4
=== RUN   TestAccResourceNotificationMask_resource
=== PAUSE TestAccResourceNotificationMask_resource
=== RUN   TestAccResourceNotificationMask_policy
=== PAUSE TestAccResourceNotificationMask_policy
=== RUN   TestAccResourceNotificationMask_alarmRule
=== PAUSE TestAccResourceNotificationMask_alarmRule
=== CONT  TestAccResourceNotificationMask_resource
=== CONT  TestAccResourceNotificationMask_alarmRule
=== CONT  TestAccResourceNotificationMask_policy
--- PASS: TestAccResourceNotificationMask_policy (56.56s)
--- PASS: TestAccResourceNotificationMask_alarmRule (130.67s)
--- PASS: TestAccResourceNotificationMask_resource (135.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ces       135.933s

```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found 
    relation_type = ALARM_RULE
    ![image](https://github.com/user-attachments/assets/8a6841a2-546d-44ad-817e-634f11fd0708)
    relation_type != ALARM_RULE
    ![image](https://github.com/user-attachments/assets/55ae09be-86f0-4092-a7bc-1037913b7c13)



    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
