### PR TITLE
feat(servicestage): add new resource supports configuration file

### DIFF
--- a/docs/resources/servicestagev3_configuration.md
+++ b/docs/resources/servicestagev3_configuration.md
@@ -1,0 +1,103 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestagev3_configuration"
+description: |-
+  Manages a configuration file resource within HuaweiCloud.
+---
+
+# huaweicloud_servicestagev3_configuration
+
+Manages a configuration file resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "group_id" {}
+variable "configuration_name" {}
+
+resource "huaweicloud_servicestagev3_configuration" "test" {
+  config_group_id = var.group_id
+  name            = var.configuration_name
+  type            = "properties"
+  content         = <<EOF
+spring.application.name=service
+cloud.servicecomb.service.name=$${spring.application.name}
+cloud.servicecomb.service.version=$${CAS_INSTANCE_VERSION}
+cloud.servicecomb.service.application=$${CAS_APPLICATION_NAME}
+cloud.servicecomb.discovery.address=$${PAAS_CSE_SC_ENDPOINT}
+cloud.servicecomb.discovery.healthCheckInterval=10
+cloud.servicecomb.discovery.pollInterval=15000
+cloud.servicecomb.discovery.waitTimeForShutDownInMillis=15000
+cloud.servicecomb.config.serverAddr=$${PAAS_CSE_CC_ENDPOINT}
+cloud.servicecomb.config.serverType=kie
+cloud.servicecomb.config.fileSource=governance.yaml,application.yaml
+EOF
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `config_group_id` - (Required, String, NonUpdatable) Specifies the ID of the configuration group to which
+  the configuration file belongs.
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the configuration file.  
+  The valid length is limited from `2` to `64`, only letters, digits, hyphens (-) and underscores (_) are allowed.  
+  The name must start with a letter and end with a letter or a digit.
+
+* `content` - (Required, String) Specifies the content of the configuration file.  
+  For details about the system variables that can be written into a configuration file, please refer to the [document](https://support.huaweicloud.com/intl/en-us/usermanual-servicestage/servicestage_03_0316.html#servicestage_03_0316__en-us_topic_0000001904007428_table62206277581).
+
+* `type` - (Required, String) Specifies the type of the configuration file.  
+  The valid values are as follows:
+  + **yaml**
+  + **properties**
+
+* `sensitive` - (Optional, Bool) Specifies whether to enable data encryption.  
+  Defaults to **false**.  
+  Only container-deployed components support data encryption. If data encryption is enabled, the configuration file is
+  mounted using secret. If data encryption is disabled, the configuration file is mounted using ConfigMap.
+  
+* `description` - (Optional, String) Specifies the description of the configuration file.  
+  The maximum length is `128` characters.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also configuration file ID.
+
+* `components` - The list of the components associated with the configuration file.  
+  The [components](#configuration_attr_components) structure is documented below.
+
+* `version` - The version of the configuration file.
+
+* `creator` - The creator of the configuration file.
+
+* `created_at` - The creation time of the configuration file, in RFC3339 format.
+
+* `updated_at` - The latest update time of the configuration file, in RFC3339 format.
+
+<a name="configuration_attr_components"></a>
+The `components` block supports:
+
+* `environment_id` - The ID of the environment.
+
+* `application_id` - The ID of the application.
+
+* `component_id` - The ID of the component.
+
+* `component_name` - The name of the component.
+
+## Import
+
+The resource can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_servicestagev3_configuration.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2300,6 +2300,7 @@ func Provider() *schema.Provider {
 			// v3 managements
 			"huaweicloud_servicestagev3_application":           servicestage.ResourceV3Application(),
 			"huaweicloud_servicestagev3_component":             servicestage.ResourceV3Component(),
+			"huaweicloud_servicestagev3_configuration":         servicestage.ResourceV3Configuration(),
 			"huaweicloud_servicestagev3_configuration_group":   servicestage.ResourceV3ConfigurationGroup(),
 			"huaweicloud_servicestagev3_environment":           servicestage.ResourceV3Environment(),
 			"huaweicloud_servicestagev3_environment_associate": servicestage.ResourceV3EnvironmentAssociate(),

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_configuration_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_configuration_test.go
@@ -1,0 +1,120 @@
+package servicestage
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/servicestage"
+)
+
+func getV3Configuration(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("servicestage", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ServiceStage client: %s", err)
+	}
+	return servicestage.GetV3ConfigurationFile(client, state.Primary.ID)
+}
+
+func TestAccV3Configuration_basic(t *testing.T) {
+	var (
+		configuration interface{}
+		resourceName  = "huaweicloud_servicestagev3_configuration.test"
+		rc            = acceptance.InitResourceCheck(resourceName, &configuration, getV3Configuration)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV3Configuration_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "config_group_id", "huaweicloud_servicestagev3_configuration_group.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "type", "properties"),
+					resource.TestCheckResourceAttr(resourceName, "content", "testkey = testvalue"),
+					resource.TestCheckResourceAttr(resourceName, "sensitive", "true"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by TF script"),
+					resource.TestCheckResourceAttr(resourceName, "components.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
+					resource.TestCheckResourceAttrSet(resourceName, "creator"),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccV3Configuration_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "type", "yaml"),
+					resource.TestCheckResourceAttr(resourceName, "sensitive", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestMatchResourceAttr(resourceName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccV3Configuration_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestagev3_configuration" "test" {
+  config_group_id = huaweicloud_servicestagev3_configuration_group.test.id
+  name            = "%[2]s"
+  type            = "properties"
+  content         = "testkey = testvalue"
+  sensitive       = true
+  description     = "Created by TF script"
+}
+`, testAccV3ConfigurationGroup_basic(name), name)
+}
+
+func testAccV3Configuration_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestagev3_configuration" "test" {
+  config_group_id = huaweicloud_servicestagev3_configuration_group.test.id
+  name            = "%[2]s"
+  type            = "yaml"
+  content         = <<EOF
+spring:
+  application:
+    name: "service"
+  cloud:
+    servicecomb:
+      service:
+        name: service
+        version: $${CAS_INSTANCE_VERSION}
+        application: $${CAS_APPLICATION_NAME}
+      discovery:
+        address: $${PAAS_CSE_SC_ENDPOINT}
+        healthCheckInterval: 10
+        pollInterval: 15000
+        waitTimeForShutDownInMillis: 15000
+      config:
+        serverAddr: $${PAAS_CSE_CC_ENDPOINT}
+        serverType: kie
+        fileSource: governance.yaml,application.yaml
+EOF
+}
+`, testAccV3ConfigurationGroup_basic(name), name)
+}

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_configuration.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_configuration.go
@@ -1,0 +1,323 @@
+package servicestage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var configurationNonUpdatableParams = []string{"config_group_id", "name"}
+
+// @API ServiceStage POST /v3/{project_id}/cas/configs
+// @API ServiceStage GET /v3/{project_id}/cas/configs/{config_id}
+// @API ServiceStage PUT /v3/{project_id}/cas/configs/{config_id}
+// @API ServiceStage DELETE /v3/{project_id}/cas/configs/{config_id}
+func ResourceV3Configuration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceV3ConfigurationCreate,
+		ReadContext:   resourceV3ConfigurationRead,
+		UpdateContext: resourceV3ConfigurationUpdate,
+		DeleteContext: resourceV3ConfigurationDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(configurationNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"config_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the configuration group to which the configuration file belongs.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the configuration file.`,
+			},
+			"content": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The content of the configuration file.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the configuration file.`,
+			},
+			"sensitive": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to enable data encryption.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the configuration file.`,
+			},
+			"components": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"environment_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the environment.`,
+						},
+						"application_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the application.`,
+						},
+						"component_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the component.`,
+						},
+						"component_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the component.`,
+						},
+					},
+				},
+				Description: `The list of the components associated with the configuration file.`,
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The version of the configuration file.`,
+			},
+			"creator": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator of the configuration file.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the configuration file, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the configuration file, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func buildV3ConfigurationCreateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"config_group_id": d.Get("config_group_id"),
+		"name":            d.Get("name"),
+		"content":         d.Get("content"),
+		"type":            d.Get("type"),
+		"sensitive":       d.Get("sensitive"),
+		"description":     utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+}
+
+func resourceV3ConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v3/{project_id}/cas/configs"
+	)
+	client, err := cfg.NewServiceClient("servicestage", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: utils.RemoveNil(buildV3ConfigurationCreateBodyParams(d)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating configuration file: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	configurationId := utils.PathSearch("id", respBody, "").(string)
+	if configurationId == "" {
+		return diag.Errorf("unable to find the configuration file ID from the API response")
+	}
+	d.SetId(configurationId)
+
+	return resourceV3ConfigurationRead(ctx, d, meta)
+}
+
+// GetV3ConfigurationFile is a method used to get configuration file detail by its ID.
+func GetV3ConfigurationFile(client *golangsdk.ServiceClient, configurationId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/cas/configs/{config_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{config_id}", configurationId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceV3ConfigurationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg             = meta.(*config.Config)
+		region          = cfg.GetRegion(d)
+		configurationId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	respBody, err := GetV3ConfigurationFile(client, configurationId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error retrieving configuration file (%s)", configurationId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("config_group_id", utils.PathSearch("config_group_id", respBody, nil)),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("content", utils.PathSearch("content", respBody, nil)),
+		d.Set("type", utils.PathSearch("type", respBody, nil)),
+		d.Set("sensitive", utils.PathSearch("sensitive", respBody, nil)),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("components", flattenConfigComponents(utils.PathSearch("components", respBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("version", utils.PathSearch("version", respBody, nil)),
+		d.Set("creator", utils.PathSearch("creator", respBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", respBody,
+			float64(0)).(float64))/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time", respBody,
+			float64(0)).(float64))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenConfigComponents(components []interface{}) []interface{} {
+	if len(components) == 0 {
+		return nil
+	}
+
+	rest := make([]interface{}, len(components))
+	for i, v := range components {
+		rest[i] = map[string]interface{}{
+			"environment_id": utils.PathSearch("environment_id", v, nil),
+			"application_id": utils.PathSearch("application_id", v, nil),
+			"component_id":   utils.PathSearch("component_id", v, nil),
+			"component_name": utils.PathSearch("component_name", v, nil),
+		}
+	}
+	return rest
+}
+
+func buildV3ConfigurationUpdateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"config_group_id": d.Get("config_group_id"),
+		"name":            d.Get("name"),
+		"content":         d.Get("content"),
+		"type":            d.Get("type"),
+		// The `description` must be specified as an empty string to be changed to empty.
+		"description": d.Get("description"),
+		"sensitive":   d.Get("sensitive"),
+	}
+}
+
+func resourceV3ConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg             = meta.(*config.Config)
+		httpUrl         = "v3/{project_id}/cas/configs/{config_id}"
+		configurationId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("servicestage", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	if d.HasChanges("content", "type", "sensitive", "description") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{config_id}", configurationId)
+		opt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json;charset=utf8",
+			},
+			JSONBody: buildV3ConfigurationUpdateBodyParams(d),
+		}
+
+		_, err = client.Request("PUT", updatePath, &opt)
+		if err != nil {
+			return diag.Errorf("error updating configuration file (%s): %s", configurationId, err)
+		}
+	}
+
+	return resourceV3ConfigurationRead(ctx, d, meta)
+}
+
+func resourceV3ConfigurationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg             = meta.(*config.Config)
+		httpUrl         = "v3/{project_id}/cas/configs/{config_id}"
+		configurationId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("servicestage", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{config_id}", configurationId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	// The delete API always returns 200 status code whether config group is exist.
+	_, err = client.Request("DELETE", deletePath, &opt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting configuration file (%s)", configurationId))
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource to manage configuration file.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to manage configuration file.
2. add related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o servicestage -f TestAccV3Configuration_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccV3Configuration_basic -timeout 360m -parallel 10
=== RUN   TestAccV3Configuration_basic
=== PAUSE TestAccV3Configuration_basic
=== CONT  TestAccV3Configuration_basic
--- PASS: TestAccV3Configuration_basic (23.16s)
PASS
coverage: 8.2% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      23.269s coverage: 8.2% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/9082fec9-1fd8-41e2-b3a8-ec71c6cffd3e)


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
