### PR TITLE
feat(lts/stream): supports favorite log steram

### DIFF
--- a/docs/resources/lts_stream.md
+++ b/docs/resources/lts_stream.md
@@ -42,6 +42,9 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) Specifies the key/value pairs of the log stream.
 
+* `is_favorite` - (Optional, Bool) Specifies whether to favorite the log stream.  
+  Defaults to **false**.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_stream.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_stream.go
@@ -20,10 +20,12 @@ import (
 const EPSTagKey string = "_sys_enterprise_project_id"
 
 // @API LTS POST /v2/{project_id}/groups/{log_group_id}/streams
+// @API LTS POST /v1/{project_id}/{resource_type}/{resource_id}/tags/action
+// @API LTS POST /v1.0/{project_id}/lts/favorite
 // @API LTS GET /v2/{project_id}/groups/{log_group_id}/streams
 // @API LTS PUT /v2/{project_id}/groups/{log_group_id}/streams-ttl/{log_stream_id}
+// @API LTS DELETE /v1.0/{project_id}/lts/favorite/{fav_res_id}
 // @API LTS DELETE /v2/{project_id}/groups/{log_group_id}/streams/{log_stream_id}
-// @API LTS POST /v1/{project_id}/{resource_type}/{resource_id}/tags/action
 func ResourceLTSStream() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceStreamCreate,
@@ -63,6 +65,11 @@ func ResourceLTSStream() *schema.Resource {
 				ForceNew: true,
 			},
 			"tags": common.TagsSchema(),
+			"is_favorite": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to favorite the log stream.`,
+			},
 			// Attributes
 			"filter_count": {
 				Type:     schema.TypeInt,
@@ -119,6 +126,12 @@ func resourceStreamCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		err = updateTags(client, "topics", streamId, d)
 		if err != nil {
 			return diag.Errorf("error creating tags of log stream %s: %s", streamId, err)
+		}
+	}
+
+	if d.Get("is_favorite").(bool) {
+		if err = favoriteLogStream(client, cfg, d); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 
@@ -216,6 +229,7 @@ func resourceStreamRead(_ context.Context, d *schema.ResourceData, meta interfac
 		d.Set("ttl_in_days", utils.PathSearch("ttl_in_days", streamResult, nil)),
 		d.Set("enterprise_project_id", utils.PathSearch("tag._sys_enterprise_project_id", streamResult, nil)),
 		d.Set("tags", ignoreSysEpsTag(utils.PathSearch("tag", streamResult, make(map[string]interface{})).(map[string]interface{}))),
+		d.Set("is_favorite", utils.PathSearch("is_favorite", streamResult, nil)),
 		d.Set("filter_count", utils.PathSearch("filter_count", streamResult, nil)),
 		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("creation_time", streamResult, float64(0)).(float64))/1000, false)),
 	)
@@ -246,6 +260,18 @@ func resourceStreamUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 
+	if d.HasChange("is_favorite") {
+		isFavorite := d.Get("is_favorite").(bool)
+		if isFavorite {
+			err = favoriteLogStream(client, cfg, d)
+		} else {
+			err = removeFavoriteLogStream(client, streamId)
+		}
+
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
 	return resourceStreamRead(ctx, d, meta)
 }
 
@@ -266,6 +292,54 @@ func updateStreamTTL(client *golangsdk.ServiceClient, logGroupId, logStreamId st
 	_, err := client.Request("PUT", updatePath, &updateOpt)
 	if err != nil {
 		return fmt.Errorf("error updating ttl_in_days of the log stream (%s): %s", logStreamId, err)
+	}
+	return nil
+}
+
+func favoriteLogStream(client *golangsdk.ServiceClient, cfg *config.Config, d *schema.ResourceData) error {
+	var (
+		httpUrl     = "v1.0/{project_id}/lts/favorite"
+		logStreamId = d.Id()
+	)
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildFavoriteLogStreamBodyParams(cfg, d, logStreamId)),
+	}
+	_, err := client.Request("POST", updatePath, &updateOpt)
+	if err != nil {
+		return fmt.Errorf("unable to favorite log stream (%s): %s", logStreamId, err)
+	}
+	return nil
+}
+
+func buildFavoriteLogStreamBodyParams(cfg *config.Config, d *schema.ResourceData, logStreamId string) map[string]interface{} {
+	return map[string]interface{}{
+		"eps_id":                 utils.ValueIgnoreEmpty(cfg.GetEnterpriseProjectID(d)),
+		"favorite_resource_id":   logStreamId,
+		"favorite_resource_type": "log_stream",
+		"log_group_id":           d.Get("group_id"),
+		"log_stream_id":          logStreamId,
+		"log_stream_name":        d.Get("stream_name"),
+		// This parameter must be set to `true`, otherwise the favoriting will not take effect.
+		"is_global": true,
+	}
+}
+
+func removeFavoriteLogStream(client *golangsdk.ServiceClient, logStreamId string) error {
+	httpUrl := "v1.0/{project_id}/lts/favorite/{fav_res_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{fav_res_id}", logStreamId)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	_, err := client.Request("DELETE", updatePath, &updateOpt)
+	if err != nil {
+		return fmt.Errorf("error removing favorite log stream (%s): %s", logStreamId, err)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Provide the ability to favorite and unfavorite for the log stream resource. The corresponding parameter name is `is_favorite`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
provide the ability to favorite and unfavorite for the log stream resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lts -f TestAccLtsStream_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccLtsStream_ -timeout 360m -parallel 10
=== RUN   TestAccLtsStream_basic
=== PAUSE TestAccLtsStream_basic
=== RUN   TestAccLtsStream_epsId
=== PAUSE TestAccLtsStream_epsId
=== CONT  TestAccLtsStream_basic
=== CONT  TestAccLtsStream_epsId
--- PASS: TestAccLtsStream_epsId (40.02s)
--- PASS: TestAccLtsStream_basic (40.49s)
PASS
coverage: 10.2% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       40.593s coverage: 10.2% of statements in ./huaweicloud/services/lts
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
