### PR TITLE
fix(dns/recordset): change the 'records' parameter type from list to set

### DIFF
--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_recordset_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_recordset_test.go
@@ -91,7 +91,7 @@ func TestAccDNSRecordset_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "description", "a recordset description"),
 					resource.TestCheckResourceAttr(rName, "status", "ENABLE"),
 					resource.TestCheckResourceAttr(rName, "ttl", "300"),
-					resource.TestCheckResourceAttr(rName, "records.0", "10.1.0.0"),
+					resource.TestCheckResourceAttr(rName, "records.#", "2"),
 					resource.TestCheckResourceAttr(rName, "line_id", "Dianxin_Shanxi"),
 					resource.TestCheckResourceAttr(rName, "weight", "3"),
 					resource.TestCheckResourceAttr(rName, "tags.key1", "value1"),
@@ -277,7 +277,7 @@ resource "huaweicloud_dns_recordset" "test" {
   description = "a recordset description"
   status      = "ENABLE"
   ttl         = 300
-  records     = ["10.1.0.0"]
+  records     = ["10.1.0.0", "9.1.0.0"]
   line_id     = "Dianxin_Shanxi"
   weight      = 3
 

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_recordset.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_recordset.go
@@ -75,7 +75,7 @@ func ResourceDNSRecordset() *schema.Resource {
 				Description: `The type of the record set.`,
 			},
 			"records": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				MinItems:    1,
 				Required:    true,
@@ -233,7 +233,7 @@ func buildCreateDNSRecordsetBodyParams(d *schema.ResourceData) map[string]interf
 		"type":        utils.ValueIgnoreEmpty(d.Get("type")),
 		"status":      utils.ValueIgnoreEmpty(d.Get("status")),
 		"ttl":         utils.ValueIgnoreEmpty(d.Get("ttl")),
-		"records":     utils.ValueIgnoreEmpty(d.Get("records")),
+		"records":     utils.ValueIgnoreEmpty(d.Get("records").(*schema.Set).List()),
 		"line":        utils.ValueIgnoreEmpty(d.Get("line_id")),
 		"tags":        utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{})),
 		"weight":      utils.ValueIgnoreEmpty(d.Get("weight")),
@@ -435,7 +435,7 @@ func buildUpdateDNSRecordsetBodyParams(d *schema.ResourceData) map[string]interf
 		"description": utils.ValueIgnoreEmpty(d.Get("description")),
 		"type":        utils.ValueIgnoreEmpty(d.Get("type")),
 		"ttl":         utils.ValueIgnoreEmpty(d.Get("ttl")),
-		"records":     utils.ValueIgnoreEmpty(d.Get("records")),
+		"records":     utils.ValueIgnoreEmpty(d.Get("records").(*schema.Set).List()),
 		"weight":      utils.ValueIgnoreEmpty(d.Get("weight")),
 	}
 	return bodyParams


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Change the 'records' parameter type from list to set to solve the problem of resource changes caused by inconsistent order.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
change the 'records' parameter type from list to set.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccDNSRecordset_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDNSRecordset_ -timeout 360m -parallel 10
=== RUN   TestAccDNSRecordset_basic
=== PAUSE TestAccDNSRecordset_basic
=== RUN   TestAccDNSRecordset_publicZone
=== PAUSE TestAccDNSRecordset_publicZone
=== RUN   TestAccDNSRecordset_privateZone
=== PAUSE TestAccDNSRecordset_privateZone
=== CONT  TestAccDNSRecordset_basic
=== CONT  TestAccDNSRecordset_privateZone
=== CONT  TestAccDNSRecordset_publicZone
--- PASS: TestAccDNSRecordset_publicZone (55.45s)
--- PASS: TestAccDNSRecordset_basic (57.38s)
--- PASS: TestAccDNSRecordset_privateZone (76.87s)
PASS
coverage: 17.2% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       76.937s coverage: 17.2% of statements in ./huaweicloud/services/dns
```

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
