### PR TITLE
feat(example/er): add example for shared er instance

### DIFF
--- a/examples/er/share_instance/README.md
+++ b/examples/er/share_instance/README.md
@@ -1,0 +1,26 @@
+# Create an ER instance to share with other accounts
+
+Configuration in this directory creates an ER instance and RAM share resource. The example includes an ER instance,
+a RAM share resource, a RAM share accepter resource, a VPC configuration, an ER attachment and
+an ER attachment accepter resource.
+Configuration in this directory describes how to share an ER instance with other accounts, and the sharer accepts or
+rejects attachment requests from other accounts.
+
+To run, configure your Huaweicloud provider as described in the
+[document](https://registry.terraform.io/providers/huaweicloud/huaweicloud/latest/docs).
+
+## Usage
+
+```
+terraform init
+terraform plan
+terraform apply
+terraform destroy
+```
+
+## Requirements
+
+| Name | Version |
+| ---- | ---- |
+| terraform | >= 0.12.0 |
+| huaweicloud | >= 1.73.4 |

--- a/examples/er/share_instance/main.tf
+++ b/examples/er/share_instance/main.tf
@@ -1,0 +1,118 @@
+# Share (owner).
+provider "huaweicloud" {
+  alias = "owner"
+
+  region     = var.region_name
+  access_key = var.owner_ak
+  secret_key = var.owner_sk
+}
+
+# Other account (principal).
+provider "huaweicloud" {
+  alias = "principal"
+
+  region     = var.region_name
+  access_key = var.principal_ak
+  secret_key = var.principal_sk
+}
+
+data "huaweicloud_er_availability_zones" "test" {
+  provider = huaweicloud.owner
+}
+
+# Owner creates an ER instance to share.
+resource "huaweicloud_er_instance" "test" {
+  provider = huaweicloud.owner
+
+  availability_zones = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
+
+  name        = var.er_instance_name
+  asn         = "64512"
+  description = "Create an ER instace to share"
+
+  enable_default_propagation     = true
+  enable_default_association     = true
+  auto_accept_shared_attachments = false
+}
+
+data "huaweicloud_ram_resource_permissions" "test" {
+  provider = huaweicloud.owner
+
+  resource_type = "er:instances"
+
+  depends_on = [huaweicloud_er_instance.test]
+}
+
+# Owner creates a RAM shared resource to initiate a shared ER request.
+resource "huaweicloud_ram_resource_share" "test" {
+  provider = huaweicloud.owner
+
+  name          = var.resource_share_name
+  principals    = [var.principal_account_id]
+  resource_urns = ["er:${var.region_name}:${var.owner_account_id}:instances:${huaweicloud_er_instance.test.id}"]
+
+  permission_ids = data.huaweicloud_ram_resource_permissions.test.permissions[*].id
+}
+
+# Principal queries the shared ER requests that need to be accepted.
+data "huaweicloud_ram_resource_share_invitations" "test" {
+  provider = huaweicloud.principal
+
+  status = "pending"
+
+  depends_on = [huaweicloud_ram_resource_share.test]
+}
+
+# Principal (ER instance acceptor) to accept request from owner shared ER.
+resource "huaweicloud_ram_resource_share_accepter" "test" {
+  provider = huaweicloud.principal
+
+  resource_share_invitation_id = try([for v in data.huaweicloud_ram_resource_share_invitations.test.resource_share_invitations : v.id if v.resource_share_id == huaweicloud_ram_resource_share.test.id][0], "")
+  action                       = "accept"
+
+  # After accepting the request, querying data.huaweicloud_ram_resource_share_invitations again will be empty.
+  # This resource is a one-time resource. Add ignore_changes to prevent resource changes when executing terraform plan.
+  lifecycle {
+    ignore_changes = [
+      resource_share_invitation_id,
+    ]
+  }
+}
+
+resource "huaweicloud_vpc" "test" {
+  provider = huaweicloud.principal
+
+  name = var.vpc_name
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  provider = huaweicloud.principal
+
+  vpc_id     = huaweicloud_vpc.test.id
+  name       = var.subnet_name
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+}
+
+# Principal creates a VPC attachment.
+resource "huaweicloud_er_vpc_attachment" "test" {
+  provider = huaweicloud.principal
+
+  instance_id = huaweicloud_er_instance.test.id
+  vpc_id      = huaweicloud_vpc.test.id
+  subnet_id   = huaweicloud_vpc_subnet.test.id
+  name        = var.attachment_name
+
+  depends_on = [huaweicloud_ram_resource_share_accepter.test]
+}
+
+# The owner accepts attachment from principals.
+resource "huaweicloud_er_attachment_accepter" "test" {
+  provider = huaweicloud.owner
+
+  instance_id   = huaweicloud_er_instance.test.id
+  attachment_id = huaweicloud_er_vpc_attachment.test.id
+  action        = "accept"
+}
+

--- a/examples/er/share_instance/variables.tf
+++ b/examples/er/share_instance/variables.tf
@@ -1,0 +1,87 @@
+variable "region_name" {
+  default = "cn-north-4"
+}
+
+variable "owner_account_id" {
+  type        = string
+  description = "The account ID of the ER instance sharer"
+
+  default   = ""
+  sensitive = true
+}
+
+variable "owner_ak" {
+  type        = string
+  description = "The AK of the ER instance sharer"
+
+  default   = ""
+  sensitive = true
+}
+
+variable "owner_sk" {
+  type        = string
+  description = "The SK of the ER instance sharer"
+
+  default   = ""
+  sensitive = true
+}
+
+variable "principal_account_id" {
+  type        = string
+  description = "The account ID of the ER instance accepter"
+
+  default   = ""
+  sensitive = true
+}
+
+
+variable "principal_ak" {
+  type        = string
+  description = "The AK of the ER instance accepter"
+
+  default   = ""
+  sensitive = true
+}
+
+variable "principal_sk" {
+  type        = string
+  description = "The sk of the ER instance accepter"
+
+  default   = ""
+  sensitive = true
+}
+
+variable "er_instance_name" {
+  type        = string
+  description = "The ID of the shared ER instance"
+
+  default = "share_attachment"
+}
+
+variable "resource_share_name" {
+  type        = string
+  description = "The ID of the shared ER instance"
+
+  default = "resource-share-er"
+}
+
+variable "vpc_name" {
+  type        = string
+  description = "The ID of the VPC of the VPC attachment"
+
+  default = "er_attachment_vpc_test"
+}
+
+variable "subnet_name" {
+  type        = string
+  description = "The ID of the subnet of the VPC attachment"
+
+  default = "er_attachment_subnet_test"
+}
+
+variable "attachment_name" {
+  type        = string
+  description = "The ID of the VPC attachment"
+
+  default = "shared_attachment"
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add example of sharing ER instance to other accounts.
![image](https://github.com/user-attachments/assets/227bd8c7-295c-426f-a36c-84a9600971ff)
![image](https://github.com/user-attachments/assets/dbab2a47-7738-4451-bbfb-bc5d02e5f677)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add example  for shared er instance
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
