### PR TITLE
docs: feat(lts/keywords_alarm): adjust parameters description and add new fields

### DIFF
--- a/docs/resources/lts_keywords_alarm_rule.md
+++ b/docs/resources/lts_keywords_alarm_rule.md
@@ -44,8 +44,10 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `name` - (Required, String, ForceNew) Specifies the name of the keywords alarm rule.
-  The value can contain no more than 64 characters.
+* `name` - (Required, String, ForceNew) Specifies the name of the keywords alarm rule.  
+  The maximum lanegth is `128` characters, only Chinese characters, letters, digits, hyphens (-) and underscores (_)
+  are allowed.  
+  The name cannot start with and end with a hyphen or a underscore.  
   Changing this parameter will create a new resource.
 
 * `keywords_requests` - (Required, List) Specifies the keywords requests.
@@ -54,14 +56,15 @@ The following arguments are supported:
 * `frequency` - (Required, List) Specifies the alarm frequency configurations.
   The [Frequency](#KeywordsAlarmRule_Frequency) structure is documented below.
 
-* `alarm_level` - (Required, String) Specifies the alarm level.
+* `alarm_level` - (Required, String) Specifies the alarm level.  
   The value can be: **INFO**, **MINOR**, **MAJOR** and **CRITICAL**.
 
 * `description` - (Optional, String) Specifies the description of the keywords alarm rule.
 
 * `send_notifications` - (Optional, Bool, ForceNew) Specifies whether to send notifications.
   Changing this parameter will create a new resource.
-
+  Defaults to **false**.
+  
 * `notification_rule` - (Optional, List, ForceNew) Specifies the notification rule.
   The [NotificationRule](#KeywordsAlarmRule_NotificationRule) structure is documented below.
   Changing this parameter will create a new resource.
@@ -72,12 +75,14 @@ The following arguments are supported:
 * `trigger_condition_frequency` - (Optional, Int) Specifies the frequency to trigger the alarm.
   Defaults to `1`.
 
-* `send_recovery_notifications` - (Optional, Bool) Specifies whether to send recovery notifications.
+* `send_recovery_notifications` - (Optional, Bool) Specifies whether to send recovery notifications.  
+  Defaults to **false**
 
 * `recovery_frequency` - (Optional, Int) Specifies the frequency to recover the alarm.
   Defaults to `3`.
 
-* `status` - (Optional, String) Specifies the status. The value can be: **RUNNING** and **STOPPING**.
+* `status` - (Optional, String) Specifies the status.  
+  The value can be: **RUNNING** and **STOPPING**.  
   Defaults to **RUNNING**.
 
 <a name="KeywordsAlarmRule_KeywordsRequests"></a>
@@ -85,16 +90,16 @@ The `KeywordsRequests` block supports:
 
 * `keywords` - (Required, String) Specifies the keywords.
 
-* `condition` - (Required, String) Specifies the keywords request condition.
+* `condition` - (Required, String) Specifies the keywords request condition.  
   The value can be: **>=**, **<=**, **<** and **>**.
 
 * `number` - (Required, Int) Specifies the line number.
 
-* `log_stream_id` - (Required, String) Specifies the log stream id.
+* `log_stream_id` - (Required, String) Specifies the ID of the log stream.
 
-* `log_group_id` - (Required, String) Specifies the log group id.
+* `log_group_id` - (Required, String) Specifies the ID of the log group.
 
-* `search_time_range_unit` - (Required, String) Specifies the unit of search time range.
+* `search_time_range_unit` - (Required, String) Specifies the unit of search time range.  
   The value can be: **minute** and **hour**.
 
 * `search_time_range` - (Required, Int) Specifies the search time range.
@@ -104,24 +109,24 @@ The `KeywordsRequests` block supports:
 <a name="KeywordsAlarmRule_Frequency"></a>
 The `Frequency` block supports:
 
-* `type` - (Required, String) Specifies the frequency type.
+* `type` - (Required, String) Specifies the frequency type.  
   The value can be: **CRON**, **HOURLY**, **DAILY**, **WEEKLY** and **FIXED_RATE**.
 
-* `cron_expression` - (Optional, String) Specifies the cron expression.
+* `cron_expression` - (Optional, String) Specifies the cron expression.  
   This parameter is used when `type` is set to **CRON**.
 
-* `hour_of_day` - (Optional, Int) Specifies the hour of day.
-  This parameter is used when `type` is set to **DAILY** or **WEEKLY**.
+* `hour_of_day` - (Optional, Int) Specifies the hour of day.  
+  This parameter is used when `type` is set to **DAILY** or **WEEKLY**.  
   The value ranges from `0` to `23`.
 
-* `day_of_week` - (Optional, Int) Specifies the day of week.
-  This parameter is used when `type` is set to **WEEKLY**.
+* `day_of_week` - (Optional, Int) Specifies the day of week.  
+  This parameter is used when `type` is set to **WEEKLY**.  
   The value ranges from `1` to `7`. `1` means Sunday.
 
-* `fixed_rate_unit` - (Optional, String) Specifies the unit of fixed rate.
+* `fixed_rate_unit` - (Optional, String) Specifies the unit of fixed rate.  
   The value can be: **minute** and **hour**.
 
-* `fixed_rate` - (Optional, Int) Specifies the unit fixed rate.
+* `fixed_rate` - (Optional, Int) Specifies the unit fixed rate.  
   This parameter is used when `type` is set to **FIXED_RATE**.
   + When the `fixed_rate_unit` is **minute**, the value ranges from `1` to `60`.
   + When the `fixed_rate_unit` is **hour**, the value ranges from `1` to `24`
@@ -172,7 +177,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `created_at` - The creation time of the alarm rule.
 
-* `updated_at` - The last update time of the alarm rule.
+* `updated_at` - The latest update time of the alarm rule.
 
 ## Import
 

--- a/docs/resources/lts_keywords_alarm_rule.md
+++ b/docs/resources/lts_keywords_alarm_rule.md
@@ -61,13 +61,18 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies the description of the keywords alarm rule.
 
-* `send_notifications` - (Optional, Bool, ForceNew) Specifies whether to send notifications.
-  Changing this parameter will create a new resource.
+* `send_notifications` - (Optional, Bool) Specifies whether to send notifications.  
   Defaults to **false**.
   
-* `notification_rule` - (Optional, List, ForceNew) Specifies the notification rule.
+* `alarm_action_rule_name` - (Optional, String) Specifies the name of the alarm action rule associated with
+  the keyword alarm rule.  
+  This parameter is available only when `send_notifications` parameter is set to **true**.
+
+  -> This parameter cannot be used together with `notification_save_rule` parameter.
+  
+* `notification_save_rule` - (Optional, List) Specifies the notification rule.
   The [NotificationRule](#KeywordsAlarmRule_NotificationRule) structure is documented below.
-  Changing this parameter will create a new resource.
+  This parameter is available only when `send_notifications` parameter is set to **true**.
 
 * `trigger_condition_count` - (Optional, Int) Specifies the count to trigger the alarm.
   Defaults to `1`.
@@ -81,8 +86,26 @@ The following arguments are supported:
 * `recovery_frequency` - (Optional, Int) Specifies the frequency to recover the alarm.
   Defaults to `3`.
 
-* `status` - (Optional, String) Specifies the status.  
-  The value can be: **RUNNING** and **STOPPING**.  
+* `alarm_rule_alias` - (Optional, String) Specifies the alias name of the keyword alarm rule.  
+  The maximum lanegth is `128` characters, only Chinese characters, letters, digits, hyphens (-) and underscores (_)
+  are allowed.  
+  The name cannot start with and end with a hyphen or a underscore.
+
+* `notification_frequency` - (Optional, Int) Specifies the notification frequency of the keyword alarm rule,
+  in minutes.  
+  Defaults to `0`, `0` means immediately notification.  
+  This parameter is available only when `send_notifications` parameter is set to **true**.
+  The valid values are as follows:
+  + **0**
+  + **5**
+  + **10**
+  + **15**
+  + **30**
+  + **60**
+  + **180**
+  + **360**
+
+* `status` - (Optional, String) Specifies the status. The value can be: **RUNNING** and **STOPPING**.
   Defaults to **RUNNING**.
 
 <a name="KeywordsAlarmRule_KeywordsRequests"></a>
@@ -105,6 +128,10 @@ The `KeywordsRequests` block supports:
 * `search_time_range` - (Required, Int) Specifies the search time range.
   + When the `search_time_range_unit` is **minute**, the value ranges from `1` to `60`.
   + When the `search_time_range_unit` is **hour**, the value ranges from `1` to `24`.
+
+* `log_group_name` - (Optional, String) Specifies the name of the log group.
+
+* `log_stream_name` - (Optional, String) Specifies the name of the log stream.
 
 <a name="KeywordsAlarmRule_Frequency"></a>
 The `Frequency` block supports:
@@ -134,38 +161,29 @@ The `Frequency` block supports:
 <a name="KeywordsAlarmRule_NotificationRule"></a>
 The `NotificationRule` block supports:
 
-* `template_name` - (Required, String, ForceNew) Specifies the notification template name.
-  Changing this parameter will create a new resource.
+* `template_name` - (Required, String) Specifies the notification template name.
 
-* `user_name` - (Required, String, ForceNew) Specifies the user name.
-  Changing this parameter will create a new resource.
+* `user_name` - (Required, String) Specifies the user name.
 
-* `topics` - (Required, List, ForceNew) Specifies the SMN topics.
+* `topics` - (Required, List) Specifies the SMN topics.
   The [Topic](#KeywordsAlarmRule_Topic) structure is documented below.
-  Changing this parameter will create a new resource.
 
-* `timezone` - (Optional, String, ForceNew) Specifies the timezone.
-  Changing this parameter will create a new resource.
+* `timezone` - (Optional, String) Specifies the timezone.
 
-* `language` - (Optional, String, ForceNew) Specifies the notification language.
-  The value can be **zh-cn** and **en-us**.
-  Changing this parameter will create a new resource.
+* `language` - (Optional, String) Specifies the notification language.  
+  The value can be **zh-cn** and **en-us**, defaults to **zh-cn**.
 
 <a name="KeywordsAlarmRule_Topic"></a>
 The `NotificationRuleTopic` block supports:
 
-* `name` - (Required, String, ForceNew) Specifies the topic name.
-  Changing this parameter will create a new resource.
+* `name` - (Required, String) Specifies the topic name.
 
-* `topic_urn` - (Required, String, ForceNew) Specifies the topic URN.
-  Changing this parameter will create a new resource.
+* `topic_urn` - (Required, String) Specifies the topic URN.
 
-* `display_name` - (Optional, String, ForceNew) Specifies the display name.
+* `display_name` - (Optional, String) Specifies the display name.
   This will be shown as the sender of the message.
-  Changing this parameter will create a new resource.
 
-* `push_policy` - (Optional, String, ForceNew) Specifies the push policy.
-  Changing this parameter will create a new resource.
+* `push_policy` - (Optional, Int) Specifies the push policy.
 
 ## Attribute Reference
 
@@ -177,7 +195,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `created_at` - The creation time of the alarm rule.
 
-* `updated_at` - The latest update time of the alarm rule.
+* `updated_at` - The last update time of the alarm rule.
+
+* `condition_expression` - The condition expression of the keyword alarm rule.
 
 ## Import
 
@@ -188,7 +208,7 @@ $ terraform import huaweicloud_lts_keywords_alarm_rule.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response. The missing attributes include: `notification_rule`.
+API response. The missing attributes include: `notification_save_rule.0.user_name`, `notification_save_rule.0.timezone,`.
 It is generally recommended running `terraform plan` after importing a certificate.
 You can then decide if changes should be applied to the certificate, or the resource definition should be updated to
 align with the certificate. Also you can ignore changes as below.
@@ -199,7 +219,7 @@ resource "huaweicloud_lts_keywords_alarm_rule" "test" {
 
   lifecycle {
     ignore_changes = [
-      notification_rule,
+      notification_save_rule.0.user_name, notification_save_rule.0.timezone,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -539,10 +539,11 @@ var (
 	HW_LTS_LOG_CONVERGE_SOURCE_LOG_GROUP_ID  = os.Getenv("HW_LTS_LOG_CONVERGE_SOURCE_LOG_GROUP_ID")
 	HW_LTS_LOG_CONVERGE_SOURCE_LOG_STREAM_ID = os.Getenv("HW_LTS_LOG_CONVERGE_SOURCE_LOG_STREAM_ID")
 
-	HW_LTS_CLUSTER_ID           = os.Getenv("HW_LTS_CLUSTER_ID")
-	HW_LTS_CLUSTER_NAME         = os.Getenv("HW_LTS_CLUSTER_NAME")
-	HW_LTS_CLUSTER_ID_ANOTHER   = os.Getenv("HW_LTS_CLUSTER_ID_ANOTHER")
-	HW_LTS_CLUSTER_NAME_ANOTHER = os.Getenv("HW_LTS_CLUSTER_NAME_ANOTHER")
+	HW_LTS_CLUSTER_ID             = os.Getenv("HW_LTS_CLUSTER_ID")
+	HW_LTS_CLUSTER_NAME           = os.Getenv("HW_LTS_CLUSTER_NAME")
+	HW_LTS_CLUSTER_ID_ANOTHER     = os.Getenv("HW_LTS_CLUSTER_ID_ANOTHER")
+	HW_LTS_CLUSTER_NAME_ANOTHER   = os.Getenv("HW_LTS_CLUSTER_NAME_ANOTHER")
+	HW_LTS_ALARM_ACTION_RULE_NAME = os.Getenv("HW_LTS_ALARM_ACTION_RULE_NAME")
 
 	HW_VPCEP_SERVICE_ID = os.Getenv("HW_VPCEP_SERVICE_ID")
 
@@ -2147,6 +2148,13 @@ func TestAccPreCheckLtsStructConfigCustom(t *testing.T) {
 	if HW_LTS_STRUCT_CONFIG_TEMPLATE_ID == "" || HW_LTS_STRUCT_CONFIG_TEMPLATE_NAME == "" {
 		t.Skip("HW_LTS_STRUCT_CONFIG_TEMPLATE_ID and HW_LTS_STRUCT_CONFIG_TEMPLATE_NAME must be" +
 			" set for LTS struct config custom acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckLtsAlarmActionRuleName(t *testing.T) {
+	if HW_LTS_ALARM_ACTION_RULE_NAME == "" {
+		t.Skip("HW_LTS_ALARM_ACTION_RULE_NAME must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_keywords_alarm_rule_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_keywords_alarm_rule_test.go
@@ -2,123 +2,190 @@ package lts
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lts"
 )
 
-func getKeywordsAlarmRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	region := acceptance.HW_REGION_NAME
-	// getKeywordsAlarmRule: Query the LTS KeywordsAlarmRule detail
-	var (
-		getKeywordsAlarmRuleHttpUrl = "v2/{project_id}/lts/alarms/keywords-alarm-rule"
-		getKeywordsAlarmRuleProduct = "lts"
-	)
-	getKeywordsAlarmRuleClient, err := cfg.NewServiceClient(getKeywordsAlarmRuleProduct, region)
+func getKeywordsAlarmRule(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("lts", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating LTS client: %s", err)
 	}
 
-	getKeywordsAlarmRulePath := getKeywordsAlarmRuleClient.Endpoint + getKeywordsAlarmRuleHttpUrl
-	getKeywordsAlarmRulePath = strings.ReplaceAll(getKeywordsAlarmRulePath, "{project_id}", getKeywordsAlarmRuleClient.ProjectID)
-
-	getKeywordsAlarmRuleOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: map[string]string{"Content-Type": "application/json"},
-	}
-
-	getKeywordsAlarmRuleResp, err := getKeywordsAlarmRuleClient.Request("GET", getKeywordsAlarmRulePath, &getKeywordsAlarmRuleOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving Keywords alarm rule: %s", err)
-	}
-
-	getKeywordsAlarmRuleRespBody, err := utils.FlattenResponse(getKeywordsAlarmRuleResp)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving Keywords alarm rule: %s", err)
-	}
-
-	jsonPath := fmt.Sprintf("keywords_alarm_rules[?keywords_alarm_rule_id =='%s']|[0]", state.Primary.ID)
-	getKeywordsAlarmRuleRespBody = utils.PathSearch(jsonPath, getKeywordsAlarmRuleRespBody, nil)
-	if getKeywordsAlarmRuleRespBody == nil {
-		return nil, golangsdk.ErrDefault404{}
-	}
-	return getKeywordsAlarmRuleRespBody, nil
+	return lts.GetKeywordsAlarmRuleById(client, state.Primary.ID)
 }
 
 func TestAccKeywordsAlarmRule_basic(t *testing.T) {
 	var (
-		obj      interface{}
-		name     = acceptance.RandomAccResourceName()
-		rName    = "huaweicloud_lts_keywords_alarm_rule.test"
-		password = acceptance.RandomPassword()
-	)
+		name      = acceptance.RandomAccResourceName()
+		aliasName = acceptance.RandomAccResourceName()
+		password  = acceptance.RandomPassword()
 
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getKeywordsAlarmRuleResourceFunc,
+		keywordAlarmRule interface{}
+		rName            = "huaweicloud_lts_keywords_alarm_rule.test"
+		rc               = acceptance.InitResourceCheck(rName, &keywordAlarmRule, getKeywordsAlarmRule)
+
+		withNotiSaveRule   = "huaweicloud_lts_keywords_alarm_rule.with_notification_save_rule"
+		rcWithNotiSaveRule = acceptance.InitResourceCheck(withNotiSaveRule, &keywordAlarmRule, getKeywordsAlarmRule)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDomainId(t)
+			acceptance.TestAccPreCheckLtsAlarmActionRuleName(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeywordsAlarmRule_step1(name, password),
+				Config: testKeywordsAlarmRule_step1(name, password, aliasName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "description", "created by terraform"),
-					resource.TestCheckResourceAttr(rName, "alarm_level", "CRITICAL"),
-					resource.TestCheckResourceAttr(rName, "status", "STOPPING"),
-					resource.TestCheckResourceAttr(rName, "frequency.0.type", "HOURLY"),
+					resource.TestCheckResourceAttr(rName, "keywords_requests.0.keywords", name+"_key_words"),
+					resource.TestCheckResourceAttr(rName, "keywords_requests.0.condition", ">"),
+					resource.TestCheckResourceAttr(rName, "keywords_requests.0.number", "100"),
+					resource.TestCheckResourceAttr(rName, "keywords_requests.0.search_time_range_unit", "minute"),
+					resource.TestCheckResourceAttr(rName, "keywords_requests.0.search_time_range", "5"),
 					resource.TestCheckResourceAttrPair(rName, "keywords_requests.0.log_group_id",
-						"huaweicloud_lts_group.test", "id"),
+						"huaweicloud_lts_group.test.0", "id"),
 					resource.TestCheckResourceAttrPair(rName, "keywords_requests.0.log_stream_id",
-						"huaweicloud_lts_stream.test", "id"),
-					resource.TestCheckResourceAttrPair(rName, "notification_rule.0.template_name",
-						"huaweicloud_lts_notification_template.test", "name"),
-					resource.TestCheckResourceAttrPair(rName, "notification_rule.0.user_name",
-						"huaweicloud_identity_user.test", "name"),
-					resource.TestCheckResourceAttrPair(rName, "notification_rule.0.topics.0.name",
-						"huaweicloud_smn_topic.test", "name"),
-					resource.TestCheckResourceAttrPair(rName, "notification_rule.0.topics.0.topic_urn",
-						"huaweicloud_smn_topic.test", "topic_urn"),
+						"huaweicloud_lts_stream.test.0", "id"),
+					resource.TestCheckResourceAttrPair(rName, "keywords_requests.0.log_group_name",
+						"huaweicloud_lts_group.test.0", "group_name"),
+					resource.TestCheckResourceAttrPair(rName, "keywords_requests.0.log_stream_name",
+						"huaweicloud_lts_stream.test.0", "stream_name"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.type", "HOURLY"),
+					resource.TestCheckResourceAttr(rName, "alarm_level", "CRITICAL"),
+					// check optional parameters.
+					resource.TestCheckResourceAttr(rName, "send_notifications", "false"),
+					resource.TestCheckResourceAttr(rName, "description", "created by terraform"),
+					resource.TestCheckResourceAttr(rName, "alarm_action_rule_name", ""),
+					resource.TestCheckResourceAttr(rName, "notification_save_rule.#", "0"),
+					resource.TestCheckResourceAttr(rName, "trigger_condition_count", "1"),
+					resource.TestCheckResourceAttr(rName, "trigger_condition_frequency", "1"),
+					resource.TestCheckResourceAttr(rName, "send_recovery_notifications", "false"),
+					resource.TestCheckResourceAttr(rName, "recovery_frequency", "3"),
+					resource.TestCheckResourceAttr(rName, "alarm_rule_alias", name),
+					resource.TestCheckResourceAttr(rName, "notification_frequency", "0"),
+					resource.TestCheckResourceAttr(rName, "status", "RUNNING"),
+					// Check attributes.
+					resource.TestCheckResourceAttrSet(rName, "domain_id"),
 					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "condition_expression"),
+					// Mainly verify the modification logic of the `notification_save_rule` parameter.
+					rcWithNotiSaveRule.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "status", "STOPPING"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "send_notifications", "true"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "trigger_condition_count", "2"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "trigger_condition_frequency", "3"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "send_recovery_notifications", "true"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "recovery_frequency", "4"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "alarm_rule_alias", aliasName),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "notification_frequency", "15"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "frequency.0.type", "FIXED_RATE"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "frequency.0.fixed_rate_unit", "minute"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "frequency.0.fixed_rate", "30"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "notification_save_rule.0.template_name", "keywords_template"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "notification_save_rule.0.topics.#", "1"),
+					resource.TestCheckResourceAttrPair(withNotiSaveRule, "notification_save_rule.0.topics.0.name",
+						"huaweicloud_smn_topic.test.0", "name"),
+					resource.TestCheckResourceAttrPair(withNotiSaveRule, "notification_save_rule.0.topics.0.topic_urn",
+						"huaweicloud_smn_topic.test.0", "topic_urn"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "notification_save_rule.0.topics.0.display_name", ""),
 				),
 			},
 			{
-				Config: testKeywordsAlarmRule_step2(name, password),
+				Config: testKeywordsAlarmRule_step2(name, password, aliasName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "description", ""),
-					resource.TestCheckResourceAttr(rName, "alarm_level", "INFO"),
-					resource.TestCheckResourceAttr(rName, "status", "RUNNING"),
+					resource.TestCheckResourceAttr(rName, "keywords_requests.0.keywords", name+"_key_words_update"),
+					resource.TestCheckResourceAttr(rName, "keywords_requests.0.condition", ">="),
+					resource.TestCheckResourceAttr(rName, "keywords_requests.0.number", "50"),
+					resource.TestCheckResourceAttr(rName, "keywords_requests.0.search_time_range_unit", "hour"),
+					resource.TestCheckResourceAttr(rName, "keywords_requests.0.search_time_range", "1"),
+					resource.TestCheckResourceAttrPair(rName, "keywords_requests.0.log_group_id",
+						"huaweicloud_lts_group.test.1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "keywords_requests.0.log_stream_id",
+						"huaweicloud_lts_stream.test.1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "keywords_requests.0.log_group_name",
+						"huaweicloud_lts_group.test.1", "group_name"),
+					resource.TestCheckResourceAttrPair(rName, "keywords_requests.0.log_stream_name",
+						"huaweicloud_lts_stream.test.1", "stream_name"),
 					resource.TestCheckResourceAttr(rName, "frequency.0.type", "DAILY"),
 					resource.TestCheckResourceAttr(rName, "frequency.0.hour_of_day", "6"),
+					resource.TestCheckResourceAttr(rName, "alarm_level", "INFO"),
+					// check optional parameters.
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "send_notifications", "true"),
+					resource.TestCheckResourceAttr(rName, "trigger_condition_count", "2"),
+					resource.TestCheckResourceAttr(rName, "trigger_condition_frequency", "3"),
+					resource.TestCheckResourceAttr(rName, "send_recovery_notifications", "true"),
+					resource.TestCheckResourceAttr(rName, "recovery_frequency", "4"),
+					resource.TestCheckResourceAttr(rName, "notification_frequency", "30"),
+					resource.TestCheckResourceAttr(rName, "notification_save_rule.0.template_name", "keywords_template"),
+					resource.TestCheckResourceAttrPair(rName, "notification_save_rule.0.user_name",
+						"huaweicloud_identity_user.test", "name"),
+					resource.TestCheckResourceAttr(rName, "notification_save_rule.0.topics.#", "1"),
+					resource.TestCheckResourceAttrPair(rName, "notification_save_rule.0.topics.0.name",
+						"huaweicloud_smn_topic.test.0", "name"),
+					resource.TestCheckResourceAttrPair(rName, "notification_save_rule.0.topics.0.topic_urn",
+						"huaweicloud_smn_topic.test.0", "topic_urn"),
+					resource.TestCheckResourceAttrPair(rName, "notification_save_rule.0.topics.0.display_name",
+						"huaweicloud_smn_topic.test.0", "display_name"),
+					resource.TestCheckResourceAttrPair(rName, "notification_save_rule.0.topics.0.push_policy",
+						"huaweicloud_smn_topic.test.0", "push_policy"),
 					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					rcWithNotiSaveRule.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "alarm_rule_alias", aliasName+"_update"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "status", "RUNNING"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "notification_save_rule.0.topics.#", "2"),
+				),
+			},
+			{
+				Config: testKeywordsAlarmRule_step3(name, password),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "frequency.0.type", "WEEKLY"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.day_of_week", "6"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.hour_of_day", "10"),
+					resource.TestCheckResourceAttr(rName, "send_notifications", "true"),
+					resource.TestCheckResourceAttr(rName, "alarm_action_rule_name", acceptance.HW_LTS_ALARM_ACTION_RULE_NAME),
+					resource.TestCheckResourceAttr(rName, "notification_save_rule.#", "0"),
+					rcWithNotiSaveRule.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "frequency.0.type", "CRON"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "frequency.0.cron_expression", "0 18 * * *"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "notification_save_rule.0.language", "en-us"),
+				),
+			},
+			{
+				Config: testKeywordsAlarmRule_step4(name, password),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "alarm_action_rule_name", acceptance.HW_LTS_ALARM_ACTION_RULE_NAME),
+					rcWithNotiSaveRule.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "send_notifications", "false"),
+					resource.TestCheckResourceAttr(rName, "notification_save_rule.#", "0"),
 				),
 			},
 			{
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"notification_rule",
-				},
+			},
+			{
+				ResourceName:            withNotiSaveRule,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"notification_save_rule.0.user_name", "notification_save_rule.0.timezone"},
 			},
 		},
 	})
