### PR TITLE
feat(servicestage/config_group): add new resource supports configuration group

### DIFF
--- a/docs/resources/servicestagev3_configuration_group.md
+++ b/docs/resources/servicestagev3_configuration_group.md
@@ -1,0 +1,53 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestagev3_configuration_group"
+description: |-
+  Manages a configuration group resource within HuaweiCloud.
+---
+
+# huaweicloud_servicestagev3_configuration_group
+
+Manages a configuration group resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variables "group_name" {}
+
+resource "huaweicloud_servicestagev3_configuration_group" "test" {
+  name = var.group_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the configuration group.  
+  The valid length is limited from `2` to `64`, only letters, digits, hyphens (-) and underscores (_) are allowed.  
+  The name must start with a letter and end with a letter or a digit.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the description of the configuration group.  
+  The maximum length is `256` characters.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also configuration group ID.
+
+* `creator` - The creator of the configuration group.
+
+* `created_at` - The creation time of the configuration group, in RFC3339 format.
+
+## Import
+
+The resource can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_servicestagev3_configuration_group.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2285,6 +2285,7 @@ func Provider() *schema.Provider {
 			// v3 managements
 			"huaweicloud_servicestagev3_application":           servicestage.ResourceV3Application(),
 			"huaweicloud_servicestagev3_component":             servicestage.ResourceV3Component(),
+			"huaweicloud_servicestagev3_configuration_group":   servicestage.ResourceV3ConfigurationGroup(),
 			"huaweicloud_servicestagev3_environment":           servicestage.ResourceV3Environment(),
 			"huaweicloud_servicestagev3_environment_associate": servicestage.ResourceV3EnvironmentAssociate(),
 

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_configuration_group_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_configuration_group_test.go
@@ -1,0 +1,65 @@
+package servicestage
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/servicestage"
+)
+
+func getV3ConfigurationGroup(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("servicestage", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ServiceStage client: %s", err)
+	}
+	return servicestage.GetV3ConfigurationGroupById(client, state.Primary.ID)
+}
+
+func TestAccV3ConfigurationGroup_basic(t *testing.T) {
+	var (
+		configurationGroup interface{}
+		resourceName       = "huaweicloud_servicestagev3_configuration_group.test"
+		rc                 = acceptance.InitResourceCheck(resourceName, &configurationGroup, getV3ConfigurationGroup)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV3ConfigurationGroup_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform test"),
+					resource.TestCheckResourceAttrSet(resourceName, "creator"),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccV3ConfigurationGroup_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_servicestagev3_configuration_group" "test" {
+  name        = "%[1]s"
+  description = "Created by terraform test"
+}
+`, name)
+}

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_configuration_group.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_configuration_group.go
@@ -1,0 +1,194 @@
+package servicestage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var v3ConfigurationGroupNonUpdatableParams = []string{"name", "description"}
+
+// @API ServiceStage POST /v3/{project_id}/cas/config-groups
+// @API ServiceStage GET /v3/{project_id}/cas/config-groups/{config_group_id}
+// @API ServiceStage DELETE /v3/{project_id}/cas/config-groups/{config_group_id}
+func ResourceV3ConfigurationGroup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceV3ConfigurationGroupCreate,
+		ReadContext:   resourceV3ConfigurationGroupRead,
+		UpdateContext: resourceV3ConfigurationGroupUpdate,
+		DeleteContext: resourceV3ConfigurationGroupDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(v3ConfigurationGroupNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the configuration group.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the configuration group.`,
+			},
+			"creator": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator of the configuration group.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the configuration group, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func buildV3ConfigurationGroupCreateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+}
+
+func resourceV3ConfigurationGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v3/{project_id}/cas/config-groups"
+	)
+	client, err := cfg.NewServiceClient("servicestage", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: utils.RemoveNil(buildV3ConfigurationGroupCreateBodyParams(d)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating configuration group: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	configGroupId := utils.PathSearch("id", respBody, "").(string)
+	if configGroupId == "" {
+		return diag.Errorf("unable to find the configuration group ID from the API response")
+	}
+	d.SetId(configGroupId)
+
+	return resourceV3ConfigurationGroupRead(ctx, d, meta)
+}
+
+// GetV3ConfigurationGroupById is a method used to get configuration group detail bu its ID.
+func GetV3ConfigurationGroupById(client *golangsdk.ServiceClient, configGroupId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/cas/config-groups/{config_group_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{config_group_id}", configGroupId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceV3ConfigurationGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		configGroupId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	respBody, err := GetV3ConfigurationGroupById(client, configGroupId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error retrieving configuration group (%s)", configGroupId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("creator", utils.PathSearch("creator", respBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", respBody,
+			float64(0)).(float64))/1000, false)))
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceV3ConfigurationGroupUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceV3ConfigurationGroupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		httpUrl       = "v3/{project_id}/cas/config-groups/{config_group_id}"
+		configGroupId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{config_group_id}", configGroupId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	// The delete API always returns 200 status code whether config group is exist.
+	_, err = client.Request("DELETE", deletePath, &opt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting configuration group (%s)", configGroupId))
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource.
2. add related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o servicestage -f TestAccV3ConfigGroup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccV3ConfigGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccV3ConfigGroup_basic
=== PAUSE TestAccV3ConfigGroup_basic
=== CONT  TestAccV3ConfigGroup_basic
--- PASS: TestAccV3ConfigGroup_basic (11.21s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      11.275s coverage: 4.7% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/e35e43ec-98c4-46ee-99fe-8165c298814a)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
