### PR TITLE
feat(servicestage): add new resource to operate component

### DIFF
--- a/docs/resources/servicestagev3_component_action.md
+++ b/docs/resources/servicestagev3_component_action.md
@@ -1,0 +1,64 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestagev3_component_action"
+description: |-
+  Use this resource to operate ServiceStage component within HuaweiCloud.
+---
+
+# huaweicloud_servicestagev3_component_action
+
+Use this resource to operate ServiceStage component within HuaweiCloud.
+
+-> This resource is only a one-time action resource for operating component. Deleting this resource will not clear
+   the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "application_id" {}
+variable "component_id" {}
+
+resource "huaweicloud_cae_component_action" "test" {
+  application_id = var.application_id
+  component_id   = var.component_id
+  action         = "sync_workload"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the component to be operated is located.  
+  If omitted, the provider-level region will be used.
+  Changing this will create a new resource.
+
+* `application_id` - (Required, String, ForceNew) Specifies the application ID to which the componnet belongs.  
+  Changing this will create a new resource.
+
+* `component_id` - (Required, String, ForceNew) Specifies the ID of the component to be operated.  
+  Changing this will create a new resource.
+
+* `action` - (Required, String, ForceNew) Specifies the action type of the component execution.  
+  The valid values are as follows:
+  + **start**
+  + **stop**
+  + **restart**
+  + **scale**
+  + **rollback**
+  + **rollback_current**
+  + **continue_deploy**
+  + **check_gray_release**
+  + **modify_gray_rule**
+  + **sync_workload**
+
+  Changing this will create a new resource.
+
+* `parameters` - (Optional, String) Specifies the metadata of this action request.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2306,6 +2306,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_servicestagev3_application":           servicestage.ResourceV3Application(),
 			"huaweicloud_servicestagev3_component":             servicestage.ResourceV3Component(),
 			"huaweicloud_servicestagev3_configuration":         servicestage.ResourceV3Configuration(),
+			"huaweicloud_servicestagev3_component_action":      servicestage.ResourceV3ComponentAction(),
 			"huaweicloud_servicestagev3_configuration_group":   servicestage.ResourceV3ConfigurationGroup(),
 			"huaweicloud_servicestagev3_environment":           servicestage.ResourceV3Environment(),
 			"huaweicloud_servicestagev3_environment_associate": servicestage.ResourceV3EnvironmentAssociate(),

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_component_action_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_component_action_test.go
@@ -1,0 +1,122 @@
+package servicestage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccV3ComponentAction_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Make sure at least one of node exist.
+			acceptance.TestAccPreCheckCceClusterId(t)
+			// At least one of JAR package must be provided.
+			acceptance.TestAccPreCheckServiceStageJarPkgStorageURLs(t, 1)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV3ComponentAction_basic_step1(),
+			},
+		},
+	})
+}
+
+func testAccV3ComponentAction_basic_base() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_cce_clusters" "test" {
+  cluster_id = "%[1]s"
+}
+
+data "huaweicloud_servicestagev3_runtime_stacks" "test" {}
+
+locals {
+  docker_runtime_stack = try([for o in data.huaweicloud_servicestagev3_runtime_stacks.test.runtime_stacks:
+    o if o.type == "Docker" && o.deploy_mode == "container"][0], {})
+}
+
+resource "huaweicloud_servicestagev3_application" "test" {
+  name                  = "%[2]s"
+  enterprise_project_id = "0"
+}
+
+resource "huaweicloud_servicestagev3_environment" "test" {
+  name                  = "%[2]s"
+  vpc_id                = try(data.huaweicloud_cce_clusters.test.clusters[0].vpc_id, "")
+  enterprise_project_id = "0"
+}
+
+resource "huaweicloud_servicestagev3_environment_associate" "test" {
+  environment_id = huaweicloud_servicestagev3_environment.test.id
+
+  resources {
+    id   = try(data.huaweicloud_cce_clusters.test.clusters[0].id, "")
+    type = "cce"
+  }
+}
+
+resource "huaweicloud_servicestagev3_component" "test" {
+  depends_on = [
+    huaweicloud_servicestagev3_environment_associate.test
+  ]
+
+  application_id = huaweicloud_servicestagev3_application.test.id
+  environment_id = huaweicloud_servicestagev3_environment.test.id
+  name           = "%[2]s"
+
+  runtime_stack {
+    deploy_mode = try(local.docker_runtime_stack.deploy_mode, "container")
+    name        = try(local.docker_runtime_stack.name, "Docker")
+    type        = try(local.docker_runtime_stack.type, "Docker")
+    version     = try(local.docker_runtime_stack.version, "1.0")
+  }
+
+  source = jsonencode({
+    kind    = "image"
+    storage = "swr"
+    url     = try(element(split(",", "%[3]s"), 0), "")
+  })
+
+  version = "1.0.1"
+  replica = 2
+
+  refer_resources {
+    id         = try(data.huaweicloud_cce_clusters.test.clusters[0].id, "")
+    type       = "cce"
+    parameters = jsonencode({
+      "namespace": "default",
+      "type": "VirtualMachine"
+    })
+  }
+
+  limit_cpu      = 0.5
+  limit_memory   = 1
+  request_cpu    = 0.5
+  request_memory = 1
+}
+`, acceptance.HW_CCE_CLUSTER_ID, name, acceptance.HW_SERVICESTAGE_JAR_PKG_STORAGE_URLS)
+}
+
+func testAccV3ComponentAction_basic_step1() string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestagev3_component_action" "test" {
+  application_id = huaweicloud_servicestagev3_application.test.id
+  component_id   = huaweicloud_servicestagev3_component.test.id
+  action         = "sync_workload"
+}
+`, testAccV3ComponentAction_basic_base())
+}

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_component_action.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_component_action.go
@@ -1,0 +1,138 @@
+package servicestage
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var v3ComponentActionNonUpdatableParams = []string{
+	"application_id",
+	"component_id",
+	"action",
+	"parameters",
+}
+
+// @API ServiceStage POST /v3/{project_id}/cas/applications/{application_id}/components/{component_id}/action
+func ResourceV3ComponentAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceComponentActionCreate,
+		ReadContext:   resourceComponentActionRead,
+		UpdateContext: resourceComponentActionUpdate,
+		DeleteContext: resourceComponentActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(v3ComponentActionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the component is located.`,
+			},
+			"application_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The application ID to which the componnet belongs.`,
+			},
+			"component_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the component to be operated.`,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The action type of the component execution.`,
+			},
+			"parameters": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsJSON,
+				Description:  `The job parameters.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildV3ComponentActionCreateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"action":     d.Get("action").(string),
+		"parameters": utils.StringToJson(d.Get("parameters").(string)),
+	}
+}
+
+func resourceComponentActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		httpUrl       = "v3/{project_id}/cas/applications/{application_id}/components/{component_id}/action"
+		applicationId = d.Get("application_id").(string)
+		componentId   = d.Get("component_id").(string)
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{application_id}", applicationId)
+	createPath = strings.ReplaceAll(createPath, "{component_id}", componentId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildV3ComponentActionCreateBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error executing component action: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	return resourceComponentActionRead(ctx, d, meta)
+}
+
+func resourceComponentActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceComponentActionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceComponentActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for operating the component. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}

--- a/huaweicloud/utils/diff_suppress_funcs.go
+++ b/huaweicloud/utils/diff_suppress_funcs.go
@@ -228,7 +228,7 @@ func FindDecreaseKeys(objA, objB map[string]interface{}) map[string]interface{} 
 // only allow the local script to take effect.
 func SuppressObjectDiffs() schema.SchemaDiffSuppressFunc {
 	return func(paramKey, o, n string, d *schema.ResourceData) bool {
-		if !strings.HasSuffix(paramKey, ".%") || !strings.HasSuffix(paramKey, ".#") {
+		if strings.HasSuffix(paramKey, ".%") || strings.HasSuffix(paramKey, ".#") {
 			log.Printf("[DEBUG] The current change object is not of type object.")
 			return false
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add new resource to operate component

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to operate component.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o servicestage -f TestAccV3ComponentAction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccV3ComponentAction_basic -timeout 360m -parallel 10
=== RUN   TestAccV3ComponentAction_basic
=== PAUSE TestAccV3ComponentAction_basic
=== CONT  TestAccV3ComponentAction_basic
--- PASS: TestAccV3ComponentAction_basic (317.58s)
PASS
coverage: 22.2% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      317.704s        coverage: 22.2% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
