### PR TITLE
feat(ELB): add parasm to elb active standby pools data source

### DIFF
--- a/docs/data-sources/elb_active_standby_pools.md
+++ b/docs/data-sources/elb_active_standby_pools.md
@@ -32,6 +32,19 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies supplementary information about the active-standby pool.
 
+* `connection_drain` - (Optional, String) Specifies whether delayed logout is enabled. Value options:
+  + **false**: Disable this option.
+  + **true**: Enable this option.
+
+* `ip_version` - (Optional, String) Specifies the IP address version supported by the pool.
+
+* `lb_algorithm` - (Optional, String) Specifies the load balancing algorithm used by the load balancer to route requests
+  to backend servers in the associated pool. Value options:
+  + **ROUND_ROBIN**: weighted round robin.
+  + **LEAST_CONNECTIONS**: weighted least connections.
+  + **SOURCE_IP**: source IP hash.
+  + **QUIC_CID**: connection ID.
+
 * `loadbalancer_id` - (Optional, String) Specifies the ID of the load balancer with which the active-standby pool is
   associated.
 
@@ -81,6 +94,13 @@ The `pools` block supports:
 
 * `any_port_enable` - Whether to enable Forward to same Port for a pool.
 
+* `enterprise_project_id` - The ID of the enterprise project.
+
+* `ip_version` - The IP address version supported by the pool.
+
+* `lb_algorithm` - The load balancing algorithm used by the load balancer to route requests to backend servers in the
+  associated pool.
+
 * `vpc_id` - The ID of the VPC where the active-standby pool works.
 
 * `connection_drain_enabled` - Whether to enable delayed logout.
