### PR TITLE
feat(evs): evs snapshot resource support new fields

### DIFF
--- a/docs/resources/evs_snapshot.md
+++ b/docs/resources/evs_snapshot.md
@@ -62,6 +62,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `size` - The size of the snapshot in GB.
 
+* `created_at` - The time when the snapshot was created.
+
+* `updated_at` - The time when the snapshot was updated.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:

--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_snapshot_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_snapshot_test.go
@@ -56,6 +56,9 @@ func TestAccEvsSnapshot_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", "available"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.key", "value"),
+					resource.TestCheckResourceAttrSet(resourceName, "size"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
 				),
 			},
 			{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- EVS snapshot resource support new fields.
  - Resource supports new fields `created_at` and `updated_at`.
  - Write back the value of the field `metadata`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run TestAccEvsSnapshot_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsSnapshot_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsSnapshot_basic
=== PAUSE TestAccEvsSnapshot_basic
=== CONT  TestAccEvsSnapshot_basic
--- PASS: TestAccEvsSnapshot_basic (67.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       67.646s
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