@@ -127,29 +194,33 @@ func TestAccKeywordsAlarmRule_basic(t *testing.T) {
 func testAlarmRule_base(name, password string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_lts_group" "test" {
-  group_name  = "%[1]s"
+  count = 2
+
+  group_name  = "%[1]s_${count.index}"
   ttl_in_days = 30
 }
 
 resource "huaweicloud_lts_stream" "test" {
-  group_id    = huaweicloud_lts_group.test.id
-  stream_name = "%[1]s"
+  count = 2
+
+  group_id    = huaweicloud_lts_group.test[count.index].id
+  stream_name = "%[1]s_${count.index}"
 }
 
 resource "huaweicloud_smn_topic" "test" {
-  name         = "%[1]s"
+  count = 2
+
+  name         = "%[1]s_${count.index}"
   display_name = "The display name of topic"
 }
 
-resource "huaweicloud_lts_notification_template" "test" {
-  name   = "%[1]s"
-  source = "LTS"
-  locale = "en-us"
-  
-  templates {
-    sub_type = "sms"
-    content  = "This body content of template."
-  }
+data "huaweicloud_lts_notification_templates" "test" {
+  domain_id = "%[3]s"
+}
+
+# 'keywords_template' is the default template provided by the system.
+locals {
+  template_name = [for v in data.huaweicloud_lts_notification_templates.test.templates[*].name : v if v == "keywords_template"][0]
 }
 
 resource "huaweicloud_identity_user" "test" {
@@ -157,25 +228,24 @@ resource "huaweicloud_identity_user" "test" {
   enabled  = true
   password = "%[2]s"
 }
-`, name, password)
+`, name, password, acceptance.HW_DOMAIN_ID)
 }
 
-func testKeywordsAlarmRule_step1(name, password string) string {
+func testKeywordsAlarmRule_step1(name, password, aliasName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_lts_keywords_alarm_rule" "test" {
   name        = "%[2]s"
-  description = "created by terraform"
   alarm_level = "CRITICAL"
-  status      = "STOPPING"
+  description = "created by terraform"
 
   keywords_requests {
     keywords               = "%[2]s_key_words"
     condition              = ">"
     number                 = 100
-    log_group_id           = huaweicloud_lts_group.test.id
-    log_stream_id          = huaweicloud_lts_stream.test.id
+    log_group_id           = huaweicloud_lts_group.test[0].id
+    log_stream_id          = huaweicloud_lts_stream.test[0].id
     search_time_range_unit = "minute"
     search_time_range      = 5
   }
@@ -183,38 +253,73 @@ resource "huaweicloud_lts_keywords_alarm_rule" "test" {
   frequency {
     type = "HOURLY"
   }
+}
 
-  notification_rule {
-    template_name = huaweicloud_lts_notification_template.test.name
+resource "huaweicloud_lts_keywords_alarm_rule" "with_notification_save_rule" {
+  name                        = "%[2]s_notification"
+  alarm_level                 = "MINOR"
+  send_notifications          = true
+  trigger_condition_count     = 2
+  trigger_condition_frequency = 3
+  send_recovery_notifications = true
+  recovery_frequency          = 4
+  alarm_rule_alias            = "%[3]s"
+  notification_frequency      = 15
+  status                      = "STOPPING"
+
+  keywords_requests {
+    keywords               = "%[2]s_key_words"
+    condition              = "<"
+    number                 = 50
+    log_group_id           = huaweicloud_lts_group.test[0].id
+    log_stream_id          = huaweicloud_lts_stream.test[0].id
+    search_time_range_unit = "hour"
+    search_time_range      = 1
+    log_group_name         = huaweicloud_lts_group.test[0].group_name
+    log_stream_name        = huaweicloud_lts_stream.test[0].stream_name
+  }
+
+  frequency {
+    type            = "FIXED_RATE"
+    fixed_rate_unit = "minute"
+    fixed_rate      = 30
+  }
+
+  notification_save_rule {
+    template_name = local.template_name
     user_name     = huaweicloud_identity_user.test.name
 
     topics {
-      name      = huaweicloud_smn_topic.test.name
-      topic_urn = huaweicloud_smn_topic.test.topic_urn
+      name      = huaweicloud_smn_topic.test[0].name
+      topic_urn = huaweicloud_smn_topic.test[0].topic_urn
     }
   }
 }
-`, testAlarmRule_base(name, password), name)
+`, testAlarmRule_base(name, password), name, aliasName)
 }
 
-func testKeywordsAlarmRule_step2(name, password string) string {
+func testKeywordsAlarmRule_step2(name, password, aliasName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_lts_keywords_alarm_rule" "test" {
-  name        = "%[2]s"
-  description = ""
-  alarm_level = "INFO"
-  status      = "RUNNING"
-  
+  name                        = "%[2]s"
+  alarm_level                 = "INFO"
+  send_notifications          = true
+  trigger_condition_count     = 2
+  trigger_condition_frequency = 3
+  send_recovery_notifications = true
+  recovery_frequency          = 4
+  notification_frequency      = 30
+
   keywords_requests {
-    keywords               = "%[2]s_key_words"
-    condition              = ">"
-    number                 = 100
-    log_group_id           = huaweicloud_lts_group.test.id
-    log_stream_id          = huaweicloud_lts_stream.test.id
-    search_time_range_unit = "minute"
-    search_time_range      = 5
+    keywords               = "%[2]s_key_words_update"
+    condition              = ">="
+    number                 = 50
+    log_group_id           = huaweicloud_lts_group.test[1].id
+    log_stream_id          = huaweicloud_lts_stream.test[1].id
+    search_time_range_unit = "hour"
+    search_time_range      = 1
   }
 
   frequency {
@@ -222,15 +327,203 @@ resource "huaweicloud_lts_keywords_alarm_rule" "test" {
     hour_of_day = 6
   }
 
-  notification_rule {
-    template_name = huaweicloud_lts_notification_template.test.name
+  notification_save_rule {
+    template_name = local.template_name
     user_name     = huaweicloud_identity_user.test.name
 
+    # Verify the 'keywords_alarm_send_code' is '1' in the modification logic.
     topics {
-      name      = huaweicloud_smn_topic.test.name
-      topic_urn = huaweicloud_smn_topic.test.topic_urn
+      name         = huaweicloud_smn_topic.test[0].name
+      topic_urn    = huaweicloud_smn_topic.test[0].topic_urn
+      display_name = huaweicloud_smn_topic.test[0].display_name
+      push_policy  = huaweicloud_smn_topic.test[0].push_policy
     }
   }
 }
-`, testAlarmRule_base(name, password), name)
+
+resource "huaweicloud_lts_keywords_alarm_rule" "with_notification_save_rule" {
+  name                        = "%[2]s_notification"
+  alarm_level                 = "MINOR"
+  send_notifications          = true
+  trigger_condition_count     = 2
+  trigger_condition_frequency = 3
+  recovery_frequency          = 4
+  alarm_rule_alias            = "%[3]s_update"
+  notification_frequency      = 15
+  status                      = "RUNNING"
+  
+  keywords_requests {
+    keywords               = "%[2]s_key_words"
+    condition              = "<"
+    number                 = 50
+    log_group_id           = huaweicloud_lts_group.test[0].id
+    log_stream_id          = huaweicloud_lts_stream.test[0].id
+    search_time_range_unit = "hour"
+    search_time_range      = 1
+  }
+
+  frequency {
+    type            = "FIXED_RATE"
+    fixed_rate_unit = "minute"
+    fixed_rate      = 30
+  }
+
+  notification_save_rule {
+    template_name = local.template_name
+    user_name     = huaweicloud_identity_user.test.name
+
+    # Verify the 'keywords_alarm_send_code' is '2' in the modification logic.
+    topics {
+      name         = huaweicloud_smn_topic.test[0].name
+      topic_urn    = huaweicloud_smn_topic.test[0].topic_urn
+      display_name = huaweicloud_smn_topic.test[0].display_name
+      push_policy  = huaweicloud_smn_topic.test[0].push_policy
+    }
+    topics {
+      name      = huaweicloud_smn_topic.test[1].name
+      topic_urn = huaweicloud_smn_topic.test[1].topic_urn
+    }
+  }
+}
+`, testAlarmRule_base(name, password), name, aliasName)
+}
+
+func testKeywordsAlarmRule_step3(name, password string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_lts_keywords_alarm_rule" "test" {
+  name                        = "%[2]s"
+  alarm_level                 = "INFO"
+  send_notifications          = true
+  trigger_condition_count     = 2
+  trigger_condition_frequency = 3
+  send_recovery_notifications = true
+  recovery_frequency          = 4
+  notification_frequency      = 15
+  alarm_action_rule_name      = "%[3]s"
+
+  keywords_requests {
+    keywords               = "%[2]s_key_words_update"
+    condition              = ">="
+    number                 = 50
+    log_group_id           = huaweicloud_lts_group.test[1].id
+    log_stream_id          = huaweicloud_lts_stream.test[1].id
+    search_time_range_unit = "hour"
+    search_time_range      = 1
+  }
+
+  frequency {
+    type        = "WEEKLY"
+    day_of_week = 6
+    hour_of_day = 10
+  }
+}
+
+resource "huaweicloud_lts_keywords_alarm_rule" "with_notification_save_rule" {
+  name                        = "%[2]s_notification"
+  alarm_level                 = "CRITICAL"
+  trigger_condition_count     = 2
+  trigger_condition_frequency = 3
+  send_recovery_notifications = true
+  recovery_frequency          = 4
+  notification_frequency      = 15
+  status                      = "RUNNING"
+  
+  keywords_requests {
+    keywords               = "%[2]s_key_words"
+    condition              = "<"
+    number                 = 50
+    log_group_id           = huaweicloud_lts_group.test[0].id
+    log_stream_id          = huaweicloud_lts_stream.test[0].id
+    search_time_range_unit = "hour"
+    search_time_range      = 1
+  }
+
+  frequency {
+    type            = "CRON"
+    cron_expression = "0 18 * * *"
+  }
+
+  notification_save_rule {
+    template_name = local.template_name
+    user_name     = huaweicloud_identity_user.test.name
+    language      = "en-us"
+
+    # Verify the 'keywords_alarm_send_code' is '0' in the modification logic.
+    topics {
+      name         = huaweicloud_smn_topic.test[0].name
+      topic_urn    = huaweicloud_smn_topic.test[0].topic_urn
+      display_name = huaweicloud_smn_topic.test[0].display_name
+      push_policy  = huaweicloud_smn_topic.test[0].push_policy
+    }
+    topics {
+      name      = huaweicloud_smn_topic.test[1].name
+      topic_urn = huaweicloud_smn_topic.test[1].topic_urn
+    }
+  }
+}
+`, testAlarmRule_base(name, password), name, acceptance.HW_LTS_ALARM_ACTION_RULE_NAME)
+}
+
+func testKeywordsAlarmRule_step4(name, password string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_lts_keywords_alarm_rule" "test" {
+  name                        = "%[2]s"
+  alarm_level                 = "INFO"
+  send_notifications          = true
+  trigger_condition_count     = 2
+  trigger_condition_frequency = 3
+  send_recovery_notifications = true
+  recovery_frequency          = 4
+  notification_frequency      = 15
+  alarm_action_rule_name      = "%[3]s"
+
+  keywords_requests {
+    keywords               = "%[2]s_key_words_update"
+    condition              = ">="
+    number                 = 50
+    log_group_id           = huaweicloud_lts_group.test[1].id
+    log_stream_id          = huaweicloud_lts_stream.test[1].id
+    search_time_range_unit = "hour"
+    search_time_range      = 1
+  }
+
+  frequency {
+    type        = "WEEKLY"
+    day_of_week = 6
+    hour_of_day = 10
+  }
+}
+
+resource "huaweicloud_lts_keywords_alarm_rule" "with_notification_save_rule" {
+  name                        = "%[2]s_notification"
+  alarm_level                 = "CRITICAL"
+  trigger_condition_count     = 2
+  trigger_condition_frequency = 3
+  recovery_frequency          = 4
+  notification_frequency      = 15
+  status                      = "RUNNING"
+  
+  keywords_requests {
+    keywords               = "%[2]s_key_words"
+    condition              = "<"
+    number                 = 50
+    log_group_id           = huaweicloud_lts_group.test[0].id
+    log_stream_id          = huaweicloud_lts_stream.test[0].id
+    search_time_range_unit = "hour"
+    search_time_range      = 1
+  }
+
+  frequency {
+    type            = "CRON"
+    cron_expression = "0 18 * * *"
+  }
+
+  # Delete 'notification_save_rule' and 'send_recovery_notifications' parameter.
+  # Verify the 'keywords_alarm_send_code' is '3' in the modification logic.
+}
+`, testAlarmRule_base(name, password), name, acceptance.HW_LTS_ALARM_ACTION_RULE_NAME)
 }

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_keywords_alarm_rule.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_keywords_alarm_rule.go
@@ -1,8 +1,3 @@
-// ---------------------------------------------------------------
-// *** AUTO GENERATED CODE ***
-// @Product LTS
-// ---------------------------------------------------------------
-
 package lts
 
 import (
@@ -75,18 +70,19 @@ func ResourceKeywordsAlarmRule() *schema.Resource {
 			"send_notifications": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				ForceNew:    true,
-				Computed:    true,
 				Description: `Specifies whether to send notifications.`,
 			},
-			"notification_rule": {
+			"alarm_action_rule_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the alarm action rule associated with the keyword alarm rule.`,
+			},
+			"notification_save_rule": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				Elem:        keywordsAlarmRuleNotificationRuleSchema(),
 				Optional:    true,
-				ForceNew:    true,
-				Computed:    true,
-				Description: `Specifies the notification rule.`,
+				Description: `The notification rule of the keyword alarm rule.`,
 			},
 			"trigger_condition_count": {
 				Type:        schema.TypeInt,
@@ -112,6 +108,18 @@ func ResourceKeywordsAlarmRule() *schema.Resource {
 				Computed:    true,
 				Description: `Specifies the frequency to recover the alarm.`,
 			},
+			"alarm_rule_alias": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies alias name of the keyword alarm rule.`,
+			},
+			"notification_frequency": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `The notification frequency of the keyword alarm rule, in minutes.`,
+			},
 			"status": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -132,6 +140,26 @@ func ResourceKeywordsAlarmRule() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: `The last update time of the alarm rule.`,
+			},
+			"condition_expression": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The condition expression of the keyword alarm rule.`,
+			},
+			// Deprecated parameters.
+			"notification_rule": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Elem:     keywordsAlarmRuleNotificationRuleSchema(),
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`The notification rule of the keyword alarm rule.`,
+					utils.SchemaDescInput{
+						Deprecated: true,
+					},
+				),
 			},
 		},
 	}
