### PR TITLE
refactor(evs): refactor volume create function in general code style

### DIFF
--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_test.go
@@ -314,7 +314,6 @@ data "huaweicloud_networking_secgroup" "test" {
 resource "huaweicloud_compute_instance" "test" {
   name                = "%s"
   description         = "terraform test"
-  hostname            = "hostname-test"
   image_id            = data.huaweicloud_images_image.test.id
   flavor_id           = data.huaweicloud_compute_flavors.test.ids[0]
   security_group_ids  = [data.huaweicloud_networking_secgroup.test.id]
@@ -730,7 +729,6 @@ data "huaweicloud_networking_secgroup" "test" {
 resource "huaweicloud_compute_instance" "test" {
   name                = "%s"
   description         = "terraform test"
-  hostname            = "hostname-test"
   image_id            = data.huaweicloud_images_image.test.id
   flavor_id           = data.huaweicloud_compute_flavors.test.ids[0]
   security_group_ids  = [data.huaweicloud_networking_secgroup.test.id]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactor volume create function in general code style.

![image](https://github.com/user-attachments/assets/ddc9dfcc-0445-4eb7-941e-bb2730f4e503)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
go test -v -coverprofile=coverage_1744170074_TestAccEvsVolume_.cov -coverpkg=./huaweicloud/services/evs ./huaweicloud/services/acceptance/evs -run TestAccEvsVolume_ -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_postPaidWithoutServer
=== PAUSE TestAccEvsVolume_postPaidWithoutServer
=== RUN   TestAccEvsVolume_postPaidWithServer
=== PAUSE TestAccEvsVolume_postPaidWithServer
=== RUN   TestAccEvsVolume_prePaidWithoutServer
=== PAUSE TestAccEvsVolume_prePaidWithoutServer
=== RUN   TestAccEvsVolume_prePaidWithServer
=== PAUSE TestAccEvsVolume_prePaidWithServer
=== RUN   TestAccEvsVolume_postPaidEditDiskType
=== PAUSE TestAccEvsVolume_postPaidEditDiskType
=== RUN   TestAccEvsVolume_prePaidEditDiskType
=== PAUSE TestAccEvsVolume_prePaidEditDiskType
=== CONT  TestAccEvsVolume_postPaidWithoutServer
=== CONT  TestAccEvsVolume_prePaidWithServer
=== CONT  TestAccEvsVolume_prePaidEditDiskType
=== CONT  TestAccEvsVolume_postPaidEditDiskType
--- PASS: TestAccEvsVolume_postPaidWithoutServer (91.99s)
=== CONT  TestAccEvsVolume_prePaidWithoutServer
--- PASS: TestAccEvsVolume_prePaidWithoutServer (192.82s)
=== CONT  TestAccEvsVolume_postPaidWithServer
--- PASS: TestAccEvsVolume_prePaidWithServer (475.49s)
--- PASS: TestAccEvsVolume_postPaidWithServer (280.97s)
--- PASS: TestAccEvsVolume_postPaidEditDiskType (1636.26s)
--- PASS: TestAccEvsVolume_prePaidEditDiskType (2149.72s)
PASS
coverage: 33.4% of statements in ./huaweicloud/services/evs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       2149.795s       coverage: 33.4% of statements in ./huaweicloud/services/evs
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
