### PR TITLE
refactor(ims): refactor `ims_obs_data_image` resource code style

### DIFF
--- a/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_obs_data_image_test.go
+++ b/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_obs_data_image_test.go
@@ -6,15 +6,55 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
+	"github.com/chnsz/golangsdk"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+func getObsDataImageResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		product = "ims"
+		httpUrl = "v2/cloudimages"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath += fmt.Sprintf("?id=%s", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving IMS OBS data image: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	image := utils.PathSearch("images[0]", getRespBody, nil)
+	// If the list API return empty, then return `404` error code.
+	if image == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return image, nil
+}
 
 func TestAccObsDataImage_basic(t *testing.T) {
 	var (
-		image        cloudimages.Image
+		image        interface{}
 		rName        = acceptance.RandomAccResourceName()
 		rNameUpdate  = rName + "-update"
 		resourceName = "huaweicloud_ims_obs_data_image.test"
@@ -25,7 +65,7 @@ func TestAccObsDataImage_basic(t *testing.T) {
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&image,
-		getImsImageResourceFunc,
+		getObsDataImageResourceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/huaweicloud/services/ims/resource_huaweicloud_ims_obs_data_image.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_ims_obs_data_image.go
@@ -2,17 +2,21 @@ package ims
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API IMS POST /v1/cloudimages/dataimages/action
@@ -27,7 +31,7 @@ func ResourceObsDataImage() *schema.Resource {
 		CreateContext: resourceObsDataImageCreate,
 		ReadContext:   resourceObsDataImageRead,
 		UpdateContext: resourceObsDataImageUpdate,
-		DeleteContext: resourceImageDelete,
+		DeleteContext: resourceObsDataImageDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -119,34 +123,57 @@ func ResourceObsDataImage() *schema.Resource {
 	}
 }
 
+func buildCreateObsDataImageBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":                  d.Get("name"),
+		"image_url":             d.Get("image_url"),
+		"min_disk":              d.Get("min_disk"),
+		"os_type":               utils.ValueIgnoreEmpty(d.Get("os_type")),
+		"description":           d.Get("description"),
+		"cmk_id":                utils.ValueIgnoreEmpty(d.Get("cmk_id")),
+		"image_tags":            utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{})),
+		"enterprise_project_id": utils.ValueIgnoreEmpty(d.Get("enterprise_project_id")),
+	}
+
+	return bodyParams
+}
+
 func resourceObsDataImageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ims"
+		httpUrl = "v1/cloudimages/dataimages/action"
 	)
 
-	client, err := cfg.ImageV1Client(region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating IMS v1 client: %s", err)
+		return diag.Errorf("error creating IMS client: %s", err)
 	}
 
-	imageTags := buildCreateImageTagsParam(d)
-	createOpts := &cloudimages.CreateDataImageByOBSOpts{
-		Name:                d.Get("name").(string),
-		Description:         d.Get("description").(string),
-		OsType:              d.Get("os_type").(string),
-		ImageUrl:            d.Get("image_url").(string),
-		MinDisk:             d.Get("min_disk").(int),
-		CmkId:               d.Get("cmk_id").(string),
-		ImageTags:           imageTags,
-		EnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
+	createPath := client.Endpoint + httpUrl
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildCreateObsDataImageBodyParams(d)),
 	}
-	createResp, err := cloudimages.CreateDataImageByOBS(client, createOpts).ExtractJobResponse()
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
 		return diag.Errorf("error creating IMS OBS data image: %s", err)
 	}
 
-	imageId, err := waitForCreateImageCompleted(client, d, createResp.JobID)
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", createRespBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("error creating IMS OBS data image: job ID is not found in API response")
+	}
+
+	imageId, err := waitForCreateObsDataImageJobCompleted(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("error waiting for IMS OBS data image to complete: %s", err)
 	}
@@ -156,48 +183,129 @@ func resourceObsDataImageCreate(ctx context.Context, d *schema.ResourceData, met
 	return resourceObsDataImageRead(ctx, d, meta)
 }
 
