### PR TITLE
feat(evs): evs resource support new attribute fields

### DIFF
--- a/docs/resources/evs_volume.md
+++ b/docs/resources/evs_volume.md
@@ -240,6 +240,72 @@ In addition to all arguments above, the following attributes are exported:
 
 * `wwn` - The unique identifier used for mounting the EVS disk.
 
+* `dedicated_storage_name` - The name of the DSS storage pool accommodating the disk.
+
+* `status` - The disk status.
+  Please refer to [EVS Disk Status](https://support.huaweicloud.com/intl/en-us/api-evs/evs_04_0040.html).
+
+* `bootable` - Whether the disk is bootable. **true**: The disk is bootable. **false**: The disk is not bootable.
+
+* `created_at` - The time when the disk was created.
+
+* `updated_at` - The time when the disk was updated.
+
+* `iops_attribute` - The disk IOPS information. This attribute appears only for a general purpose SSD V2 or an extreme
+  SSD V2 disk. The [iops_attribute](#iops_attribute_struct) structure is documented below.
+
+* `throughput_attribute` - The disk throughput information. This attribute appears only for a general purpose SSD V2 disk.
+  The [throughput_attribute](#throughput_attribute_struct) structure is documented below.
+
+* `links` - The disk URI.
+  The [links](#links_struct) structure is documented below.
+
+* `all_metadata` - The key-value pair disk metadata. Valid key-value pairs are as follows:
+  + **__system__cmkid**: The encryption CMK ID in metadata. This attribute is used together with **__system__encrypted**
+    for encryption.
+  + **__system__encrypted**: The encryption field in metadata. The value can be `0` (no encryption) or `1` (encryption).
+    If this attribute is not specified, the encryption attribute of the disk is the same as that of the data source.
+    If the disk is not created from a data source, the disk is not encrypted by default.
+  + **full_clone**: The creation method when the disk is created from a snapshot. `0`: linked clone. `1`: full clone.
+  + **hw:passthrough**: If this attribute value is **true**, the disk device type is SCSI, which allows ECS OSs to directly
+    access the underlying storage media and supports SCSI reservation commands. If this attribute is set to **false**,
+    the disk device type is VBD, which is also the default type. VBD supports only simple SCSI read/write commands.
+    If this attribute is not specified, the disk device type is VBD.
+  + **orderID**: The attribute that describes the disk billing mode in metadata. If this attribute has a value, the disk
+    is billed on a yearly/monthly basis. If this attribute is empty, the disk is billed on a pay-per-use basis.
+
+* `serial_number` - The disk serial number. This field is returned only for non-HyperMetro SCSI disks and is used for
+  disk mapping in the VM.
+
+* `service_type` - The service type. Supported services are **EVS**, **DSS**, and **DESS**.
+
+* `all_volume_image_metadata` - The metadata of the disk image.
+
+<a name="links_struct"></a>
+The `links` block supports:
+
+* `href` - The corresponding shortcut link.
+
+* `rel` - The shortcut link marker name.
+
+<a name="iops_attribute_struct"></a>
+The `iops_attribute` block supports:
+
+* `frozened` - The frozen tag.
+
+* `id` - The ID of the disk IOPS.
+
+* `total_val` - The IOPS.
+
+<a name="throughput_attribute_struct"></a>
+The `throughput_attribute` block supports:
+
+* `frozened` - The frozen tag.
+
+* `id` - The throughput ID.
+
+* `total_val` - The throughput.
+
 <a name="attachment_struct"></a>
 The `attachment` block supports:
 
@@ -249,10 +315,13 @@ The `attachment` block supports:
 
 * `device` - The device name.
 
-* `dedicated_storage_name` - The name of the DSS storage pool accommodating the disk.
+* `attached_at` - The time when the disk was attached.
 
-* `status` - The disk status.
-  Please refer to [EVS Disk Status](https://support.huaweicloud.com/intl/en-us/api-evs/evs_04_0040.html).
+* `host_name` - The name of the physical host housing the cloud server to which the disk is attached.
+
+* `attached_volume_id` - The ID of the attached disk.
+
+* `volume_id` - The disk ID.
 
 ## Timeouts
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

EVS resource support new attribute fields.
![image](https://github.com/user-attachments/assets/4259e1da-881d-4289-b2e2-e2498d27bfcf)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
go test -v -coverprofile=coverage_1744705857_TestAccEvsVolume_.cov -coverpkg=./huaweicloud/services/evs ./huaweicloud/services/acceptance/evs -run TestAccEvsVolume_ -timeout 360m -parallel 7
=== RUN   TestAccEvsVolume_postPaidWithoutServer
=== PAUSE TestAccEvsVolume_postPaidWithoutServer
=== RUN   TestAccEvsVolume_postPaidWithServer
=== PAUSE TestAccEvsVolume_postPaidWithServer
=== RUN   TestAccEvsVolume_prePaidWithoutServer
=== PAUSE TestAccEvsVolume_prePaidWithoutServer
=== RUN   TestAccEvsVolume_prePaidWithServer
=== PAUSE TestAccEvsVolume_prePaidWithServer
=== RUN   TestAccEvsVolume_postPaidEditDiskType
=== PAUSE TestAccEvsVolume_postPaidEditDiskType
=== RUN   TestAccEvsVolume_prePaidEditDiskType
=== PAUSE TestAccEvsVolume_prePaidEditDiskType
=== CONT  TestAccEvsVolume_postPaidWithoutServer
=== CONT  TestAccEvsVolume_prePaidEditDiskType
=== CONT  TestAccEvsVolume_postPaidWithServer
=== CONT  TestAccEvsVolume_postPaidEditDiskType
=== CONT  TestAccEvsVolume_prePaidWithServer
=== CONT  TestAccEvsVolume_prePaidWithoutServer
--- PASS: TestAccEvsVolume_postPaidWithoutServer (99.13s)
--- PASS: TestAccEvsVolume_prePaidWithoutServer (211.07s)
--- PASS: TestAccEvsVolume_postPaidWithServer (324.14s)
--- PASS: TestAccEvsVolume_prePaidWithServer (460.84s)
--- PASS: TestAccEvsVolume_prePaidEditDiskType (1025.63s)
--- PASS: TestAccEvsVolume_postPaidEditDiskType (1986.15s)
PASS
coverage: 36.3% of statements in ./huaweicloud/services/evs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       1986.215s       coverage: 36.3% of statements in ./huaweicloud/services/evs
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
