### PR TITLE
feat(as): the AS bandwidth policy support new fields and attributes

### DIFF
--- a/docs/resources/as_bandwidth_policy.md
+++ b/docs/resources/as_bandwidth_policy.md
@@ -17,10 +17,11 @@ Manages an AS bandwidth scaling policy resource within HuaweiCloud.
 ### AS Recurrence Policy
 
 ```hcl
+variable "scaling_policy_name" {}
 variable "bandwidth_id" {}
 
-resource "huaweicloud_as_bandwidth_policy" "bw_policy" {
-  scaling_policy_name = "bw_policy"
+resource "huaweicloud_as_bandwidth_policy" "test" {
+  scaling_policy_name = var.scaling_policy_name
   scaling_policy_type = "RECURRENCE"
   bandwidth_id        = var.bandwidth_id
   cool_down_time      = 600
@@ -29,6 +30,7 @@ resource "huaweicloud_as_bandwidth_policy" "bw_policy" {
     operation = "ADD"
     size      = 1
   }
+
   scheduled_policy {
     launch_time      = "07:00"
     recurrence_type  = "Weekly"
@@ -42,10 +44,11 @@ resource "huaweicloud_as_bandwidth_policy" "bw_policy" {
 ### AS Scheduled Policy
 
 ```hcl
+variable "scaling_policy_name" {}
 variable "bandwidth_id" {}
 