-func resourceObsDataImageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
-		mErr   *multierror.Error
-	)
-
-	client, err := cfg.ImageV2Client(region)
-	if err != nil {
-		return diag.Errorf("error creating IMS v2 client: %s", err)
+func waitForCreateObsDataImageJobCompleted(ctx context.Context, client *golangsdk.ServiceClient, jobId string,
+	timeout time.Duration) (string, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      obsDataImageJobStatusRefreshFunc(jobId, client),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 
-	imageList, err := GetImageList(client, d.Id())
+	getRespBody, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf("error retrieving IMS OBS data images: %s", err)
+		return "", fmt.Errorf("error waiting for IMS OBS data image job (%s) to succeed: %s", jobId, err)
+	}
+
+	imageId := utils.PathSearch("entities.image_id", getRespBody, "").(string)
+	if imageId == "" {
+		return "", errors.New("the image ID is not found in API response")
+	}
+
+	return imageId, nil
+}
+
+func obsDataImageJobStatusRefreshFunc(jobId string, client *golangsdk.ServiceClient) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		getPath := client.Endpoint + "v1/{project_id}/jobs/{job_id}"
+		getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+		getPath = strings.ReplaceAll(getPath, "{job_id}", fmt.Sprintf("%v", jobId))
+		getOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+
+		getResp, err := client.Request("GET", getPath, &getOpt)
+		if err != nil {
+			return getResp, "ERROR", fmt.Errorf("error retrieving IMS OBS data image job: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return getRespBody, "ERROR", err
+		}
+
+		status := utils.PathSearch("status", getRespBody, "").(string)
+		if status == "SUCCESS" {
+			return getRespBody, "COMPLETED", nil
+		}
+
+		if status == "FAIL" {
+			return getRespBody, "COMPLETED", errors.New("the OBS data image creation job execution failed")
+		}
+
+		if status == "" {
+			return getRespBody, "ERROR", errors.New("status field is not found in API response")
+		}
+
+		return getRespBody, "PENDING", nil
+	}
+}
+
+func getObsDataImage(client *golangsdk.ServiceClient, imageId string) (interface{}, error) {
+	// If the `enterprise_project_id` is not filled, the list API will query images under all enterprise projects.
+	// So there's no need to fill `enterprise_project_id` here.
+	getPath := client.Endpoint + "v2/cloudimages"
+	getPath += fmt.Sprintf("?id=%s", imageId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving IMS OBS data image: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("images[0]", getRespBody, nil), nil
+}
+
+func resourceObsDataImageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ims"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating IMS client: %s", err)
+	}
+
+	image, err := getObsDataImage(client, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	// If the list API return empty, then process `CheckDeleted` logic.
-	if len(imageList) < 1 {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "IMS OBS data image")
+	if image == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving IMS OBS data image")
 	}
 
