### PR TITLE
feat(nat): the private dnat and snat rule datasource support new fields

### DIFF
--- a/docs/data-sources/nat_private_dnat_rules.md
+++ b/docs/data-sources/nat_private_dnat_rules.md
@@ -2,7 +2,8 @@
 subcategory: "NAT Gateway (NAT)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_nat_private_dnat_rules"
-description: ""
+description: |-
+  Use this data source to get the list of private DNAT rules.
 ---
 
 # huaweicloud_nat_private_dnat_rules
@@ -61,6 +62,10 @@ The following arguments are supported:
 
 * `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the private DNAT
   rules belong.
+
+* `description` - (Optional, List) Specifies the description of the private DNAT rule.
+
+* `external_ip_address` - (Optional, List) Specifies the transit IP address used to the private DNAT rule.
 
 ## Attribute Reference
 

--- a/docs/data-sources/nat_private_snat_rules.md
+++ b/docs/data-sources/nat_private_snat_rules.md
@@ -2,7 +2,8 @@
 subcategory: "NAT Gateway (NAT)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_nat_private_snat_rules"
-description: ""
+description: |-
+  Use this data source to get the list of private SNAT rules.
 ---
 
 # huaweicloud_nat_private_snat_rules
@@ -42,6 +43,8 @@ The following arguments are supported:
 
 * `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the private SNAT
   rules belong.
+
+* `description` - (Optional, List) Specifies the description of the private SNAT rule.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/nat/data_source_huaweicloud_nat_private_dnat_rules_test.go
+++ b/huaweicloud/services/acceptance/nat/data_source_huaweicloud_nat_private_dnat_rules_test.go
@@ -46,6 +46,9 @@ func TestAccDatasourcePrivateDnatRules_basic(t *testing.T) {
 
 		byEps   = "data.huaweicloud_nat_private_dnat_rules.filter_by_eps"
 		dcByEps = acceptance.InitDataSourceCheck(byEps)
+
+		byDescription   = "data.huaweicloud_nat_private_dnat_rules.filter_by_description"
+		dcByDescription = acceptance.InitDataSourceCheck(byDescription)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -85,6 +88,9 @@ func TestAccDatasourcePrivateDnatRules_basic(t *testing.T) {
 
 					dcByEps.CheckResourceExists(),
 					resource.TestCheckOutput("eps_filter_is_useful", "true"),
+
+					dcByDescription.CheckResourceExists(),
+					resource.TestCheckOutput("description_filter_is_useful", "true"),
 				),
 			},
 		},
@@ -339,6 +345,25 @@ locals {
 
 output "eps_filter_is_useful" {
   value = alltrue(local.eps_filter_result) && length(local.eps_filter_result) > 0
+}
+
+locals {
+  description = data.huaweicloud_nat_private_dnat_rules.test.rules[0].description
+}
+
+data "huaweicloud_nat_private_dnat_rules" "filter_by_description" {
+  description = [local.description]
+}
+
+locals {
+  description_filter_result = [
+    for v in data.huaweicloud_nat_private_dnat_rules.filter_by_description.rules[*].description : 
+    v == local.description
+  ]
+}
+
+output "description_filter_is_useful" {
+  value = alltrue(local.description_filter_result) && length(local.description_filter_result) > 0
 }
 `, baseConfig)
 }

--- a/huaweicloud/services/acceptance/nat/data_source_huaweicloud_nat_private_snat_rules_test.go
+++ b/huaweicloud/services/acceptance/nat/data_source_huaweicloud_nat_private_snat_rules_test.go
@@ -37,6 +37,9 @@ func TestAccDatasourcePrivateSnatRules_basic(t *testing.T) {
 
 		byEps   = "data.huaweicloud_nat_private_snat_rules.filter_by_eps"
 		dcByEps = acceptance.InitDataSourceCheck(byEps)
+
+		byDescription   = "data.huaweicloud_nat_private_snat_rules.filter_by_description"
+		dcByDescription = acceptance.InitDataSourceCheck(byDescription)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -67,6 +70,9 @@ func TestAccDatasourcePrivateSnatRules_basic(t *testing.T) {
 
 					dcByEps.CheckResourceExists(),
 					resource.TestCheckOutput("eps_filter_is_useful", "true"),
+
+					dcByDescription.CheckResourceExists(),
+					resource.TestCheckOutput("description_filter_is_useful", "true"),
 				),
 			},
 		},
@@ -251,6 +257,25 @@ locals {
 
 output "subnet_id_filter_is_useful" {
   value = alltrue(local.subnet_id_filter_result) && length(local.subnet_id_filter_result) > 0
+}
+
+locals {
+  description = data.huaweicloud_nat_private_snat_rules.test.rules[0].description
+}
+
+data "huaweicloud_nat_private_snat_rules" "filter_by_description" {
+  description = [local.description]
+}
+
+locals {
+  description_filter_result = [
+    for v in data.huaweicloud_nat_private_snat_rules.filter_by_description.rules[*].description : 
+    v == local.description
+  ]
+}
+
+output "description_filter_is_useful" {
+  value = alltrue(local.description_filter_result) && length(local.description_filter_result) > 0
 }
 `, baseConfig)
 }