@@ -174,6 +202,18 @@ func keywordsAlarmRuleKeywordsRequestsSchema() *schema.Resource {
 				Type:        schema.TypeInt,
 				Required:    true,
 				Description: `Specifies the search time range.`,
+			},
+			"log_stream_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The name of the log stream.`,
+			},
+			"log_group_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The name of the log group.`,
 			},
 		},
 	}
@@ -229,33 +269,27 @@ func keywordsAlarmRuleNotificationRuleSchema() *schema.Resource {
 			"template_name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `Specifies the notification template name.`,
 			},
 			"user_name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `Specifies the user name.`,
 			},
 			"topics": {
 				Type:        schema.TypeList,
 				Elem:        keywordsAlarmRuleNotificationRuleTopicSchema(),
 				Required:    true,
-				ForceNew:    true,
 				Description: `Specifies the SMN topics.`,
 			},
 			"timezone": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Computed:    true,
-				ForceNew:    true,
 				Description: `Specifies the timezone.`,
 			},
 			"language": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 				Computed:    true,
 				Description: `Specifies the notification language.`,
 			},
@@ -270,27 +304,21 @@ func keywordsAlarmRuleNotificationRuleTopicSchema() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `Specifies the topic name.`,
 			},
 			"topic_urn": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `Specifies the topic URN.`,
 			},
 			"display_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
