### PR TITLE
feat(ims): the `images_images` data source support new fields

### DIFF
--- a/docs/data-sources/images_images.md
+++ b/docs/data-sources/images_images.md
@@ -93,6 +93,12 @@ data "huaweicloud_images_images" "bms_image" {
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the image.
   For enterprise users, if omitted, will query the images under all enterprise projects.
 
+* `__support_agent_list` - (Optional, String) Specifies whether the image supports host security or host monitoring.
+  The valid values are as follows:
+  + **hss**: Host security.
+  + **ces**: Host monitoring.
+  + **hss,ces**: Both support.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -158,3 +164,7 @@ The `images` block supports:
 * `created_at` - The creation time of the image, in RFC3339 format.
 
 * `updated_at` - The last update time of the image, in RFC3339 format.
+
+* `__support_agent_list` - Does the image support host security or host monitoring.
+  The valid value is **hss**, **ces**, or **hss,ces**. If it is empty, it means that the image does not support host
+  security or host monitoring.

--- a/huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_images_test.go
+++ b/huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_images_test.go
@@ -115,6 +115,7 @@ func TestAccImagesDataSource_private_basic(t *testing.T) {
 					resource.TestCheckOutput("is_name_filter_useful", "true"),
 					resource.TestCheckOutput("is_flavor_id_filter_useful", "true"),
 					resource.TestCheckOutput("is_tag_filter_useful", "true"),
+					resource.TestCheckOutput("is_support_agent_list_filter_useful", "true"),
 					resource.TestCheckOutput("not_found_validation_pass", "true"),
 				),
 			},
@@ -247,6 +248,16 @@ data "huaweicloud_images_images" "tag_filter" {
 
 output "is_tag_filter_useful" {
   value = length(data.huaweicloud_images_images.tag_filter.images) > 0
+}
+
+# Filter using __support_agent_list.
+data "huaweicloud_images_images" "support_agent_list_filter" {
+  visibility           = "private"
+  __support_agent_list = "hss,ces"
+}
+
+output "is_support_agent_list_filter_useful" {
+  value = length(data.huaweicloud_images_images.support_agent_list_filter.images) > 0
 }
 
 # Filter using non existent name.

--- a/huaweicloud/services/ims/data_source_huaweicloud_images_images.go
+++ b/huaweicloud/services/ims/data_source_huaweicloud_images_images.go
@@ -88,6 +88,10 @@ func DataSourceImagesImages() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"__support_agent_list": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"os_version": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -205,6 +209,10 @@ func ImagesImageRefSchema() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"__support_agent_list": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -273,6 +281,11 @@ func dataSourceImagesImagesRead(_ context.Context, d *schema.ResourceData, meta 
 		if nameRegexRes != nil && !nameRegexRes.MatchString(image.Name) {
 			continue
 		}
+
+		if v, ok := d.GetOk("__support_agent_list"); ok && v.(string) != item.SupportAgentList {
+			continue
+		}
+
 		ids = append(ids, image.ID)
 		resultImages = append(resultImages, flattenImage(&image))
 	}
@@ -312,6 +325,7 @@ func flattenImage(image *cloudimages.Image) map[string]interface{} {
 		"active_at":             image.ActiveAt,
 		"created_at":            image.CreatedAt.Format(time.RFC3339),
 		"updated_at":            image.UpdatedAt.Format(time.RFC3339),
+		"__support_agent_list":  image.SupportAgentList,
 	}
 
 	if size, err := strconv.Atoi(image.ImageSize); err == nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

`images_images` data source support new fields

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccImagesDataSource_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccImagesDataSource_ -timeout 360m -parallel 4
=== RUN   TestAccImagesDataSource_basic
=== PAUSE TestAccImagesDataSource_basic
=== RUN   TestAccImagesDataSource_private_basic
=== PAUSE TestAccImagesDataSource_private_basic
=== CONT  TestAccImagesDataSource_basic
=== CONT  TestAccImagesDataSource_private_basic
--- PASS: TestAccImagesDataSource_basic (47.18s)
--- PASS: TestAccImagesDataSource_private_basic (424.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       425.019s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
