### PR TITLE
fix(ims): optimize waitFor methods

### DIFF
--- a/huaweicloud/services/ims/resource_huaweicloud_ims_ecs_system_image.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_ims_ecs_system_image.go
@@ -197,12 +197,17 @@ func waitForCreateEcsSystemImageJobCompleted(ctx context.Context, client *golang
 		PollInterval: 10 * time.Second,
 	}
 
-	_, err := stateConf.WaitForStateContext(ctx)
+	getRespBody, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
 		return "", fmt.Errorf("error waiting for IMS ECS system image job (%s) to succeed: %s", jobId, err)
 	}
 
-	return getEcsSystemImageIdByJobId(client, jobId)
+	imageId := utils.PathSearch("entities.image_id", getRespBody, "").(string)
+	if imageId == "" {
+		return "", errors.New("the image ID is not found in API response")
+	}
+
+	return imageId, nil
 }
 
 func ecsSystemImageJobStatusRefreshFunc(jobId string, client *golangsdk.ServiceClient) resource.StateRefreshFunc {
@@ -226,7 +231,7 @@ func ecsSystemImageJobStatusRefreshFunc(jobId string, client *golangsdk.ServiceC
 
 		status := utils.PathSearch("status", getRespBody, "").(string)
 		if status == "SUCCESS" {
-			return "SUCCESS", "COMPLETED", nil
+			return getRespBody, "COMPLETED", nil
 		}
 
 		if status == "FAIL" {
@@ -239,32 +244,6 @@ func ecsSystemImageJobStatusRefreshFunc(jobId string, client *golangsdk.ServiceC
 
 		return getRespBody, "PENDING", nil
 	}
-}
-
-func getEcsSystemImageIdByJobId(client *golangsdk.ServiceClient, jobId string) (string, error) {
-	getPath := client.Endpoint + "v1/{project_id}/jobs/{job_id}"
-	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
-	getPath = strings.ReplaceAll(getPath, "{job_id}", fmt.Sprintf("%v", jobId))
-	getOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-
-	getResp, err := client.Request("GET", getPath, &getOpt)
-	if err != nil {
-		return "", fmt.Errorf("error retrieving IMS ECS system image job: %s", err)
-	}
-
-	getRespBody, err := utils.FlattenResponse(getResp)
-	if err != nil {
-		return "", err
-	}
-
-	imageId := utils.PathSearch("entities.image_id", getRespBody, "").(string)
-	if imageId == "" {
-		return "", errors.New("the image ID is not found in API response")
-	}
-
-	return imageId, nil
 }
 
 func getEcsSystemImage(client *golangsdk.ServiceClient, imageId string) (interface{}, error) {

--- a/huaweicloud/services/ims/resource_huaweicloud_ims_evs_system_image.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_ims_evs_system_image.go
@@ -206,12 +206,17 @@ func waitForCreateEvsSystemImageJobCompleted(ctx context.Context, client *golang
 		PollInterval: 10 * time.Second,
 	}
 
-	_, err := stateConf.WaitForStateContext(ctx)
+	getRespBody, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
 		return "", fmt.Errorf("error waiting for IMS EVS system image job (%s) to succeed: %s", jobId, err)
 	}
 
-	return getEvsSystemImageIdByJobId(client, jobId)
+	imageId := utils.PathSearch("entities.image_id", getRespBody, "").(string)
+	if imageId == "" {
+		return "", errors.New("the image ID is not found in API response")
+	}
+
+	return imageId, nil
 }
 
 func evsSystemImageJobStatusRefreshFunc(jobId string, client *golangsdk.ServiceClient) resource.StateRefreshFunc {
@@ -235,7 +240,7 @@ func evsSystemImageJobStatusRefreshFunc(jobId string, client *golangsdk.ServiceC
 
 		status := utils.PathSearch("status", getRespBody, "").(string)
 		if status == "SUCCESS" {
-			return "SUCCESS", "COMPLETED", nil
+			return getRespBody, "COMPLETED", nil
 		}
 
 		if status == "FAIL" {
@@ -248,32 +253,6 @@ func evsSystemImageJobStatusRefreshFunc(jobId string, client *golangsdk.ServiceC
 
 		return getRespBody, "PENDING", nil
 	}
-}
-
-func getEvsSystemImageIdByJobId(client *golangsdk.ServiceClient, jobId string) (string, error) {
-	getPath := client.Endpoint + "v1/{project_id}/jobs/{job_id}"
-	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
-	getPath = strings.ReplaceAll(getPath, "{job_id}", fmt.Sprintf("%v", jobId))
-	getOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-
-	getResp, err := client.Request("GET", getPath, &getOpt)
-	if err != nil {
-		return "", fmt.Errorf("error retrieving IMS EVS system image job: %s", err)
-	}
-
-	getRespBody, err := utils.FlattenResponse(getResp)
-	if err != nil {
-		return "", err
-	}
-
-	imageId := utils.PathSearch("entities.image_id", getRespBody, "").(string)
-	if imageId == "" {
-		return "", errors.New("the image ID is not found in API response")
-	}
-
-	return imageId, nil
 }
 
 func getEvsSystemImage(client *golangsdk.ServiceClient, imageId string) (interface{}, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

optimize waitFor methods

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

optimize waitFor methods

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccEcsSystemImage_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccEcsSystemImage_basic -timeout 360m -parallel 4
=== RUN   TestAccEcsSystemImage_basic
=== PAUSE TestAccEcsSystemImage_basic
=== CONT  TestAccEcsSystemImage_basic
--- PASS: TestAccEcsSystemImage_basic (491.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       491.644s


$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccEvsDataImage_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccEvsDataImage_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsDataImage_basic
=== PAUSE TestAccEvsDataImage_basic
=== CONT  TestAccEvsDataImage_basic
--- PASS: TestAccEvsDataImage_basic (509.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       509.994s


$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccEvsSystemImage_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccEvsSystemImage_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsSystemImage_basic
=== PAUSE TestAccEvsSystemImage_basic
=== CONT  TestAccEvsSystemImage_basic
--- PASS: TestAccEvsSystemImage_basic (439.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       439.566s


$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccObsSystemImage_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccObsSystemImage_ -timeout 360m -parallel 4
=== RUN   TestAccObsSystemImage_basic
=== PAUSE TestAccObsSystemImage_basic
=== RUN   TestAccObsSystemImage_withBMSType
=== PAUSE TestAccObsSystemImage_withBMSType
=== CONT  TestAccObsSystemImage_basic
=== CONT  TestAccObsSystemImage_withBMSType
--- PASS: TestAccObsSystemImage_basic (177.66s)
--- PASS: TestAccObsSystemImage_withBMSType (358.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       358.193s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
