### PR TITLE
feat(cce): save more attributes in node and node pool

### DIFF
--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -252,22 +252,19 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the CCE node resource.
   If omitted, the provider-level region will be used. Changing this creates a new CCE node resource.
 
-* `cluster_id` - (Required, String, ForceNew) Specifies the ID of the cluster.
-  Changing this parameter will create a new resource.
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the cluster.
 
 * `name` - (Optional, String) Specifies the node name.
 
-* `flavor_id` - (Required, String, ForceNew) Specifies the flavor ID. Changing this parameter will create a new
+* `flavor_id` - (Required, String, NonUpdatable) Specifies the flavor ID.
   resource.
 
-* `availability_zone` - (Required, String, ForceNew) Specifies the name of the available partition (AZ). Changing this
-  parameter will create a new resource.
+* `availability_zone` - (Required, String, NonUpdatable) Specifies the name of the available partition (AZ).
 
-* `os` - (Optional, String, ForceNew) Specifies the operating system of the node.
+* `os` - (Optional, String, NonUpdatable) Specifies the operating system of the node.
   The value can be **EulerOS 2.9** and **CentOS 7.6** e.g. For more details,
   please see [documentation](https://support.huaweicloud.com/intl/en-us/api-cce/node-os.html).
   This parameter is required when the `node_image_id` in `extend_params` is not specified.
-  Changing this parameter will create a new resource.
 
 * `key_pair` - (Optional, String) Specifies the key pair name when logging in to select the key pair mode.
   This parameter and `password` are alternative.
@@ -282,46 +279,46 @@ The following arguments are supported:
 * `private_key` - (Optional, String) Specifies the private key of the in used `key_pair`. This parameter is mandatory
   when replacing or unbinding a keypair if the CCE node is in **Active** state.
 
-* `root_volume` - (Required, List, ForceNew) Specifies the configuration of the system disk.
-  Changing this parameter will create a new resource.
+* `root_volume` - (Required, List, NonUpdatable) Specifies the configuration of the system disk.
 
-  + `size` - (Required, Int, ForceNew) Specifies the disk size in GB.
-    Changing this parameter will create a new resource.
-  + `volumetype` - (Required, String, ForceNew) Specifies the disk type.
-    Changing this parameter will create a new resource.
-  + `extend_params` - (Optional, Map, ForceNew) Specifies the disk expansion parameters.
-    Changing this parameter will create a new resource.
-  + `kms_key_id` - (Optional, String, ForceNew) Specifies the ID of a KMS key. This is used to encrypt the volume.
-    Changing this parameter will create a new resource.
-  + `dss_pool_id` - (Optional, String, ForceNew) Specifies the DSS pool ID. This field is used only for
-    dedicated storage. Changing this parameter will create a new resource.
-  + `iops` - (Optional, Int, ForceNew) Specifies the iops of the disk,
+  + `size` - (Required, Int, NonUpdatable) Specifies the disk size in GB.
+
+  + `volumetype` - (Required, String, NonUpdatable) Specifies the disk type.
+
+  + `extend_params` - (Optional, Map, NonUpdatable) Specifies the disk expansion parameters.
+
+  + `kms_key_id` - (Optional, String, NonUpdatable) Specifies the ID of a KMS key. This is used to encrypt the volume.
+
+  + `dss_pool_id` - (Optional, String, NonUpdatable) Specifies the DSS pool ID. This field is used only for
+
+  + `iops` - (Optional, Int, NonUpdatable) Specifies the iops of the disk,
     required when `volumetype` is **GPSSD2** or **ESSD2**.
-  + `throughput` - (Optional, Int, ForceNew) Specifies the throughput of the disk in MiB/s,
+
+  + `throughput` - (Optional, Int, NonUpdatable) Specifies the throughput of the disk in MiB/s,
     required when `volumetype` is **GPSSD2**.
 
-* `data_volumes` - (Required, List, ForceNew) Specifies the configurations of the data disk.
-  Changing this parameter will create a new resource.
+* `data_volumes` - (Required, List, NonUpdatable) Specifies the configurations of the data disk.
 
-  + `size` - (Required, Int, ForceNew) Specifies the disk size in GB.
-    Changing this parameter will create a new resource.
-  + `volumetype` - (Required, String, ForceNew) Specifies the disk type.
-    Changing this parameter will create a new resource.
-  + `extend_params` - (Optional, Map, ForceNew) Specifies the disk expansion parameters.
-    Changing this parameter will create a new resource.
-  + `kms_key_id` - (Optional, String, ForceNew) Specifies the ID of a KMS key. This is used to encrypt the volume.
-    Changing this parameter will create a new resource.
-  + `dss_pool_id` - (Optional, String, ForceNew) Specifies the DSS pool ID. This field is used only for
-    dedicated storage. Changing this parameter will create a new resource.
-  + `iops` - (Optional, Int, ForceNew) Specifies the iops of the disk,
+  + `size` - (Required, Int, NonUpdatable) Specifies the disk size in GB.
+
+  + `volumetype` - (Required, String, NonUpdatable) Specifies the disk type.
+
+  + `extend_params` - (Optional, Map, NonUpdatable) Specifies the disk expansion parameters.
+
+  + `kms_key_id` - (Optional, String, NonUpdatable) Specifies the ID of a KMS key. This is used to encrypt the volume.
+
+  + `dss_pool_id` - (Optional, String, NonUpdatable) Specifies the DSS pool ID. This field is used only for
+
+  + `iops` - (Optional, Int, NonUpdatable) Specifies the iops of the disk,
     required when `volumetype` is **GPSSD2** or **ESSD2**.
-  + `throughput` - (Optional, Int, ForceNew) Specifies the throughput of the disk in MiB/s,
+
+  + `throughput` - (Optional, Int, NonUpdatable) Specifies the throughput of the disk in MiB/s,
     required when `volumetype` is **GPSSD2**.
 
     -> You need to create an agency (EVSAccessKMS) when disk encryption is used in the current project for the first
     time ever.
 
-* `storage` - (Optional, List, ForceNew) Specifies the disk initialization management parameter.
+* `storage` - (Optional, List, NonUpdatable) Specifies the disk initialization management parameter.
   If omitted, disks are managed based on the DockerLVMConfigOverride parameter in extendParam.
   This parameter is supported for clusters of v1.15.11 and later.
   If the node has both local and EVS disks attached,
@@ -330,194 +327,179 @@ The following arguments are supported:
   If you want to use the shared disk space (with the runtime and Kubernetes partitions cancelled),
   this parameter must be specified.
   If you want to store system components in the system disk, this parameter must be specified.
-  Changing this parameter will create a new resource.
 
-  + `selectors` - (Required, List, ForceNew) Specifies the disk selection.
+  + `selectors` - (Required, List, NonUpdatable) Specifies the disk selection.
     Matched disks are managed according to match labels and storage type. Structure is documented below.
-    Changing this parameter will create a new resource.
-  + `groups` - (Required, List, ForceNew) Specifies the storage group consists of multiple storage devices.
+
+  + `groups` - (Required, List, NonUpdatable) Specifies the storage group consists of multiple storage devices.
     This is used to divide storage space. Structure is documented below.
-    Changing this parameter will create a new resource.
 
-* `subnet_id` - (Optional, String, ForceNew) Specifies the ID of the subnet to which the NIC belongs.
-  Changing this parameter will create a new resource.
+* `subnet_id` - (Optional, String, NonUpdatable) Specifies the ID of the subnet to which the NIC belongs.
 
-* `fixed_ip` - (Optional, String, ForceNew) Specifies the fixed IP of the NIC.
-  Changing this parameter will create a new resource.
+* `fixed_ip` - (Optional, String, NonUpdatable) Specifies the fixed IP of the NIC.
 
-* `extension_nics` - (Optional, List, ForceNew) Specifies extension NICs of the node.
+* `extension_nics` - (Optional, List, NonUpdatable) Specifies extension NICs of the node.
   The [object](#extension_nics) structure is documented below.
-  Changing this parameter will create a new resource.
 
-* `eip_id` - (Optional, String, ForceNew) Specifies the ID of the EIP.
-  Changing this parameter will create a new resource.
+* `eip_id` - (Optional, String, NonUpdatable) Specifies the ID of the EIP.
 
 -> **NOTE:** If the eip_id parameter is configured, you do not need to configure the bandwidth parameters:
 `iptype`, `bandwidth_charge_mode`, `bandwidth_size` and `share_type`.
 
-* `iptype` - (Optional, String, ForceNew) Specifies the elastic IP type.
-  Changing this parameter will create a new resource.
+* `iptype` - (Optional, String, NonUpdatable) Specifies the elastic IP type.
 
-* `bandwidth_charge_mode` - (Optional, String, ForceNew) Specifies the bandwidth billing type.
-  Changing this parameter will create a new resource.
+* `bandwidth_charge_mode` - (Optional, String, NonUpdatable) Specifies the bandwidth billing type.
 
-* `sharetype` - (Optional, String, ForceNew) Specifies the bandwidth sharing type.
-  Changing this parameter will create a new resource.
+* `sharetype` - (Optional, String, NonUpdatable) Specifies the bandwidth sharing type.
 
-* `bandwidth_size` - (Optional, Int, ForceNew) Specifies the bandwidth size.
-  Changing this parameter will create a new resource.
+* `bandwidth_size` - (Optional, Int, NonUpdatable) Specifies the bandwidth size.
 
-* `ecs_group_id` - (Optional, String, ForceNew) Specifies the ECS group ID. If specified, the node will be created under
-  the cloud server group. Changing this parameter will create a new resource.
+* `ecs_group_id` - (Optional, String, NonUpdatable) Specifies the ECS group ID. If specified, the node will be created under
+  the cloud server group.
 
-* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the CCE node. Valid values are *prePaid*
-  and *postPaid*, defaults to *postPaid*. Changing this creates a new resource.
+* `charging_mode` - (Optional, String, NonUpdatable) Specifies the charging mode of the CCE node. Valid values are *prePaid*
+  and *postPaid*, defaults to *postPaid*.
 
-* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the CCE node.
+* `period_unit` - (Optional, String, NonUpdatable) Specifies the charging period unit of the CCE node.
   Valid values are *month* and *year*. This parameter is mandatory if `charging_mode` is set to *prePaid*.
-  Changing this creates a new resource.
 
-* `period` - (Optional, Int, ForceNew) Specifies the charging period of the CCE node. If `period_unit` is set to *month*
+* `period` - (Optional, Int, NonUpdatable) Specifies the charging period of the CCE node. If `period_unit` is set to *month*
   , the value ranges from 1 to 9. If `period_unit` is set to *year*, the value ranges from 1 to 3. This parameter is
-  mandatory if `charging_mode` is set to *prePaid*. Changing this creates a new resource.
+  mandatory if `charging_mode` is set to *prePaid*.
 
 * `auto_renew` - (Optional, String) Specifies whether auto renew is enabled. Valid values are "true" and "false".
 
-* `runtime` - (Optional, String, ForceNew) Specifies the runtime of the CCE node. Valid values are *docker* and
-  *containerd*. Changing this creates a new resource.
+* `runtime` - (Optional, String, NonUpdatable) Specifies the runtime of the CCE node. Valid values are *docker* and
+  *containerd*.
 
-* `extend_params` - (Optional, List, ForceNew) Specifies the extended parameters.
+* `extend_params` - (Optional, List, NonUpdatable) Specifies the extended parameters.
   The [object](#extend_params) structure is documented below.
-  Changing this parameter will create a new resource.
 
-* `dedicated_host_id` - (Optional, String, ForceNew) Specifies the ID of the DeH to which the node is scheduled.
-  Changing this parameter will create a new resource.
+* `dedicated_host_id` - (Optional, String, NonUpdatable) Specifies the ID of the DeH to which the node is scheduled.
 
-* `initialized_conditions` - (Optional, List, ForceNew) Specifies the custom initialization flags.
-  Changing this parameter will create a new resource.
+* `initialized_conditions` - (Optional, List, NonUpdatable) Specifies the custom initialization flags.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of the CCE node.
-  Changing this parameter will create a new resource.
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID of the CCE node.
 
-* `labels` - (Optional, Map, ForceNew) Specifies the tags of a Kubernetes node, key/value pair format.
-  Changing this parameter will create a new resource.
+* `labels` - (Optional, Map, NonUpdatable) Specifies the tags of a Kubernetes node, key/value pair format.
 
 * `tags` - (Optional, Map) Specifies the tags of a VM node, key/value pair format.
 
-* `taints` - (Optional, List, ForceNew) Specifies the taints configuration of the nodes to set anti-affinity.
-  Changing this parameter will create a new resource. Each taint contains the following parameters:
+* `taints` - (Optional, List, NonUpdatable) Specifies the taints configuration of the nodes to set anti-affinity.
+  Each taint contains the following parameters:
 
-  + `key` - (Required, String, ForceNew) A key must contain 1 to 63 characters starting with a letter or digit.
+  + `key` - (Required, String, NonUpdatable) A key must contain 1 to 63 characters starting with a letter or digit.
     Only letters, digits, hyphens (-), underscores (_), and periods (.) are allowed. A DNS subdomain name can be used
-    as the prefix of a key. Changing this parameter will create a new resource.
-  + `value` - (Optional, String, ForceNew) A value must start with a letter or digit and can contain a maximum of 63
-    characters, including letters, digits, hyphens (-), underscores (_), and periods (.). Changing this parameter will
-    create a new resource.
-  + `effect` - (Required, String, ForceNew) Available options are NoSchedule, PreferNoSchedule, and NoExecute.
-    Changing this parameter will create a new resource.
+    as the prefix of a key.
 
-* `hostname_config` - (Optional, List, ForceNew) Specifies the hostname config of the kubernetes node,
+  + `value` - (Optional, String, NonUpdatable) A value must start with a letter or digit and can contain a maximum of 63
+    characters, including letters, digits, hyphens (-), underscores (_), and periods (.).
+
+  + `effect` - (Required, String, NonUpdatable) Available options are NoSchedule, PreferNoSchedule, and NoExecute.
+
+* `hostname_config` - (Optional, List, NonUpdatable) Specifies the hostname config of the kubernetes node,
   which is supported by clusters of v1.23.6-r0 to v1.25 or clusters of v1.25.2-r0 or later versions.
   The [object](#hostname_config) structure is documented below.
-  Changing this parameter will create a new resource.
 
 <a name="extension_nics"></a>
 The `extension_nics` block supports:
 
-* `subnet_id` - (Required, String, ForceNew) Specifies the ID of the subnet to which the NIC belongs.
-  Changing this parameter will create a new resource.
+* `subnet_id` - (Required, String, NonUpdatable) Specifies the ID of the subnet to which the NIC belongs.
 
 <a name="extend_params"></a>
 The `extend_params` block supports:
 
-* `max_pods` - (Optional, Int, ForceNew) Specifies the maximum number of instances a node is allowed to create.
-  Changing this parameter will create a new resource.
+* `max_pods` - (Optional, Int, NonUpdatable) Specifies the maximum number of instances a node is allowed to create.
 
-* `docker_base_size` - (Optional, Int, ForceNew) Specifies the available disk space of a single container on a node,
-  in GB. Changing this parameter will create a new resource.
+* `docker_base_size` - (Optional, Int, NonUpdatable) Specifies the available disk space of a single container on a node,
+  in GB.
 
-* `preinstall` - (Optional, String, ForceNew) Specifies the script to be executed before installation.
-  The input value can be a Base64 encoded string or not. Changing this parameter will create a new resource.
+* `preinstall` - (Optional, String, NonUpdatable) Specifies the script to be executed before installation.
+  The input value can be a Base64 encoded string or not.
 
-* `postinstall` - (Optional, String, ForceNew) Specifies the script to be executed after installation.
-  The input value can be a Base64 encoded string or not. Changing this parameter will create a new resource.
+* `postinstall` - (Optional, String, NonUpdatable) Specifies the script to be executed after installation.
+  The input value can be a Base64 encoded string or not.
 
-* `node_image_id` - (Optional, String, ForceNew) Specifies the image ID to create the node.
-  Changing this parameter will create a new resource.
+* `node_image_id` - (Optional, String, NonUpdatable) Specifies the image ID to create the node.
 
-* `node_multi_queue` - (Optional, String, ForceNew) Specifies the number of ENI queues.
-  Example setting: **"[{\"queue\":4}]"**. Changing this parameter will create a new resource.
+* `node_multi_queue` - (Optional, String, NonUpdatable) Specifies the number of ENI queues.
+  Example setting: **"[{\"queue\":4}]"**.
 
-* `nic_threshold` - (Optional, String, ForceNew) Specifies the ENI pre-binding thresholds.
-  Example setting: **"0.3:0.6"**. Changing this parameter will create a new resource.
+* `nic_threshold` - (Optional, String, NonUpdatable) Specifies the ENI pre-binding thresholds.
+  Example setting: **"0.3:0.6"**.
 
-* `agency_name` - (Optional, String, ForceNew) Specifies the agency name.
-  Changing this parameter will create a new resource.
+* `agency_name` - (Optional, String, NonUpdatable) Specifies the agency name.
 
-* `kube_reserved_mem` - (Optional, Int, ForceNew) Specifies the reserved node memory, which is reserved for
-  Kubernetes-related components. Changing this parameter will create a new resource.
+* `kube_reserved_mem` - (Optional, Int, NonUpdatable) Specifies the reserved node memory, which is reserved for
+  Kubernetes-related components.
 
-* `system_reserved_mem` - (Optional, Int, ForceNew) Specifies the reserved node memory, which is reserved
-  value for system components. Changing this parameter will create a new resource.
+* `system_reserved_mem` - (Optional, Int, NonUpdatable) Specifies the reserved node memory, which is reserved
+  value for system components.
 
-* `security_reinforcement_type` - (Optional, String, ForceNew) Specifies the security reinforcement type.
-  The value can be: **null** or **cybersecurity**. Changing this parameter will create a new resource.
+* `security_reinforcement_type` - (Optional, String, NonUpdatable) Specifies the security reinforcement type.
+  The value can be: **null** or **cybersecurity**.
 
 The `selectors` block supports:
 
-* `name` - (Required, String, ForceNew) Specifies the selector name, used as the index of `selector_names` in storage group.
-  The name of each selector must be unique. Changing this parameter will create a new resource.
-* `type` - (Optional, String, ForceNew) Specifies the storage type. Currently, only **evs (EVS volumes)** is supported.
-  The default value is **evs**. Changing this parameter will create a new resource.
-* `match_label_size` - (Optional, String, ForceNew) Specifies the matched disk size. If omitted,
-  the disk size is not limited. Example: 100. Changing this parameter will create a new resource.
-* `match_label_volume_type` - (Optional, String, ForceNew) Specifies the EVS disk type. Currently,
+* `name` - (Required, String, NonUpdatable) Specifies the selector name, used as the index of `selector_names`
+  in storage group. The name of each selector must be unique.
+
+* `type` - (Optional, String, NonUpdatable) Specifies the storage type. Currently, only **evs (EVS volumes)** is supported.
+  The default value is **evs**.
+
+* `match_label_size` - (Optional, String, NonUpdatable) Specifies the matched disk size. If omitted,
+  the disk size is not limited. Example: 100.
+
+* `match_label_volume_type` - (Optional, String, NonUpdatable) Specifies the EVS disk type. Currently,
   **SSD**, **GPSSD**, and **SAS** are supported. If omitted, the disk type is not limited.
-  Changing this parameter will create a new resource.
-* `match_label_metadata_encrypted` - (Optional, String, ForceNew) Specifies the disk encryption identifier.
+
+* `match_label_metadata_encrypted` - (Optional, String, NonUpdatable) Specifies the disk encryption identifier.
   Values can be: **0** indicates that the disk is not encrypted and **1** indicates that the disk is encrypted.
-  If omitted, whether the disk is encrypted is not limited. Changing this parameter will create a new resource.
-* `match_label_metadata_cmkid` - (Optional, String, ForceNew) Specifies the customer master key ID of an encrypted
-  disk. Changing this parameter will create a new resource.
-* `match_label_count` - (Optional, String, ForceNew) Specifies the number of disks to be selected. If omitted,
-  all disks of this type are selected. Changing this parameter will create a new resource.
+  If omitted, whether the disk is encrypted is not limited.
+
+* `match_label_metadata_cmkid` - (Optional, String, NonUpdatable) Specifies the customer master key ID of an encrypted
+  disk.
+
+* `match_label_count` - (Optional, String, NonUpdatable) Specifies the number of disks to be selected. If omitted,
+  all disks of this type are selected.
 
 The `groups` block supports:
 
-* `name` - (Required, String, ForceNew) Specifies the name of a virtual storage group. Each group name must be unique.
-  Changing this parameter will create a new resource.
-* `cce_managed` - (Optional, Bool, ForceNew) Specifies the whether the storage space is for **kubernetes** and
-  **runtime** components. Only one group can be set to true. The default value is **false**.
-  Changing this parameter will create a new resource.
-* `selector_names` - (Required, List, ForceNew) Specifies the list of names of selectors to match.
-  This parameter corresponds to name in `selectors`. A group can match multiple selectors,
-  but a selector can match only one group. Changing this parameter will create a new resource.
-* `virtual_spaces` - (Required, List, ForceNew) Specifies the detailed management of space configuration in a group.
-  Changing this parameter will create a new resource.
+* `name` - (Required, String, NonUpdatable) Specifies the name of a virtual storage group. Each group name must be unique.
 
-  + `name` - (Required, String, ForceNew) Specifies the virtual space name. Currently, only **kubernetes**, **runtime**,
-    and **user** are supported. Changing this parameter will create a new resource.
-  + `size` - (Required, String, ForceNew) Specifies the size of a virtual space. Only an integer percentage is supported.
+* `cce_managed` - (Optional, Bool, NonUpdatable) Specifies the whether the storage space is for **kubernetes** and
+  **runtime** components. Only one group can be set to true. The default value is **false**.
+
+* `selector_names` - (Required, List, NonUpdatable) Specifies the list of names of selectors to match.
+  This parameter corresponds to name in `selectors`. A group can match multiple selectors,
+  but a selector can match only one group.
+
+* `virtual_spaces` - (Required, List, NonUpdatable) Specifies the detailed management of space configuration in a group.
+
+  + `name` - (Required, String, NonUpdatable) Specifies the virtual space name. Currently, only **kubernetes**, **runtime**,
+    and **user** are supported.
+
+  + `size` - (Required, String, NonUpdatable) Specifies the size of a virtual space. Only an integer percentage is supported.
     Example: 90%. Note that the total percentage of all virtual spaces in a group cannot exceed 100%.
-    Changing this parameter will create a new resource.
-  + `lvm_lv_type` - (Optional, String, ForceNew) Specifies the LVM write mode, values can be **linear** and **striped**.
-    This parameter takes effect only in **kubernetes** and **user** configuration. Changing this parameter will create
-    a new resource.
-  + `lvm_path` - (Optional, String, ForceNew) Specifies the absolute path to which the disk is attached.
-    This parameter takes effect only in **user** configuration. Changing this parameter will create a new resource.
-  + `runtime_lv_type` - (Optional, String, ForceNew) Specifies the LVM write mode, values can be **linear** and **striped**.
-    This parameter takes effect only in **runtime** configuration. Changing this parameter will create a new resource.
+
+  + `lvm_lv_type` - (Optional, String, NonUpdatable) Specifies the LVM write mode, values can be **linear** and **striped**.
+    This parameter takes effect only in **kubernetes** and **user** configuration.
+
+  + `lvm_path` - (Optional, String, NonUpdatable) Specifies the absolute path to which the disk is attached.
+    This parameter takes effect only in **user** configuration.
+
+  + `runtime_lv_type` - (Optional, String, NonUpdatable) Specifies the LVM write mode, values can be **linear** and **striped**.
+    This parameter takes effect only in **runtime** configuration.
 
 <a name="hostname_config"></a>
 The `hostname_config` block supports:
 
-* `type` - (Required, String, ForceNew) Specifies the hostname type of the kubernetes node.
+* `type` - (Required, String, NonUpdatable) Specifies the hostname type of the kubernetes node.
   The value can be:
   + **privateIp**: The Kubernetes node is named after its IP address.
   + **cceNodeName**: The Kubernetes node is named after the CCE node.
   
   If `hostname_config` not specified, the default value is **privateIp**.
-  Changing this parameter will create a new resource.
 
   ~>For a node which is configured using cceNodeName, the name is the same as the Kubernetes node name and the ECS name.
     The node name cannot be changed. If the ECS name is changed on the ECS console, the node name will retain unchanged

--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -260,46 +260,42 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) The region in which to create the CCE pool resource. If omitted, the
   provider-level region will be used. Changing this creates a new CCE node pool resource.
 
-* `cluster_id` - (Required, String, ForceNew) Specifies the cluster ID.
-  Changing this parameter will create a new resource.
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the cluster ID.
 
 * `name` - (Required, String) Specifies the node pool name.
 
 * `initial_node_count` - (Required, Int) Specifies the initial number of expected nodes in the node pool.
   This parameter can be also used to manually scale the node count afterwards.
 
-* `flavor_id` - (Required, String, ForceNew) Specifies the flavor ID. Changing this parameter will create a new
-  resource.
+* `flavor_id` - (Required, String, NonUpdatable) Specifies the flavor ID.
 
-* `type` - (Optional, String, ForceNew) Specifies the node pool type. Possible values are: **vm** and **ElasticBMS**.
+* `type` - (Optional, String, NonUpdatable) Specifies the node pool type. Possible values are: **vm** and **ElasticBMS**.
 
-* `availability_zone` - (Optional, String, ForceNew) Specifies the name of the available partition (AZ). Default value
-  is random to create nodes in a random AZ in the node pool. Changing this parameter will create a new resource.
+* `availability_zone` - (Optional, String, NonUpdatable) Specifies the name of the available partition (AZ). Default value
+  is random to create nodes in a random AZ in the node pool.
 
 * `os` - (Optional, String) Specifies the operating system of the node.
   The value can be **EulerOS 2.9** and **CentOS 7.6** e.g. For more details,
   please see [documentation](https://support.huaweicloud.com/intl/en-us/api-cce/node-os.html).
   This parameter is required when the `node_image_id` in `extend_params` is not specified.
 
-* `key_pair` - (Optional, String, ForceNew) Specifies the key pair name when logging in to select the key pair mode.
-  This parameter and `password` are alternative. Changing this parameter will create a new resource.
+* `key_pair` - (Optional, String, NonUpdatable) Specifies the key pair name when logging in to select the key pair mode.
+  This parameter and `password` are alternative.
 
-* `password` - (Optional, String, ForceNew) Specifies the root password when logging in to select the password mode.
+* `password` - (Optional, String, NonUpdatable) Specifies the root password when logging in to select the password mode.
   The password consists of 8 to 26 characters and must contain at least three of following: uppercase letters,
   lowercase letters, digits, special characters(!@$%^-_=+[{}]:,./?~#*).
   This parameter can be plain or salted and is alternative to `key_pair`.
-  Changing this parameter will create a new resource.
 
 * `subnet_id` - (Optional, String) Specifies the ID of the subnet to which the NIC belongs.
 
 * `subnet_list` - (Optional, List) Specifies the ID list of the subnet to which the NIC belongs.
 
-* `ecs_group_id` - (Optional, String, ForceNew) Specifies the ECS group ID. If specified, the node will be created under
-  the cloud server group. Changing this parameter will create a new resource.
+* `ecs_group_id` - (Optional, String, NonUpdatable) Specifies the ECS group ID. If specified, the node will be created under
+  the cloud server group.
 
-* `extend_params` - (Optional, List, ForceNew) Specifies the extended parameters.
+* `extend_params` - (Optional, List, NonUpdatable) Specifies the extended parameters.
   The [object](#extend_params) structure is documented below.
-  Changing this parameter will create a new resource.
 
 * `scall_enable` - (Optional, Bool) Specifies whether to enable auto scaling.
   If Autoscaler is enabled, install the autoscaler add-on to use the auto scaling feature.
@@ -313,13 +309,13 @@ The following arguments are supported:
 * `priority` - (Optional, Int) Specifies the weight of the node pool.
   A node pool with a higher weight has a higher priority during scaling.
 
-* `security_groups` - (Optional, List, ForceNew) Specifies the list of custom security group IDs for the node pool.
+* `security_groups` - (Optional, List, NonUpdatable) Specifies the list of custom security group IDs for the node pool.
   If specified, the nodes will be put in these security groups. When specifying a security group, do not modify
   the rules of the port on which CCE running depends. For details, see
   [documentation](https://support.huaweicloud.com/intl/en-us/cce_faq/cce_faq_00265.html).
 
-* `pod_security_groups` - (Optional, List, ForceNew) Specifies the list of security group IDs for the pod.
-  Only supported in CCE Turbo clusters of v1.19 and above. Changing this parameter will create a new resource.
+* `pod_security_groups` - (Optional, List, NonUpdatable) Specifies the list of security group IDs for the pod.
+  Only supported in CCE Turbo clusters of v1.19 and above.
 
 * `initialized_conditions` - (Optional, List) Specifies the custom initialization flags.
 
@@ -327,28 +323,26 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) Specifies the tags of a VM node, key/value pair format.
 
-* `root_volume` - (Required, List, ForceNew) Specifies the configuration of the system disk.
-  The structure is described below. Changing this parameter will create a new resource.
+* `root_volume` - (Required, List, NonUpdatable) Specifies the configuration of the system disk.
+  The structure is described below.
 
-* `data_volumes` - (Required, List, ForceNew) Specifies the configuration of the data disks.
-  The structure is described below. Changing this parameter will create a new resource.
+* `data_volumes` - (Required, List, NonUpdatable) Specifies the configuration of the data disks.
+  The structure is described below.
 
-* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the CCE node pool. Valid values are
-  *prePaid* and *postPaid*, defaults to *postPaid*. Changing this parameter will create a new resource.
+* `charging_mode` - (Optional, String, NonUpdatable) Specifies the charging mode of the CCE node pool. Valid values are
+  *prePaid* and *postPaid*, defaults to *postPaid*.
 
-* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the CCE node pool.
+* `period_unit` - (Optional, String, NonUpdatable) Specifies the charging period unit of the CCE node pool.
   Valid values are *month* and *year*. This parameter is mandatory if `charging_mode` is set to *prePaid*.
-  Changing this parameter will create a new resource.
 
-* `period` - (Optional, Int, ForceNew) Specifies the charging period of the CCE node pool. If `period_unit` is set to
+* `period` - (Optional, Int, NonUpdatable) Specifies the charging period of the CCE node pool. If `period_unit` is set to
   *month*, the value ranges from 1 to 9. If `period_unit` is set to *year*, the value ranges from 1 to 3. This parameter
-  is mandatory if `charging_mode` is set to *prePaid*. Changing this parameter will create a new resource.
+  is mandatory if `charging_mode` is set to *prePaid*.
 
-* `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled. Valid values are "true" and "false".
-  Changing this parameter will create a new resource.
+* `auto_renew` - (Optional, String, NonUpdatable) Specifies whether auto renew is enabled. Valid values are "true" and "false".
 
-* `runtime` - (Optional, String, ForceNew) Specifies the runtime of the CCE node pool. Valid values are *docker* and
-  *containerd*. Changing this creates a new resource.
+* `runtime` - (Optional, String, NonUpdatable) Specifies the runtime of the CCE node pool. Valid values are *docker* and
+  *containerd*.
 
 * `taints` - (Optional, List) Specifies the taints configuration of the nodes to set anti-affinity.
   The structure is described below.
@@ -365,15 +359,14 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the node pool.
   If updated, the new value will apply only to new nodes.
 
-* `hostname_config` - (Optional, List, ForceNew) Specifies the hostname config of the kubernetes node,
+* `hostname_config` - (Optional, List, NonUpdatable) Specifies the hostname config of the kubernetes node,
   which is supported by clusters of v1.23.6-r0 to v1.25 or clusters of v1.25.2-r0 or later versions.
   The [object](#hostname_config) structure is documented below.
-  Changing this parameter will create a new resource.
 
 * `extension_scale_groups` - (Optional, List) Specifies the configurations of extended scaling groups in the node pool.
   The [object](#extension_scale_groups) structure is documented below.
 
-* `storage` - (Optional, List, ForceNew) Specifies the disk initialization management parameter.
+* `storage` - (Optional, List, NonUpdatable) Specifies the disk initialization management parameter.
   If omitted, disks are managed based on the DockerLVMConfigOverride parameter in extendParam.
   This parameter is supported for clusters of v1.15.11 and later.
   If the node has both local and EVS disks attached,
@@ -382,55 +375,47 @@ The following arguments are supported:
   If you want to use the shared disk space (with the runtime and Kubernetes partitions cancelled),
   this parameter must be specified.
   If you want to store system components in the system disk, this parameter must be specified.
-  Changing this parameter will create a new resource.
 
-  + `selectors` - (Required, List, ForceNew) Specifies the disk selection.
+  + `selectors` - (Required, List, NonUpdatable) Specifies the disk selection.
     Matched disks are managed according to match labels and storage type. Structure is documented below.
-    Changing this parameter will create a new resource.
-  + `groups` - (Required, List, ForceNew) Specifies the storage group consists of multiple storage devices.
+
+  + `groups` - (Required, List, NonUpdatable) Specifies the storage group consists of multiple storage devices.
     This is used to divide storage space. Structure is documented below.
-    Changing this parameter will create a new resource.
 
 The `root_volume` block supports:
 
-* `size` - (Required, Int, ForceNew) Specifies the disk size in GB. Changing this parameter will create a new resource.
+* `size` - (Required, Int, NonUpdatable) Specifies the disk size in GB.
 
-* `volumetype` - (Required, String, ForceNew) Specifies the disk type. Changing this parameter will create a new resource.
+* `volumetype` - (Required, String, NonUpdatable) Specifies the disk type.
 
-* `extend_params` - (Optional, Map, ForceNew) Specifies the disk expansion parameters.
-  Changing this parameter will create a new resource.
+* `extend_params` - (Optional, Map, NonUpdatable) Specifies the disk expansion parameters.
 
-* `kms_key_id` - (Optional, String, ForceNew) Specifies the KMS key ID. This is used to encrypt the volume.
-  Changing this parameter will create a new resource.
+* `kms_key_id` - (Optional, String, NonUpdatable) Specifies the KMS key ID. This is used to encrypt the volume.
 
-* `dss_pool_id` - (Optional, String, ForceNew) Specifies the DSS pool ID. This field is used only for dedicated storage.
-  Changing this parameter will create a new resource.
+* `dss_pool_id` - (Optional, String, NonUpdatable) Specifies the DSS pool ID. This field is used only for dedicated storage.
 
-* `iops` - (Optional, Int, ForceNew) Specifies the iops of the disk,
+* `iops` - (Optional, Int, NonUpdatable) Specifies the iops of the disk,
   required when `volumetype` is **GPSSD2** or **ESSD2**.
   
-* `throughput` - (Optional, Int, ForceNew) Specifies the throughput of the disk in MiB/s,
+* `throughput` - (Optional, Int, NonUpdatable) Specifies the throughput of the disk in MiB/s,
   required when `volumetype` is **GPSSD2**.
 
 The `data_volumes` block supports:
 
-* `size` - (Required, Int, ForceNew) Specifies the disk size in GB. Changing this parameter will create a new resource.
+* `size` - (Required, Int, NonUpdatable) Specifies the disk size in GB.
 
-* `volumetype` - (Required, String, ForceNew) Specifies the disk type. Changing this parameter will create a new resource.
+* `volumetype` - (Required, String, NonUpdatable) Specifies the disk type.
 
-* `extend_params` - (Optional, Map, ForceNew) Specifies the disk expansion parameters.
-  Changing this parameter will create a new resource.
+* `extend_params` - (Optional, Map, NonUpdatable) Specifies the disk expansion parameters.
 
-* `kms_key_id` - (Optional, String, ForceNew) Specifies the KMS key ID. This is used to encrypt the volume.
-  Changing this parameter will create a new resource.
+* `kms_key_id` - (Optional, String, NonUpdatable) Specifies the KMS key ID. This is used to encrypt the volume.
 
-* `dss_pool_id` - (Optional, String, ForceNew) Specifies the DSS pool ID. This field is used only for dedicated storage.
-  Changing this parameter will create a new resource.
+* `dss_pool_id` - (Optional, String, NonUpdatable) Specifies the DSS pool ID. This field is used only for dedicated storage.
 
-* `iops` - (Optional, Int, ForceNew) Specifies the iops of the disk,
+* `iops` - (Optional, Int, NonUpdatable) Specifies the iops of the disk,
   required when `volumetype` is **GPSSD2** or **ESSD2**.
   
-* `throughput` - (Optional, Int, ForceNew) Specifies the throughput of the disk in MiB/s,
+* `throughput` - (Optional, Int, NonUpdatable) Specifies the throughput of the disk in MiB/s,
   required when `volumetype` is **GPSSD2**.
 
   -> You need to create an agency (EVSAccessKMS) when disk encryption is used in the current project for the first time ever.
@@ -449,94 +434,97 @@ The `taints` block supports:
 <a name="extend_params"></a>
 The `extend_params` block supports:
 
-* `max_pods` - (Optional, Int, ForceNew) Specifies the maximum number of instances a node is allowed to create.
-  Changing this parameter will create a new resource.
+* `max_pods` - (Optional, Int, NonUpdatable) Specifies the maximum number of instances a node is allowed to create.
 
-* `docker_base_size` - (Optional, Int, ForceNew) Specifies the available disk space of a single container on a node,
-  in GB. Changing this parameter will create a new resource.
+* `docker_base_size` - (Optional, Int, NonUpdatable) Specifies the available disk space of a single container on a node,
+  in GB.
 
-* `preinstall` - (Optional, String, ForceNew) Specifies the script to be executed before installation.
-  The input value can be a Base64 encoded string or not. Changing this parameter will create a new resource.
+* `preinstall` - (Optional, String, NonUpdatable) Specifies the script to be executed before installation.
+  The input value can be a Base64 encoded string or not.
 
-* `postinstall` - (Optional, String, ForceNew) Specifies the script to be executed after installation.
-  The input value can be a Base64 encoded string or not. Changing this parameter will create a new resource.
+* `postinstall` - (Optional, String, NonUpdatable) Specifies the script to be executed after installation.
+  The input value can be a Base64 encoded string or not.
 
-* `node_image_id` - (Optional, String, ForceNew) Specifies the image ID to create the node.
-  Changing this parameter will create a new resource.
+* `node_image_id` - (Optional, String, NonUpdatable) Specifies the image ID to create the node.
 
-* `node_multi_queue` - (Optional, String, ForceNew) Specifies the number of ENI queues.
-  Example setting: **"[{\"queue\":4}]"**. Changing this parameter will create a new resource.
+* `node_multi_queue` - (Optional, String, NonUpdatable) Specifies the number of ENI queues.
+  Example setting: **"[{\"queue\":4}]"**.
 
-* `nic_threshold` - (Optional, String, ForceNew) Specifies the ENI pre-binding thresholds.
-  Example setting: **"0.3:0.6"**. Changing this parameter will create a new resource.
+* `nic_threshold` - (Optional, String, NonUpdatable) Specifies the ENI pre-binding thresholds.
+  Example setting: **"0.3:0.6"**.
 
-* `agency_name` - (Optional, String, ForceNew) Specifies the agency name.
-  Changing this parameter will create a new resource.
+* `agency_name` - (Optional, String, NonUpdatable) Specifies the agency name.
 
-* `kube_reserved_mem` - (Optional, Int, ForceNew) Specifies the reserved node memory, which is reserved for
-  Kubernetes-related components. Changing this parameter will create a new resource.
+* `kube_reserved_mem` - (Optional, Int, NonUpdatable) Specifies the reserved node memory, which is reserved for
+  Kubernetes-related components.
 
-* `system_reserved_mem` - (Optional, Int, ForceNew) Specifies the reserved node memory, which is reserved
-  value for system components. Changing this parameter will create a new resource.
+* `system_reserved_mem` - (Optional, Int, NonUpdatable) Specifies the reserved node memory, which is reserved
+  value for system components.
 
-* `security_reinforcement_type` - (Optional, String, ForceNew) Specifies the security reinforcement type.
-  The value can be: **null** or **cybersecurity**. Changing this parameter will create a new resource.
+* `security_reinforcement_type` - (Optional, String, NonUpdatable) Specifies the security reinforcement type.
+  The value can be: **null** or **cybersecurity**.
 
 The `selectors` block supports:
 
-* `name` - (Required, String, ForceNew) Specifies the selector name, used as the index of `selector_names` in storage group.
-  The name of each selector must be unique. Changing this parameter will create a new resource.
-* `type` - (Optional, String, ForceNew) Specifies the storage type. Currently, only **evs (EVS volumes)** is supported.
-  The default value is **evs**. Changing this parameter will create a new resource.
-* `match_label_size` - (Optional, String, ForceNew) Specifies the matched disk size. If omitted,
-  the disk size is not limited. Example: 100. Changing this parameter will create a new resource.
-* `match_label_volume_type` - (Optional, String, ForceNew) Specifies the EVS disk type. Currently,
+* `name` - (Required, String, NonUpdatable) Specifies the selector name, used as the index of `selector_names`
+  in storage group. The name of each selector must be unique.
+
+* `type` - (Optional, String, NonUpdatable) Specifies the storage type. Currently, only **evs (EVS volumes)** is supported.
+  The default value is **evs**.
+
+* `match_label_size` - (Optional, String, NonUpdatable) Specifies the matched disk size. If omitted,
+  the disk size is not limited. Example: 100.
+
+* `match_label_volume_type` - (Optional, String, NonUpdatable) Specifies the EVS disk type. Currently,
   **SSD**, **GPSSD**, and **SAS** are supported. If omitted, the disk type is not limited.
-  Changing this parameter will create a new resource.
-* `match_label_metadata_encrypted` - (Optional, String, ForceNew) Specifies the disk encryption identifier.
+
+* `match_label_metadata_encrypted` - (Optional, String, NonUpdatable) Specifies the disk encryption identifier.
   Values can be: **0** indicates that the disk is not encrypted and **1** indicates that the disk is encrypted.
-  If omitted, whether the disk is encrypted is not limited. Changing this parameter will create a new resource.
-* `match_label_metadata_cmkid` - (Optional, String, ForceNew) Specifies the customer master key ID of an encrypted
-  disk. Changing this parameter will create a new resource.
-* `match_label_count` - (Optional, String, ForceNew) Specifies the number of disks to be selected. If omitted,
-  all disks of this type are selected. Changing this parameter will create a new resource.
+  If omitted, whether the disk is encrypted is not limited.
+
+* `match_label_metadata_cmkid` - (Optional, String, NonUpdatable) Specifies the customer master key ID of an encrypted
+  disk.
+
+* `match_label_count` - (Optional, String, NonUpdatable) Specifies the number of disks to be selected. If omitted,
+  all disks of this type are selected.
 
 The `groups` block supports:
 
-* `name` - (Required, String, ForceNew) Specifies the name of a virtual storage group. Each group name must be unique.
-  Changing this parameter will create a new resource.
-* `cce_managed` - (Optional, Bool, ForceNew) Specifies the whether the storage space is for **kubernetes** and
-  **runtime** components. Only one group can be set to true. The default value is **false**.
-  Changing this parameter will create a new resource.
-* `selector_names` - (Required, List, ForceNew) Specifies the list of names of selectors to match.
-  This parameter corresponds to name in `selectors`. A group can match multiple selectors,
-  but a selector can match only one group. Changing this parameter will create a new resource.
-* `virtual_spaces` - (Required, List, ForceNew) Specifies the detailed management of space configuration in a group.
-  Changing this parameter will create a new resource.
+* `name` - (Required, String, NonUpdatable) Specifies the name of a virtual storage group. Each group name must be unique.
 
-  + `name` - (Required, String, ForceNew) Specifies the virtual space name. Currently, only **kubernetes**, **runtime**,
-    and **user** are supported. Changing this parameter will create a new resource.
-  + `size` - (Required, String, ForceNew) Specifies the size of a virtual space. Only an integer percentage is supported.
+* `cce_managed` - (Optional, Bool, NonUpdatable) Specifies the whether the storage space is for **kubernetes** and
+  **runtime** components. Only one group can be set to true. The default value is **false**.
+
+* `selector_names` - (Required, List, NonUpdatable) Specifies the list of names of selectors to match.
+  This parameter corresponds to name in `selectors`. A group can match multiple selectors,
+  but a selector can match only one group.
+
+* `virtual_spaces` - (Required, List, NonUpdatable) Specifies the detailed management of space configuration in a group.
+
+  + `name` - (Required, String, NonUpdatable) Specifies the virtual space name. Currently, only **kubernetes**, **runtime**,
+    and **user** are supported.
+
+  + `size` - (Required, String, NonUpdatable) Specifies the size of a virtual space. Only an integer percentage is supported.
     Example: 90%. Note that the total percentage of all virtual spaces in a group cannot exceed 100%.
-    Changing this parameter will create a new resource.
-  + `lvm_lv_type` - (Optional, String, ForceNew) Specifies the LVM write mode, values can be **linear** and **striped**.
-    This parameter takes effect only in **kubernetes** and **user** configuration. Changing this parameter will create
-    a new resource.
-  + `lvm_path` - (Optional, String, ForceNew) Specifies the absolute path to which the disk is attached.
-    This parameter takes effect only in **user** configuration. Changing this parameter will create a new resource.
-  + `runtime_lv_type` - (Optional, String, ForceNew) Specifies the LVM write mode, values can be **linear** and **striped**.
-    This parameter takes effect only in **runtime** configuration. Changing this parameter will create a new resource.
+
+  + `lvm_lv_type` - (Optional, String, NonUpdatable) Specifies the LVM write mode, values can be **linear** and **striped**.
+    This parameter takes effect only in **kubernetes** and **user** configuration.
+
+  + `lvm_path` - (Optional, String, NonUpdatable) Specifies the absolute path to which the disk is attached.
+    This parameter takes effect only in **user** configuration.
+
+  + `runtime_lv_type` - (Optional, String, NonUpdatable) Specifies the LVM write mode, values can be **linear** and **striped**.
+    This parameter takes effect only in **runtime** configuration.
 
 <a name="hostname_config"></a>
 The `hostname_config` block supports:
 
-* `type` - (Required, String, ForceNew) Specifies the hostname type of the kubernetes node.
+* `type` - (Required, String, NonUpdatable) Specifies the hostname type of the kubernetes node.
   The value can be:
   + **privateIp**: The Kubernetes node is named after its IP address.
   + **cceNodeName**: The Kubernetes node is named after the CCE node.
   
   If `hostname_config` not specified, the default value is **privateIp**.
-  Changing this parameter will create a new resource.
 
   ~>For a node which is configured using cceNodeName, the name is the same as the Kubernetes node name and the ECS name.
     The node name cannot be changed. If the ECS name is changed on the ECS console, the node name will retain unchanged

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
@@ -84,7 +84,7 @@ func TestAccNodePool_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccNodePoolImportStateIdFunc(resourceName),
 				ImportStateVerifyIgnore: []string{
-					"initial_node_count", "extend_params",
+					"initial_node_count", "extend_params", "enable_force_new",
 				},
 			},
 		},
@@ -153,6 +153,12 @@ resource "huaweicloud_cce_node_pool" "test" {
 #! /bin/bash
 date
 EOF
+  }
+
+  lifecycle {
+    ignore_changes = [
+      extend_params
+    ]
   }
 }
 `, baseConfig, name)
@@ -253,6 +259,8 @@ resource "huaweicloud_cce_node_pool" "test" {
 date
 EOF
   }
+
+  enable_force_new = true
 
   lifecycle {
     ignore_changes = [
@@ -990,7 +998,7 @@ func TestAccNodePool_extensionScaleGroups(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccNodePoolImportStateIdFunc(resourceName),
 				ImportStateVerifyIgnore: []string{
-					"initial_node_count", "extend_params", "extension_scale_groups",
+					"initial_node_count", "extension_scale_groups",
 				},
 			},
 		},

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_test.go
@@ -513,10 +513,12 @@ resource "huaweicloud_cce_node" "test" {
   }
 
   // Assign EIP
-  iptype="5_bgp"
-  bandwidth_charge_mode="traffic"
-  sharetype= "PER"
-  bandwidth_size= 100
+  iptype                = "5_bgp"
+  bandwidth_charge_mode = "traffic"
+  sharetype             = "PER"
+  bandwidth_size        = 100
+
+  enable_force_new = true
 }
 `, testAccNode_Base(rName), rName)
 }
@@ -559,6 +561,8 @@ resource "huaweicloud_cce_node" "test" {
 
   // Assign existing EIP
   eip_id = huaweicloud_vpc_eip.test.id
+
+  enable_force_new = true
 }
 `, testAccNode_Base(rName), rName)
 }

--- a/huaweicloud/services/cce/common.go
+++ b/huaweicloud/services/cce/common.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/cce/v3/nodes"
 
@@ -17,7 +18,6 @@ func resourceNodeExtendParamsSchema(conflictList []string) *schema.Schema {
 	return &schema.Schema{
 		Type:          schema.TypeList,
 		Optional:      true,
-		ForceNew:      true,
 		MaxItems:      1,
 		ConflictsWith: conflictList,
 		Elem: &schema.Resource{
@@ -25,64 +25,52 @@ func resourceNodeExtendParamsSchema(conflictList []string) *schema.Schema {
 				"max_pods": {
 					Type:     schema.TypeInt,
 					Optional: true,
-					ForceNew: true,
 				},
 				"docker_base_size": {
 					Type:     schema.TypeInt,
 					Optional: true,
-					ForceNew: true,
 				},
 				"preinstall": {
 					Type:      schema.TypeString,
 					Optional:  true,
-					ForceNew:  true,
 					StateFunc: utils.DecodeHashAndHexEncode,
 				},
 				"postinstall": {
 					Type:      schema.TypeString,
 					Optional:  true,
-					ForceNew:  true,
 					StateFunc: utils.DecodeHashAndHexEncode,
 				},
 				"node_image_id": {
 					Type:     schema.TypeString,
 					Optional: true,
-					ForceNew: true,
 				},
 				"node_multi_queue": {
 					Type:     schema.TypeString,
 					Optional: true,
-					ForceNew: true,
 				},
 				"nic_threshold": {
 					Type:     schema.TypeString,
 					Optional: true,
-					ForceNew: true,
 				},
 				"agency_name": {
 					Type:     schema.TypeString,
 					Optional: true,
-					ForceNew: true,
 				},
 				"kube_reserved_mem": {
 					Type:     schema.TypeInt,
 					Optional: true,
-					ForceNew: true,
 				},
 				"system_reserved_mem": {
 					Type:     schema.TypeInt,
 					Optional: true,
-					ForceNew: true,
 				},
 				"security_reinforcement_type": {
 					Type:     schema.TypeString,
 					Optional: true,
-					ForceNew: true,
 				},
 				"market_type": {
 					Type:     schema.TypeString,
 					Optional: true,
-					ForceNew: true,
 					Description: utils.SchemaDesc(
 						"",
 						utils.SchemaDescInput{
@@ -93,7 +81,99 @@ func resourceNodeExtendParamsSchema(conflictList []string) *schema.Schema {
 				"spot_price": {
 					Type:     schema.TypeString,
 					Optional: true,
-					ForceNew: true,
+					Description: utils.SchemaDesc(
+						"",
+						utils.SchemaDescInput{
+							Internal: true,
+						},
+					),
+				},
+			},
+		},
+	}
+}
+
+func resourceNodePoolExtendParamsSchema(conflictList []string) *schema.Schema {
+	return &schema.Schema{
+		Type:          schema.TypeList,
+		Optional:      true,
+		MaxItems:      1,
+		Computed:      true,
+		ConflictsWith: conflictList,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"max_pods": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
+				"docker_base_size": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
+				"preinstall": {
+					Type:      schema.TypeString,
+					Optional:  true,
+					StateFunc: utils.DecodeHashAndHexEncode,
+					Computed:  true,
+				},
+				"postinstall": {
+					Type:      schema.TypeString,
+					Optional:  true,
+					StateFunc: utils.DecodeHashAndHexEncode,
+					Computed:  true,
+				},
+				"node_image_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"node_multi_queue": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"nic_threshold": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"agency_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"kube_reserved_mem": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
+				"system_reserved_mem": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
+				"security_reinforcement_type": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"market_type": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					Description: utils.SchemaDesc(
+						"",
+						utils.SchemaDescInput{
+							Internal: true,
+						},
+					),
+				},
+				"spot_price": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
 					Description: utils.SchemaDesc(
 						"",
 						utils.SchemaDescInput{
@@ -219,28 +299,50 @@ func buildExtendParams(d *schema.ResourceData) map[string]interface{} {
 	return utils.RemoveNil(res)
 }
 
+func flattenExtendParams(extendParams map[string]interface{}) []map[string]interface{} {
+	if len(extendParams) == 0 {
+		return nil
+	}
+
+	res := []map[string]interface{}{
+		{
+			"max_pods":                    utils.PathSearch("maxPods", extendParams, nil),
+			"docker_base_size":            utils.PathSearch("dockerBaseSize", extendParams, nil),
+			"preinstall":                  utils.PathSearch("alpha.cce/preInstall", extendParams, nil),
+			"postinstall":                 utils.PathSearch("alpha.cce/postInstall", extendParams, nil),
+			"node_image_id":               utils.PathSearch("alpha.cce/NodeImageID", extendParams, nil),
+			"node_multi_queue":            utils.PathSearch("nicMultiqueue", extendParams, nil),
+			"nic_threshold":               utils.PathSearch("nicThreshold", extendParams, nil),
+			"agency_name":                 utils.PathSearch("agency_name", extendParams, nil),
+			"kube_reserved_mem":           utils.PathSearch("kubeReservedMem", extendParams, nil),
+			"system_reserved_mem":         utils.PathSearch("systemReservedMem", extendParams, nil),
+			"security_reinforcement_type": utils.PathSearch("securityReinforcementType", extendParams, nil),
+			"market_type":                 utils.PathSearch("marketType", extendParams, nil),
+			"spot_price":                  utils.PathSearch("spotPrice", extendParams, nil),
+		},
+	}
+
+	return res
+}
+
 func resourceNodeRootVolume() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Required: true,
-		ForceNew: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"size": {
 					Type:     schema.TypeInt,
 					Required: true,
-					ForceNew: true,
 				},
 				"volumetype": {
 					Type:     schema.TypeString,
 					Required: true,
-					ForceNew: true,
 				},
 				"extend_params": {
 					Type:     schema.TypeMap,
 					Optional: true,
-					ForceNew: true,
 					Computed: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
@@ -248,32 +350,27 @@ func resourceNodeRootVolume() *schema.Schema {
 					Type:     schema.TypeString,
 					Optional: true,
 					Computed: true,
-					ForceNew: true,
 				},
 				"dss_pool_id": {
 					Type:     schema.TypeString,
 					Optional: true,
 					Computed: true,
-					ForceNew: true,
 				},
 				"iops": {
 					Type:     schema.TypeInt,
 					Optional: true,
 					Computed: true,
-					ForceNew: true,
 				},
 				"throughput": {
 					Type:     schema.TypeInt,
 					Optional: true,
 					Computed: true,
-					ForceNew: true,
 				},
 
 				// Internal parameters
 				"hw_passthrough": {
 					Type:        schema.TypeBool,
 					Optional:    true,
-					ForceNew:    true,
 					Computed:    true,
 					Description: "schema: Internal",
 				},
@@ -282,7 +379,6 @@ func resourceNodeRootVolume() *schema.Schema {
 				"extend_param": {
 					Type:       schema.TypeString,
 					Optional:   true,
-					ForceNew:   true,
 					Deprecated: "use extend_params instead",
 				},
 			},
@@ -295,7 +391,6 @@ func resourceNodeDataVolume() *schema.Schema {
 		Type:     schema.TypeList,
 		Optional: true,
 		Computed: true,
-		ForceNew: true,
 		Description: utils.SchemaDesc("", utils.SchemaDescInput{
 			Required: true,
 		}),
@@ -304,17 +399,14 @@ func resourceNodeDataVolume() *schema.Schema {
 				"size": {
 					Type:     schema.TypeInt,
 					Required: true,
-					ForceNew: true,
 				},
 				"volumetype": {
 					Type:     schema.TypeString,
 					Required: true,
-					ForceNew: true,
 				},
 				"extend_params": {
 					Type:     schema.TypeMap,
 					Optional: true,
-					ForceNew: true,
 					Computed: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
@@ -322,32 +414,27 @@ func resourceNodeDataVolume() *schema.Schema {
 					Type:     schema.TypeString,
 					Optional: true,
 					Computed: true,
-					ForceNew: true,
 				},
 				"dss_pool_id": {
 					Type:     schema.TypeString,
 					Optional: true,
 					Computed: true,
-					ForceNew: true,
 				},
 				"iops": {
 					Type:     schema.TypeInt,
 					Optional: true,
 					Computed: true,
-					ForceNew: true,
 				},
 				"throughput": {
 					Type:     schema.TypeInt,
 					Optional: true,
 					Computed: true,
-					ForceNew: true,
 				},
 
 				// Internal parameters
 				"hw_passthrough": {
 					Type:        schema.TypeBool,
 					Optional:    true,
-					ForceNew:    true,
 					Computed:    true,
 					Description: "schema: Internal",
 				},
@@ -356,7 +443,6 @@ func resourceNodeDataVolume() *schema.Schema {
 				"extend_param": {
 					Type:       schema.TypeString,
 					Optional:   true,
-					ForceNew:   true,
 					Deprecated: "use extend_params instead",
 				},
 			},
@@ -515,123 +601,6 @@ func flattenResourceNodeDataVolume(d *schema.ResourceData, dataVolumes []nodes.V
 }
 
 func resourceNodeStorageSchema() *schema.Schema {
-	return &schema.Schema{
-		Type:     schema.TypeList,
-		Optional: true,
-		ForceNew: true,
-		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"selectors": {
-					Type:     schema.TypeList,
-					Required: true,
-					ForceNew: true,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"name": {
-								Type:     schema.TypeString,
-								Required: true,
-								ForceNew: true,
-							},
-							"type": {
-								Type:     schema.TypeString,
-								Optional: true,
-								ForceNew: true,
-								Default:  "evs",
-							},
-							"match_label_size": {
-								Type:     schema.TypeString,
-								Optional: true,
-								ForceNew: true,
-							},
-							"match_label_volume_type": {
-								Type:     schema.TypeString,
-								Optional: true,
-								ForceNew: true,
-							},
-							"match_label_metadata_encrypted": {
-								Type:     schema.TypeString,
-								Optional: true,
-								ForceNew: true,
-							},
-							"match_label_metadata_cmkid": {
-								Type:     schema.TypeString,
-								Optional: true,
-								ForceNew: true,
-							},
-							"match_label_count": {
-								Type:     schema.TypeString,
-								Optional: true,
-								ForceNew: true,
-							},
-						},
-					},
-				},
-				"groups": {
-					Type:     schema.TypeList,
-					Required: true,
-					ForceNew: true,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"name": {
-								Type:     schema.TypeString,
-								Required: true,
-								ForceNew: true,
-							},
-							"cce_managed": {
-								Type:     schema.TypeBool,
-								Optional: true,
-								ForceNew: true,
-							},
-							"selector_names": {
-								Type:     schema.TypeList,
-								Required: true,
-								ForceNew: true,
-								Elem:     &schema.Schema{Type: schema.TypeString},
-							},
-							"virtual_spaces": {
-								Type:     schema.TypeList,
-								Required: true,
-								ForceNew: true,
-								Elem: &schema.Resource{
-									Schema: map[string]*schema.Schema{
-										"name": {
-											Type:     schema.TypeString,
-											Required: true,
-											ForceNew: true,
-										},
-										"size": {
-											Type:     schema.TypeString,
-											Required: true,
-											ForceNew: true,
-										},
-										"lvm_lv_type": {
-											Type:     schema.TypeString,
-											Optional: true,
-											ForceNew: true,
-										},
-										"lvm_path": {
-											Type:     schema.TypeString,
-											Optional: true,
-											ForceNew: true,
-										},
-										"runtime_lv_type": {
-											Type:     schema.TypeString,
-											Optional: true,
-											ForceNew: true,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func resourceNodeStorageUpdatableSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -863,4 +832,103 @@ func flattenResourceNodeStorage(storageRaw *nodes.StorageSpec) []map[string]inte
 			"groups":    storageGroups,
 		},
 	}
+}
+
+func flattenResourceNodeTaints(taints []nodes.TaintSpec) []map[string]interface{} {
+	if len(taints) == 0 {
+		return nil
+	}
+
+	res := make([]map[string]interface{}, len(taints))
+
+	for i, v := range taints {
+		res[i] = map[string]interface{}{
+			"key":    utils.PathSearch("key", v, nil),
+			"value":  utils.PathSearch("value", v, nil),
+			"effect": utils.PathSearch("effect", v, nil),
+		}
+	}
+
+	return res
+}
+
+func schemaChargingMode(conflicts []string) *schema.Schema {
+	resourceSchema := schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		Computed: true,
+		ValidateFunc: validation.StringInSlice([]string{
+			"prePaid", "postPaid",
+		}, false),
+		ConflictsWith: conflicts,
+	}
+
+	return &resourceSchema
+}
+
+func schemaPeriodUnit(conflicts []string) *schema.Schema {
+	resourceSchema := schema.Schema{
+		Type:         schema.TypeString,
+		Optional:     true,
+		RequiredWith: []string{"period"},
+		ValidateFunc: validation.StringInSlice([]string{
+			"month", "year",
+		}, false),
+		ConflictsWith: conflicts,
+	}
+
+	return &resourceSchema
+}
+
+func schemaPeriod(conflicts []string) *schema.Schema {
+	resourceSchema := schema.Schema{
+		Type:          schema.TypeInt,
+		Optional:      true,
+		RequiredWith:  []string{"period_unit"},
+		ValidateFunc:  validation.IntBetween(1, 9),
+		ConflictsWith: conflicts,
+	}
+
+	return &resourceSchema
+}
+
+func schemaAutoRenew(conflicts []string) *schema.Schema {
+	resourceSchema := schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		ValidateFunc: validation.StringInSlice([]string{
+			"true", "false",
+		}, false),
+		ConflictsWith: conflicts,
+	}
+
+	return &resourceSchema
+}
+
+func schemaAutoRenewComputed(conflicts []string) *schema.Schema {
+	resourceSchema := schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		Computed: true,
+		ValidateFunc: validation.StringInSlice([]string{
+			"true", "false",
+		}, false),
+		ConflictsWith: conflicts,
+	}
+
+	return &resourceSchema
+}
+
+func schemaAutoPay(conflicts []string) *schema.Schema {
+	resourceSchema := schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		ValidateFunc: validation.StringInSlice([]string{
+			"true", "false",
+		}, false),
+		ConflictsWith: conflicts,
+		Deprecated:    "Deprecated",
+	}
+
+	return &resourceSchema
 }

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_attach.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_attach.go
@@ -139,7 +139,7 @@ func ResourceNodeAttach() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"storage": resourceNodeStorageUpdatableSchema(),
+			"storage": resourceNodeStorageSchema(),
 			"taints": {
 				Type:     schema.TypeList,
 				Optional: true,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. save more attributes
2. replace ForceNew with NonUpdatable

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccNode_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccNode_ -timeout 360m -parallel 4
=== RUN   TestAccNode_basic
=== PAUSE TestAccNode_basic
=== RUN   TestAccNode_eip
=== PAUSE TestAccNode_eip
=== RUN   TestAccNode_volume_encryption
=== PAUSE TestAccNode_volume_encryption
=== RUN   TestAccNode_prePaid
=== PAUSE TestAccNode_prePaid
=== RUN   TestAccNode_password
=== PAUSE TestAccNode_password
=== RUN   TestAccNode_storage
=== PAUSE TestAccNode_storage
=== CONT  TestAccNode_basic
=== CONT  TestAccNode_prePaid
=== CONT  TestAccNode_volume_encryption
=== CONT  TestAccNode_storage
=== NAME  TestAccNode_prePaid
    acceptance.go:1078: This environment does not support prepaid tests
--- SKIP: TestAccNode_prePaid (0.00s)
=== CONT  TestAccNode_eip
=== NAME  TestAccNode_volume_encryption
    acceptance.go:1553: This environment does not support KMS tests
--- SKIP: TestAccNode_volume_encryption (0.02s)
=== CONT  TestAccNode_password
--- PASS: TestAccNode_storage (927.38s)
--- PASS: TestAccNode_basic (973.29s)
--- PASS: TestAccNode_password (989.21s)
--- PASS: TestAccNode_eip (1258.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1258.515s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccNodePool_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccNodePool_ -timeout 360m -parallel 4
=== RUN   TestAccNodePool_basic
=== PAUSE TestAccNodePool_basic
=== RUN   TestAccNodePool_tagsLabelsTaints
=== PAUSE TestAccNodePool_tagsLabelsTaints
=== RUN   TestAccNodePool_volume_encryption
=== PAUSE TestAccNodePool_volume_encryption
=== RUN   TestAccNodePool_prePaid
=== PAUSE TestAccNodePool_prePaid
=== RUN   TestAccNodePool_SecurityGroups
=== PAUSE TestAccNodePool_SecurityGroups
=== RUN   TestAccNodePool_serverGroup
=== PAUSE TestAccNodePool_serverGroup
=== RUN   TestAccNodePool_storage
=== PAUSE TestAccNodePool_storage
=== RUN   TestAccNodePool_extensionScaleGroups
=== PAUSE TestAccNodePool_extensionScaleGroups
=== CONT  TestAccNodePool_basic
=== CONT  TestAccNodePool_SecurityGroups
=== CONT  TestAccNodePool_storage
=== CONT  TestAccNodePool_volume_encryption
    acceptance.go:1553: This environment does not support KMS tests
--- SKIP: TestAccNodePool_volume_encryption (0.00s)
=== CONT  TestAccNodePool_prePaid
    acceptance.go:1078: This environment does not support prepaid tests
--- SKIP: TestAccNodePool_prePaid (0.02s)
=== CONT  TestAccNodePool_tagsLabelsTaints
--- PASS: TestAccNodePool_storage (804.60s)
=== CONT  TestAccNodePool_serverGroup
--- PASS: TestAccNodePool_SecurityGroups (827.69s)
=== CONT  TestAccNodePool_extensionScaleGroups
--- PASS: TestAccNodePool_tagsLabelsTaints (866.74s)
--- PASS: TestAccNodePool_basic (1226.86s)
--- PASS: TestAccNodePool_serverGroup (687.89s)
--- PASS: TestAccNodePool_extensionScaleGroups (842.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1669.752s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
