### PR TITLE
refactor(ims): refactor `ims_evs_data_image` resource code style

### DIFF
--- a/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_evs_data_image_test.go
+++ b/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_evs_data_image_test.go
@@ -6,15 +6,56 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
+	"github.com/chnsz/golangsdk"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+func getEvsDataImageResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		product = "ims"
+		httpUrl = "v2/cloudimages"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath += fmt.Sprintf("?id=%s", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving IMS EVS data image: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	image := utils.PathSearch("images[0]", getRespBody, nil)
+	// If the list API return empty, then return `404` error code.
+	if image == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return image, nil
+}
 
 func TestAccEvsDataImage_basic(t *testing.T) {
 	var (
-		image        cloudimages.Image
+		image        interface{}
 		rName        = acceptance.RandomAccResourceName()
 		rNameUpdate  = rName + "-update"
 		resourceName = "huaweicloud_ims_evs_data_image.test"
@@ -25,7 +66,7 @@ func TestAccEvsDataImage_basic(t *testing.T) {
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&image,
-		getImsImageResourceFunc,
+		getEvsDataImageResourceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -101,6 +142,27 @@ func testAccEvsDataImage_base(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s"
+  image_name         = "Ubuntu 18.04 server 64bit"
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+}
+
 resource "huaweicloud_evs_volume" "test" {
   name              = "%[2]s"
   volume_type       = "GPSSD"
@@ -109,7 +171,7 @@ resource "huaweicloud_evs_volume" "test" {
   size              = 100
   charging_mode     = "postPaid"
 }
-`, testAccEcsSystemImage_base(rName), rName)
+`, common.TestBaseNetwork(rName), rName)
 }
 
 func testAccEvsDataImage_basic(rName string) string {
@@ -136,6 +198,7 @@ func testAccEvsDataImage_update1(rName, rNameUpdate, migrateEpsId string) string
 resource "huaweicloud_ims_evs_data_image" "test" {
   name                  = "%[2]s"
   volume_id             = huaweicloud_evs_volume.test.id
+  description           = ""
   enterprise_project_id = "%[3]s"
  
   tags = {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

refactor `ims_evs_data_image` resource code style

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

***Create a resource using the old code package:***
![image](https://github.com/user-attachments/assets/e733febc-dc1b-4334-bb10-dfdb57e869f5)


***Execute terraform plan using new code package:***
![image](https://github.com/user-attachments/assets/c65c8b1d-51bc-4559-ae5e-45802ae4531e)


***In summary, it can be considered that this reconstruction will have no impact on existing users.***


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

refactor `ims_evs_data_image` resource code style

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccEvsDataImage_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccEvsDataImage_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsDataImage_basic
=== PAUSE TestAccEvsDataImage_basic
=== CONT  TestAccEvsDataImage_basic
--- PASS: TestAccEvsDataImage_basic (411.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       411.211s

```
![image](https://github.com/user-attachments/assets/006de873-6122-4200-8d1f-8d68c98672af)


* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/5d4ddb8e-a6eb-4424-9251-1383b0e9009e)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/user-attachments/assets/5c288161-ba8e-41ec-82cf-26f810d0b34c)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
