### PR TITLE
fix(workspace/desktop): missing content-type causes deletion error

### DIFF
--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop.go
@@ -358,7 +358,10 @@ func resourceDesktopCreate(ctx context.Context, d *schema.ResourceData, meta int
 	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
 	createOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildDesktopCreateOpts(d, conf)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildDesktopCreateOpts(d, conf)),
 	}
 	resp, err := client.Request("POST", createPath, &createOpts)
 	if err != nil {
@@ -559,6 +562,9 @@ func updateDesktopFlavor(ctx context.Context, client *golangsdk.ServiceClient, d
 	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
 	opts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 		JSONBody: map[string]interface{}{
 			"desktops": []map[string]interface{}{
 				{
@@ -644,6 +650,9 @@ func updateDesktopVolumes(ctx context.Context, client *golangsdk.ServiceClient, 
 			}
 			newVolumeOpts := golangsdk.RequestOpts{
 				KeepResponseBody: true,
+				MoreHeaders: map[string]string{
+					"Content-Type": "application/json",
+				},
 				JSONBody: map[string]interface{}{
 					"addDesktopVolumesReq": []map[string]interface{}{
 						{
@@ -679,6 +688,9 @@ func updateDesktopVolumes(ctx context.Context, client *golangsdk.ServiceClient, 
 			expandHttpUrl = "v2/{project_id}/volumes/expand"
 			expandOpts    = golangsdk.RequestOpts{
 				KeepResponseBody: true,
+				MoreHeaders: map[string]string{
+					"Content-Type": "application/json",
+				},
 				JSONBody: map[string]interface{}{
 					"expandVolumesReq": expandSlice,
 				},
@@ -717,6 +729,9 @@ func updateDesktopNetwork(ctx context.Context, client *golangsdk.ServiceClient, 
 		desktopId = d.Id()
 		opts      = golangsdk.RequestOpts{
 			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
 			JSONBody: map[string]interface{}{
 				"vpc_id":             d.Get("vpc_id").(string),
 				"subnet_id":          utils.PathSearch("network_id", nicRaw[0], nil),
@@ -803,7 +818,10 @@ func updateDesktopPowerAction(ctx context.Context, client *golangsdk.ServiceClie
 		}
 		opts = golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			JSONBody:         utils.RemoveNil(params),
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: utils.RemoveNil(params),
 		}
 	)
 
@@ -827,6 +845,9 @@ func updateDesktopImage(ctx context.Context, client *golangsdk.ServiceClient, d 
 		desktopId   = d.Id()
 		rebuildOpts = golangsdk.RequestOpts{
 			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
 			JSONBody: map[string]interface{}{
 				"desktop_ids": []string{desktopId},
 				"image_type":  d.Get("image_type"),
@@ -1010,6 +1031,9 @@ func resourceDesktopDelete(ctx context.Context, d *schema.ResourceData, meta int
 		isDeleteUser = d.Get("delete_user").(bool)
 		opts         = golangsdk.RequestOpts{
 			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
 		}
 	)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In `cn-southwest-2` region, the lack of `Content-Type` in the request header caused deletion error.

Error information: 
![image](https://github.com/user-attachments/assets/326b01b0-e6c1-4fdd-82fc-94ea0f84bc8b)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o workspace -f TestAccDesktop_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDesktop_ -timeout 360m -parallel 10
=== RUN   TestAccDesktop_basic
--- PASS: TestAccDesktop_basic (1353.74s)
=== RUN   TestAccDesktop_UpdateWithEpsId
--- PASS: TestAccDesktop_UpdateWithEpsId (508.55s)
=== RUN   TestAccDesktop_powerAction
--- PASS: TestAccDesktop_powerAction (830.06s)
PASS
coverage: 14.2% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 2692.488s       coverage: 14.2% of statements in ./huaweicloud/services/workspace
huawei@wuzhuanhong-dev:~/go/src/github.c
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
