### PR TITLE
refactor(ims): refactor `ims_obs_iso_image` resource code style

### DIFF
--- a/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_obs_iso_image_test.go
+++ b/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_obs_iso_image_test.go
@@ -9,35 +9,52 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ims"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// This method is being used by other resources and will be deleted in the future.
-func getImsImageResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := cfg.ImageV2Client(acceptance.HW_REGION_NAME)
+func getObsIsoImageResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		product = "ims"
+		httpUrl = "v2/cloudimages"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating IMS v2 client: %s", err)
+		return nil, fmt.Errorf("error creating IMS client: %s", err)
 	}
 
-	imageList, err := ims.GetImageList(client, state.Primary.ID)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving IMS images: %s", err)
+	getPath := client.Endpoint + httpUrl
+	getPath += fmt.Sprintf("?id=%s", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
 
-	if len(imageList) < 1 {
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving IMS OBS ISO image: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	image := utils.PathSearch("images[0]", getRespBody, nil)
+	// If the list API return empty, then return `404` error code.
+	if image == nil {
 		return nil, golangsdk.ErrDefault404{}
 	}
 
-	return imageList[0], nil
+	return image, nil
 }
 
 func TestAccObsIsoImage_basic(t *testing.T) {
 	var (
-		image        cloudimages.Image
+		image        interface{}
 		rName        = acceptance.RandomAccResourceName()
 		rNameUpdate  = rName + "-update"
 		resourceName = "huaweicloud_ims_obs_iso_image.test"
@@ -48,7 +65,7 @@ func TestAccObsIsoImage_basic(t *testing.T) {
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&image,
-		getImsImageResourceFunc,
+		getObsIsoImageResourceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/huaweicloud/services/ims/resource_huaweicloud_ims_obs_iso_image.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_ims_obs_iso_image.go
@@ -2,26 +2,21 @@ package ims
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
-	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/imageservice/v2/images"
-	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
-	"github.com/chnsz/golangsdk/openstack/ims/v2/tags"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API IMS POST /v2/cloudimages/action
@@ -36,7 +31,7 @@ func ResourceObsIsoImage() *schema.Resource {
 		CreateContext: resourceObsIsoImageCreate,
 		ReadContext:   resourceObsIsoImageRead,
 		UpdateContext: resourceObsIsoImageUpdate,
-		DeleteContext: resourceImageDelete,
+		DeleteContext: resourceObsIsoImageDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -152,39 +147,65 @@ func ResourceObsIsoImage() *schema.Resource {
 	}
 }
 
+func buildCreateObsIsoImageBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":                  d.Get("name"),
+		"image_url":             d.Get("image_url"),
+		"min_disk":              d.Get("min_disk"),
+		"os_version":            d.Get("os_version"),
+		"description":           d.Get("description"),
+		"type":                  "IsoImage",
+		"cmk_id":                utils.ValueIgnoreEmpty(d.Get("cmk_id")),
+		"architecture":          utils.ValueIgnoreEmpty(d.Get("architecture")),
+		"max_ram":               utils.ValueIgnoreEmpty(d.Get("max_ram")),
+		"min_ram":               utils.ValueIgnoreEmpty(d.Get("min_ram")),
+		"image_tags":            utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{})),
+		"enterprise_project_id": utils.ValueIgnoreEmpty(d.Get("enterprise_project_id")),
+	}
+
+	if d.Get("is_config").(bool) {
+		bodyParams["is_config"] = true
+	}
+
+	return bodyParams
+}
+
 func resourceObsIsoImageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ims"
+		httpUrl = "v2/cloudimages/action"
 	)
 
-	client, err := cfg.ImageV2Client(region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating IMS v2 client: %s", err)
+		return diag.Errorf("error creating IMS client: %s", err)
 	}
 
-	imageTags := buildCreateImageTagsParam(d)
-	createOpts := &cloudimages.CreateByOBSOpts{
-		Name:                d.Get("name").(string),
-		Description:         d.Get("description").(string),
-		OsVersion:           d.Get("os_version").(string),
-		ImageUrl:            d.Get("image_url").(string),
-		MinDisk:             d.Get("min_disk").(int),
-		IsConfig:            d.Get("is_config").(bool),
-		CmkId:               d.Get("cmk_id").(string),
-		ImageTags:           imageTags,
-		Type:                "IsoImage",
-		MaxRam:              d.Get("max_ram").(int),
-		MinRam:              d.Get("min_ram").(int),
-		Architecture:        d.Get("architecture").(string),
-		EnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
+	createPath := client.Endpoint + httpUrl
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildCreateObsIsoImageBodyParams(d)),
 	}