--- a/huaweicloud/services/nat/data_source_huaweicloud_nat_private_dnat_rules.go
+++ b/huaweicloud/services/nat/data_source_huaweicloud_nat_private_dnat_rules.go
@@ -77,6 +77,18 @@ func DataSourcePrivateDnatRules() *schema.Resource {
 				Optional:    true,
 				Description: "The ID of the enterprise project to which the private DNAT rules belong.",
 			},
+			"description": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The description of the private DNAT rule.",
+			},
+			"external_ip_address": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The transit IP address used to the private DNAT rule.",
+			},
 			"rules": {
 				Type:        schema.TypeList,
 				Elem:        dnatRulesSchema(),
@@ -275,6 +287,8 @@ func filterListDnatRulesResponseBody(all []interface{}, d *schema.ResourceData) 
 func buildListDnatRulesQueryParams(d *schema.ResourceData, cfg *config.Config) string {
 	res := ""
 	epsID := cfg.GetEnterpriseProjectID(d)
+	descriptionList := d.Get("description").([]interface{})
+	externalIpAddresses := d.Get("external_ip_address").([]interface{})
 
 	if v, ok := d.GetOk("rule_id"); ok {
 		res = fmt.Sprintf("%s&id=%v", res, v)
@@ -293,6 +307,16 @@ func buildListDnatRulesQueryParams(d *schema.ResourceData, cfg *config.Config) s
 	}
 	if v, ok := d.GetOk("backend_private_ip"); ok {
 		res = fmt.Sprintf("%s&private_ip_address=%v", res, v)
+	}
+	if len(descriptionList) > 0 {
+		for _, v := range descriptionList {
+			res = fmt.Sprintf("%s&description=%v", res, v)
+		}
+	}
+	if len(externalIpAddresses) > 0 {
+		for _, v := range externalIpAddresses {
+			res = fmt.Sprintf("%s&external_ip_address=%v", res, v)
+		}
 	}
 	if epsID != "" {
 		res = fmt.Sprintf("%s&enterprise_project_id=%v", res, epsID)

--- a/huaweicloud/services/nat/data_source_huaweicloud_nat_private_snat_rules.go
+++ b/huaweicloud/services/nat/data_source_huaweicloud_nat_private_snat_rules.go
@@ -62,6 +62,12 @@ func DataSourcePrivateSnatRules() *schema.Resource {
 				Optional:    true,
 				Description: "The ID of the enterprise project to which the private SNAT rules belong.",
 			},
+			"description": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The description of the private SNAT rule.",
+			},
 			"rules": {
 				Type:        schema.TypeList,
 				Elem:        snatRulesSchema(),
@@ -215,6 +221,7 @@ func flattenListSnatRuleResponseBody(resp interface{}) []interface{} {
 func buildListSnatRulesQueryParams(d *schema.ResourceData, cfg *config.Config) string {
 	res := ""
 	epsID := cfg.GetEnterpriseProjectID(d)
+	descriptionList := d.Get("description").([]interface{})
 
 	if v, ok := d.GetOk("rule_id"); ok {
 		res = fmt.Sprintf("%s&id=%v", res, v)
@@ -233,6 +240,11 @@ func buildListSnatRulesQueryParams(d *schema.ResourceData, cfg *config.Config) s
 	}
 	if v, ok := d.GetOk("transit_ip_address"); ok {
 		res = fmt.Sprintf("%s&transit_ip_address=%v", res, v)
+	}
+	if len(descriptionList) > 0 {
+		for _, v := range descriptionList {
+			res = fmt.Sprintf("%s&description=%v", res, v)
+		}
 	}
 	if epsID != "" {
 		res = fmt.Sprintf("%s&enterprise_project_id=%v", res, epsID)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The private dnat and snat rule datasource support new fields.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccDatasourcePrivateDnatRules_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccDatasourcePrivateDnatRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourcePrivateDnatRules_basic
=== PAUSE TestAccDatasourcePrivateDnatRules_basic
=== CONT  TestAccDatasourcePrivateDnatRules_basic
--- PASS: TestAccDatasourcePrivateDnatRules_basic (161.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       161.463s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccDatasourcePrivateSnatRules_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccDatasourcePrivateSnatRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourcePrivateSnatRules_basic
=== PAUSE TestAccDatasourcePrivateSnatRules_basic
=== CONT  TestAccDatasourcePrivateSnatRules_basic
--- PASS: TestAccDatasourcePrivateSnatRules_basic (60.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       60.070s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