@@ -98,6 +118,13 @@ The `pools` block supports:
 
 * `healthmonitor` - The health check configured for the active-standby pool.
   The [healthmonitor](#elb_healthmonitor) structure is documented below.
+
+* `quic_cid_hash_strategy` - The multi-path distribution configuration based on destination connection IDs.
+  The [quic_cid_hash_strategy](#elb_quic_cid_hash_strategy) structure is documented below.
+
+* `created_at` - The time when the backend server group was created.
+
+* `updated_at` - The time when the backend server group was updated.
 
 <a name="elb_listeners"></a>
 The `listeners` block supports:
@@ -132,6 +159,54 @@ The `members` block supports:
 
 * `role` - The active-standby status of the member.
 
+* `reason` - Why health check fails.
+  The [reason](#ELB_member_reason) structure is documented below.
+
+* `status` - The health status of the backend server if `listener_id` under status is specified. If `listener_id` under
+  status is not specified, operating_status of member takes precedence.
+  The [status](#ELB_member_status) structure is documented below.
+
+<a name="ELB_member_reason"></a>
+The `reason` block supports:
+
+* `reason_code` - The code of the health check failures. The value can be:
+  + **CONNECT_TIMEOUT**: The connection with the backend server times out during a health check.
+  + **CONNECT_REFUSED**: The load balancer rejects connections with the backend server during a health check.
+  + **CONNECT_FAILED**: The load balancer fails to establish connections with the backend server during a health check.
+  + **CONNECT_INTERRUPT**: The load balancer is disconnected from the backend server during a health check.
+  + **SSL_HANDSHAKE_ERROR**: The SSL handshakes with the backend server fail during a health check.
+  + **RECV_RESPONSE_FAILED**: The load balancer fails to receive responses from the backend server during a health check.
+  + **RECV_RESPONSE_TIMEOUT**: The load balancer does not receive responses from the backend server within the timeout
+    duration during a health check.
+  + **SEND_REQUEST_FAILED**: The load balancer fails to send a health check request to the backend server during a health
+    check.
+  + **SEND_REQUEST_TIMEOUT**: The load balancer fails to send a health check request to the backend server within the
+    timeout duration.
+  + **RESPONSE_FORMAT_ERROR**: The load balancer receives invalid responses from the backend server during a health check.
+  + **RESPONSE_MISMATCH**: The response code received from the backend server is different from the preset code.
+
+* `expected_response` - The expected HTTP status code. This parameter will take effect only when `type` is set to **HTTP**,
+  **HTTPS** or **GRPC**.
+  + A specific status code. If `type` is set to **GRPC**, the status code ranges from **0** to **99**. If `type` is set
+    to other values, the status code ranges from **200** to **599**.
+  + A list of status codes that are separated with commas (,). A maximum of five status codes are supported.
+  + A status code range. Different ranges are separated with commas (,). A maximum of five ranges are supported.
+
+* `healthcheck_response` - The returned HTTP status code in the response. This parameter will take effect only when `type`
+  is set to **HTTP**, **HTTPS** or **GRPC**.
+  + A specific status code. If type is set to **GRPC**, the status code ranges from **0** to **99**. If `type` is set to
+    other values, the status code ranges from **200** to **599**.
+
+<a name="ELB_member_status"></a>
+The `status` block supports:
+
+* `listener_id` - The ID of the listener associated with the backend server.
+
+* `operating_status` - The health status of the backend server. The value can be:
+  + **ONLINE**: The backend server is running normally.
+  + **NO_MONITOR**: No health check is configured for the backend server group to which the backend server belongs.
+  + **OFFLINE**: The cloud server used as the backend server is stopped or does not exist.
+
 <a name="elb_healthmonitor"></a>
 The `healthmonitor` block supports:
 
@@ -160,3 +235,10 @@ The `healthmonitor` block supports:
 * `type` - The health check protocol.
 
 * `url_path` - The HTTP request path for the health check.
+
+<a name="elb_quic_cid_hash_strategy"></a>
+The `quic_cid_hash_strategy` block supports:
+
+* `len` - The length of the hash factor in the connection ID, in byte.
+
+* `offset` - The start position in the connection ID as the hash factor, in byte.

--- a/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_active_standby_pools_test.go
+++ b/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_active_standby_pools_test.go
@@ -10,47 +10,80 @@ import (
 )
 
 func TestAccDatasourceActiveStandbyPools_basic(t *testing.T) {
-	rName := "data.huaweicloud_elb_active_standby_pools.test"
-	dc := acceptance.InitDataSourceCheck(rName)
-	name := acceptance.RandomAccResourceName()
+	dataSource := "data.huaweicloud_elb_active_standby_pools.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceActiveStandbyPools_basic(name),
+				Config: testAccDatasourceActiveStandbyPools_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(rName, "pools.#"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.id"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.name"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.type"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.protocol"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.any_port_enable"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.members.0.address"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.members.0.protocol_port"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.members.0.role"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.members.1.address"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.members.1.protocol_port"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.members.1.role"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.healthmonitor.0.delay"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.healthmonitor.0.expected_codes"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.healthmonitor.0.http_method"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.healthmonitor.0.max_retries"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.healthmonitor.0.max_retries_down"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.healthmonitor.0.timeout"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.healthmonitor.0.type"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.connection_drain_enabled"),
-					resource.TestCheckResourceAttrSet(rName, "pools.0.connection_drain_timeout"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.protocol"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.any_port_enable"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.ip_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.lb_algorithm"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.members.0.address"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.members.0.protocol_port"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.members.0.role"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.members.1.address"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.members.1.protocol_port"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.members.1.role"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.healthmonitor.0.delay"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.healthmonitor.0.expected_codes"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.healthmonitor.0.http_method"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.healthmonitor.0.max_retries"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.healthmonitor.0.max_retries_down"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.healthmonitor.0.timeout"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.healthmonitor.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.connection_drain_enabled"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.connection_drain_timeout"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.updated_at"),
 					resource.TestCheckOutput("name_filter_is_useful", "true"),
 					resource.TestCheckOutput("pool_id_filter_is_useful", "true"),
 					resource.TestCheckOutput("description_filter_is_useful", "true"),
+					resource.TestCheckOutput("connection_drain_filter_is_useful", "true"),
+					resource.TestCheckOutput("ip_version_filter_is_useful", "true"),
+					resource.TestCheckOutput("lb_algorithm_filter_is_useful", "true"),
 					resource.TestCheckOutput("protocol_filter_is_useful", "true"),
 					resource.TestCheckOutput("type_filter_is_useful", "true"),
 					resource.TestCheckOutput("healthmonitor_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("loadbalancer_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("listener_id_filter_is_useful", "true"),
 					resource.TestCheckOutput("vpc_id_filter_is_useful", "true"),
 					resource.TestCheckOutput("member_address_filter_is_useful", "true"),
+					resource.TestCheckOutput("member_instance_id_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceActiveStandbyPools_quic(t *testing.T) {
+	dataSource := "data.huaweicloud_elb_active_standby_pools.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceActiveStandbyPools_quic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.quic_cid_hash_strategy.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.quic_cid_hash_strategy.0.len"),
+					resource.TestCheckResourceAttrSet(dataSource, "pools.0.quic_cid_hash_strategy.0.offset"),
 				),
 			},
 		},
@@ -109,6 +142,54 @@ output "description_filter_is_useful" {
 }
 
 locals {
+  connection_drain = huaweicloud_elb_active_standby_pool.test.connection_drain_enabled
+}
+
+data "huaweicloud_elb_active_standby_pools" "connection_drain_filter" {
+  depends_on = [huaweicloud_elb_active_standby_pool.test]
+
+  connection_drain = huaweicloud_elb_active_standby_pool.test.connection_drain_enabled
+}
+
+output "connection_drain_filter_is_useful" {
+  value = length(data.huaweicloud_elb_active_standby_pools.connection_drain_filter.pools) > 0 && alltrue(
+  [for v in data.huaweicloud_elb_active_standby_pools.connection_drain_filter.pools[*].connection_drain_enabled : v == local.connection_drain]
+  )
+}
+
+locals {
+  ip_version = huaweicloud_elb_active_standby_pool.test.ip_version
+}
+
+data "huaweicloud_elb_active_standby_pools" "ip_version_filter" {
+  depends_on = [huaweicloud_elb_active_standby_pool.test]
+
+  ip_version = huaweicloud_elb_active_standby_pool.test.ip_version
+}
+
+output "ip_version_filter_is_useful" {
+  value = length(data.huaweicloud_elb_active_standby_pools.ip_version_filter.pools) > 0 && alltrue(
+  [for v in data.huaweicloud_elb_active_standby_pools.ip_version_filter.pools[*].ip_version : v == local.ip_version]
+  )
+}
+
+locals {
+  lb_algorithm = huaweicloud_elb_active_standby_pool.test.lb_algorithm
+}
+
+data "huaweicloud_elb_active_standby_pools" "lb_algorithm_filter" {
+  depends_on = [huaweicloud_elb_active_standby_pool.test]
+
+  lb_algorithm = huaweicloud_elb_active_standby_pool.test.lb_algorithm
+}
+
+output "lb_algorithm_filter_is_useful" {
+  value = length(data.huaweicloud_elb_active_standby_pools.lb_algorithm_filter.pools) > 0 && alltrue(
+  [for v in data.huaweicloud_elb_active_standby_pools.lb_algorithm_filter.pools[*].lb_algorithm : v == local.lb_algorithm]
+  )
+}
+
+locals {
   protocol = huaweicloud_elb_active_standby_pool.test.protocol
 }
 
@@ -158,6 +239,38 @@ output "healthmonitor_id_filter_is_useful" {
 }
 
 locals {
+  loadbalancer_id = huaweicloud_elb_loadbalancer.test.id
+}
+
+data "huaweicloud_elb_active_standby_pools" "loadbalancer_id_filter" {
+  depends_on = [huaweicloud_elb_active_standby_pool.test]
+
+  loadbalancer_id = huaweicloud_elb_loadbalancer.test.id
+}
+
+output "loadbalancer_id_filter_is_useful" {
+  value = length(data.huaweicloud_elb_active_standby_pools.loadbalancer_id_filter.pools) > 0 && alltrue(
+  [for v in data.huaweicloud_elb_active_standby_pools.loadbalancer_id_filter.pools[*].loadbalancers.0.id : v == local.loadbalancer_id]
+  )
+}
+
+locals {
+  listener_id = huaweicloud_elb_listener.test.id
+}
+
+data "huaweicloud_elb_active_standby_pools" "listener_id_filter" {
+  depends_on = [huaweicloud_elb_active_standby_pool.test]
+
+  listener_id = huaweicloud_elb_listener.test.id
+}
+
+output "listener_id_filter_is_useful" {
+  value = length(data.huaweicloud_elb_active_standby_pools.listener_id_filter.pools) > 0 && alltrue(
+  [for v in data.huaweicloud_elb_active_standby_pools.listener_id_filter.pools[*].listeners.0.id : v == local.listener_id]
+  )
+}
+
+locals {
   vpc_id = huaweicloud_elb_active_standby_pool.test.vpc_id
 }
 
@@ -188,5 +301,32 @@ output "member_address_filter_is_useful" {
   [for v in data.huaweicloud_elb_active_standby_pools.member_address_filter.pools[*].members[*].address : contains(v, local.member_address)]
   )
 }
+
+locals {
+  member_instance_id = tolist(huaweicloud_elb_active_standby_pool.test.members).0.instance_id
+}
+
+data "huaweicloud_elb_active_standby_pools" "member_instance_id_filter" {
+  depends_on = [huaweicloud_elb_active_standby_pool.test]
+
+  member_instance_id = tolist(huaweicloud_elb_active_standby_pool.test.members).0.instance_id
+}
+
+output "member_instance_id_filter_is_useful" {
+  value = length(data.huaweicloud_elb_active_standby_pools.member_instance_id_filter.pools) > 0 && alltrue(
+  [for v in data.huaweicloud_elb_active_standby_pools.member_instance_id_filter.pools[*].members[*].instance_id :
+  contains(v, local.member_instance_id)]
+  )
+}
 `, testAccElbActiveStandbyPoolConfig_basic(name), name)
+}
+
+func testAccDatasourceActiveStandbyPools_quic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_elb_active_standby_pools" "test" {
+  depends_on = [huaweicloud_elb_active_standby_pool.test] 
+}
+`, testAccElbActiveStandbyPoolConfig_quic_protocol(name), name)
 }

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_active_standby_pools.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_active_standby_pools.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/pagination"
 
@@ -36,6 +38,21 @@ func DataSourceActiveStandbyPools() *schema.Resource {
 				Optional: true,
 			},
 			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"connection_drain": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"true", "false",
+				}, false),
+			},
+			"ip_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"lb_algorithm": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -107,6 +124,18 @@ func poolsActiveStandbyPoolsSchema() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ip_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"lb_algorithm": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"connection_drain_enabled": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -130,13 +159,26 @@ func poolsActiveStandbyPoolsSchema() *schema.Resource {
 				Computed: true,
 			},
 			"members": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Elem:     poolsActiveStandbyPoolMembersSchema(),
 				Computed: true,
 			},
 			"healthmonitor": {
 				Type:     schema.TypeList,
 				Elem:     poolsActiveStandbyPoolHealthmonitorSchema(),
+				Computed: true,
+			},
+			"quic_cid_hash_strategy": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     poolsActiveStandbyPoolQuicCidHashStrategySchema(),
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
@@ -211,6 +253,52 @@ func poolsActiveStandbyPoolMembersSchema() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"reason": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     poolsActiveStandbyPoolMemberReasonSchema(),
+			},
+			"status": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     poolsActiveStandbyPoolMemberStatusSchema(),
+			},
+		},
+	}
+	return &sc
+}
+
+func poolsActiveStandbyPoolMemberReasonSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"reason_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expected_response": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"healthcheck_response": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func poolsActiveStandbyPoolMemberStatusSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"listener_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"operating_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 	return &sc
@@ -270,6 +358,21 @@ func poolsActiveStandbyPoolHealthmonitorSchema() *schema.Resource {
 		},
 	}
 	return &sc