-	createResp, err := cloudimages.CreateImageByOBS(client, createOpts).ExtractJobResponse()
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
 		return diag.Errorf("error creating IMS OBS ISO image: %s", err)
 	}
 
-	imageId, err := waitForCreateImageCompleted(client, d, createResp.JobID)
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", createRespBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("error creating IMS OBS ISO image: job ID is not found in API response")
+	}
+
+	imageId, err := waitForCreateObsIsoImageJobCompleted(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("error waiting for IMS OBS ISO image to complete: %s", err)
 	}
@@ -194,52 +215,133 @@ func resourceObsIsoImageCreate(ctx context.Context, d *schema.ResourceData, meta
 	return resourceObsIsoImageRead(ctx, d, meta)
 }
 
-func resourceObsIsoImageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
-		mErr   *multierror.Error
-	)
-
-	client, err := cfg.ImageV2Client(region)
-	if err != nil {
-		return diag.Errorf("error creating IMS v2 client: %s", err)
+func waitForCreateObsIsoImageJobCompleted(ctx context.Context, client *golangsdk.ServiceClient, jobId string,
+	timeout time.Duration) (string, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      obsIsoImageJobStatusRefreshFunc(jobId, client),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 
-	imageList, err := GetImageList(client, d.Id())
+	getRespBody, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf("error retrieving IMS OBS ISO images: %s", err)
+		return "", fmt.Errorf("error waiting for IMS OBS ISO image job (%s) to succeed: %s", jobId, err)
+	}
+
+	imageId := utils.PathSearch("entities.image_id", getRespBody, "").(string)
+	if imageId == "" {
+		return "", errors.New("the image ID is not found in API response")
+	}
+
+	return imageId, nil
+}
+
+func obsIsoImageJobStatusRefreshFunc(jobId string, client *golangsdk.ServiceClient) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		getPath := client.Endpoint + "v1/{project_id}/jobs/{job_id}"
+		getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+		getPath = strings.ReplaceAll(getPath, "{job_id}", fmt.Sprintf("%v", jobId))
+		getOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+
+		getResp, err := client.Request("GET", getPath, &getOpt)
+		if err != nil {
+			return getResp, "ERROR", fmt.Errorf("error retrieving IMS OBS ISO image job: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return getRespBody, "ERROR", err
+		}
+
+		status := utils.PathSearch("status", getRespBody, "").(string)
+		if status == "SUCCESS" {
+			return getRespBody, "COMPLETED", nil
+		}
+
+		if status == "FAIL" {
+			return getRespBody, "COMPLETED", errors.New("the OBS ISO image creation job execution failed")
+		}
+
+		if status == "" {
+			return getRespBody, "ERROR", errors.New("status field is not found in API response")
+		}
+
+		return getRespBody, "PENDING", nil
+	}
+}
+
+func getObsIsoImage(client *golangsdk.ServiceClient, imageId string) (interface{}, error) {
+	// If the `enterprise_project_id` is not filled, the list API will query images under all enterprise projects.
+	// So there's no need to fill `enterprise_project_id` here.
+	getPath := client.Endpoint + "v2/cloudimages"
+	getPath += fmt.Sprintf("?id=%s", imageId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving IMS OBS ISO image: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("images[0]", getRespBody, nil), nil
+}
+
+func resourceObsIsoImageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ims"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating IMS client: %s", err)
+	}
+
+	image, err := getObsIsoImage(client, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	// If the list API return empty, then process `CheckDeleted` logic.
-	if len(imageList) < 1 {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "IMS OBS ISO image")
+	if image == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving IMS OBS ISO image")
 	}
 