-				Computed:    true,
 				Description: `Specifies the display name.`,
 			},
 			"push_policy": {
-				Type:        schema.TypeString,
+				Type:        schema.TypeInt,
 				Optional:    true,
-				ForceNew:    true,
-				Computed:    true,
 				Description: `Specifies the push policy.`,
 			},
 		},
@@ -317,10 +345,7 @@ func resourceKeywordsAlarmRuleCreate(ctx context.Context, d *schema.ResourceData
 
 	createKeywordsAlarmRuleOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 	}
 
 	createKeywordsAlarmRuleOpt.JSONBody = utils.RemoveNil(buildCreateKeywordsAlarmRuleBodyParams(d, cfg))
@@ -340,28 +365,17 @@ func resourceKeywordsAlarmRuleCreate(ctx context.Context, d *schema.ResourceData
 	}
 	d.SetId(ruleId)
 
-	if d.Get("status").(string) == "STOPPING" {
-		// updateKeywordsAlarmRuleStatus: Update the LTS KeywordsAlarmRule status.
-		var (
-			updateKeywordsAlarmRuleStatusHttpUrl = "v2/{project_id}/lts/alarms/status"
-		)
-
-		updateKeywordsAlarmRuleStatusPath := createKeywordsAlarmRuleClient.Endpoint + updateKeywordsAlarmRuleStatusHttpUrl
-		updateKeywordsAlarmRuleStatusPath = strings.ReplaceAll(updateKeywordsAlarmRuleStatusPath,
-			"{project_id}", createKeywordsAlarmRuleClient.ProjectID)
-
-		updateKeywordsAlarmRuleStatusOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
-			MoreHeaders: map[string]string{"Content-Type": "application/json"},
-		}
-
-		updateKeywordsAlarmRuleStatusOpt.JSONBody = utils.RemoveNil(buildUpdateKeywordsAlarmRuleStatusBodyParams(d))
-		_, err = createKeywordsAlarmRuleClient.Request("PUT", updateKeywordsAlarmRuleStatusPath, &updateKeywordsAlarmRuleStatusOpt)
+	if _, ok := d.GetOk("alarm_rule_alias"); ok {
+		err = updateKeywordAlarmRule(createKeywordsAlarmRuleClient, buildUpdateKeywordsAlarmRuleBodyParams(d, cfg))
 		if err != nil {
-			return diag.Errorf("error updating Keywords alarm rule: %s", err)
+			return diag.Errorf("error updating alias name of the keyword alarm rule (%s): %s", err, ruleId)
+		}
+	}
+
+	if d.Get("status").(string) == "STOPPING" {
+		err = updateAlarmRuleStatus(createKeywordsAlarmRuleClient, ruleId, "keywords", "STOPPING")
+		if err != nil {
+			return diag.Errorf("error stopping keyword alarm rule: %s", err)
 		}
 	}
 
