### PR TITLE
feat(servicestage): component supports new parameters

### DIFF
--- a/docs/resources/servicestagev3_component.md
+++ b/docs/resources/servicestagev3_component.md
@@ -204,11 +204,14 @@ The following arguments are supported:
 * `version` - (Required, String) Specifies the version of the component.  
   The format is **{number}.{number}.{number}** or **{number}.{number}.{number}.{number}**, e.g. **1.0.1**.
 
-* `replica` - (Required, Int, ForceNew) Specifies the replica number of the component.  
-  Changing this will create a new resource.
-
 * `refer_resources` - (Required, List) Specifies the configuration of the reference resources.  
   The [refer_resources](#servicestage_v3_component_refer_resources) structure is documented below.
+
+* `config_mode` - (Optional, String) Specifies the configuration mode of the component.
+  The valid values are as follows:
+  + **yaml**
+
+* `workload_content` - (Optional, String) Specifies the workload content of the component.
 
 * `description` - (Optional, String) Specifies the description of the component.  
   The value can contain a maximum of `128` characters.
@@ -217,6 +220,9 @@ The following arguments are supported:
 
 * `build` - (Optional, String) Specifies the build configuration of the component, in JSON format.  
   For the keys, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/api-servicestage/servicestage_06_0076.html#servicestage_06_0076__en-us_topic_0220056060_table7559740).
+
+* `replica` - (Optional, Int, ForceNew) Specifies the replica number of the component.  
+  Changing this will create a new resource.
 
 * `limit_cpu` - (Optional, Float) Specifies the maximum number of the CPU limit.  
   The unit is **Core**.
@@ -516,7 +522,7 @@ $ terraform import huaweicloud_servicestagev3_component.test <application_id>/<i
 
 Note that the imported state may not be identical to your resource definition, due to attributes missing from the API
 response, security or some other reason.
-The missing attribute is `tags`.
+The missing attribute is `workload_content`, `tags`.
 It is generally recommended running `terraform plan` after importing resource.
 You can decide if changes should be applied to resource, or the definition should be updated to align with the resource.
 Also you can ignore changes as below.
@@ -527,7 +533,7 @@ resource "huaweicloud_servicestagev3_component" "test" {
 
   lifecycle {
     ignore_changes = [
-      tags,
+      workload_content, tags,
     ]
   }
 }

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_component.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_component.go
@@ -34,6 +34,18 @@ var (
 		"deploy_strategy.0.gray_release",
 		"update_strategy",
 	}
+
+	componentNonUpdatableParams = []string{
+		"application_id",
+		"environment_id",
+		"name",
+		"runtime_stack",
+		"runtime_stack.*.name",
+		"runtime_stack.*.type",
+		"runtime_stack.*.deploy_mode",
+		"runtime_stack.*.version",
+		"replica",
+	}
 )
 
 // @API ServiceStage POST /v3/{project_id}/cas/applications/{application_id}/components