-	image := imageList[0]
-	imageTags := flattenImageTags(d, client)
-	mErr = multierror.Append(
+	dataOrigin := utils.PathSearch("__data_origin", image, "").(string)
+	mErr := multierror.Append(
 		d.Set("region", region),
-		d.Set("name", image.Name),
-		d.Set("image_url", flattenSpecificValueFormDataOrigin(image.DataOrigin, "file")),
-		d.Set("min_disk", image.MinDisk),
-		d.Set("os_version", image.OsVersion),
-		d.Set("description", image.Description),
-		d.Set("cmk_id", image.SystemCmkid),
-		d.Set("architecture", flattenArchitecture(image.SupportArm)),
-		d.Set("max_ram", flattenMaxRAM(image.MaxRam)),
-		d.Set("min_ram", image.MinRam),
-		d.Set("tags", imageTags),
-		d.Set("enterprise_project_id", image.EnterpriseProjectID),
-		d.Set("status", image.Status),
-		d.Set("visibility", image.Visibility),
-		d.Set("image_size", image.ImageSize),
-		d.Set("os_type", image.OsType),
-		d.Set("disk_format", image.DiskFormat),
-		d.Set("data_origin", image.DataOrigin),
-		d.Set("active_at", image.ActiveAt),
-		d.Set("created_at", image.CreatedAt.Format(time.RFC3339)),
-		d.Set("updated_at", image.UpdatedAt.Format(time.RFC3339)),
+		d.Set("name", utils.PathSearch("name", image, nil)),
+		d.Set("image_url", flattenSpecificValueFormDataOrigin(dataOrigin, "file")),
+		d.Set("min_disk", utils.PathSearch("min_disk", image, nil)),
+		d.Set("os_version", utils.PathSearch("__os_version", image, nil)),
+		d.Set("description", utils.PathSearch("__description", image, nil)),
+		d.Set("cmk_id", utils.PathSearch("__system__cmkid", image, nil)),
+		d.Set("architecture", flattenArchitecture(utils.PathSearch("__support_arm", image, "").(string))),
+		d.Set("max_ram", flattenMaxRAM(utils.PathSearch("max_ram", image, "").(string))),
+		d.Set("min_ram", utils.PathSearch("min_ram", image, nil)),
+		d.Set("tags", flattenIMSImageTags(client, d.Id())),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", image, nil)),
+		d.Set("status", utils.PathSearch("status", image, nil)),
+		d.Set("visibility", utils.PathSearch("visibility", image, nil)),
+		d.Set("image_size", utils.PathSearch("__image_size", image, nil)),
+		d.Set("os_type", utils.PathSearch("__os_type", image, nil)),
+		d.Set("disk_format", utils.PathSearch("disk_format", image, nil)),
+		d.Set("data_origin", dataOrigin),
+		d.Set("active_at", utils.PathSearch("active_at", image, nil)),
+		d.Set("created_at", utils.PathSearch("created_at", image, nil)),
+		d.Set("updated_at", utils.PathSearch("updated_at", image, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -247,183 +349,99 @@ func resourceObsIsoImageRead(_ context.Context, d *schema.ResourceData, meta int
 
 func resourceObsIsoImageUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
-	)
-
-	client, err := cfg.ImageV2Client(region)
-	if err != nil {
-		return diag.Errorf("error creating IMS v2 client: %s", err)
-	}
-
-	err = updateImage(ctx, cfg, client, d)
-	if err != nil {
-		return diag.Errorf("error updating IMS OBS ISO image: %s", err)
-	}
-
-	return resourceObsIsoImageRead(ctx, d, meta)
-}
-
-// This method is being used by other resources and will be deleted in the future.
-func buildCreateImageTagsParam(d *schema.ResourceData) []cloudimages.ImageTag {
-	var imageTags []cloudimages.ImageTag
-
-	rawTags := d.Get("tags").(map[string]interface{})
-	for key, val := range rawTags {
-		imageTag := cloudimages.ImageTag{
-			Key:   key,
-			Value: val.(string),
-		}
-		imageTags = append(imageTags, imageTag)
-	}
-
-	return imageTags
-}
-
-// This method is being used by other resources and will be deleted in the future.
-func waitForCreateImageCompleted(client *golangsdk.ServiceClient, d *schema.ResourceData, jobId string) (string, error) {
-	err := cloudimages.WaitForJobSuccess(client, int(d.Timeout(schema.TimeoutCreate)/time.Second), jobId)
-	if err != nil {
-		return "", err
-	}
-
-	imageId, err := cloudimages.GetJobEntity(client, jobId, "image_id")
-	if err != nil {
-		return "", err
-	}
-
-	v, ok := imageId.(string)
-	if !ok {
-		return "", errors.New("an unexpected conversion error occurred with image_id")
-	}
-
-	return v, nil
-}
-
-// This method is being used by other resources and will be deleted in the future.
-func GetImageList(client *golangsdk.ServiceClient, imageId string) ([]cloudimages.Image, error) {
-	// If the `enterprise_project_id` is not filled, the list API will query images under all enterprise projects.
-	// So there's no need to fill `enterprise_project_id` here.
-	listOpts := &cloudimages.ListOpts{
-		ID: imageId,
-	}
-	allPages, err := cloudimages.List(client, listOpts).AllPages()
-	if err != nil {
-		return nil, err
-	}
-
-	allImages, err := cloudimages.ExtractImages(allPages)
-	if err != nil {
-		return nil, fmt.Errorf("unable to extract images: %s", err)
-	}
-
-	return allImages, nil
-}
-
-// This method is being used by other resources and will be deleted in the future.
-func flattenImageTags(d *schema.ResourceData, client *golangsdk.ServiceClient) map[string]string {
-	tagList, err := tags.Get(client, d.Id()).Extract()
-	if err == nil {
-		tagMap := make(map[string]string)
-		for _, val := range tagList.Tags {
-			tagMap[val.Key] = val.Value
-		}
-
-		return tagMap
-	}
-	log.Printf("[WARN] failed fetch image tags: %s", err)
-
-	return nil
-}
-
-// This method is being used by other resources and will be deleted in the future.
-func convertTagMapToTags(tagMap map[string]interface{}) []tags.Tag {
-	var tagList []tags.Tag
-
-	for k, v := range tagMap {
-		tag := tags.Tag{
-			Key:   k,
-			Value: v.(string),
-		}
-		tagList = append(tagList, tag)
-	}
-
-	return tagList
-}
-
-// This method is being used by other resources and will be deleted in the future.
-func updateImage(ctx context.Context, cfg *config.Config, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
-	var (
-		imageId = d.Id()
+		cfg     = meta.(*config.Config)
 		region  = cfg.GetRegion(d)
+		product = "ims"
+		httpUrl = "v2/cloudimages/{image_id}"
+		imageId = d.Id()
 	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating IMS client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{image_id}", imageId)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
 
 	if d.HasChange("name") {
-		updateOpts := make(cloudimages.UpdateOpts, 0)
-		nameOpt := cloudimages.UpdateImageProperty{
-			Op:    cloudimages.ReplaceOp,
-			Name:  "name",
-			Value: d.Get("name").(string),
+		bodyParams := []map[string]interface{}{
+			{
+				"op":    "replace",
+				"path":  "/name",
+				"value": d.Get("name"),
+			},
 		}
-		updateOpts = append(updateOpts, nameOpt)
-		_, err := cloudimages.Update(client, imageId, updateOpts).Extract()
+
+		updateOpt.JSONBody = bodyParams
+		_, err = client.Request("PATCH", updatePath, &updateOpt)
 		if err != nil {
-			return fmt.Errorf("failed update name: %s", err)
+			return diag.Errorf("error updating IMS OBS ISO image name field: %s", err)
 		}
 	}
 
 	if d.HasChange("description") {
-		updateOpts := make(cloudimages.UpdateOpts, 0)
-		descriptionOpt := cloudimages.UpdateImageProperty{
-			Op:    cloudimages.ReplaceOp,
-			Name:  "__description",
-			Value: d.Get("description").(string),
+		bodyParams := []map[string]interface{}{
+			{
+				"op":    "replace",
+				"path":  "/__description",
+				"value": d.Get("description"),
+			},
 		}
-		updateOpts = append(updateOpts, descriptionOpt)
-		_, err := cloudimages.Update(client, imageId, updateOpts).Extract()
+
+		updateOpt.JSONBody = bodyParams
+		_, err = client.Request("PATCH", updatePath, &updateOpt)
 		if err != nil {
-			err = dealUpdateDescriptionErr(d, client, err)
+			err = processUpdateDescriptionError(d, client, err)
 			if err != nil {
-				return err
+				return diag.Errorf("error updating IMS OBS ISO image description field: %s", err)
 			}
 		}
 	}
 
 	if d.HasChange("max_ram") {
-		updateOpts := make(cloudimages.UpdateOpts, 0)
-		maxRAMOpt := cloudimages.UpdateImageProperty{
-			Op:    cloudimages.ReplaceOp,
-			Name:  "max_ram",
-			Value: strconv.Itoa(d.Get("max_ram").(int)),
+		bodyParams := []map[string]interface{}{
+			{
+				"op":    "replace",
+				"path":  "/max_ram",
+				"value": d.Get("max_ram"),
+			},
 		}
-		updateOpts = append(updateOpts, maxRAMOpt)
-		_, err := cloudimages.Update(client, imageId, updateOpts).Extract()
+
+		updateOpt.JSONBody = bodyParams
+		_, err = client.Request("PATCH", updatePath, &updateOpt)
 		if err != nil {
-			err = dealUpdateMaxRAMErr(d, client, err)
+			err = processUpdateMaxRAMError(d, client, err)
 			if err != nil {
-				return err
+				return diag.Errorf("error updating IMS OBS ISO image max_ram field: %s", err)
 			}
 		}
 	}
 
 	if d.HasChange("min_ram") {
-		updateOpts := make(cloudimages.UpdateOpts, 0)
-		minRAMOpt := cloudimages.UpdateImageProperty{
-			Op:    cloudimages.ReplaceOp,
-			Name:  "min_ram",
-			Value: d.Get("min_ram").(int),
+		bodyParams := []map[string]interface{}{
+			{
+				"op":    "replace",
+				"path":  "/min_ram",
+				"value": d.Get("min_ram"),
+			},
 		}
-		updateOpts = append(updateOpts, minRAMOpt)
-		_, err := cloudimages.Update(client, imageId, updateOpts).Extract()
+
+		updateOpt.JSONBody = bodyParams
+		_, err = client.Request("PATCH", updatePath, &updateOpt)
 		if err != nil {
-			return fmt.Errorf("failed update min_ram: %s", err)
+			return diag.Errorf("error updating IMS OBS ISO image min_ram field: %s", err)
 		}
 	}
 
 	if d.HasChange("tags") {
-		err := updateImageTags(client, d)
+		err = updateIMSImageTags(client, d)
 		if err != nil {
-			return err
+			return diag.Errorf("error updating IMS OBS ISO image tags field: %s", err)
 		}
 	}
 
@@ -434,169 +452,78 @@ func updateImage(ctx context.Context, cfg *config.Config, client *golangsdk.Serv
 			RegionId:     region,
 			ProjectId:    client.ProjectID,
 		}
-		if err := cfg.MigrateEnterpriseProject(ctx, d, migrateOpts); err != nil {
-			return err
+		if err = cfg.MigrateEnterpriseProject(ctx, d, migrateOpts); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 
-	return nil
+	return resourceObsIsoImageRead(ctx, d, meta)
 }
 
-// This method is being used by other resources and will be deleted in the future.
-func updateImageTags(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
-	var (
-		oRaw, nRaw = d.GetChange("tags")
-		oMap       = oRaw.(map[string]interface{})
-		nMap       = nRaw.(map[string]interface{})
-		imageId    = d.Id()
-	)
-
-	// Remove old tags
-	if len(oMap) > 0 {
-		deleteOpts := tags.BatchOpts{Action: tags.ActionDelete, Tags: convertTagMapToTags(oMap)}
-		deleteTags := tags.BatchAction(client, imageId, deleteOpts)
-		if deleteTags.Err != nil {
-			return fmt.Errorf("faild delete old tags: %s", deleteTags.Err)
-		}
-	}
-
-	// Create new tags
-	if len(nMap) > 0 {
-		createOpts := tags.BatchOpts{Action: tags.ActionCreate, Tags: convertTagMapToTags(nMap)}
-		createTags := tags.BatchAction(client, imageId, createOpts)
-		if createTags.Err != nil {
-			return fmt.Errorf("faild create new tags: %s", createTags.Err)
-		}
-	}
-
-	return nil
-}
-
-// This method is being used by other resources and will be deleted in the future.
-func dealUpdateDescriptionErr(d *schema.ResourceData, client *golangsdk.ServiceClient, err error) error {
-	if errCode, ok := err.(golangsdk.ErrDefault400); ok {
-		var apiError interface{}
-		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
-			return jsonErr
-		}
-		errorCode, errorCodeErr := jmespath.Search("error.code", apiError)
-		if errorCodeErr != nil {
-			return fmt.Errorf("error parse errorCode from response body: %s", errorCodeErr)
-		}
-		if errorCode != "IMG.0035" {
-			return err
-		}
-		updateOpts := make(cloudimages.UpdateOpts, 0)
-		description := cloudimages.UpdateImageProperty{
-			Op:    cloudimages.AddOp,
-			Name:  "__description",
-			Value: d.Get("description").(string),
-		}
-		updateOpts = append(updateOpts, description)
-
-		_, err = cloudimages.Update(client, d.Id(), updateOpts).Extract()
-		if err != nil {
-			return fmt.Errorf("failed update description: %s", err)
-		}
-		return nil
-	}
-
-	return fmt.Errorf("failed update description field: %s", err)
-}
-
-// This method is being used by other resources and will be deleted in the future.
-func dealUpdateMaxRAMErr(d *schema.ResourceData, client *golangsdk.ServiceClient, err error) error {
-	if errCode, ok := err.(golangsdk.ErrDefault400); ok {
-		var apiError interface{}
-		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
-			return jsonErr
-		}
-
-		errorCode, errorCodeErr := jmespath.Search("error.code", apiError)
-		if errorCodeErr != nil {
-			return fmt.Errorf("error parse errorCode from response body: %s", errorCodeErr)
-		}
-
-		if errorCode != "IMG.0035" {
-			return err
-		}
-
-		updateOpts := make(cloudimages.UpdateOpts, 0)
-		description := cloudimages.UpdateImageProperty{
-			Op:    cloudimages.AddOp,
-			Name:  "max_ram",
-			Value: d.Get("max_ram").(int),
-		}
-		updateOpts = append(updateOpts, description)
-
-		_, err = cloudimages.Update(client, d.Id(), updateOpts).Extract()
-		if err != nil {
-			return fmt.Errorf("failed update max_ram: %s", err)
-		}
-
-		return nil
-	}
-
-	return fmt.Errorf("failed update max_ram field: %s", err)
-}
-
-// This method is being used by other resources and will be deleted in the future.
-func resourceImageDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceObsIsoImageDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg     = meta.(*config.Config)
 		region  = cfg.GetRegion(d)
+		product = "ims"
+		httpUrl = "v2/images/{image_id}"
 		imageId = d.Id()
 	)
 
-	client, err := cfg.ImageV2Client(region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating IMS v2 client: %s", err)
+		return diag.Errorf("error creating IMS client: %s", err)
 	}
 
 	// Before deleting, call the query API first, if the query result is empty, then process `CheckDeleted` logic.
-	imageList, err := GetImageList(client, imageId)
+	image, err := getObsIsoImage(client, imageId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	if len(imageList) < 1 {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "IMS image")
+	if image == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "IMS OBS ISO image")
 	}
 
-	if err = images.Delete(client, imageId).Err; err != nil {
-		return diag.Errorf("error deleting IMS image: %s", err)
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{image_id}", imageId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting IMS OBS ISO image: %s", err)
 	}
 
 	// Because the delete API always return `204` status code,
 	// so we need to call the list query API to check if the image has been successfully deleted.
-	err = waitForDeleteImageCompleted(ctx, client, d)
+	err = waitForObsIsoImageDeleted(ctx, client, d)
 	if err != nil {
-		return diag.Errorf("error waiting for IMS image deleted: %s", err)
+		return diag.Errorf("error waiting for IMS OBS ISO image to be deleted: %s", err)
 	}
 
 	return nil
 }
 
-// This method is being used by other resources and will be deleted in the future.
-func waitForDeleteImageCompleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+func waitForObsIsoImageDeleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			listResp, err := GetImageList(client, d.Id())
+			image, err := getObsIsoImage(client, d.Id())
 			if err != nil {
-				return nil, "ERROR", nil
+				return nil, "ERROR", err
 			}
 
-			if len(listResp) < 1 {
-				return "success", "COMPLETED", nil
+			if image == nil {
+				return "SUCCESS", "COMPLETED", nil
 			}
 
-			return listResp, "PENDING", nil
+			return image, "PENDING", nil
 		},
-		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
-		MinTimeout: 3 * time.Second,
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 3 * time.Second,
 	}
 
 	_, err := stateConf.WaitForStateContext(ctx)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

refactor `ims_obs_iso_image` resource code style

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

***Create a resource using the old code package:***
![image](https://github.com/user-attachments/assets/50b13707-2c61-455a-acbb-2b58d77b86ce)

***Execute terraform plan using new code package:***
![image](https://github.com/user-attachments/assets/b3e87b3d-96f2-44de-b687-d1ac57d9e4cb)

***In summary, it can be considered that this reconstruction will have no impact on existing users.***



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

refactor `ims_obs_iso_image` resource code style

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccObsIsoImage_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccObsIsoImage_basic -timeout 360m -parallel 4
=== RUN   TestAccObsIsoImage_basic
=== PAUSE TestAccObsIsoImage_basic
=== CONT  TestAccObsIsoImage_basic
--- PASS: TestAccObsIsoImage_basic (178.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       178.665s

```
![image](https://github.com/user-attachments/assets/ef95436b-45d8-481e-9e04-8dfd9ac6737d)


* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/324cef8a-c1e1-4ece-ad08-08d4defd82d6)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/user-attachments/assets/8137b99a-6a1a-4181-b399-d1f9a907643a)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
