### PR TITLE
feat(fgs/function): new parameter lts_custom_tag supported

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -526,6 +526,10 @@ The following arguments are supported:
 
   -> Only Java runtime supports the configurations of the heartbeat and restore hook.
 
+* `lts_custom_tag` - (Optional, Map) Specifies the custom tags configuration that used to filter the LTS logs.
+
+  -> This parameter is only supported by the `v2` version of the function.
+
 <a name="function_func_mounts"></a>
 The `func_mounts` block supports:
 

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -874,33 +874,96 @@ func TestAccFunction_logConfig(t *testing.T) {
 	var (
 		obj interface{}
 
-		name         = acceptance.RandomAccResourceName()
-		resourceName = "huaweicloud_fgs_function.test"
+		name = acceptance.RandomAccResourceName()
 
-		rc = acceptance.InitResourceCheck(resourceName, &obj, getFunction)
+		createWithLtsParams      = "huaweicloud_fgs_function.create_with_lts_params"
+		rcCreateWithLtsParams    = acceptance.InitResourceCheck(createWithLtsParams, &obj, getFunction)
+		createWithoutLtsParams   = "huaweicloud_fgs_function.create_without_lts_params"
+		rcCreateWithoutLtsParams = acceptance.InitResourceCheck(createWithoutLtsParams, &obj, getFunction)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckFgsAgency(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcCreateWithLtsParams.CheckResourceDestroy(),
+			rcCreateWithoutLtsParams.CheckResourceDestroy(),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFunction_logConfig_step1(name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "functiongraph_version", "v1"),
-					resource.TestCheckResourceAttrSet(resourceName, "log_group_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "log_stream_id"),
+					rcCreateWithLtsParams.CheckResourceExists(),
+					resource.TestCheckResourceAttr(createWithLtsParams, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_group_id",
+						"huaweicloud_lts_group.test.0", "id"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_group_name",
+						"huaweicloud_lts_group.test.0", "group_name"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_stream_id",
+						"huaweicloud_lts_stream.test.0", "id"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_stream_name",
+						"huaweicloud_lts_stream.test.0", "stream_name"),
+					resource.TestCheckResourceAttr(createWithLtsParams, "lts_custom_tag.%", "2"),
+					resource.TestCheckResourceAttr(createWithLtsParams, "lts_custom_tag.foo", "bar"),
+					resource.TestCheckResourceAttr(createWithLtsParams, "lts_custom_tag.key", "value"),
+					rcCreateWithoutLtsParams.CheckResourceExists(),
+					resource.TestCheckResourceAttr(createWithoutLtsParams, "functiongraph_version", "v2"),
+					// In some regions (such as 'cn-north-4'), the FunctionGraph service automatically binds the groups
+					// and streams created by FunctionGraph to functions that do not have LTS set.
+					resource.TestCheckResourceAttrSet(createWithoutLtsParams, "log_group_id"),
+					resource.TestCheckNoResourceAttr(createWithoutLtsParams, "log_group_name"),
+					resource.TestCheckResourceAttrSet(createWithoutLtsParams, "log_stream_id"),
+					resource.TestCheckNoResourceAttr(createWithoutLtsParams, "log_stream_name"),
 				),
 			},
 			{
 				Config: testAccFunction_logConfig_step2(name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "functiongraph_version", "v1"),
-					resource.TestCheckResourceAttrSet(resourceName, "log_group_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "log_stream_id"),
+					rcCreateWithLtsParams.CheckResourceExists(),
+					resource.TestCheckResourceAttr(createWithLtsParams, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_group_id",
+						"huaweicloud_lts_group.test.1", "id"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_group_name",
+						"huaweicloud_lts_group.test.1", "group_name"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_stream_id",
+						"huaweicloud_lts_stream.test.1", "id"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_stream_name",
+						"huaweicloud_lts_stream.test.1", "stream_name"),
+					resource.TestCheckResourceAttr(createWithLtsParams, "lts_custom_tag.%", "2"),
+					resource.TestCheckResourceAttr(createWithLtsParams, "lts_custom_tag.foo", "baar"),
+					resource.TestCheckResourceAttr(createWithLtsParams, "lts_custom_tag.new_key", "value"),
+					rcCreateWithoutLtsParams.CheckResourceExists(),
+					resource.TestCheckResourceAttr(createWithoutLtsParams, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttrPair(createWithoutLtsParams, "log_group_id",
+						"huaweicloud_lts_group.test.0", "id"),
+					resource.TestCheckResourceAttrPair(createWithoutLtsParams, "log_group_name",
+						"huaweicloud_lts_group.test.0", "group_name"),
+					resource.TestCheckResourceAttrPair(createWithoutLtsParams, "log_stream_id",
+						"huaweicloud_lts_stream.test.0", "id"),
+					resource.TestCheckResourceAttrPair(createWithoutLtsParams, "log_stream_name",
+						"huaweicloud_lts_stream.test.0", "stream_name"),
+					resource.TestCheckResourceAttr(createWithoutLtsParams, "lts_custom_tag.%", "2"),
+					resource.TestCheckResourceAttr(createWithoutLtsParams, "lts_custom_tag.foo", "bar"),
+					resource.TestCheckResourceAttr(createWithoutLtsParams, "lts_custom_tag.key", "value"),
+				),
+			},
+			{
+				Config: testAccFunction_logConfig_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rcCreateWithLtsParams.CheckResourceExists(),
+					resource.TestCheckResourceAttr(createWithLtsParams, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_group_id",
+						"huaweicloud_lts_group.test.1", "id"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_group_name",
+						"huaweicloud_lts_group.test.1", "group_name"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_stream_id",
+						"huaweicloud_lts_stream.test.1", "id"),
+					resource.TestCheckResourceAttrPair(createWithLtsParams, "log_stream_name",
+						"huaweicloud_lts_stream.test.1", "stream_name"),
+					resource.TestCheckResourceAttr(createWithLtsParams, "lts_custom_tag.%", "0"),
 				),
 			},
 		},
@@ -931,8 +994,8 @@ func testAccFunction_logConfig_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_fgs_function" "test" {
-  name                  = "%[2]s"
+resource "huaweicloud_fgs_function" "create_with_lts_params" {
+  name                  = "%[2]s_with_lts_params"
   memory_size           = 128
   runtime               = "Python2.7"
   timeout               = 3
@@ -941,22 +1004,41 @@ resource "huaweicloud_fgs_function" "test" {
   code_type             = "inline"
   func_code             = base64encode(var.script_content)
   description           = "Created by terraform script"
-  functiongraph_version = "v1"
+  functiongraph_version = "v2"
+  agency                = "%[3]s"
 
   log_group_id    = huaweicloud_lts_group.test[0].id
   log_stream_id   = huaweicloud_lts_stream.test[0].id
   log_group_name  = huaweicloud_lts_group.test[0].group_name
   log_stream_name = huaweicloud_lts_stream.test[0].stream_name
+  lts_custom_tag = {
+    foo = "bar"
+    key = "value"
+  }
 }
-`, testAccFunction_logConfig_base(name), name)
+
+resource "huaweicloud_fgs_function" "create_without_lts_params" {
+  name                  = "%[2]s_without_lts_params"
+  memory_size           = 128
+  runtime               = "Python2.7"
+  timeout               = 3
+  app                   = "default"
+  handler               = "index.handler"
+  code_type             = "inline"
+  func_code             = base64encode(var.script_content)
+  description           = "Created by terraform script"
+  functiongraph_version = "v2"
+  agency                = "%[3]s"
+}
+`, testAccFunction_logConfig_base(name), name, acceptance.HW_FGS_AGENCY_NAME)
 }
 
 func testAccFunction_logConfig_step2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_fgs_function" "test" {