@@ -370,18 +384,23 @@ func resourceKeywordsAlarmRuleCreate(ctx context.Context, d *schema.ResourceData
 
 func buildCreateKeywordsAlarmRuleBodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
 	bodyParams := map[string]interface{}{
-		"keywords_alarm_rule_name":        d.Get("name"),
-		"keywords_alarm_rule_description": utils.ValueIgnoreEmpty(d.Get("description")),
-		"keywords_requests":               buildKeywordsAlarmRuleRequestBodyKeywordsRequests(d.Get("keywords_requests")),
-		"frequency":                       buildKeywordsAlarmRuleRequestBodyFrequency(d.Get("frequency")),
-		"keywords_alarm_level":            d.Get("alarm_level"),
+		// Required parameter.
+		"keywords_alarm_rule_name": d.Get("name"),
+		"keywords_requests":        buildKeywordsAlarmRuleRequestBodyKeywordsRequests(d.Get("keywords_requests")),
+		"frequency":                buildKeywordsAlarmRuleRequestBodyFrequency(d.Get("frequency")),
+		"keywords_alarm_level":     d.Get("alarm_level"),
+		"domain_id":                cfg.DomainID,
+		// Optional parameter.
 		"keywords_alarm_send":             utils.ValueIgnoreEmpty(d.Get("send_notifications")),
-		"domain_id":                       cfg.DomainID,
+		"keywords_alarm_rule_description": utils.ValueIgnoreEmpty(d.Get("description")),
+		"alarm_action_rule_name":          utils.ValueIgnoreEmpty(d.Get("alarm_action_rule_name")),
 		"notification_rule":               buildKeywordsAlarmRuleRequestBodyNotificationRule(d.Get("notification_rule")),
+		"notification_save_rule":          buildKeywordsAlarmRuleRequestBodyNotificationRule(d.Get("notification_save_rule")),
 		"trigger_condition_count":         utils.ValueIgnoreEmpty(d.Get("trigger_condition_count")),
 		"trigger_condition_frequency":     utils.ValueIgnoreEmpty(d.Get("trigger_condition_frequency")),
 		"whether_recovery_policy":         utils.ValueIgnoreEmpty(d.Get("send_recovery_notifications")),
 		"recovery_policy":                 utils.ValueIgnoreEmpty(d.Get("recovery_frequency")),
+		"notification_frequency":          d.Get("notification_frequency"),
 	}
 	return bodyParams
 }