+}
+
+func poolsActiveStandbyPoolQuicCidHashStrategySchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"len": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"offset": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
 }
 
 func resourceActiveStandbyPoolsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -344,6 +447,9 @@ func flattenListActiveStandbyPoolsBodyPools(resp interface{}) []interface{} {
 			"protocol":                 utils.PathSearch("protocol", v, nil),
 			"type":                     utils.PathSearch("type", v, nil),
 			"any_port_enable":          utils.PathSearch("any_port_enable", v, nil),
+			"enterprise_project_id":    utils.PathSearch("enterprise_project_id", v, nil),
+			"ip_version":               utils.PathSearch("ip_version", v, nil),
+			"lb_algorithm":             utils.PathSearch("lb_algorithm", v, nil),
 			"vpc_id":                   utils.PathSearch("vpc_id", v, nil),
 			"connection_drain_enabled": utils.PathSearch("connection_drain.enable", v, nil),
 			"connection_drain_timeout": utils.PathSearch("connection_drain.timeout", v, nil),
@@ -351,6 +457,9 @@ func flattenListActiveStandbyPoolsBodyPools(resp interface{}) []interface{} {
 			"loadbalancers":            flattenActiveStandbyPoolLoadbalancers(v),
 			"members":                  flattenActiveStandbyPoolMember(v),
 			"healthmonitor":            flattenActiveStandbyPoolMonitor(v),
+			"quic_cid_hash_strategy":   flattenActiveStandbyPoolQuicCidHashStrategy(v),
+			"created_at":               utils.PathSearch("created_at", v, nil),
+			"updated_at":               utils.PathSearch("updated_at", v, nil),
 		})
 	}
 	return rst