-resource "huaweicloud_as_bandwidth_policy" "bw_policy" {
-  scaling_policy_name = "bw_policy"
+resource "huaweicloud_as_bandwidth_policy" "test" {
+  scaling_policy_name = var.scaling_policy_name
   scaling_policy_type = "SCHEDULED"
   bandwidth_id        = var.bandwidth_id
   cool_down_time      = 600
@@ -54,6 +57,7 @@ resource "huaweicloud_as_bandwidth_policy" "bw_policy" {
     operation = "ADD"
     size      = 1
   }
+
   scheduled_policy {
     launch_time = "2022-09-30T12:00Z"
   }
@@ -63,11 +67,12 @@ resource "huaweicloud_as_bandwidth_policy" "bw_policy" {
 ### AS Alarm Policy
 
 ```hcl
+variable "scaling_policy_name" {}
 variable "bandwidth_id" {}
 variable "alarm_id" {}
 
 resource "huaweicloud_as_bandwidth_policy" "test" {
-  scaling_policy_name = "bw_policy"
+  scaling_policy_name = var.scaling_policy_name
   scaling_policy_type = "ALARM"
   bandwidth_id        = var.bandwidth_id
   alarm_id            = var.alarm_id
@@ -76,6 +81,28 @@ resource "huaweicloud_as_bandwidth_policy" "test" {
     operation = "ADD"
     size      = 1
     limits    = 300
+  }
+}
+```
+
+### AS Interval Alarm Policy
+
+```hcl
+variable "scaling_policy_name" {}
+variable "bandwidth_id" {}
+variable "alarm_id" {}
+
+resource "huaweicloud_as_bandwidth_policy" "test" {
+  scaling_policy_name = var.scaling_policy_name
+  scaling_policy_type = "INTERVAL_ALARM"
+  bandwidth_id        = var.bandwidth_id
+  alarm_id            = var.alarm_id
+
+  interval_alarm_actions {
+    lower_bound = "0"
+    upper_bound = "5"
+    operation   = "ADD"
+    size        = 1
   }
 }
 ```
@@ -91,81 +118,124 @@ The following arguments are supported:
   The name contains only letters, digits, underscores (_), and hyphens (-), and cannot exceed 64 characters.
 
 * `scaling_policy_type` - (Required, String) Specifies the AS policy type. The options are as follows:
-  - **ALARM** (corresponding to `alarm_id`): indicates that the scaling action is triggered by an alarm.
-  - **SCHEDULED** (corresponding to `scheduled_policy`): indicates that the scaling action is triggered as scheduled.
-  - **RECURRENCE** (corresponding to `scheduled_policy`): indicates that the scaling action is triggered periodically.
+  + **ALARM** (corresponding to `alarm_id`): Indicates that the scaling action is triggered by an alarm.
+  + **SCHEDULED** (corresponding to `scheduled_policy`): Indicates that the scaling action is triggered as scheduled.
+  + **RECURRENCE** (corresponding to `scheduled_policy`): Indicates that the scaling action is triggered periodically.
+  + **INTERVAL_ALARM** (corresponding to `alarm_id`): Indicates that the scaling action is triggered by an alarm.
 
 * `bandwidth_id` - (Required, String) Specifies the scaling bandwidth ID.
 
 * `alarm_id` - (Optional, String) Specifies the alarm rule ID.
-  This parameter is mandatory when `scaling_policy_type` is set to ALARM.
+  This parameter is mandatory when `scaling_policy_type` is set to **ALARM** or **INTERVAL_ALARM**.
 
 * `cool_down_time` - (Optional, Int) Specifies the cooldown period (in seconds).
-  The value ranges from 0 to 86400 and is 300 by default.
+  The value ranges from `0` to `86,400` and is `300` by default.
 
 * `description` - (Optional, String) Specifies the description of the AS policy.
-  The value can contain 0 to 256 characters.
+  The value can contain `0` to `256` characters.
 
 * `action` - (Optional, String) Specifies identification of operation the AS bandwidth policy.
   After the AS bandwidth policy created, the status is inservice, indicates the AS bandwidth policy is enabled.
   The valid values are as follows:
-  - **resume**: Indicates enable the AS bandwidth policy.
-  - **pause**: Indicates disable the AS bandwidth policy.
+  + **resume**: Indicates enable the AS bandwidth policy.
+  + **pause**: Indicates disable the AS bandwidth policy.
 
 * `scaling_policy_action` - (Optional, List) Specifies the scaling action of the AS policy.
-  The [object](#ASBandWidthPolicy_ScalingPolicyAction) structure is documented below.
+  The [scaling_policy_action](#ASBandWidthPolicy_ScalingPolicyAction) structure is documented below.
 
 * `scheduled_policy` - (Optional, List) Specifies the periodic or scheduled AS policy.
-  This parameter is mandatory when `scaling_policy_type` is set to SCHEDULED or RECURRENCE.
-  The [object](#ASBandWidthPolicy_ScheduledPolicy) structure is documented below.
+  This parameter is mandatory when `scaling_policy_type` is set to **SCHEDULED** or **RECURRENCE**.
+  The [scheduled_policy](#ASBandWidthPolicy_ScheduledPolicy) structure is documented below.
+
+* `interval_alarm_actions` - (Optional, List) Specifies the alarm interval of the bandwidth policy.
+  The [interval_alarm_actions](#bandwidth_policy_interval_alarm) structure is documented below.
+
+  -> 1. This parameter is valid and mandatory when `scaling_policy_type` is set to **INTERVAL_ALARM**.
+  <br/>2. If the alarm rule `condition.comparison_operator` is set to **=**, the `scaling_policy_type`
+    not support set to **INTERVAL_ALARM**.
 
 <a name="ASBandWidthPolicy_ScalingPolicyAction"></a>
 The `scaling_policy_action` block supports:
 
-* `operation` - (Optional, String) Specifies the operation to be performed. The default operation is ADD.
+* `operation` - (Optional, String) Specifies the operation to be performed. The default operation is **ADD**.
   The options are as follows:
-  - **ADD**: indicates adding the bandwidth size.
-  - **REDUCE**: indicates reducing the bandwidth size.
-  - **SET**: indicates setting the bandwidth size to a specified value.
+  + **ADD**: Indicates adding the bandwidth size.
+  + **REDUCE**: Indicates reducing the bandwidth size.
+  + **SET**: Indicates setting the bandwidth size to a specified value.
 
 * `size` - (Optional, Int) Specifies the bandwidth (Mbit/s).
-  The value is an integer from 1 to 2000. The default value is 1.
+  The value is an integer from `1` to `2,000`. The default value is `1`.
 
 * `limits` - (Optional, Int) Specifies the operation restrictions.
-  - If operation is not SET, this parameter takes effect and the unit is Mbit/s.
-  - If operation is set to ADD, this parameter indicates the maximum bandwidth allowed.
-  - If operation is set to REDUCE, this parameter indicates the minimum bandwidth allowed.
+  If `operation` is not **SET**, this parameter takes effect and the unit is Mbit/s.
+  If `operation` is set to **ADD**, this parameter indicates the maximum bandwidth allowed.
+  If `operation` is set to **REDUCE**, this parameter indicates the minimum bandwidth allowed.
 
 <a name="ASBandWidthPolicy_ScheduledPolicy"></a>
 The `scheduled_policy` block supports:
 
 * `launch_time` - (Required, String) Specifies the time when the scaling action is triggered.
   The time format complies with UTC.
-  - If scaling_policy_type is set to SCHEDULED, the time format is YYYY-MM-DDThh:mmZ.
-  - If scaling_policy_type is set to RECURRENCE, the time format is hh:mm.
+  If `scaling_policy_type` is set to **SCHEDULED**, the time format is **YYYY-MM-DDThh:mmZ**.
+  If `scaling_policy_type` is set to **RECURRENCE**, the time format is **hh:mm**.
 
 * `recurrence_type` - (Optional, String) Specifies the periodic triggering type.
-  This parameter is mandatory when scaling_policy_type is set to RECURRENCE. The options are as follows:
-  - **Daily**: indicates that the scaling action is triggered once a day.
-  - **Weekly**: indicates that the scaling action is triggered once a week.
-  - **Monthly**: indicates that the scaling action is triggered once a month.
+  This parameter is mandatory when `scaling_policy_type` is set to **RECURRENCE**.
+  The valid values are as follows:
+  + **Daily**: Indicates that the scaling action is triggered once a day.
+  + **Weekly**: Indicates that the scaling action is triggered once a week.
+  + **Monthly**: Indicates that the scaling action is triggered once a month.
 
 * `recurrence_value` - (Optional, String) Specifies the day when a periodic scaling action is triggered.
-  This parameter is mandatory when scaling_policy_type is set to RECURRENCE.
-  - If recurrence_type is set to Daily, the value is null, indicating that the scaling action is triggered once a day.
-  - If recurrence_type is set to Weekly, the value ranges from 1 (Sunday) to 7 (Saturday).
-    The digits refer to dates in each week and separated by a comma, such as 1,3,5.
-  - If recurrence_type is set to Monthly, the value ranges from 1 to 31.
-    The digits refer to the dates in each month and separated by a comma, such as 1,10,13,28.
+  This parameter is mandatory when `scaling_policy_type` is set to **RECURRENCE**.
+  <br/>If `recurrence_type` is set to **Daily**, the value is null, indicating that the scaling action is triggered
+  once a day.
+  <br/>If `recurrence_type` is set to **Weekly**, the value ranges from `1` (Sunday) to `7` (Saturday).
+  The digits refer to dates in each week and separated by a comma, such as **1,3,5**.
+  <br/>If `recurrence_type` is set to **Monthly**, the value ranges from `1` to `31`.
+  The digits refer to the dates in each month and separated by a comma, such as **1,10,13,28**.
 
 * `start_time` - (Optional, String) Specifies the start time of the scaling action triggered periodically.
   The time format complies with UTC. The default value is the local time.
-  The time format is YYYY-MM-DDThh:mmZ.
+  The time format is **YYYY-MM-DDThh:mmZ**.
 
 * `end_time` - (Optional, String) Specifies the end time of the scaling action triggered periodically.
   The time format complies with UTC. This parameter is mandatory when scaling_policy_type is set to RECURRENCE.
   When the scaling action is triggered periodically, the end time cannot be earlier than the current and start time.
-  The time format is YYYY-MM-DDThh:mmZ.
+  The time format is **YYYY-MM-DDThh:mmZ**.
+
+<a name="bandwidth_policy_interval_alarm"></a>
+The `interval_alarm_actions` block supports:
+
+* `lower_bound` - (Optional, String) Specifies the lower limit of the value range.
+  The value is null by default. The minimum lower limit allowed is `-1.174271E108`.
+
+* `upper_bound` - (Optional, String) Specifies the upper limit of the value range.
+  The value is null by default. The maximum upper limit allowed is `1.174271E108`.
+
+-> 1. If the `lower_bound` is null, the `upper_bound` must be less than or equal to `0`.
+<br/>2. If the `upper_bound` is null, the `lower_bound` must be greater than or equal to `0`.
+<br/>3. The `lower_bound` and the `upper_bound` cannot be both `0` at the same time.
+<br/>4. The `lower_bound` and `upper_bound` can not be less than `0` when the
+  alarm rule `condition.comparison_operator` is set to **>** or **>=**.
+<br/>5. The `lower_bound` and `upper_bound` can be less than `0` when the
+  alarm rule `condition.comparison_operator` is set to **<** or **<=**.
+<br/>6. If adding multiple alarm intervals, each interval value range cannot overlap.
+
+* `operation` - (Optional, String) Specifies the operation to be performed.
+  The valid values are as follows:
+  + **ADD** (default): Indicates adding the bandwidth size.
+  + **REDUCE**: Indicates reducing the bandwidth size.
+  + **SET**: Indicates setting the bandwidth size to a specified value.
+
+* `size` - (Optional, Int) Specifies the operation size, unit is Mbit/s.
+  The valid values from `1` to `300`, the default value is `1`.
+
+* `limits` - (Optional, Int) Specifies the operation restrictions, unit is Mbit/s.
+  The valid values from `1` to `2,000`.
+  If `operation` is not **SET**, this parameter takes effect.
+  If `operation` is set to **ADD**, this parameter indicates the maximum bandwidth allowed.
+  If `operation` is set to **REDUCE**, this parameter indicates the minimum bandwidth allowed.
 
 ## Attribute Reference
 
@@ -176,6 +246,20 @@ In addition to all arguments above, the following attributes are exported:
 * `scaling_resource_type` - The scaling resource type. The value is fixed to **BANDWIDTH**.
 
 * `status` - The AS policy status. The value can be **INSERVICE**, **PAUSED** and **EXECUTING**.
+
+* `create_time` - The creation time of the bandwidth policy, in UTC format.
+
+* `meta_data` - The bandwidth policy additional information.
+  The [meta_data](#bandwidth_policy_meta_data_struct) structure is documented below.
+
+<a name="bandwidth_policy_meta_data_struct"></a>
+The `meta_data` block supports:
+
+* `metadata_bandwidth_share_type` - The bandwidth sharing type in the bandwidth policy.
+
+* `metadata_eip_id` - The EIP ID for the bandwidth in the bandwidth policy.
+
+* `metadata_eip_address` - The EIP IP address for the bandwidth in the bandwidth policy.
 
 ## Timeouts
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The AS bandwidth policy support new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASBandWidthPolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASBandWidthPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccASBandWidthPolicy_basic
=== PAUSE TestAccASBandWidthPolicy_basic
=== CONT  TestAccASBandWidthPolicy_basic
--- PASS: TestAccASBandWidthPolicy_basic (80.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        80.449s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASBandWidthPolicy_alarm"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASBandWidthPolicy_alarm -timeout 360m -parallel 4
=== RUN   TestAccASBandWidthPolicy_alarm
=== PAUSE TestAccASBandWidthPolicy_alarm
=== CONT  TestAccASBandWidthPolicy_alarm
--- PASS: TestAccASBandWidthPolicy_alarm (27.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        27.331s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASBandWidthPolicy_intervalAlarm"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASBandWidthPolicy_intervalAlarm -timeout 360m -parallel 4
=== RUN   TestAccASBandWidthPolicy_intervalAlarm
=== PAUSE TestAccASBandWidthPolicy_intervalAlarm
=== CONT  TestAccASBandWidthPolicy_intervalAlarm
--- PASS: TestAccASBandWidthPolicy_intervalAlarm (41.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        42.036s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