@@ -52,6 +64,8 @@ func ResourceV3Component() *schema.Resource {
 			StateContext: resourceV3ComponentImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(componentNonUpdatableParams),
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
 			Update: schema.DefaultTimeout(20 * time.Minute),
@@ -69,51 +83,43 @@ func ResourceV3Component() *schema.Resource {
 			"application_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The application ID to which the component belongs.`,
 			},
 			"environment_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The environment ID where the component is deployed.`,
 			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The name of the component.`,
 			},
 			"runtime_stack": {
 				Type:     schema.TypeList,
 				Required: true,
-				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
 							Type:        schema.TypeString,
 							Required:    true,
-							ForceNew:    true,
 							Description: `The stack name.`,
 						},
 						"type": {
 							Type:        schema.TypeString,
 							Required:    true,
-							ForceNew:    true,
 							Description: `The stack type.`,
 						},
 						"deploy_mode": {
 							Type:        schema.TypeString,
 							Required:    true,
-							ForceNew:    true,
 							Description: `The deploy mode of the stack.`,
 						},
 						"version": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Computed:    true,
-							ForceNew:    true,
 							Description: `The stack version.`,
 						},
 					},
@@ -131,12 +137,6 @@ func ResourceV3Component() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: `The version of the component.`,
-			},
-			"replica": {
-				Type:        schema.TypeInt,
-				Required:    true,
-				ForceNew:    true,
-				Description: `The replica number of the component.`,
 			},
 			"refer_resources": {
 				Type:     schema.TypeSet,
@@ -163,6 +163,18 @@ func ResourceV3Component() *schema.Resource {
 				},
 				Description: `The configuration of the reference resources.`,
 			},
+			"config_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The configuration mode of the component.`,
+			},
+			"workload_content": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The workload content of the component, in JSON format.`,
+			},
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -176,29 +188,40 @@ func ResourceV3Component() *schema.Resource {
 				DiffSuppressFunc: utils.SuppressObjectDiffs(),
 				Description:      `The build configuration of the component, in JSON format.`,
 			},
+			"replica": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `The replica number of the component.`,
+			},
 			"limit_cpu": {
 				Type:        schema.TypeFloat,
 				Optional:    true,
+				Computed:    true,
 				Description: `The maximum number of the CPU limit.`,
 			},
 			"limit_memory": {
 				Type:        schema.TypeFloat,
 				Optional:    true,
+				Computed:    true,
 				Description: `The maximum number of the memory limit.`,
 			},
 			"request_cpu": {
 				Type:        schema.TypeFloat,
 				Optional:    true,
+				Computed:    true,
 				Description: `The number of the CPU request resources.`,
 			},
 			"request_memory": {
 				Type:        schema.TypeFloat,
 				Optional:    true,
+				Computed:    true,
 				Description: `The number of the memory request resources.`,
 			},
 			"envs": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -209,6 +232,7 @@ func ResourceV3Component() *schema.Resource {
 						"value": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: `The value of the environment variable.`,
 						},
 					},
@@ -218,6 +242,7 @@ func ResourceV3Component() *schema.Resource {
 			"storages": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
@@ -267,6 +292,7 @@ func ResourceV3Component() *schema.Resource {
 			"deploy_strategy": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -337,6 +363,7 @@ the new value next time the change is made. The corresponding parameter name is 
 			"post_start": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				MaxItems:    1,
 				Elem:        componentLifecycleSchema(),
 				Description: `The post start configuration.`,
@@ -344,6 +371,7 @@ the new value next time the change is made. The corresponding parameter name is 
 			"pre_stop": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				MaxItems:    1,
 				Elem:        componentLifecycleSchema(),
 				Description: `The pre stop configuration.`,
@@ -351,6 +379,7 @@ the new value next time the change is made. The corresponding parameter name is 
 			"mesher": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -386,6 +415,7 @@ the new value next time the change is made. The corresponding parameter name is 
 			"logs": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"log_path": {
@@ -415,6 +445,7 @@ the new value next time the change is made. The corresponding parameter name is 
 			"custom_metric": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -440,18 +471,21 @@ the new value next time the change is made. The corresponding parameter name is 
 			"affinity": {
 				Type:        schema.TypeSet,
 				Optional:    true,
+				Computed:    true,
 				Elem:        componentAffinitySchema(),
 				Description: `The affinity configuration of the component.`,
 			},
 			"anti_affinity": {
 				Type:        schema.TypeSet,
 				Optional:    true,
+				Computed:    true,
 				Elem:        componentAffinitySchema(),
 				Description: `The anti-affinity configuration of the component.`,
 			},
 			"liveness_probe": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				MaxItems:    1,
 				Elem:        componentProbeSchema(),
 				Description: "The liveness probe configuration of the component.",
@@ -459,6 +493,7 @@ the new value next time the change is made. The corresponding parameter name is 
 			"readiness_probe": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				MaxItems:    1,
 				Elem:        componentProbeSchema(),
 				Description: "The readiness probe configuration of the component.",
@@ -466,6 +501,7 @@ the new value next time the change is made. The corresponding parameter name is 
 			"external_accesses": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"protocol": {
@@ -506,6 +542,13 @@ the new value next time the change is made. The corresponding parameter name is 
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: `The latest update time of the component, in RFC3339 format.`,
+			},
+			// Internal parameters/attributes.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
 			},
 			"source_origin": {
 				Type:     schema.TypeString,
@@ -577,26 +620,31 @@ func componentLifecycleSchema() *schema.Resource {
 			"scheme": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: `The HTTP request type.`,
 			},
 			"host": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: `The host (IP) of the lifecycle configuration.`,
 			},
 			"port": {
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Computed:    true,
 				Description: `The port number of the lifecycle configuration.`,
 			},
 			"path": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: `The request path of the lifecycle configuration.`,
 			},
 			"command": {
 				Type:        schema.TypeSet,
 				Optional:    true,
+				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `The command list of the lifecycle configuration.`,
 			},
@@ -940,16 +988,18 @@ func buildV3ComponentCreateBodyParams(d *schema.ResourceData) map[string]interfa
 		"runtime_stack":   utils.ValueIgnoreEmpty(buildV3ComponentRuntimeStackConfig(d.Get("runtime_stack").([]interface{}))),
 		"source":          utils.StringToJson(d.Get("source").(string)),
 		"version":         d.Get("version").(string),
-		"replica":         d.Get("replica").(int),
 		"refer_resources": utils.ValueIgnoreEmpty(buildV3ComponentReferResources(d.Get("refer_resources").(*schema.Set))),
 		// Optional parameters.
 		"environment_id":    d.Get("environment_id").(string),
+		"config_mode":       utils.ValueIgnoreEmpty(d.Get("config_mode")),
+		"workload_content":  utils.ValueIgnoreEmpty(d.Get("workload_content")),
 		"description":       utils.ValueIgnoreEmpty(d.Get("description")),
 		"build":             utils.StringToJson(d.Get("build").(string)),
-		"limit_cpu":         d.Get("limit_cpu").(float64),
-		"limit_memory":      d.Get("limit_memory").(float64),
-		"request_cpu":       d.Get("request_cpu").(float64),
-		"request_memory":    d.Get("request_memory").(float64),
+		"replica":           utils.ValueIgnoreEmpty(d.Get("replica").(int)),
+		"limit_cpu":         utils.ValueIgnoreEmpty(d.Get("limit_cpu").(float64)),
+		"limit_memory":      utils.ValueIgnoreEmpty(d.Get("limit_memory").(float64)),
+		"request_cpu":       utils.ValueIgnoreEmpty(d.Get("request_cpu").(float64)),
+		"request_memory":    utils.ValueIgnoreEmpty(d.Get("request_memory").(float64)),
 		"envs":              utils.ValueIgnoreEmpty(buildV3ComponentEnvVariables(d.Get("envs").(*schema.Set))),
 		"storages":          utils.ValueIgnoreEmpty(buildV3ComponentStorages(d.Get("storages").(*schema.Set))),
 		"deploy_strategy":   utils.ValueIgnoreEmpty(buildV3ComponentDeployStrategy(d.Get("deploy_strategy").([]interface{}))),
@@ -1375,6 +1425,7 @@ func resourceV3ComponentRead(_ context.Context, d *schema.ResourceData, meta int
 		d.Set("runtime_stack", flattenV3ComponentRuntimeStackConfig(utils.PathSearch("runtime_stack", respBody,
 			make(map[string]interface{})).(map[string]interface{}))),
 		d.Set("environment_id", utils.PathSearch("environment_id", respBody, nil)),
+		d.Set("config_mode", utils.PathSearch("config_mode", respBody, nil)),
 		d.Set("description", utils.PathSearch("description", respBody, nil)),
 		d.Set("source", utils.JsonToString(utils.PathSearch("source", respBody, nil))),
 		d.Set("build", utils.JsonToString(utils.PathSearch("build", respBody, nil))),
@@ -1429,7 +1480,6 @@ func buildV3ComponentUpdteBodyParams(d *schema.ResourceData) map[string]interfac
 		// Cannot be updated but the request body needs them.
 		"name":          d.Get("name").(string),
 		"runtime_stack": utils.ValueIgnoreEmpty(buildV3ComponentRuntimeStackConfig(d.Get("runtime_stack").([]interface{}))),
-		"replica":       d.Get("replica").(int),
 		// Required parameters
 		"source":          utils.StringToJson(d.Get("source").(string)),
 		"version":         d.Get("version").(string),
@@ -1437,6 +1487,7 @@ func buildV3ComponentUpdteBodyParams(d *schema.ResourceData) map[string]interfac
 		// Optional parameters.
 		"description":       d.Get("description").(string),
 		"build":             utils.StringToJson(d.Get("build").(string)),
+		"replica":           d.Get("replica").(int),
 		"limit_cpu":         d.Get("limit_cpu").(float64),
 		"limit_memory":      d.Get("limit_memory").(float64),
 		"request_cpu":       d.Get("request_cpu").(float64),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
component supports new parameters:
- config_mode
- workload_content

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. component supports new parameters
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o servicestage -f TestAccV3Component_yaml
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccV3Component_yaml -timeout 360m -parallel 10
=== RUN   TestAccV3Component_yaml
=== PAUSE TestAccV3Component_yaml
=== CONT  TestAccV3Component_yaml
--- PASS: TestAccV3Component_yaml (317.87s)
PASS
coverage: 22.5% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      317.965s        coverage: 22.5% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
