### PR TITLE
feat(er): add new data source for all resource tags

### DIFF
--- a/docs/data-sources/er_tags.md
+++ b/docs/data-sources/er_tags.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Enterprise Router (ER)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_er_tags"
+description: |-
+  Use this data source to query the tag list of all resources of the same type within HuaweiCloud.
+---
+
+# huaweicloud_er_tags
+
+Use this data source to query the tag list of all resources of the same type within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_er_tags" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource tags.  
+  If omitted, the provider-level region will be used.
+
+* `resource_type` - (Required, String) Specifies the resource type to which the tags belong that to be queried.  
+  The valid values are as follows:
+  + **instance**: enterprise router instance.
+  + **route-table**: route table.
+  + **vpc-attachment**: VPC connection.
+  + **vgw-attachment**: virtual gateway connection.
+  + **peering-attachment**: peering connection.
+  + **vpn-attachment**: VPN gateway connection.
+  + **ecn-attachment**: enterprise network connection.
+  + **cfw-attachment**: cloud firewall connection.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tags` - The list of all tags for resources of the same type.  
+  The [tags](#er_project_tags) structure is documented below.
+
+<a name="er_project_tags"></a>
+The `tags` block supports:
+
+* `key` - The key of the resource tag.
+
+* `values` - All values corresponding to the key.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -853,6 +853,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_er_propagations":       er.DataSourcePropagations(),
 			"huaweicloud_er_quotas":             er.DataSourceErQuotas(),
 			"huaweicloud_er_route_tables":       er.DataSourceRouteTables(),
+			"huaweicloud_er_tags":               er.DataSourceTags(),
 			"huaweicloud_er_availability_zones": er.DataSourceAvailabilityZones(),
 
 			"huaweicloud_evs_volumes":            evs.DataSourceEvsVolumesV2(),

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_tags_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_tags_test.go
@@ -1,0 +1,85 @@
+package er
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataTags_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_er_tags.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataTags_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "tags.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "tags.0.key"),
+					resource.TestMatchResourceAttr(all, "tags.0.values.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckOutput("tags_validation", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataTags_base() string {
+	var (
+		name = acceptance.RandomAccResourceName()
+		// The valid value is range from 64512 to 65534, maintain an upper limit as the boundary value of asn+count.
+		bgpAsNum = acctest.RandIntRange(64512, 65533)
+	)
+
+	return fmt.Sprintf(`
+data "huaweicloud_er_availability_zones" "test" {}
+
+resource "huaweicloud_er_instance" "test" {
+  count = 2
+
+  availability_zones = try(slice(data.huaweicloud_er_availability_zones.test.names, 0, 1), [])
+  name               = format("%[1]s_%%d", count.index)
+  asn                = %[2]d+count.index
+
+  tags = {
+    foo = format("bar%%d", count.index)
+  }
+
+  lifecycle {
+    ignore_changes = [
+      availability_zones, # Available instances in an availability zone may be sold out, so its value may be empty.
+    ]
+  }
+}
+`, name, bgpAsNum)
+}
+
+func testAccDataTags_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_tags" "test" {
+  depends_on = [huaweicloud_er_instance.test]
+
+  resource_type = "instance"
+}
+
+output "tags_validation" {
+  value = length([for t in data.huaweicloud_er_tags.test.tags: t.key == "foo" &&
+    alltrue([for k, v in huaweicloud_er_instance.test[*].tags: contains(t.values, v) if k == "foo"])]) > 0
+}
+`, testAccDataTags_base())
+}

--- a/huaweicloud/services/er/data_source_huaweicloud_er_tags.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_tags.go
@@ -1,0 +1,130 @@
+package er
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ER GET /v3/{project_id}/{resource_type}/tags
+func DataSourceTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region in which to query the resource tags.`,
+			},
+			"resource_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The resource type to which the tags belong that to be queried.`,
+			},
+			"tags": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of all tags for resources of the same type.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The key of the resource tag.`,
+						},
+						"values": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `All values corresponding to the key.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func listProjectTags(client *golangsdk.ServiceClient, resourceType string) ([]interface{}, error) {
+	httpUrl := "v3/{project_id}/{resource_type}/tags"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{resource_type}", resourceType)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+	return utils.PathSearch("tags", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenProjectTags(tags []interface{}) []map[string]interface{} {
+	if len(tags) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(tags))
+	for _, tag := range tags {
+		result = append(result, map[string]interface{}{
+			"key":    utils.PathSearch("key", tag, nil),
+			"values": utils.PathSearch("values", tag, make([]interface{}, 0)),
+		})
+	}
+
+	return result
+}
+
+func dataSourceTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		resourceType = d.Get("resource_type").(string)
+	)
+	client, err := cfg.NewServiceClient("er", region)
+	if err != nil {
+		return diag.Errorf("error creating ER client: %s", err)
+	}
+
+	tagList, err := listProjectTags(client, resourceType)
+	if err != nil {
+		return diag.Errorf("error querying tags of the ER service: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("tags", flattenProjectTags(tagList)),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving data source fields of the ER project tags: %s", mErr)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new data source that used to query the tag list of all resources of the same type.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Add new data source for all resource tags.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o er -f TestAccDataSourceTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/er" -v -coverprofile="./huaweicloud/services/acceptance/er/er_coverage.cov" -coverpkg="./huaweicloud/services/er" -run TestAccDataSourceTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceTags_basic
=== PAUSE TestAccDataSourceTags_basic
=== CONT  TestAccDataSourceTags_basic
--- PASS: TestAccDataSourceTags_basic (50.22s)
PASS
coverage: 13.6% of statements in ./huaweicloud/services/er
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        50.333s coverage: 13.6% of statements in ./huaweicloud/services/er
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