-  name                  = "%[2]s"
+resource "huaweicloud_fgs_function" "create_with_lts_params" {
+  name                  = "%[2]s_with_lts_params"
   memory_size           = 128
   runtime               = "Python2.7"
   timeout               = 3
@@ -965,14 +1047,61 @@ resource "huaweicloud_fgs_function" "test" {
   code_type             = "inline"
   func_code             = base64encode(var.script_content)
   description           = "Created by terraform script"
-  functiongraph_version = "v1"
+  functiongraph_version = "v2"
+  agency                = "%[3]s"
 
   log_group_id    = huaweicloud_lts_group.test[1].id
   log_stream_id   = huaweicloud_lts_stream.test[1].id
   log_group_name  = huaweicloud_lts_group.test[1].group_name
   log_stream_name = huaweicloud_lts_stream.test[1].stream_name
+  lts_custom_tag  = {
+    foo     = "baar"
+    new_key = "value"
+  }
 }
-`, testAccFunction_logConfig_base(name), name)
+
+resource "huaweicloud_fgs_function" "create_without_lts_params" {
+  name                  = "%[2]s_without_lts_params"
+  memory_size           = 128
+  runtime               = "Python2.7"
+  timeout               = 3
+  app                   = "default"
+  handler               = "index.handler"
+  code_type             = "inline"
+  func_code             = base64encode(var.script_content)
+  description           = "Created by terraform script"
+  functiongraph_version = "v2"
+  agency                = "%[3]s"
+
+  log_group_id    = huaweicloud_lts_group.test[0].id
+  log_stream_id   = huaweicloud_lts_stream.test[0].id
+  log_group_name  = huaweicloud_lts_group.test[0].group_name
+  log_stream_name = huaweicloud_lts_stream.test[0].stream_name
+  lts_custom_tag  = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccFunction_logConfig_base(name), name, acceptance.HW_FGS_AGENCY_NAME)
+}
+
+func testAccFunction_logConfig_step3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_fgs_function" "create_with_lts_params" {
+  name                  = "%[2]s_with_lts_params"
+  memory_size           = 128
+  runtime               = "Python2.7"
+  timeout               = 3
+  app                   = "default"
+  handler               = "index.handler"
+  code_type             = "inline"
+  func_code             = base64encode(var.script_content)
+  description           = "Created by terraform script"
+  functiongraph_version = "v2"
+}
+`, testAccFunction_logConfig_base(name), name, acceptance.HW_FGS_AGENCY_NAME)
 }
 
 func TestAccFunction_strategy(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new parameter 'lts_custom_tag'.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFunction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_basic -timeout 360m -parallel 10
=== RUN   TestAccFunction_basic
=== PAUSE TestAccFunction_basic
=== CONT  TestAccFunction_basic
--- PASS: TestAccFunction_basic (79.16s)
PASS
coverage: 22.8% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       79.216s coverage: 22.8% of statements in ./huaweicloud/services/fgs
```
```
./scripts/coverage.sh -o fgs -f TestAccFunction_logConfig
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_logConfig -timeout 360m -parallel 10
=== RUN   TestAccFunction_logConfig
=== PAUSE TestAccFunction_logConfig
=== CONT  TestAccFunction_logConfig
--- PASS: TestAccFunction_logConfig (41.94s)
PASS
coverage: 14.7% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       42.124s coverage: 14.7% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
