### PR TITLE
feat(nat): the private snat rule resource support new fields

### DIFF
--- a/docs/resources/nat_private_snat_rule.md
+++ b/docs/resources/nat_private_snat_rule.md
@@ -49,7 +49,8 @@ The following arguments are supported:
 * `gateway_id` - (Required, String, ForceNew) Specifies the private NAT gateway ID to which the SNAT rule belongs.  
   Changing this will create a new resource.
 
-* `transit_ip_id` - (Required, String) Specifies the ID of the transit IP associated with SNAT rule.
+* `transit_ip_ids` - (Required, List) Specifies the IDs of the transit IPs associated with the private SNAT rule.
+  The maximum of `20` transit IPs can be bound, and the transit IPs must belong the same transit subnet.
 
 * `cidr` - (Optional, String, ForceNew) Specifies the CIDR block of the match rule.  
   Changing this will create a new resource.  
@@ -74,14 +75,40 @@ In addition to all arguments above, the following attributes are exported:
 
 * `updated_at` - The latest update time of the SNAT rule.
 
-* `transit_ip_address` - The address of the transit IP.
+* `transit_ip_associations` - The transit IP list associate with the private SNAT rule.
+  The [transit_ip_associations](#snat_transit_ip_associations) structure is documented below.
 
 * `enterprise_project_id` - The ID of the enterprise project to which the private SNAT rule belongs.
 
+<a name="snat_transit_ip_associations"></a>
+The `transit_ip_associations` block supports:
+
+* `transit_ip_id` - The ID of the transit IP associated with the private SNAT rule.
+
+* `transit_ip_address` - The IP address of the transit IP associated with the private SNAT rule.
+
 ## Import
 
-SNAT rules can be imported using their `id`, e.g.
+The private SNAT rule can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_nat_private_snat_rule.test df9b61e9-79c1-4a75-bfab-736e224ced71
+$ terraform import huaweicloud_nat_private_snat_rule.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `transit_ip_ids`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_nat_private_snat_rule" "test" {
+  ...
+  
+  lifecycle {
+    ignore_changes = [
+      transit_ip_ids,
+    ]
+  }
+}
 ```

--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_snat_rule_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_snat_rule_test.go
@@ -47,14 +47,11 @@ func TestAccPrivateSnatRule_basic(t *testing.T) {
 				Config: testAccPrivateSnatRule_basic_step_1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(rName, "gateway_id",
-						"huaweicloud_nat_private_gateway.test", "id"),
-					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
-						"huaweicloud_nat_private_transit_ip.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id", "huaweicloud_nat_private_gateway.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "subnet_id", "huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttr(rName, "transit_ip_ids.#", "2"),
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
-					resource.TestCheckResourceAttrPair(rName, "subnet_id",
-						"huaweicloud_vpc_subnet.test", "id"),
-					resource.TestCheckResourceAttrSet(rName, "transit_ip_address"),
+					resource.TestCheckResourceAttr(rName, "transit_ip_associations.#", "2"),
 					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
 				),
 			},
@@ -63,14 +60,14 @@ func TestAccPrivateSnatRule_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "description", ""),
-					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
-						"huaweicloud_nat_private_transit_ip.standby", "id"),
+					resource.TestCheckResourceAttr(rName, "transit_ip_ids.#", "1"),
 				),
 			},
 			{
-				ResourceName:      rName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"transit_ip_ids"},
 			},
 		},
 	})
@@ -90,12 +87,12 @@ resource "huaweicloud_vpc_subnet" "transit_ip_used" {
   gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.transit_ip_used.cidr, 4, 1), 1)
 }
 
-resource "huaweicloud_nat_private_transit_ip" "test" {
+resource "huaweicloud_nat_private_transit_ip" "test1" {
   subnet_id             = huaweicloud_vpc_subnet.transit_ip_used.id
   enterprise_project_id = "0"
 }
 
-resource "huaweicloud_nat_private_transit_ip" "standby" {
+resource "huaweicloud_nat_private_transit_ip" "test2" {
   subnet_id             = huaweicloud_vpc_subnet.transit_ip_used.id
   enterprise_project_id = "0"
 }
@@ -106,39 +103,39 @@ func testAccPrivateSnatRule_base(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-%[2]s
-
 resource "huaweicloud_nat_private_gateway" "test" {
   subnet_id             = huaweicloud_vpc_subnet.test.id
-  name                  = "%[3]s"
+  name                  = "%[2]s"
   enterprise_project_id = "0"
 }
-`, common.TestBaseNetwork(name), testAccPrivateSnatRule_transitIpConfig(name), name)
+`, common.TestBaseNetwork(name), name)
 }
 
 func testAccPrivateSnatRule_basic_step_1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
+%[2]s
 
 resource "huaweicloud_nat_private_snat_rule" "test" {
-  gateway_id    = huaweicloud_nat_private_gateway.test.id
-  description   = "Created by acc test"
-  transit_ip_id = huaweicloud_nat_private_transit_ip.test.id
-  subnet_id     = huaweicloud_vpc_subnet.test.id
+  gateway_id     = huaweicloud_nat_private_gateway.test.id
+  description    = "Created by acc test"
+  transit_ip_ids = [huaweicloud_nat_private_transit_ip.test1.id,huaweicloud_nat_private_transit_ip.test2.id]
+  subnet_id      = huaweicloud_vpc_subnet.test.id
 }
-`, testAccPrivateSnatRule_base(name))
+`, testAccPrivateSnatRule_base(name), testAccPrivateSnatRule_transitIpConfig(name))
 }
 
 func testAccPrivateSnatRule_basic_step_2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
+%[2]s
 
 resource "huaweicloud_nat_private_snat_rule" "test" {
-  gateway_id    = huaweicloud_nat_private_gateway.test.id
-  transit_ip_id = huaweicloud_nat_private_transit_ip.standby.id
-  subnet_id     = huaweicloud_vpc_subnet.test.id
+  gateway_id     = huaweicloud_nat_private_gateway.test.id
+  transit_ip_ids = [huaweicloud_nat_private_transit_ip.test2.id]
+  subnet_id      = huaweicloud_vpc_subnet.test.id
 }
-`, testAccPrivateSnatRule_base(name))
+`, testAccPrivateSnatRule_base(name), testAccPrivateSnatRule_transitIpConfig(name))
 }
 
 func TestAccPrivateSnatRule_cidr(t *testing.T) {
@@ -166,13 +163,10 @@ func TestAccPrivateSnatRule_cidr(t *testing.T) {
 				Config: testAccPrivateSnatRule_cidr_step_1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(rName, "gateway_id",
-						"huaweicloud_nat_private_gateway.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id", "huaweicloud_nat_private_gateway.test", "id"),
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
-					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
-						"huaweicloud_nat_private_transit_ip.test", "id"),
-					resource.TestCheckResourceAttrPair(rName, "cidr",
-						"huaweicloud_vpc_subnet.test", "cidr"),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id", "huaweicloud_nat_private_transit_ip.test1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "cidr", "huaweicloud_vpc_subnet.test", "cidr"),
 					resource.TestCheckResourceAttrSet(rName, "transit_ip_address"),
 					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
 				),
@@ -182,8 +176,7 @@ func TestAccPrivateSnatRule_cidr(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "description", ""),
-					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
-						"huaweicloud_nat_private_transit_ip.standby", "id"),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id", "huaweicloud_nat_private_transit_ip.test2", "id"),
 				),
 			},
 			{
@@ -198,24 +191,26 @@ func TestAccPrivateSnatRule_cidr(t *testing.T) {
 func testAccPrivateSnatRule_cidr_step_1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
+%[2]s
 
 resource "huaweicloud_nat_private_snat_rule" "test" {
   gateway_id    = huaweicloud_nat_private_gateway.test.id
   description   = "Created by acc test"
-  transit_ip_id = huaweicloud_nat_private_transit_ip.test.id
+  transit_ip_id = huaweicloud_nat_private_transit_ip.test1.id
   cidr          = huaweicloud_vpc_subnet.test.cidr
 }
-`, testAccPrivateSnatRule_base(name))
+`, testAccPrivateSnatRule_base(name), testAccPrivateSnatRule_transitIpConfig(name))
 }
 
 func testAccPrivateSnatRule_cidr_step_2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
+%[2]s
 
 resource "huaweicloud_nat_private_snat_rule" "test" {
   gateway_id    = huaweicloud_nat_private_gateway.test.id
-  transit_ip_id = huaweicloud_nat_private_transit_ip.standby.id
+  transit_ip_id = huaweicloud_nat_private_transit_ip.test2.id
   cidr          = huaweicloud_vpc_subnet.test.cidr
 }
-`, testAccPrivateSnatRule_base(name))
+`, testAccPrivateSnatRule_base(name), testAccPrivateSnatRule_transitIpConfig(name))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The private snat rule resource support new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateSnatRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateSnatRule_basic -timeout 360m -parallel 4
=== RUN   TestAccPrivateSnatRule_basic
=== PAUSE TestAccPrivateSnatRule_basic
=== CONT  TestAccPrivateSnatRule_basic
--- PASS: TestAccPrivateSnatRule_basic (74.35s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       74.403s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateSnatRule_cidr"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateSnatRule_cidr -timeout 360m -parallel 4
=== RUN   TestAccPrivateSnatRule_cidr
=== PAUSE TestAccPrivateSnatRule_cidr
=== CONT  TestAccPrivateSnatRule_cidr
--- PASS: TestAccPrivateSnatRule_cidr (74.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       74.688s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
