### PR TITLE
fix(as): remove invalid as configuration user_data attribute settings

### DIFF
--- a/docs/resources/as_configuration.md
+++ b/docs/resources/as_configuration.md
@@ -408,15 +408,20 @@ $ terraform import huaweicloud_as_configuration.test 18518c8a-9d15-416b-8add-2ee
 ```
 
 Note that the imported state may not be identical to your resource definition, due to `instance_config.0.instance_id`,
-`instance_config.0.admin_pass`, and `instance_config.0.metadata` are missing from the API response.
-You can ignore changes after importing an AS configuration as below.
+`instance_config.0.admin_pass`, `instance_config.0.user_data`, and `instance_config.0.metadata` are missing from the
+API response. You can ignore changes after importing an AS configuration as below.
 
 ```hcl
 resource "huaweicloud_as_configuration" "test" {
   ...
 
   lifecycle {
-    ignore_changes = [ instance_config.0.instance_id, instance_config.0.admin_pass, instance_config.0.metadata ]
+    ignore_changes = [
+      instance_config.0.instance_id,
+      instance_config.0.admin_pass,
+      instance_config.0.user_data,
+      instance_config.0.metadata,
+    ]
   }
 }
 ```

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_configuration_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_configuration_test.go
@@ -63,10 +63,13 @@ func TestAccASConfiguration_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"instance_config.0.metadata"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"instance_config.0.metadata",
+					"instance_config.0.user_data",
+				},
 			},
 		},
 	})
@@ -121,7 +124,7 @@ func TestAccASConfiguration_spot_ecsPassword(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"instance_config.0.metadata"},
+				ImportStateVerifyIgnore: []string{"instance_config.0.metadata", "instance_config.0.user_data"},
 			},
 		},
 	})
@@ -208,6 +211,7 @@ func TestAccASConfiguration_instance(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"instance_config.0.instance_id",
+					"instance_config.0.user_data",
 				},
 			},
 		},

--- a/huaweicloud/services/as/resource_huaweicloud_as_configuration.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_configuration.go
@@ -541,7 +541,7 @@ func flattenInstanceConfig(instanceConfig configurations.InstanceConfig, d *sche
 			"ecs_group_id":           instanceConfig.ServerGroupID,
 			"tenancy":                instanceConfig.Tenancy,
 			"dedicated_host_id":      instanceConfig.DedicatedHostID,
-			"user_data":              instanceConfig.UserData,
+			"user_data":              d.Get("instance_config.0.user_data"),
 			"admin_pass":             d.Get("instance_config.0.admin_pass"),
 			"metadata":               d.Get("instance_config.0.metadata"),
 			"disk":                   flattenInstanceDisks(instanceConfig.Disk),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove invalid as configuration user_data attribute settings. The attribute user_data cannot be obtained during query, so the settings of this field need to be ignored.
The error message is as follows:
![image](https://github.com/user-attachments/assets/fe9d75bd-6c75-4bc6-ba91-9483a5e28cd8)



**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_basic -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_basic
=== PAUSE TestAccASConfiguration_basic
=== CONT  TestAccASConfiguration_basic
--- PASS: TestAccASConfiguration_basic (58.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        58.701s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_spot_ecsPassword'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_spot_ecsPassword -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_spot_ecsPassword
=== PAUSE TestAccASConfiguration_spot_ecsPassword
=== CONT  TestAccASConfiguration_spot_ecsPassword
--- PASS: TestAccASConfiguration_spot_ecsPassword (57.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        57.236s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_windowsPassword'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_windowsPassword -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_windowsPassword
=== PAUSE TestAccASConfiguration_windowsPassword
=== CONT  TestAccASConfiguration_windowsPassword
--- PASS: TestAccASConfiguration_windowsPassword (58.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        58.996s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_instance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_instance -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_instance
=== PAUSE TestAccASConfiguration_instance
=== CONT  TestAccASConfiguration_instance
--- PASS: TestAccASConfiguration_instance (156.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        156.051s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_bandwidth_new_disk'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_bandwidth_new_disk -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_bandwidth_new_disk
=== PAUSE TestAccASConfiguration_bandwidth_new_disk
=== CONT  TestAccASConfiguration_bandwidth_new_disk
--- PASS: TestAccASConfiguration_bandwidth_new_disk (57.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        57.669s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_snapshot'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_snapshot -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_snapshot
=== PAUSE TestAccASConfiguration_snapshot
=== CONT  TestAccASConfiguration_snapshot
--- PASS: TestAccASConfiguration_snapshot (869.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        869.909s
```

* [X] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
