### PR TITLE
refactor(ims): refactor `ims_cbr_whole_image` resource code style

### DIFF
--- a/huaweicloud/services/ims/resource_huaweicloud_ims_cbr_whole_image.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_ims_cbr_whole_image.go
@@ -2,18 +2,21 @@ package ims
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API IMS POST /v1/cloudimages/wholeimages/action
@@ -28,7 +31,7 @@ func ResourceCbrWholeImage() *schema.Resource {
 		CreateContext: resourceCbrWholeImageCreate,
 		ReadContext:   resourceCbrWholeImageRead,
 		UpdateContext: resourceCbrWholeImageUpdate,
-		DeleteContext: resourceWholeImageDelete,
+		DeleteContext: resourceCbrWholeImageDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -121,35 +124,57 @@ func ResourceCbrWholeImage() *schema.Resource {
 	}
 }
 
+func buildCreateCbrWholeImageBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":                  d.Get("name"),
+		"backup_id":             d.Get("backup_id"),
+		"description":           d.Get("description"),
+		"max_ram":               utils.ValueIgnoreEmpty(d.Get("max_ram")),
+		"min_ram":               utils.ValueIgnoreEmpty(d.Get("min_ram")),
+		"image_tags":            utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{})),
+		"enterprise_project_id": utils.ValueIgnoreEmpty(d.Get("enterprise_project_id")),
+		"whole_image_type":      "CBR",
+	}
+
+	return bodyParams
+}
+
 func resourceCbrWholeImageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ims"
+		httpUrl = "v1/cloudimages/wholeimages/action"
 	)
 
-	client, err := cfg.ImageV1Client(region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating IMS v1 client: %s", err)
+		return diag.Errorf("error creating IMS client: %s", err)
 	}
 
-	imageTags := buildCreateImageTagsParam(d)
-	createOpts := &cloudimages.CreateWholeImageOpts{
-		Name:                d.Get("name").(string),
-		BackupId:            d.Get("backup_id").(string),
-		Description:         d.Get("description").(string),
-		MaxRam:              d.Get("max_ram").(int),
-		MinRam:              d.Get("min_ram").(int),
-		ImageTags:           imageTags,
-		EnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
-		WholeImageType:      "CBR",
+	createPath := client.Endpoint + httpUrl
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildCreateCbrWholeImageBodyParams(d)),
 	}
 
-	createResp, err := cloudimages.CreateWholeImageByServer(client, createOpts).ExtractJobResponse()
+	createResp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
 		return diag.Errorf("error creating IMS CBR whole image: %s", err)
 	}
 
-	imageId, err := waitForCreateImageCompleted(client, d, createResp.JobID)
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", createRespBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("error creating IMS CBR whole image: job ID is not found in API response")
+	}
+
+	imageId, err := waitForCreateCbrWholeImageJobCompleted(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("error waiting for IMS CBR whole image to complete: %s", err)
 	}
@@ -159,49 +184,129 @@ func resourceCbrWholeImageCreate(ctx context.Context, d *schema.ResourceData, me
 	return resourceCbrWholeImageRead(ctx, d, meta)
 }
 
-func resourceCbrWholeImageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
-		mErr   *multierror.Error
-	)
-
-	client, err := cfg.ImageV2Client(region)
-	if err != nil {
-		return diag.Errorf("error creating IMS v2 client: %s", err)
+func waitForCreateCbrWholeImageJobCompleted(ctx context.Context, client *golangsdk.ServiceClient, jobId string,
+	timeout time.Duration) (string, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      cbrWholeImageJobStatusRefreshFunc(jobId, client),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 
-	imageList, err := GetImageList(client, d.Id())
+	getRespBody, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf("error retrieving IMS CBR whole images: %s", err)
+		return "", fmt.Errorf("error waiting for IMS CBR whole image job (%s) to succeed: %s", jobId, err)
+	}
+
+	imageId := utils.PathSearch("entities.image_id", getRespBody, "").(string)
+	if imageId == "" {
+		return "", errors.New("the image ID is not found in API response")
+	}
+
+	return imageId, nil
+}
+
+func cbrWholeImageJobStatusRefreshFunc(jobId string, client *golangsdk.ServiceClient) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		getPath := client.Endpoint + "v1/{project_id}/jobs/{job_id}"
+		getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+		getPath = strings.ReplaceAll(getPath, "{job_id}", fmt.Sprintf("%v", jobId))
+		getOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+
+		getResp, err := client.Request("GET", getPath, &getOpt)
+		if err != nil {
+			return getResp, "ERROR", fmt.Errorf("error retrieving IMS CBR whole image job: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return getRespBody, "ERROR", err
+		}
+
+		status := utils.PathSearch("status", getRespBody, "").(string)
+		if status == "SUCCESS" {
+			return getRespBody, "COMPLETED", nil
+		}
+
+		if status == "FAIL" {
+			return getRespBody, "COMPLETED", errors.New("the CBR whole image creation job execution failed")
+		}
+
+		if status == "" {
+			return getRespBody, "ERROR", errors.New("status field is not found in API response")
+		}
+
+		return getRespBody, "PENDING", nil
+	}
+}
+
+func getCbrWholeImage(client *golangsdk.ServiceClient, imageId string) (interface{}, error) {
+	// If the `enterprise_project_id` is not filled, the list API will query images under all enterprise projects.
+	// So there's no need to fill `enterprise_project_id` here.
+	getPath := client.Endpoint + "v2/cloudimages"
+	getPath += fmt.Sprintf("?id=%s", imageId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving IMS CBR whole image: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("images[0]", getRespBody, nil), nil
+}
+
+func resourceCbrWholeImageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ims"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating IMS client: %s", err)
+	}
+
+	image, err := getCbrWholeImage(client, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	// If the list API return empty, then process `CheckDeleted` logic.
-	if len(imageList) < 1 {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "IMS CBR whole image")
+	if image == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving IMS CBR whole image")
 	}
 
