### PR TITLE
feat(cbr): add new data source for all resource tags

### DIFF
--- a/docs/data-sources/cbr_tags.md
+++ b/docs/data-sources/cbr_tags.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbr_tags"
+description: |-
+  Use this data source to query the tag list of all resources of the same type within HuaweiCloud.
+---
+
+# huaweicloud_cbr_tags
+
+Use this data source to query the tag list of all resources of the same type within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cbr_tags" "test" {
+  resource_type = "vault"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource tags.  
+  If omitted, the provider-level region will be used.
+
+* `resource_type` - (Required, String) Specifies the resource type to which the tags belong that to be queried.  
+  The valid values are as follows:
+  + **vault**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tags` - The list of all tags for resources of the same type.  
+  The [tags](#cbr_project_tags) structure is documented below.
+
+<a name="cbr_project_tags"></a>
+The `tags` block supports:
+
+* `key` - The key of the resource tag.
+
+* `values` - All values corresponding to the key.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -527,6 +527,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbr_backup":   cbr.DataSourceBackup(),
 			"huaweicloud_cbr_vaults":   cbr.DataSourceVaults(),
 			"huaweicloud_cbr_policies": cbr.DataSourcePolicies(),
+			"huaweicloud_cbr_tags":     cbr.DataSourceTags(),
 
 			"huaweicloud_cbh_instances":          cbh.DataSourceCbhInstances(),
 			"huaweicloud_cbh_flavors":            cbh.DataSourceCbhFlavors(),

--- a/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_tags_test.go
+++ b/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_tags_test.go
@@ -1,0 +1,75 @@
+package cbr
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataTags_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_cbr_tags.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataTags_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "tags.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "tags.0.key"),
+					resource.TestMatchResourceAttr(all, "tags.0.values.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckOutput("tags_validation", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataTags_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cbr_vault" "test" {
+  count = 2
+
+  name                  = format("%[1]s_%%d", count.index)
+  type                  = "server"
+  consistent_level      = "crash_consistent"
+  protection_type       = "backup"
+  size                  = 200
+  enterprise_project_id = "0"
+
+  tags = {
+    foo = format("bar%%d", count.index)
+  }
+}
+`, name)
+}
+
+func testAccDataTags_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_cbr_tags" "test" {
+  depends_on = [huaweicloud_cbr_vault.test]
+
+  resource_type = "vault"
+}
+
+output "tags_validation" {
+  value = length([for t in data.huaweicloud_cbr_tags.test.tags: t.key == "foo" &&
+    alltrue([for k, v in huaweicloud_cbr_vault.test[*].tags: contains(t.values, v) if k == "foo"])]) > 0
+}
+`, testAccDataTags_base(name))
+}

--- a/huaweicloud/services/cbr/data_source_huaweicloud_cbr_tags.go
+++ b/huaweicloud/services/cbr/data_source_huaweicloud_cbr_tags.go
@@ -1,0 +1,130 @@
+package cbr
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CBR GET /v3/{project_id}/vault/tags
+func DataSourceTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region in which to query the resource tags.`,
+			},
+			"resource_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The resource type to which the tags belong that to be queried.`,
+			},
+			"tags": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of all tags for resources of the same type.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The key of the resource tag.`,
+						},
+						"values": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `All values corresponding to the key.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func listProjectTags(client *golangsdk.ServiceClient, resourceType string) ([]interface{}, error) {
+	httpUrl := "v3/{project_id}/{resource_type}/tags"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{resource_type}", resourceType)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+	return utils.PathSearch("tags", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenProjectTags(tags []interface{}) []map[string]interface{} {
+	if len(tags) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(tags))
+	for _, tag := range tags {
+		result = append(result, map[string]interface{}{
+			"key":    utils.PathSearch("key", tag, nil),
+			"values": utils.PathSearch("values", tag, make([]interface{}, 0)),
+		})
+	}
+
+	return result
+}
+
+func dataSourceTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		resourceType = d.Get("resource_type").(string)
+	)
+	client, err := cfg.NewServiceClient("cbr", region)
+	if err != nil {
+		return diag.Errorf("error creating CBR client: %s", err)
+	}
+
+	tagList, err := listProjectTags(client, resourceType)
+	if err != nil {
+		return diag.Errorf("error querying tags of the CBR service: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("tags", flattenProjectTags(tagList)),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving data source fields of the CBR project tags: %s", mErr)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new data source that used to query the tag list of all resources of the same type.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source for all resource tags.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cbr -f TestAccDataTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccDataTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataTags_basic
=== PAUSE TestAccDataTags_basic
=== CONT  TestAccDataTags_basic
--- PASS: TestAccDataTags_basic (15.24s)
PASS
coverage: 16.4% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       15.297s coverage: 16.4% of statements in ./huaweicloud/services/cbr
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
