### PR TITLE
refactor(nat): refactor the private SNAT rule resource code style

### DIFF
--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_snat_rule_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_snat_rule_test.go
@@ -7,26 +7,25 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/nat/v3/snats"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/nat"
 )
 
 func getPrivateSnatRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := cfg.NatV3Client(acceptance.HW_REGION_NAME)
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("nat", region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating NAT v3 client: %s", err)
 	}
 
-	return snats.Get(client, state.Primary.ID)
+	return nat.GetPrivateSnatRule(client, state.Primary.ID)
 }
 
 func TestAccPrivateSnatRule_basic(t *testing.T) {
 	var (
-		obj snats.Rule
-
+		obj   interface{}
 		rName = "huaweicloud_nat_private_snat_rule.test"
 		name  = acceptance.RandomAccResourceNameWithDash()
 	)
@@ -144,7 +143,7 @@ resource "huaweicloud_nat_private_snat_rule" "test" {
 
 func TestAccPrivateSnatRule_cidr(t *testing.T) {
 	var (
-		obj snats.Rule
+		obj interface{}
 
 		rName = "huaweicloud_nat_private_snat_rule.test"
 		name  = acceptance.RandomAccResourceNameWithDash()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactor the private SNAT rule resource code style.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateSnatRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateSnatRule_basic -timeout 360m -parallel 4
=== RUN   TestAccPrivateSnatRule_basic
=== PAUSE TestAccPrivateSnatRule_basic
=== CONT  TestAccPrivateSnatRule_basic
--- PASS: TestAccPrivateSnatRule_basic (77.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       77.407s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateSnatRule_cidr"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateSnatRule_cidr -timeout 360m -parallel 4
=== RUN   TestAccPrivateSnatRule_cidr
=== PAUSE TestAccPrivateSnatRule_cidr
=== CONT  TestAccPrivateSnatRule_cidr
--- PASS: TestAccPrivateSnatRule_cidr (77.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       77.149s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/0cd440b6-36c7-40aa-9e77-4f326197438d)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/b3a479be-a32a-46dc-87ce-0230b1f37e2c)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
