### PR TITLE
refactor(evs): refactor volume read function in general code style

### DIFF
--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_test.go
@@ -49,7 +49,7 @@ func TestAccEvsVolume_postPaidWithoutServer(t *testing.T) {
 						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
-					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "SCSI"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -70,7 +70,7 @@ func TestAccEvsVolume_postPaidWithoutServer(t *testing.T) {
 						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description update"),
-					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "SCSI"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
@@ -91,7 +91,7 @@ func TestAccEvsVolume_postPaidWithoutServer(t *testing.T) {
 						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
-					resource.TestCheckResourceAttr(resourceName, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "SCSI"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(resourceName, "multiattach", "false"),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
@@ -128,7 +128,7 @@ resource "huaweicloud_evs_volume" "test" {
   volume_type           = "GPSSD2"
   iops                  = 3000
   throughput            = 125
-  device_type           = "VBD"
+  device_type           = "SCSI"
   multiattach           = false
   enterprise_project_id = "%s"
 
@@ -152,7 +152,7 @@ resource "huaweicloud_evs_volume" "test" {
   volume_type           = "GPSSD2"
   iops                  = 4000
   throughput            = 150
-  device_type           = "VBD"
+  device_type           = "SCSI"
   multiattach           = false
   enterprise_project_id = "%s"
 
@@ -175,7 +175,7 @@ resource "huaweicloud_evs_volume" "test" {
   volume_type           = "GPSSD2"
   iops                  = 4000
   throughput            = 150
-  device_type           = "VBD"
+  device_type           = "SCSI"
   multiattach           = false
   enterprise_project_id = "%s"
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactor volume read function in general code style.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
go test -v -coverprofile=coverage_1744253571_TestAccEvsVolume_.cov -coverpkg=./huaweicloud/services/evs ./huaweicloud/services/acceptance/evs -run TestAccEvsVolume_ -timeout 360m -parallel 7
=== RUN   TestAccEvsVolume_postPaidWithoutServer
=== PAUSE TestAccEvsVolume_postPaidWithoutServer
=== RUN   TestAccEvsVolume_postPaidWithServer
=== PAUSE TestAccEvsVolume_postPaidWithServer
=== RUN   TestAccEvsVolume_prePaidWithoutServer
=== PAUSE TestAccEvsVolume_prePaidWithoutServer
=== RUN   TestAccEvsVolume_prePaidWithServer
=== PAUSE TestAccEvsVolume_prePaidWithServer
=== RUN   TestAccEvsVolume_postPaidEditDiskType
=== PAUSE TestAccEvsVolume_postPaidEditDiskType
=== RUN   TestAccEvsVolume_prePaidEditDiskType
=== PAUSE TestAccEvsVolume_prePaidEditDiskType
=== CONT  TestAccEvsVolume_postPaidWithoutServer
=== CONT  TestAccEvsVolume_prePaidWithServer
=== CONT  TestAccEvsVolume_prePaidWithoutServer
=== CONT  TestAccEvsVolume_postPaidEditDiskType
=== CONT  TestAccEvsVolume_prePaidEditDiskType
=== CONT  TestAccEvsVolume_postPaidWithServer
--- PASS: TestAccEvsVolume_postPaidWithoutServer (99.56s)
--- PASS: TestAccEvsVolume_prePaidWithoutServer (201.27s)
--- PASS: TestAccEvsVolume_postPaidWithServer (304.08s)
--- PASS: TestAccEvsVolume_prePaidWithServer (490.01s)
--- PASS: TestAccEvsVolume_postPaidEditDiskType (741.46s)
--- PASS: TestAccEvsVolume_prePaidEditDiskType (1048.95s)
PASS
coverage: 33.2% of statements in ./huaweicloud/services/evs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       1049.019s       coverage: 33.2% of statements in ./huaweicloud/services/evs
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
  
![image](https://github.com/user-attachments/assets/02a36c50-d955-48f4-bff9-e9b57ea31a55)


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
