### PR TITLE
refactor(ims): refactor `ims_evs_system_image` resource code style

### DIFF
--- a/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_evs_system_image_test.go
+++ b/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_evs_system_image_test.go
@@ -6,15 +6,56 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
+	"github.com/chnsz/golangsdk"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+func getEvsSystemImageResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		product = "ims"
+		httpUrl = "v2/cloudimages"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath += fmt.Sprintf("?id=%s", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving IMS EVS system image: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	image := utils.PathSearch("images[0]", getRespBody, nil)
+	// If the list API return empty, then return `404` error code.
+	if image == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return image, nil
+}
 
 func TestAccEvsSystemImage_basic(t *testing.T) {
 	var (
-		image        cloudimages.Image
+		image        interface{}
 		rName        = acceptance.RandomAccResourceName()
 		rNameUpdate  = rName + "-update"
 		resourceName = "huaweicloud_ims_evs_system_image.test"
@@ -25,7 +66,7 @@ func TestAccEvsSystemImage_basic(t *testing.T) {
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&image,
-		getImsImageResourceFunc,
+		getEvsSystemImageResourceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -108,6 +149,42 @@ func TestAccEvsSystemImage_basic(t *testing.T) {
 	})
 }
 
+func testAccEvsSystemImage_base(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s"
+  image_name         = "Ubuntu 18.04 server 64bit"
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+}
+
+resource "huaweicloud_evs_volume" "test" {
+  name              = "%[2]s"
+  volume_type       = "GPSSD"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  server_id         = huaweicloud_compute_instance.test.id
+  size              = 100
+  charging_mode     = "postPaid"
+}
+`, common.TestBaseNetwork(rName), rName)
+}
+
 func testAccEvsSystemImage_basic(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -126,7 +203,7 @@ resource "huaweicloud_ims_evs_system_image" "test" {
     key = "value"
   }
 }
-`, testAccEvsDataImage_base(rName), rName)
+`, testAccEvsSystemImage_base(rName), rName)
 }
 
 func testAccEvsSystemImage_update1(rName, rNameUpdate, migrateEpsId string, maxRAM, minRAM int) string {
@@ -148,7 +225,7 @@ resource "huaweicloud_ims_evs_system_image" "test" {
     key2 = "value2"
   }
 }
-`, testAccEvsDataImage_base(rName), rNameUpdate, migrateEpsId, maxRAM, minRAM)
+`, testAccEvsSystemImage_base(rName), rNameUpdate, migrateEpsId, maxRAM, minRAM)
 }
 
 func testAccEvsSystemImage_update2(rName, rNameUpdate, defaultEpsId string, maxRAM, minRAM int) string {
@@ -170,5 +247,5 @@ resource "huaweicloud_ims_evs_system_image" "test" {
     key2 = "value2"
   }
 }
-`, testAccEvsDataImage_base(rName), rNameUpdate, defaultEpsId, maxRAM, minRAM)
+`, testAccEvsSystemImage_base(rName), rNameUpdate, defaultEpsId, maxRAM, minRAM)
 }

--- a/huaweicloud/services/ims/resource_huaweicloud_ims_evs_system_image.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_ims_evs_system_image.go
@@ -2,17 +2,21 @@ package ims
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API IMS POST /v2/cloudimages/action
@@ -27,7 +31,7 @@ func ResourceEvsSystemImage() *schema.Resource {
 		CreateContext: resourceEvsSystemImageCreate,
 		ReadContext:   resourceEvsSystemImageRead,
 		UpdateContext: resourceEvsSystemImageUpdate,
-		DeleteContext: resourceImageDelete,
+		DeleteContext: resourceEvsSystemImageDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -130,36 +134,58 @@ func ResourceEvsSystemImage() *schema.Resource {
 	}
 }
 
+func buildCreateEvsSystemImageBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":                  d.Get("name"),
+		"volume_id":             d.Get("volume_id"),
+		"os_version":            d.Get("os_version"),
+		"type":                  utils.ValueIgnoreEmpty(d.Get("type")),
+		"description":           d.Get("description"),
+		"min_ram":               utils.ValueIgnoreEmpty(d.Get("min_ram")),
+		"max_ram":               utils.ValueIgnoreEmpty(d.Get("max_ram")),
+		"image_tags":            utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{})),
+		"enterprise_project_id": utils.ValueIgnoreEmpty(d.Get("enterprise_project_id")),
+	}
+
+	return bodyParams
+}
+
 func resourceEvsSystemImageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ims"
+		httpUrl = "v2/cloudimages/action"
 	)
 
-	client, err := cfg.ImageV2Client(region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating IMS v2 client: %s", err)
+		return diag.Errorf("error creating IMS client: %s", err)
 	}
 
-	imageTags := buildCreateImageTagsParam(d)
-	createOpts := &cloudimages.CreateSystemImageByVolumeOpts{
-		Name:                d.Get("name").(string),
-		VolumeId:            d.Get("volume_id").(string),
-		OsVersion:           d.Get("os_version").(string),
-		Type:                d.Get("type").(string),
-		Description:         d.Get("description").(string),
-		MinRam:              d.Get("min_ram").(int),
-		MaxRam:              d.Get("max_ram").(int),
-		ImageTags:           imageTags,
-		EnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
+	createPath := client.Endpoint + httpUrl
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildCreateEvsSystemImageBodyParams(d)),
 	}
 
-	createResp, err := cloudimages.CreateImageByServer(client, createOpts).ExtractJobResponse()
+	createResp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
 		return diag.Errorf("error creating IMS EVS system image: %s", err)
 	}
 
-	imageId, err := waitForCreateImageCompleted(client, d, createResp.JobID)
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", createRespBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("error creating IMS EVS system image: job ID is not found in API response")
+	}
+
+	imageId, err := waitForCreateEvsSystemImageJobCompleted(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("error waiting for IMS EVS system image to complete: %s", err)
 	}
@@ -169,50 +195,152 @@ func resourceEvsSystemImageCreate(ctx context.Context, d *schema.ResourceData, m
 	return resourceEvsSystemImageRead(ctx, d, meta)
 }
 
-func resourceEvsSystemImageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
-		mErr   *multierror.Error
-	)
-
-	client, err := cfg.ImageV2Client(region)
-	if err != nil {
-		return diag.Errorf("error creating IMS v2 client: %s", err)
+func waitForCreateEvsSystemImageJobCompleted(ctx context.Context, client *golangsdk.ServiceClient, jobId string,
+	timeout time.Duration) (string, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"PENDING"},
+		Target:     []string{"COMPLETED"},
+		Refresh:    evsSystemImageJobStatusRefreshFunc(jobId, client),
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 10 * time.Second,
 	}
 
-	imageList, err := GetImageList(client, d.Id())
+	_, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf("error retrieving IMS EVS system images: %s", err)
+		return "", fmt.Errorf("error waiting for IMS EVS system image job (%s) to succeed: %s", jobId, err)
+	}
+
+	return getEvsSystemImageIdByJobId(client, jobId)
+}
+
+func evsSystemImageJobStatusRefreshFunc(jobId string, client *golangsdk.ServiceClient) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		getPath := client.Endpoint + "v1/{project_id}/jobs/{job_id}"
+		getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+		getPath = strings.ReplaceAll(getPath, "{job_id}", fmt.Sprintf("%v", jobId))
+		getOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+
+		getResp, err := client.Request("GET", getPath, &getOpt)
+		if err != nil {
+			return getResp, "ERROR", fmt.Errorf("error retrieving IMS EVS system image job: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return getRespBody, "ERROR", err
+		}
+
+		status := utils.PathSearch("status", getRespBody, "").(string)
+		if status == "SUCCESS" {
+			return "SUCCESS", "COMPLETED", nil
+		}
+
+		if status == "FAIL" {
+			return getRespBody, "COMPLETED", errors.New("the EVS system image creation job execution failed")
+		}
+
+		if status == "" {
+			return getRespBody, "ERROR", errors.New("status field is not found in API response")
+		}
+
+		return getRespBody, "PENDING", nil
+	}
+}
+
+func getEvsSystemImageIdByJobId(client *golangsdk.ServiceClient, jobId string) (string, error) {
+	getPath := client.Endpoint + "v1/{project_id}/jobs/{job_id}"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{job_id}", fmt.Sprintf("%v", jobId))
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return "", fmt.Errorf("error retrieving IMS EVS system image job: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return "", err
+	}
+
+	imageId := utils.PathSearch("entities.image_id", getRespBody, "").(string)
+	if imageId == "" {
+		return "", errors.New("the image ID is not found in API response")
+	}
+
+	return imageId, nil
+}
+
+func getEvsSystemImage(client *golangsdk.ServiceClient, imageId string) (interface{}, error) {
+	// If the `enterprise_project_id` is not filled, the list API will query images under all enterprise projects.
+	// So there's no need to fill `enterprise_project_id` here.
+	getPath := client.Endpoint + "v2/cloudimages"
+	getPath += fmt.Sprintf("?id=%s", imageId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving IMS EVS system image: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("images[0]", getRespBody, nil), nil
+}
+
+func resourceEvsSystemImageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ims"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating IMS client: %s", err)
+	}
+
+	image, err := getEvsSystemImage(client, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	// If the list API return empty, then process `CheckDeleted` logic.
-	if len(imageList) < 1 {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "IMS EVS system image")
+	if image == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving IMS EVS system image")
 	}
 
-	image := imageList[0]
-	imageTags := flattenImageTags(d, client)
-	mErr = multierror.Append(
+	dataOrigin := utils.PathSearch("__data_origin", image, "").(string)
+	mErr := multierror.Append(
 		d.Set("region", region),
-		d.Set("name", image.Name),
-		d.Set("volume_id", flattenSpecificValueFormDataOrigin(image.DataOrigin, "volume")),
-		d.Set("os_version", image.OsVersion),
-		d.Set("description", image.Description),
-		d.Set("max_ram", flattenMaxRAM(image.MaxRam)),
-		d.Set("min_ram", image.MinRam),
-		d.Set("tags", imageTags),
-		d.Set("enterprise_project_id", image.EnterpriseProjectID),
-		d.Set("status", image.Status),
-		d.Set("visibility", image.Visibility),
-		d.Set("image_size", image.ImageSize),
-		d.Set("os_type", image.OsType),
-		d.Set("min_disk", image.MinDisk),
-		d.Set("disk_format", image.DiskFormat),
-		d.Set("data_origin", image.DataOrigin),
-		d.Set("active_at", image.ActiveAt),
-		d.Set("created_at", image.CreatedAt.Format(time.RFC3339)),
-		d.Set("updated_at", image.UpdatedAt.Format(time.RFC3339)),
+		d.Set("name", utils.PathSearch("name", image, nil)),
+		d.Set("volume_id", flattenSpecificValueFormDataOrigin(dataOrigin, "volume")),
+		d.Set("os_version", utils.PathSearch("__os_version", image, nil)),
+		d.Set("description", utils.PathSearch("__description", image, nil)),
+		d.Set("max_ram", flattenMaxRAM(utils.PathSearch("max_ram", image, "").(string))),
+		d.Set("min_ram", utils.PathSearch("min_ram", image, nil)),
+		d.Set("tags", flattenIMSImageTags(client, d.Id())),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", image, nil)),
+		d.Set("status", utils.PathSearch("status", image, nil)),
+		d.Set("visibility", utils.PathSearch("visibility", image, nil)),
+		d.Set("image_size", utils.PathSearch("__image_size", image, nil)),
+		d.Set("os_type", utils.PathSearch("__os_type", image, nil)),
+		d.Set("min_disk", utils.PathSearch("min_disk", image, nil)),
+		d.Set("disk_format", utils.PathSearch("disk_format", image, nil)),
+		d.Set("data_origin", dataOrigin),
+		d.Set("active_at", utils.PathSearch("active_at", image, nil)),
+		d.Set("created_at", utils.PathSearch("created_at", image, nil)),
+		d.Set("updated_at", utils.PathSearch("updated_at", image, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -220,19 +348,184 @@ func resourceEvsSystemImageRead(_ context.Context, d *schema.ResourceData, meta 
 
 func resourceEvsSystemImageUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ims"
+		httpUrl = "v2/cloudimages/{image_id}"
+		imageId = d.Id()
 	)
 
-	client, err := cfg.ImageV2Client(region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating IMS v2 client: %s", err)
+		return diag.Errorf("error creating IMS client: %s", err)
 	}
 
-	err = updateImage(ctx, cfg, client, d)
-	if err != nil {
-		return diag.Errorf("error updating IMS EVS system image: %s", err)
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{image_id}", imageId)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	if d.HasChange("name") {
+		bodyParams := []map[string]interface{}{
+			{
+				"op":    "replace",
+				"path":  "/name",
+				"value": d.Get("name"),
+			},
+		}
+
+		updateOpt.JSONBody = bodyParams
+		_, err = client.Request("PATCH", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating IMS EVS system image name field: %s", err)
+		}
+	}
+
+	if d.HasChange("description") {
+		bodyParams := []map[string]interface{}{
+			{
+				"op":    "replace",
+				"path":  "/__description",
+				"value": d.Get("description"),
+			},
+		}
+
+		updateOpt.JSONBody = bodyParams
+		_, err = client.Request("PATCH", updatePath, &updateOpt)
+		if err != nil {
+			err = processUpdateDescriptionError(d, client, err)
+			if err != nil {
+				return diag.Errorf("error updating IMS EVS system image description field: %s", err)
+			}
+		}
+	}
+
+	if d.HasChange("max_ram") {
+		bodyParams := []map[string]interface{}{
+			{
+				"op":    "replace",
+				"path":  "/max_ram",
+				"value": d.Get("max_ram"),
+			},
+		}
+
+		updateOpt.JSONBody = bodyParams
+		_, err = client.Request("PATCH", updatePath, &updateOpt)
+		if err != nil {
+			err = processUpdateMaxRAMError(d, client, err)
+			if err != nil {
+				return diag.Errorf("error updating IMS EVS system image max_ram field: %s", err)
+			}
+		}
+	}
+
+	if d.HasChange("min_ram") {
+		bodyParams := []map[string]interface{}{
+			{
+				"op":    "replace",
+				"path":  "/min_ram",
+				"value": d.Get("min_ram"),
+			},
+		}
+
+		updateOpt.JSONBody = bodyParams
+		_, err = client.Request("PATCH", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating IMS EVS system image min_ram field: %s", err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		err = updateIMSImageTags(client, d)
+		if err != nil {
+			return diag.Errorf("error updating IMS EVS system image tags field: %s", err)
+		}
+	}
+
+	if d.HasChange("enterprise_project_id") {
+		migrateOpts := config.MigrateResourceOpts{
+			ResourceId:   imageId,
+			ResourceType: "images",
+			RegionId:     region,
+			ProjectId:    client.ProjectID,
+		}
+		if err := cfg.MigrateEnterpriseProject(ctx, d, migrateOpts); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return resourceEvsSystemImageRead(ctx, d, meta)
+}
+
+func resourceEvsSystemImageDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ims"
+		httpUrl = "v2/images/{image_id}"
+		imageId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating IMS client: %s", err)
+	}
+
+	// Before deleting, call the query API first, if the query result is empty, then process `CheckDeleted` logic.
+	image, err := getEvsSystemImage(client, imageId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if image == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "IMS EVS system image")
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{image_id}", imageId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting IMS EVS system image: %s", err)
+	}
+
+	// Because the delete API always return `204` status code,
+	// so we need to call the list query API to check if the image has been successfully deleted.
+	err = waitForEvsSystemImageDeleted(ctx, client, d)
+	if err != nil {
+		return diag.Errorf("error waiting for IMS EVS system image to be deleted: %s", err)
+	}
+
+	return nil
+}
+
+func waitForEvsSystemImageDeleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			image, err := getEvsSystemImage(client, d.Id())
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			if image == nil {
+				return "SUCCESS", "COMPLETED", nil
+			}
+
+			return image, "PENDING", nil
+		},
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+
+	return err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

refactor `ims_evs_system_image` resource code style

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

***Create a resource using the old code package:***
![image](https://github.com/user-attachments/assets/92f49ecd-0c8c-4400-bc2c-11f459933d93)


***Execute terraform plan using new code package:***
![image](https://github.com/user-attachments/assets/b40bbcdd-328c-47f0-8844-1afb8f27608b)


***In summary, it can be considered that this reconstruction will have no impact on existing users.***


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

refactor `ims_evs_system_image` resource code style

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccEvsSystemImage_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccEvsSystemImage_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsSystemImage_basic
=== PAUSE TestAccEvsSystemImage_basic
=== CONT  TestAccEvsSystemImage_basic
--- PASS: TestAccEvsSystemImage_basic (420.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       420.379s

```
![image](https://github.com/user-attachments/assets/fb188a23-a6c1-4fee-8d79-4e927ee6088b)


* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/69ea0055-4645-4819-8b65-9213e4d685c2)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/user-attachments/assets/621ddfdb-3e03-4241-819b-2cb292917996)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