-	image := imageList[0]
-	imageTags := flattenImageTags(d, client)
-
-	mErr = multierror.Append(
+	dataOrigin := utils.PathSearch("__data_origin", image, "").(string)
+	mErr := multierror.Append(
 		d.Set("region", region),
-		d.Set("name", image.Name),
-		d.Set("backup_id", image.BackupID),
-		d.Set("description", image.Description),
-		d.Set("max_ram", flattenMaxRAM(image.MaxRam)),
-		d.Set("min_ram", image.MinRam),
-		d.Set("tags", imageTags),
-		d.Set("enterprise_project_id", image.EnterpriseProjectID),
-		d.Set("status", image.Status),
-		d.Set("visibility", image.Visibility),
-		d.Set("os_version", image.OsVersion),
-		d.Set("min_disk", image.MinDisk),
-		d.Set("disk_format", image.DiskFormat),
-		d.Set("data_origin", image.DataOrigin),
-		d.Set("active_at", image.ActiveAt),
-		d.Set("created_at", image.CreatedAt.Format(time.RFC3339)),
-		d.Set("updated_at", image.UpdatedAt.Format(time.RFC3339)),
+		d.Set("name", utils.PathSearch("name", image, nil)),
+		d.Set("backup_id", utils.PathSearch("__backup_id", image, nil)),
+		d.Set("description", utils.PathSearch("__description", image, nil)),
+		d.Set("max_ram", flattenMaxRAM(utils.PathSearch("max_ram", image, "").(string))),
+		d.Set("min_ram", utils.PathSearch("min_ram", image, nil)),
+		d.Set("tags", flattenIMSImageTags(client, d.Id())),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", image, nil)),
+		d.Set("status", utils.PathSearch("status", image, nil)),
+		d.Set("visibility", utils.PathSearch("visibility", image, nil)),
+		d.Set("os_version", utils.PathSearch("__os_version", image, nil)),
+		d.Set("min_disk", utils.PathSearch("min_disk", image, nil)),
+		d.Set("disk_format", utils.PathSearch("disk_format", image, nil)),
+		d.Set("data_origin", dataOrigin),
+		d.Set("active_at", utils.PathSearch("active_at", image, nil)),
+		d.Set("created_at", utils.PathSearch("created_at", image, nil)),
+		d.Set("updated_at", utils.PathSearch("updated_at", image, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -209,48 +314,143 @@ func resourceCbrWholeImageRead(_ context.Context, d *schema.ResourceData, meta i
 
 func resourceCbrWholeImageUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ims"
+		httpUrl = "v2/cloudimages/{image_id}"
+		imageId = d.Id()
 	)
 
-	client, err := cfg.ImageV2Client(region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating IMS v2 client: %s", err)
+		return diag.Errorf("error creating IMS client: %s", err)
 	}
 
-	err = updateImage(ctx, cfg, client, d)
-	if err != nil {
-		return diag.Errorf("error updating IMS CBR whole image: %s", err)
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{image_id}", imageId)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	if d.HasChange("name") {
+		bodyParams := []map[string]interface{}{
+			{
+				"op":    "replace",
+				"path":  "/name",
+				"value": d.Get("name"),
+			},
+		}
+
+		updateOpt.JSONBody = bodyParams
+		_, err = client.Request("PATCH", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating IMS CBR whole image name field: %s", err)
+		}
+	}
+
+	if d.HasChange("description") {
+		bodyParams := []map[string]interface{}{
+			{
+				"op":    "replace",
+				"path":  "/__description",
+				"value": d.Get("description"),
+			},
+		}
+
+		updateOpt.JSONBody = bodyParams
+		_, err = client.Request("PATCH", updatePath, &updateOpt)
+		if err != nil {
+			err = processUpdateDescriptionError(d, client, err)
+			if err != nil {
+				return diag.Errorf("error updating IMS CBR whole image description field: %s", err)
+			}
+		}
+	}
+
+	if d.HasChange("max_ram") {
+		bodyParams := []map[string]interface{}{
+			{
+				"op":    "replace",
+				"path":  "/max_ram",
+				"value": d.Get("max_ram"),
+			},
+		}
+
+		updateOpt.JSONBody = bodyParams
+		_, err = client.Request("PATCH", updatePath, &updateOpt)
+		if err != nil {
+			err = processUpdateMaxRAMError(d, client, err)
+			if err != nil {
+				return diag.Errorf("error updating IMS CBR whole image max_ram field: %s", err)
+			}
+		}
+	}
+
+	if d.HasChange("min_ram") {
+		bodyParams := []map[string]interface{}{
+			{
+				"op":    "replace",
+				"path":  "/min_ram",
+				"value": d.Get("min_ram"),
+			},
+		}
+
+		updateOpt.JSONBody = bodyParams
+		_, err = client.Request("PATCH", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating IMS CBR whole image min_ram field: %s", err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		err = updateIMSImageTags(client, d)
+		if err != nil {
+			return diag.Errorf("error updating IMS CBR whole image tags field: %s", err)
+		}
+	}
+
+	if d.HasChange("enterprise_project_id") {
+		migrateOpts := config.MigrateResourceOpts{
+			ResourceId:   imageId,
+			ResourceType: "images",
+			RegionId:     region,
+			ProjectId:    client.ProjectID,
+		}
+		if err := cfg.MigrateEnterpriseProject(ctx, d, migrateOpts); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return resourceCbrWholeImageRead(ctx, d, meta)
 }
 
-// This method will be removed in the next PR.
-func resourceWholeImageDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCbrWholeImageDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg     = meta.(*config.Config)
 		region  = cfg.GetRegion(d)
+		product = "ims"
+		httpUrl = "v2/images/{image_id}"
 		imageId = d.Id()
 	)
 
-	client, err := cfg.ImageV2Client(region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating IMS v2 client: %s", err)
+		return diag.Errorf("error creating IMS client: %s", err)
 	}
 
 	// Before deleting, call the query API first, if the query result is empty, then process `CheckDeleted` logic.
-	imageList, err := GetImageList(client, imageId)
+	image, err := getCbrWholeImage(client, imageId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	if len(imageList) < 1 {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "IMS whole image")
+	if image == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "IMS CBR whole image")
 	}
 
 	// For the whole image, need to use `delete_backup` to control whether to delete backup when deleting image.
-	deletePath := client.Endpoint + "v2/images/{image_id}"
+	deletePath := client.Endpoint + httpUrl
 	deletePath = strings.ReplaceAll(deletePath, "{image_id}", imageId)
 	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -261,15 +461,41 @@ func resourceWholeImageDelete(ctx context.Context, d *schema.ResourceData, meta 
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return diag.Errorf("error deleting IMS whole image: %s", err)
+		return diag.Errorf("error deleting IMS CBR whole image: %s", err)
 	}
 
 	// Because the delete API always return `204` status code,
 	// so we need to call the list query API to check if the image has been successfully deleted.
-	err = waitForDeleteImageCompleted(ctx, client, d)
+	err = waitForCbrWholeImageDeleted(ctx, client, d)
 	if err != nil {
-		return diag.Errorf("error waiting for IMS whole image deleted: %s", err)
+		return diag.Errorf("error waiting for IMS CBR whole image to be deleted: %s", err)
 	}
 
 	return nil
+}
+
+func waitForCbrWholeImageDeleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			image, err := getCbrWholeImage(client, d.Id())
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			if image == nil {
+				return "SUCCESS", "COMPLETED", nil
+			}
+
+			return image, "PENDING", nil
+		},
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 3 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+
+	return err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

refactor `ims_cbr_whole_image` resource code style

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

***Create a resource using the old code package:***
![image](https://github.com/user-attachments/assets/c45e046c-207d-467e-80a7-f21a641c45d2)

***Execute terraform plan using new code package:***
![image](https://github.com/user-attachments/assets/23350c09-0670-4dff-830d-356b70e67193)

***In summary, it can be considered that this reconstruction will have no impact on existing users.***


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

refactor `ims_cbr_whole_image` resource code style

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccCbrWholeImage_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccCbrWholeImage_basic -timeout 360m -parallel 4
=== RUN   TestAccCbrWholeImage_basic
=== PAUSE TestAccCbrWholeImage_basic
=== CONT  TestAccCbrWholeImage_basic
--- PASS: TestAccCbrWholeImage_basic (1036.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       1036.215s

```
![image](https://github.com/user-attachments/assets/e17c2957-1306-4452-a51c-69ef99469a70)


* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/e9fc80de-e6e0-4285-8c4b-463566fa346c)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/user-attachments/assets/c5c156ba-b302-403d-9d43-e268d82cbdc1)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