-	image := imageList[0]
-	imageTags := flattenImageTags(d, client)
-	mErr = multierror.Append(
+	dataOrigin := utils.PathSearch("__data_origin", image, "").(string)
+	mErr := multierror.Append(
 		d.Set("region", region),
-		d.Set("name", image.Name),
-		d.Set("image_url", flattenSpecificValueFormDataOrigin(image.DataOrigin, "file")),
-		d.Set("min_disk", image.MinDisk),
-		d.Set("os_type", image.OsType),
-		d.Set("description", image.Description),
-		d.Set("cmk_id", image.SystemCmkid),
-		d.Set("tags", imageTags),
-		d.Set("enterprise_project_id", image.EnterpriseProjectID),
-		d.Set("status", image.Status),
-		d.Set("visibility", image.Visibility),
-		d.Set("image_size", image.ImageSize),
-		d.Set("disk_format", image.DiskFormat),
-		d.Set("data_origin", image.DataOrigin),
-		d.Set("active_at", image.ActiveAt),
-		d.Set("created_at", image.CreatedAt.Format(time.RFC3339)),
-		d.Set("updated_at", image.UpdatedAt.Format(time.RFC3339)),
+		d.Set("name", utils.PathSearch("name", image, nil)),
+		d.Set("image_url", flattenSpecificValueFormDataOrigin(dataOrigin, "file")),
+		d.Set("min_disk", utils.PathSearch("min_disk", image, nil)),
+		d.Set("os_type", utils.PathSearch("__os_type", image, nil)),
+		d.Set("description", utils.PathSearch("__description", image, nil)),
+		d.Set("cmk_id", utils.PathSearch("__system__cmkid", image, nil)),
+		d.Set("tags", flattenIMSImageTags(client, d.Id())),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", image, nil)),
+		d.Set("status", utils.PathSearch("status", image, nil)),
+		d.Set("visibility", utils.PathSearch("visibility", image, nil)),
+		d.Set("image_size", utils.PathSearch("__image_size", image, nil)),
+		d.Set("disk_format", utils.PathSearch("disk_format", image, nil)),
+		d.Set("data_origin", dataOrigin),
+		d.Set("active_at", utils.PathSearch("active_at", image, nil)),
+		d.Set("created_at", utils.PathSearch("created_at", image, nil)),
+		d.Set("updated_at", utils.PathSearch("updated_at", image, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -205,19 +313,149 @@ func resourceObsDataImageRead(_ context.Context, d *schema.ResourceData, meta in
 
 func resourceObsDataImageUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ims"
+		httpUrl = "v2/cloudimages/{image_id}"
+		imageId = d.Id()
 	)
 
-	client, err := cfg.ImageV2Client(region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating IMS v2 client: %s", err)
+		return diag.Errorf("error creating IMS client: %s", err)
 	}
 
-	err = updateImage(ctx, cfg, client, d)
-	if err != nil {
-		return diag.Errorf("error updating IMS OBS data image: %s", err)
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{image_id}", imageId)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	if d.HasChange("name") {
+		bodyParams := []map[string]interface{}{
+			{
+				"op":    "replace",
+				"path":  "/name",
+				"value": d.Get("name"),
+			},
+		}
+
+		updateOpt.JSONBody = bodyParams
+		_, err = client.Request("PATCH", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating IMS OBS data image name field: %s", err)
+		}
+	}
+
+	if d.HasChange("description") {
+		bodyParams := []map[string]interface{}{
+			{
+				"op":    "replace",
+				"path":  "/__description",
+				"value": d.Get("description"),
+			},
+		}
+
+		updateOpt.JSONBody = bodyParams
+		_, err = client.Request("PATCH", updatePath, &updateOpt)
+		if err != nil {
+			err = processUpdateDescriptionError(d, client, err)
+			if err != nil {
+				return diag.Errorf("error updating IMS OBS data image description field: %s", err)
+			}
+		}
+	}
+
+	if d.HasChange("tags") {
+		err = updateIMSImageTags(client, d)
+		if err != nil {
+			return diag.Errorf("error updating IMS OBS data image tags field: %s", err)
+		}
+	}
+
+	if d.HasChange("enterprise_project_id") {
+		migrateOpts := config.MigrateResourceOpts{
+			ResourceId:   imageId,
+			ResourceType: "images",
+			RegionId:     region,
+			ProjectId:    client.ProjectID,
+		}
+		if err := cfg.MigrateEnterpriseProject(ctx, d, migrateOpts); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return resourceObsDataImageRead(ctx, d, meta)
+}
+
+func resourceObsDataImageDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ims"
+		httpUrl = "v2/images/{image_id}"
+		imageId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating IMS client: %s", err)
+	}
+
+	// Before deleting, call the query API first, if the query result is empty, then process `CheckDeleted` logic.
+	image, err := getObsDataImage(client, imageId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if image == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "IMS OBS data image")
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{image_id}", imageId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting IMS OBS data image: %s", err)
+	}
+
+	// Because the delete API always return `204` status code,
+	// so we need to call the list query API to check if the image has been successfully deleted.
+	err = waitForObsDataImageDeleted(ctx, client, d)
+	if err != nil {
+		return diag.Errorf("error waiting for IMS OBS data image to be deleted: %s", err)
+	}
+
+	return nil
+}
+
+func waitForObsDataImageDeleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			image, err := getObsDataImage(client, d.Id())
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			if image == nil {
+				return "SUCCESS", "COMPLETED", nil
+			}
+
+			return image, "PENDING", nil
+		},
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 3 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+
+	return err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

refactor `ims_obs_data_image` resource code style

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

***Create a resource using the old code package:***
![image](https://github.com/user-attachments/assets/cb980e8b-922e-4944-b586-a189e5f733a9)

***Execute terraform plan using new code package:***
![image](https://github.com/user-attachments/assets/206fb8f7-4a8e-431d-9601-e6b9d76e0f12)


***In summary, it can be considered that this reconstruction will have no impact on existing users.***


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

refactor `ims_obs_data_image` resource code style

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccObsDataImage_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccObsDataImage_basic -timeout 360m -parallel 4
=== RUN   TestAccObsDataImage_basic
=== PAUSE TestAccObsDataImage_basic
=== CONT  TestAccObsDataImage_basic
--- PASS: TestAccObsDataImage_basic (340.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       340.193s

```
![image](https://github.com/user-attachments/assets/73bcbde8-d75c-4aa9-b4cb-41b8ce3763a5)


* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/2a95b18a-fd8e-47de-a946-5aeca5a0739b)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/user-attachments/assets/927c4534-bab1-4deb-bc20-f0dbd5c1c706)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