@@ -403,6 +422,8 @@ func buildKeywordsAlarmRuleRequestBodyKeywordsRequests(rawParams interface{}) []
 				"log_group_id":           utils.ValueIgnoreEmpty(raw["log_group_id"]),
 				"search_time_range_unit": utils.ValueIgnoreEmpty(raw["search_time_range_unit"]),
 				"search_time_range":      utils.ValueIgnoreEmpty(raw["search_time_range"]),
+				"log_group_name":         utils.ValueIgnoreEmpty(raw["log_group_name"]),
+				"log_stream_name":        utils.ValueIgnoreEmpty(raw["log_stream_name"]),
 			}
 		}
 		return rst
@@ -465,15 +486,44 @@ func buildKeywordsNotificationRuleTopic(rawParams interface{}) []map[string]inte
 		for i, v := range rawArray {
 			raw := v.(map[string]interface{})
 			rst[i] = map[string]interface{}{
-				"name":         utils.ValueIgnoreEmpty(raw["name"]),
-				"topic_urn":    utils.ValueIgnoreEmpty(raw["topic_urn"]),
+				"name":         raw["name"],
+				"topic_urn":    raw["topic_urn"],
 				"display_name": utils.ValueIgnoreEmpty(raw["display_name"]),
-				"push_policy":  utils.ValueIgnoreEmpty(raw["push_policy"]),
+				// Valid values: `0` and `1`.
+				"push_policy": raw["push_policy"],
 			}
 		}
 		return rst
 	}
 	return nil