@@ -414,6 +523,8 @@ func flattenActiveStandbyPoolMember(resp interface{}) []interface{} {
 			"instance_id":      utils.PathSearch("instance_id", v, nil),
 			"operating_status": utils.PathSearch("operating_status", v, nil),
 			"ip_version":       utils.PathSearch("ip_version", v, nil),
+			"reason":           flattenActiveStandbyPoolMemberReason(v),
+			"status":           flattenActiveStandbyPoolMemberStatus(v),
 		})
 	}
 	return rst
@@ -445,6 +556,21 @@ func flattenActiveStandbyPoolMonitor(resp interface{}) []interface{} {
 	return rst
 }
 
+func flattenActiveStandbyPoolQuicCidHashStrategy(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("quic_cid_hash_strategy", resp, nil)
+	if curJson == nil {
+		return nil
+	}
+
+	rst := []interface{}{
+		map[string]interface{}{
+			"len":    utils.PathSearch("len", curJson, nil),
+			"offset": utils.PathSearch("offset", curJson, nil),
+		},
+	}
+	return rst
+}
+
 func buildListActiveStandbyPoolsQueryParams(d *schema.ResourceData) string {
 	res := ""
 	if v, ok := d.GetOk("pool_id"); ok {
@@ -455,6 +581,16 @@ func buildListActiveStandbyPoolsQueryParams(d *schema.ResourceData) string {
 	}
 	if v, ok := d.GetOk("description"); ok {
 		res = fmt.Sprintf("%s&description=%v", res, v)
+	}
+	if v, ok := d.GetOk("connection_drain"); ok {
+		connectionDrain, _ := strconv.ParseBool(v.(string))
+		res = fmt.Sprintf("%s&connection_drain=%v", res, connectionDrain)
+	}
+	if v, ok := d.GetOk("ip_version"); ok {
+		res = fmt.Sprintf("%s&ip_version=%v", res, v)
+	}
+	if v, ok := d.GetOk("lb_algorithm"); ok {
+		res = fmt.Sprintf("%s&lb_algorithm=%v", res, v)
 	}
 	if v, ok := d.GetOk("loadbalancer_id"); ok {
 		res = fmt.Sprintf("%s&loadbalancer_id=%v", res, v)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add parasm to elb active standby pools data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add parasm to elb active standby pools data source
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/elb/ TESTARGS='-run TestAccDatasourceActiveStandbyPools_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v -run TestAccDatasourceActiveStandbyPools_ -timeout 360m -parallel 4
=== RUN   TestAccDatasourceActiveStandbyPools_basic
=== PAUSE TestAccDatasourceActiveStandbyPools_basic
=== RUN   TestAccDatasourceActiveStandbyPools_quic
=== PAUSE TestAccDatasourceActiveStandbyPools_quic
=== CONT  TestAccDatasourceActiveStandbyPools_basic
=== CONT  TestAccDatasourceActiveStandbyPools_quic
--- PASS: TestAccDatasourceActiveStandbyPools_quic (83.79s)
--- PASS: TestAccDatasourceActiveStandbyPools_basic (285.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       285.332s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
