### PR TITLE
feat(servicestage): add new data source to query component execution records

### DIFF
--- a/docs/data-sources/servicestagev3_component_records.md
+++ b/docs/data-sources/servicestagev3_component_records.md
@@ -1,0 +1,87 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestagev3_component_records"
+description: |-
+  Use this data source to query the list of component execution records within HuaweiCloud.
+---
+
+# huaweicloud_servicestagev3_component_records
+
+Use this data source to query the list of component execution records within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "application_id" {}
+variable "component_id" {}
+
+data "huaweicloud_servicestagev3_component_records" "test" {
+  application_id = var.application_id
+  component_id   = var.component_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the application and component are located.
+
+* `application_id` - (Required, String) Specifies the ID of the application to which the component belongs.
+
+* `component_id` - (Required, String) Specifies the ID of the component to which the records belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID, in UUID format.
+
+* `records` - The list of component execution record.  
+  The [records](#servicestage_v3_component_records) structure is documented below.
+
+<a name="servicestage_v3_component_records"></a>
+The `applications` block supports:
+
+* `begin_time` - The begin time of the component execution record.
+
+* `end_time` - The end time of the component execution record.
+
+* `description` - The description of the component execution record.
+
+* `instance_id` - The instance ID of the component execution record.
+
+* `version` - The version number of the component execution record.
+
+* `current_used` - Whether version is current used.
+
+* `status` - The status of the component execution record.
+
+* `deploy_type` - The deploy type of the component execution record.
+
+* `jobs` - The list of component jobs.  
+  The [jobs](#servicestage_v3_component_record_jobs) structure is documented below.
+
+<a name="servicestage_v3_component_record_jobs"></a>
+The `jobs` block supports:
+
+* `sequence` - The sequence of the job execution.
+
+* `job_id` - The job ID.
+
+* `job_info` - The job detail.
+  The [job_info](#servicestage_v3_component_record_job_info) structure is documented below.
+
+<a name="servicestage_v3_component_record_job_info"></a>
+The `job_info` block supports:
+
+* `source_url` - The source URL of the component.
+
+* `first_batch_weight` - The weight of the first batch execution.`
+
+* `first_batch_replica` - The replica of the first batch execution.
+
+* `replica` - The total replica number.
+
+* `remaining_batch` - The remaining batch number.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1217,10 +1217,11 @@ func Provider() *schema.Provider {
 			// Querying by Ver.2 APIs
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),
 			// Querying by Ver.3 APIs
-			"huaweicloud_servicestagev3_applications":   servicestage.DataSourceV3Applications(),
-			"huaweicloud_servicestagev3_components":     servicestage.DataSourceV3Components(),
-			"huaweicloud_servicestagev3_environments":   servicestage.DataSourceV3Environments(),
-			"huaweicloud_servicestagev3_runtime_stacks": servicestage.DataSourceV3RuntimeStacks(),
+			"huaweicloud_servicestagev3_applications":      servicestage.DataSourceV3Applications(),
+			"huaweicloud_servicestagev3_components":        servicestage.DataSourceV3Components(),
+			"huaweicloud_servicestagev3_component_records": servicestage.DataSourceV3ComponentRecords(),
+			"huaweicloud_servicestagev3_environments":      servicestage.DataSourceV3Environments(),
+			"huaweicloud_servicestagev3_runtime_stacks":    servicestage.DataSourceV3RuntimeStacks(),
 
 			"huaweicloud_smn_topics":              smn.DataSourceTopics(),
 			"huaweicloud_smn_message_templates":   smn.DataSourceSmnMessageTemplates(),

--- a/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestagev3_component_records_test.go
+++ b/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestagev3_component_records_test.go
@@ -1,0 +1,217 @@
+package servicestage
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataV3ComponentRecords_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		all = "data.huaweicloud_servicestagev3_component_records.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Make sure at least one of node exist.
+			acceptance.TestAccPreCheckCceClusterId(t)
+			acceptance.TestAccPreCheckImageUrl(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataV3ComponentRecords_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "records.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckOutput("is_begin_time_set", "true"),
+					resource.TestCheckOutput("is_end_time_set", "true"),
+					resource.TestCheckOutput("is_description_set", "true"),
+					resource.TestCheckOutput("is_instance_id_set", "true"),
+					resource.TestCheckOutput("is_version_set", "true"),
+					resource.TestCheckOutput("is_current_used_set", "true"),
+					resource.TestCheckOutput("is_status_set", "true"),
+					resource.TestCheckOutput("is_deploy_type_set", "true"),
+					resource.TestCheckOutput("is_jobs_set", "true"),
+					resource.TestCheckOutput("is_job_sequence_set", "true"),
+					resource.TestCheckOutput("is_job_job_id_set", "true"),
+					resource.TestCheckOutput("is_job_info_set", "true"),
+					resource.TestCheckOutput("is_job_info_source_url_set", "true"),
+					resource.TestCheckOutput("is_job_info_first_batch_weight_set", "true"),
+					resource.TestCheckOutput("is_job_info_first_batch_replica_set", "true"),
+					resource.TestCheckOutput("is_job_info_replica_set", "true"),
+					resource.TestCheckOutput("is_job_info_remaining_batch_set", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataV3ComponentRecords_basic(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_cce_clusters" "test" {
+  cluster_id = "%[1]s"
+}
+  
+resource "huaweicloud_servicestagev3_application" "test" {
+  name                  = "%[2]s"
+  enterprise_project_id = "0"
+}
+  
+resource "huaweicloud_servicestagev3_environment" "test" {
+  name                  = "%[2]s"
+  vpc_id                = try(data.huaweicloud_cce_clusters.test.clusters[0].vpc_id, "")
+  enterprise_project_id = "0"
+}
+
+resource "huaweicloud_servicestagev3_environment_associate" "test" {
+  environment_id = huaweicloud_servicestagev3_environment.test.id
+
+  resources {
+    type = "cce"
+    id   = try(data.huaweicloud_cce_clusters.test.clusters[0].id, "")
+  }
+}
+
+data "huaweicloud_servicestagev3_runtime_stacks" "test" {}
+
+locals {
+  docker_runtime_stack = try([for o in data.huaweicloud_servicestagev3_runtime_stacks.test.runtime_stacks:
+    o if o.type == "Docker" && o.deploy_mode == "container"][0], {})
+}
+
+resource "huaweicloud_servicestagev3_component" "test" {
+  depends_on = [
+    huaweicloud_servicestagev3_environment_associate.test
+  ]
+
+  application_id = huaweicloud_servicestagev3_application.test.id
+  environment_id = huaweicloud_servicestagev3_environment.test.id
+  name           = "%[2]s"
+
+  runtime_stack {
+    deploy_mode = try(local.docker_runtime_stack.deploy_mode, "container")
+    type        = try(local.docker_runtime_stack.type, "Docker")
+    name        = try(local.docker_runtime_stack.name, "Docker")
+    version     = try(local.docker_runtime_stack.version, null)
+  }
+
+  source = jsonencode({
+    "auth": "iam",
+    "kind": "image",
+    "storage": "swr",
+    "url": "%[3]s"
+  })
+
+  version = "1.0.1"
+  replica = 2
+
+  refer_resources {
+    id         = try(data.huaweicloud_cce_clusters.test.clusters[0].id, "")
+    type       = "cce"
+    parameters = jsonencode({
+      "namespace": "default",
+      "type": "VirtualMachine"
+    })
+  }
+
+  limit_cpu      = 0.5
+  limit_memory   = 1
+  request_cpu    = 0.5
+  request_memory = 1
+}
+
+data "huaweicloud_servicestagev3_component_records" "test" {
+  application_id = huaweicloud_servicestagev3_application.test.id
+  component_id   = huaweicloud_servicestagev3_component.test.id
+}
+
+locals {
+  component_record = try(data.huaweicloud_servicestagev3_component_records.test.records[0], null)
+}
+
+output "is_begin_time_set" {
+  value = lookup(local.component_record, "begin_time", null) != null
+}
+
+output "is_end_time_set" {
+  value = lookup(local.component_record, "end_time", null) != null
+}
+
+output "is_description_set" {
+  value = lookup(local.component_record, "description", null) != null
+}
+
+output "is_instance_id_set" {
+  value = lookup(local.component_record, "instance_id", null) != null
+}
+
+output "is_version_set" {
+  value = lookup(local.component_record, "version", null) != null
+}
+
+output "is_current_used_set" {
+  value = lookup(local.component_record, "current_used", null) != null
+}
+
+output "is_status_set" {
+  value = lookup(local.component_record, "status", null) != null
+}
+
+output "is_deploy_type_set" {
+  value = lookup(local.component_record, "deploy_type", null) != null
+}
+
+output "is_jobs_set" {
+  value = length(lookup(local.component_record, "jobs", [])) > 0
+}
+
+locals {
+  component_record_job = try(lookup(local.component_record, "jobs", [])[0], {})
+}
+
+output "is_job_sequence_set" {
+  value = lookup(local.component_record_job, "sequence", null) != null
+}
+
+output "is_job_job_id_set" {
+  value = lookup(local.component_record_job, "job_id", null) != null
+}
+
+output "is_job_info_set" {
+  value = length(lookup(local.component_record_job, "job_info", [])) > 0
+}
+
+locals {
+  component_record_job_info = try(lookup(local.component_record_job, "job_info", [])[0], {})
+}
+
+output "is_job_info_source_url_set" {
+  value = lookup(local.component_record_job_info, "source_url", null) != null
+}
+
+output "is_job_info_first_batch_weight_set" {
+  value = lookup(local.component_record_job_info, "first_batch_weight", null) != null
+}
+
+output "is_job_info_first_batch_replica_set" {
+  value = lookup(local.component_record_job_info, "first_batch_replica", null) != null
+}
+
+output "is_job_info_replica_set" {
+  value = lookup(local.component_record_job_info, "replica", null) != null
+}
+
+output "is_job_info_remaining_batch_set" {
+  value = lookup(local.component_record_job_info, "remaining_batch", null) != null
+}
+`, acceptance.HW_CCE_CLUSTER_ID, name, acceptance.HW_BUILD_IMAGE_URL)
+}

--- a/huaweicloud/services/servicestage/data_source_huaweicloud_servicestagev3_component_records.go
+++ b/huaweicloud/services/servicestage/data_source_huaweicloud_servicestagev3_component_records.go
@@ -1,0 +1,278 @@
+package servicestage
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ServiceStage GET /v3/{project_id}/cas/applications/{application_id}/components/{component_id}/records
+func DataSourceV3ComponentRecords() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV3ComponentRecordsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the components are located.`,
+			},
+			"application_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the application to which the component belongs.`,
+			},
+			"component_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the component to which the records belong.`,
+			},
+			"records": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"begin_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The begin time of the component execution record.`,
+						},
+						"end_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The end time of the component execution record.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the component execution record.`,
+						},
+						"instance_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The instance ID of the component execution record.`,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The version number of the component execution record.`,
+						},
+						"current_used": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether version is current used.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the component execution record.`,
+						},
+						"deploy_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The deploy type of the component execution record.`,
+						},
+						"jobs": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        v3componentRecordJobSchema(),
+							Description: "The list of component jobs.",
+						},
+					},
+				},
+				Description: "The list of component execution record.",
+			},
+		},
+	}
+}
+
+func v3componentRecordJobSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"sequence": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The sequence of the job execution.`,
+			},
+			"job_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The job ID.`,
+			},
+			"job_info": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"source_url": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The source URL of the component.`,
+						},
+						"first_batch_weight": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The weight of the first batch execution.`,
+						},
+						"first_batch_replica": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The replica of the first batch execution.`,
+						},
+						"replica": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The total replica number.`,
+						},
+						"remaining_batch": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The remaining batch number.`,
+						},
+					},
+				},
+				Description: `The job detail.`,
+			},
+		},
+	}
+}
+
+func queryV3ComponentRecords(client *golangsdk.ServiceClient, applicationId, componentId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v3/{project_id}/cas/applications/{application_id}/components/{component_id}/records?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{application_id}", applicationId)
+	listPath = strings.ReplaceAll(listPath, "{component_id}", componentId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		records := utils.PathSearch("records", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, records...)
+		if len(records) < limit {
+			break
+		}
+		offset += len(records)
+	}
+
+	return result, nil
+}
+
+func flattenV3ComponentRecordJobInfo(jobInfo interface{}) []map[string]interface{} {
+	if jobInfo == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"source_url":          utils.PathSearch("source_url", jobInfo, nil),
+			"first_batch_weight":  utils.PathSearch("first_batch_weight", jobInfo, nil),
+			"first_batch_replica": utils.PathSearch("first_batch_replica", jobInfo, nil),
+			"replica":             utils.PathSearch("replica", jobInfo, nil),
+			"remaining_batch":     utils.PathSearch("remaining_batch", jobInfo, nil),
+		},
+	}
+}
+
+func flattenV3ComponentRecordJobs(jobs []interface{}) []map[string]interface{} {
+	if len(jobs) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(jobs))
+	for _, job := range jobs {
+		result = append(result, map[string]interface{}{
+			"sequence": utils.PathSearch("sequence", job, nil),
+			"job_id":   utils.PathSearch("job_id", job, nil),
+			"job_info": flattenV3ComponentRecordJobInfo(utils.PathSearch("job_info", job, nil)),
+		})
+	}
+
+	return result
+}
+
+func flattenV3ComponentRecords(records []interface{}) []map[string]interface{} {
+	if len(records) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(records))
+	for _, record := range records {
+		result = append(result, map[string]interface{}{
+			"begin_time":   utils.PathSearch("begin_time", record, nil),
+			"end_time":     utils.PathSearch("end_time", record, nil),
+			"description":  utils.JsonToString(utils.PathSearch("description", record, nil)),
+			"instance_id":  utils.PathSearch("instance_id", record, nil),
+			"version":      utils.PathSearch("version", record, nil),
+			"current_used": utils.PathSearch("current_used", record, nil),
+			"status":       utils.PathSearch("status", record, nil),
+			"deploy_type":  utils.PathSearch("deploy_type", record, nil),
+			"jobs":         flattenV3ComponentRecordJobs(utils.PathSearch("jobs", record, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func dataSourceV3ComponentRecordsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		applicationId = d.Get("application_id").(string)
+		componentId   = d.Get("component_id").(string)
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	records, err := queryV3ComponentRecords(client, applicationId, componentId)
+	if err != nil {
+		return diag.Errorf("error getting component records: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("records", flattenV3ComponentRecords(records)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New data source supported that used to query component execution record list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query component execution records.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o servicestage -f TestAccDataV3ComponentRecords_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccDataV3ComponentRecords_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV3ComponentRecords_basic
=== PAUSE TestAccDataV3ComponentRecords_basic
=== CONT  TestAccDataV3ComponentRecords_basic
--- PASS: TestAccDataV3ComponentRecords_basic (45.17s)
PASS
coverage: 23.2% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      45.249s coverage: 23.2% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