+}
+
+func GetKeywordsAlarmRuleById(client *golangsdk.ServiceClient, alarmRuleId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/lts/alarms/keywords-alarm-rule"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonPath := fmt.Sprintf("keywords_alarm_rules[?keywords_alarm_rule_id =='%s']|[0]", alarmRuleId)
+	keywordsAlarmRule := utils.PathSearch(jsonPath, respBody, nil)
+	if keywordsAlarmRule == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return keywordsAlarmRule, nil
 }
 
 func resourceKeywordsAlarmRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -482,42 +532,14 @@ func resourceKeywordsAlarmRuleRead(_ context.Context, d *schema.ResourceData, me
 
 	var mErr *multierror.Error
 
-	// getKeywordsAlarmRule: Query the LTS KeywordsAlarmRule detail
-	var (
-		getKeywordsAlarmRuleHttpUrl = "v2/{project_id}/lts/alarms/keywords-alarm-rule"
-		getKeywordsAlarmRuleProduct = "lts"
-	)
-	getKeywordsAlarmRuleClient, err := cfg.NewServiceClient(getKeywordsAlarmRuleProduct, region)
+	client, err := cfg.NewServiceClient("lts", region)
 	if err != nil {
 		return diag.Errorf("error creating LTS client: %s", err)
 	}
 
-	getKeywordsAlarmRulePath := getKeywordsAlarmRuleClient.Endpoint + getKeywordsAlarmRuleHttpUrl
-	getKeywordsAlarmRulePath = strings.ReplaceAll(getKeywordsAlarmRulePath, "{project_id}", getKeywordsAlarmRuleClient.ProjectID)
-
-	getKeywordsAlarmRuleOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: map[string]string{"Content-Type": "application/json"},
-	}
-
-	getKeywordsAlarmRuleResp, err := getKeywordsAlarmRuleClient.Request("GET", getKeywordsAlarmRulePath, &getKeywordsAlarmRuleOpt)
-
+	getKeywordsAlarmRuleRespBody, err := GetKeywordsAlarmRuleById(client, d.Id())
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving KeywordsAlarmRule")
-	}
-
-	getKeywordsAlarmRuleRespBody, err := utils.FlattenResponse(getKeywordsAlarmRuleResp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	jsonPath := fmt.Sprintf("keywords_alarm_rules[?keywords_alarm_rule_id =='%s']|[0]", d.Id())
-	getKeywordsAlarmRuleRespBody = utils.PathSearch(jsonPath, getKeywordsAlarmRuleRespBody, nil)
-	if getKeywordsAlarmRuleRespBody == nil {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "no data found")
+		return common.CheckDeletedDiag(d, err, "error retrieving keyword alarm rule")
 	}
 
 	mErr = multierror.Append(
@@ -529,16 +551,21 @@ func resourceKeywordsAlarmRuleRead(_ context.Context, d *schema.ResourceData, me
 		d.Set("frequency", flattenGetKeywordsAlarmRuleResponseBodyFrequency(getKeywordsAlarmRuleRespBody)),
 		d.Set("alarm_level", utils.PathSearch("keywords_alarm_level", getKeywordsAlarmRuleRespBody, nil)),
 		d.Set("send_notifications", utils.PathSearch("keywords_alarm_send", getKeywordsAlarmRuleRespBody, nil)),
+		d.Set("alarm_action_rule_name", utils.PathSearch("alarm_action_rule_name", getKeywordsAlarmRuleRespBody, nil)),
+		d.Set("notification_save_rule", flattenNotificationSaveRule(d, getKeywordsAlarmRuleRespBody)),
 		d.Set("domain_id", utils.PathSearch("domain_id", getKeywordsAlarmRuleRespBody, nil)),
 		d.Set("trigger_condition_count", utils.PathSearch("trigger_condition_count", getKeywordsAlarmRuleRespBody, nil)),
 		d.Set("trigger_condition_frequency", utils.PathSearch("trigger_condition_frequency", getKeywordsAlarmRuleRespBody, nil)),
 		d.Set("send_recovery_notifications", utils.PathSearch("whether_recovery_policy", getKeywordsAlarmRuleRespBody, nil)),
 		d.Set("recovery_frequency", utils.PathSearch("recovery_policy", getKeywordsAlarmRuleRespBody, nil)),
+		d.Set("alarm_rule_alias", utils.PathSearch("alarm_rule_alias", getKeywordsAlarmRuleRespBody, nil)),
+		d.Set("notification_frequency", utils.PathSearch("notification_frequency", getKeywordsAlarmRuleRespBody, nil)),
 		d.Set("status", utils.PathSearch("status", getKeywordsAlarmRuleRespBody, nil)),
 		d.Set("created_at", utils.FormatTimeStampUTC(
 			int64(utils.PathSearch("create_time", getKeywordsAlarmRuleRespBody, float64(0)).(float64)/1000))),
 		d.Set("updated_at", utils.FormatTimeStampUTC(
 			int64(utils.PathSearch("update_time", getKeywordsAlarmRuleRespBody, float64(0)).(float64)/1000))),
+		d.Set("condition_expression", utils.PathSearch("condition_expression", getKeywordsAlarmRuleRespBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -560,6 +587,8 @@ func flattenGetKeywordsAlarmRuleResponseBodyKeywordsRequests(resp interface{}) [
 			"log_group_id":           utils.PathSearch("log_group_id", v, nil),
 			"search_time_range_unit": utils.PathSearch("search_time_range_unit", v, nil),
 			"search_time_range":      utils.PathSearch("search_time_range", v, nil),
+			"log_group_name":         utils.PathSearch("log_group_name", v, nil),
+			"log_stream_name":        utils.PathSearch("log_stream_name", v, nil),
 		})
 	}
 	return rst
@@ -585,9 +614,47 @@ func flattenGetKeywordsAlarmRuleResponseBodyFrequency(resp interface{}) []interf
 	return rst
 }
 
+func flattenNotificationSaveRule(d *schema.ResourceData, resp interface{}) []interface{} {
+	topics := utils.PathSearch("topics", resp, make([]interface{}, 0)).([]interface{})
+	if len(topics) == 0 {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"template_name": utils.PathSearch("template_name", resp, nil),
+			"user_name":     d.Get("notification_save_rule.0.user_name"),
+			"topics":        flattenNotificationSaveRuleTopics(topics),
+			"timezone":      d.Get("notification_save_rule.0.timezone"),
+			"language":      utils.PathSearch("language", resp, nil),
+		},
+	}
+}
+
+func flattenNotificationSaveRuleTopics(topics []interface{}) []interface{} {
+	rest := make([]interface{}, len(topics))
+	for i, v := range topics {
+		rest[i] = map[string]interface{}{
+			"name":         utils.PathSearch("name", v, nil),
+			"topic_urn":    utils.PathSearch("topic_urn", v, nil),
+			"display_name": utils.PathSearch("display_name", v, nil),
+			"push_policy":  utils.PathSearch("push_policy", v, nil),
+		}
+	}
+
+	return rest
+}
+
 func resourceKeywordsAlarmRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+	var (
+		cfg                = meta.(*config.Config)
+		keywordAlarmRuleId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("lts", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
 
 	updateKeywordsAlarmRuleChanges := []string{
 		"description",
@@ -598,70 +665,48 @@ func resourceKeywordsAlarmRuleUpdate(ctx context.Context, d *schema.ResourceData
 		"trigger_condition_frequency",
 		"send_recovery_notifications",
 		"recovery_frequency",
+		"send_notifications",
+		"alarm_action_rule_name",
+		"notification_save_rule",
+		"alarm_rule_alias",
+		"notification_frequency",
 	}
 
 	if d.HasChanges(updateKeywordsAlarmRuleChanges...) {
-		// updateKeywordsAlarmRule: Update the LTS KeywordsAlarmRule.
-		var (
-			updateKeywordsAlarmRuleHttpUrl = "v2/{project_id}/lts/alarms/keywords-alarm-rule"
-			updateKeywordsAlarmRuleProduct = "lts"
-		)
-		updateKeywordsAlarmRuleClient, err := cfg.NewServiceClient(updateKeywordsAlarmRuleProduct, region)
+		err = updateKeywordAlarmRule(client, updateKeywordAlarmRuleParams(d, cfg))
 		if err != nil {
-			return diag.Errorf("error creating LTS client: %s", err)
-		}
-
-		updateKeywordsAlarmRulePath := updateKeywordsAlarmRuleClient.Endpoint + updateKeywordsAlarmRuleHttpUrl
-		updateKeywordsAlarmRulePath = strings.ReplaceAll(updateKeywordsAlarmRulePath, "{project_id}", updateKeywordsAlarmRuleClient.ProjectID)
-
-		updateKeywordsAlarmRuleOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
-			MoreHeaders: map[string]string{"Content-Type": "application/json"},
-		}
-
-		updateKeywordsAlarmRuleOpt.JSONBody = utils.RemoveNil(buildUpdateKeywordsAlarmRuleBodyParams(d, cfg))
-		_, err = updateKeywordsAlarmRuleClient.Request("PUT", updateKeywordsAlarmRulePath, &updateKeywordsAlarmRuleOpt)
-		if err != nil {
-			return diag.Errorf("error updating Keywords alarm rule: %s", err)
+			return diag.Errorf("error updating keyword alarm rule (%s): %s", err, keywordAlarmRuleId)
 		}
 	}
-	updateKeywordsAlarmRuleStatusChanges := []string{
-		"status",
-	}
 
-	if d.HasChanges(updateKeywordsAlarmRuleStatusChanges...) {
-		// updateKeywordsAlarmRuleStatus: Update the LTS KeywordsAlarmRule status.
-		var (
-			updateKeywordsAlarmRuleStatusHttpUrl = "v2/{project_id}/lts/alarms/status"
-			updateKeywordsAlarmRuleStatusProduct = "lts"
-		)
-		updateKeywordsAlarmRuleStatusClient, err := cfg.NewServiceClient(updateKeywordsAlarmRuleStatusProduct, region)
+	if d.HasChange("status") {
+		err = updateAlarmRuleStatus(client, keywordAlarmRuleId, "keywords", d.Get("status").(string))
 		if err != nil {
-			return diag.Errorf("error creating LTS client: %s", err)
-		}
-
-		updateKeywordsAlarmRuleStatusPath := updateKeywordsAlarmRuleStatusClient.Endpoint + updateKeywordsAlarmRuleStatusHttpUrl
-		updateKeywordsAlarmRuleStatusPath = strings.ReplaceAll(updateKeywordsAlarmRuleStatusPath,
-			"{project_id}", updateKeywordsAlarmRuleStatusClient.ProjectID)
-
-		updateKeywordsAlarmRuleStatusOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
-			MoreHeaders: map[string]string{"Content-Type": "application/json"},
-		}
-
-		updateKeywordsAlarmRuleStatusOpt.JSONBody = utils.RemoveNil(buildUpdateKeywordsAlarmRuleStatusBodyParams(d))
-		_, err = updateKeywordsAlarmRuleStatusClient.Request("PUT", updateKeywordsAlarmRuleStatusPath, &updateKeywordsAlarmRuleStatusOpt)
-		if err != nil {
-			return diag.Errorf("error updating Keywords alarm rule: %s", err)
+			return diag.Errorf("error updating status of the keyword alarm rule (%s): %s", err, keywordAlarmRuleId)
 		}
 	}
 	return resourceKeywordsAlarmRuleRead(ctx, d, meta)
+}
+
+func updateKeywordAlarmRuleParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
+	bodyParams := buildUpdateKeywordsAlarmRuleBodyParams(d, cfg)
+	if !d.HasChange("notification_save_rule.0.topics") {
+		return bodyParams
+	}
+	oRaw, nRaw := d.GetChange("notification_save_rule.0.topics")
+	oTopics := oRaw.([]interface{})
+	nTopics := nRaw.([]interface{})
+	// `1` means add the topics.
+	// `2` means modify the topics.
+	// `3` means delete the topics.
+	bodyParams["keywords_alarm_send_code"] = 2
+	if len(oTopics) == 0 && len(nTopics) != 0 {
+		bodyParams["keywords_alarm_send_code"] = 1
+	}
+	if len(nTopics) == 0 && !d.Get("send_notifications").(bool) {
+		bodyParams["keywords_alarm_send_code"] = 3
+	}
+	return bodyParams
 }
 
 func buildUpdateKeywordsAlarmRuleBodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
@@ -673,21 +718,58 @@ func buildUpdateKeywordsAlarmRuleBodyParams(d *schema.ResourceData, cfg *config.
 		"frequency":                       buildKeywordsAlarmRuleRequestBodyFrequency(d.Get("frequency")),
 		"keywords_alarm_level":            d.Get("alarm_level"),
 		"keywords_alarm_send":             utils.ValueIgnoreEmpty(d.Get("send_notifications")),
-		"keywords_alarm_send_code":        0,
-		"domain_id":                       cfg.DomainID,
-		"trigger_condition_count":         utils.ValueIgnoreEmpty(d.Get("trigger_condition_count")),
-		"trigger_condition_frequency":     utils.ValueIgnoreEmpty(d.Get("trigger_condition_frequency")),
-		"whether_recovery_policy":         utils.ValueIgnoreEmpty(d.Get("send_recovery_notifications")),
-		"recovery_policy":                 utils.ValueIgnoreEmpty(d.Get("recovery_frequency")),
+		// `0` means do not modify the topics.
+		"keywords_alarm_send_code":    0,
+		"domain_id":                   cfg.DomainID,
+		"trigger_condition_count":     utils.ValueIgnoreEmpty(d.Get("trigger_condition_count")),
+		"trigger_condition_frequency": utils.ValueIgnoreEmpty(d.Get("trigger_condition_frequency")),
+		"whether_recovery_policy":     utils.ValueIgnoreEmpty(d.Get("send_recovery_notifications")),
+		"recovery_policy":             utils.ValueIgnoreEmpty(d.Get("recovery_frequency")),
+		"alarm_action_rule_name":      utils.ValueIgnoreEmpty(d.Get("alarm_action_rule_name")),
+		"alarm_rule_alias":            utils.ValueIgnoreEmpty(d.Get("alarm_rule_alias")),
+		"notification_save_rule":      buildKeywordsAlarmRuleRequestBodyNotificationRule(d.Get("notification_save_rule")),
+		"notification_frequency":      d.Get("notification_frequency"),
 	}
+
 	return bodyParams
 }
 
-func buildUpdateKeywordsAlarmRuleStatusBodyParams(d *schema.ResourceData) map[string]interface{} {
+func updateKeywordAlarmRule(client *golangsdk.ServiceClient, params map[string]interface{}) error {
+	updateHttpUrl := "v2/{project_id}/lts/alarms/keywords-alarm-rule"
+	updatePath := client.Endpoint + updateHttpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(params),
+	}
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
+func updateAlarmRuleStatus(client *golangsdk.ServiceClient, alarmRuleId, alarmRuleType, status string) error {
+	updateAlarmRuleStatusHttpUrl := "v2/{project_id}/lts/alarms/status"
+	updateAlarmRuleStatusPath := client.Endpoint + updateAlarmRuleStatusHttpUrl
+	updateAlarmRuleStatusPath = strings.ReplaceAll(updateAlarmRuleStatusPath, "{project_id}", client.ProjectID)
+	updateAlarmRuleStatusOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildUpdateAlarmRuleStatusBodyParams(alarmRuleId, alarmRuleType, status)),
+	}
+	_, err := client.Request("PUT", updateAlarmRuleStatusPath, &updateAlarmRuleStatusOpt)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func buildUpdateAlarmRuleStatusBodyParams(alarmRuleId, alarmRuletype, status string) map[string]interface{} {
 	bodyParams := map[string]interface{}{
-		"alarm_rule_id": d.Id(),
-		"type":          "keywords",
-		"status":        utils.ValueIgnoreEmpty(d.Get("status")),
+		"alarm_rule_id": alarmRuleId,
+		"type":          alarmRuletype,
+		"status":        status,
 	}
 	return bodyParams
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Adjust description of the parameters in document.
2. This resource support new fields:
+ Add new parameters: `alarm_action_rule_name`, `alarm_rule_alias`, `notification_frequency`, `keywords_requests.log_group_name`, `keywords_requests.log_stream_name`.
+ The `send_notifications` parameters supports modify.
+ User `notification_save_rule` instend in `notification_rule` (After testing, the specified `notification_rule` does not take effect, so it is deprecated). 
+ Add new attritubes: `condition_expression`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. adjust description of the parameters in document.
2. this resource support new fields.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o lts -f TestAccKeywordsAlarmRule_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccKeywordsAlarmRule_ -timeout 360m -parallel 10
=== RUN   TestAccKeywordsAlarmRule_basic
=== PAUSE TestAccKeywordsAlarmRule_basic
=== CONT  TestAccKeywordsAlarmRule_basic
--- PASS: TestAccKeywordsAlarmRule_basic (115.74s)
PASS
coverage: 13.1% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       116.202s        coverage: 13.1% of statements in ./huaweicloud/services/lts
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found   
![image](https://github.com/user-attachments/assets/8e90a99e-bb16-4a8d-ab69-ffae7f53f73b)


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
