### PR TITLE
refactor(nat): refactor the private NAT gateway resource code style

### DIFF
--- a/docs/resources/nat_private_gateway.md
+++ b/docs/resources/nat_private_gateway.md
@@ -2,7 +2,8 @@
 subcategory: "NAT Gateway (NAT)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_nat_private_gateway"
-description: ""
+description: |-
+  Manages a gateway resource of the **private** NAT within HuaweiCloud.
 ---
 
 # huaweicloud_nat_private_gateway
@@ -14,13 +15,12 @@ Manages a gateway resource of the **private** NAT within HuaweiCloud.
 ```hcl
 variable "subnet_id" {}
 variable "gateway_name" {}
+variable "gateway_spec" {}
 
 resource "huaweicloud_nat_private_gateway" "test" {
   subnet_id             = var.subnet_id
   name                  = var.gateway_name
-  spec                  = "Small"
-  description           = "Created by terraform script"
-  enterprise_project_id = "0"
+  spec                  = var.gateway_spec
 }
 ```
 
@@ -80,5 +80,5 @@ In addition to all arguments above, the following attributes are exported:
 The private NAT gateways can be imported using their `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_nat_private_gateway.test 13d9d015-9d6f-483d-882d-d996cdf2c1d0
+$ terraform import huaweicloud_nat_private_gateway.test <id>
 ```

--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_gateway_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_gateway_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/nat/v3/gateways"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
@@ -16,22 +14,21 @@ import (
 )
 
 func getPrivateGatewayResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := cfg.NatV3Client(acceptance.HW_REGION_NAME)
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("nat", region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating NAT v3 client: %s", err)
 	}
 
-	return gateways.Get(client, state.Primary.ID)
+	return nat.GetPrivateGateway(client, state.Primary.ID)
 }
 
 func TestAccPrivateGateway_basic(t *testing.T) {
 	var (
-		obj gateways.Gateway
-
+		obj        interface{}
 		rName      = "huaweicloud_nat_private_gateway.test"
 		name       = acceptance.RandomAccResourceNameWithDash()
 		updateName = acceptance.RandomAccResourceNameWithDash()
-		baseConfig = common.TestBaseNetwork(name)
 	)
 
 	rc := acceptance.InitResourceCheck(
@@ -48,30 +45,31 @@ func TestAccPrivateGateway_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrivateGateway_basic_step_1(name, baseConfig),
+				Config: testAccPrivateGateway_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "subnet_id", "huaweicloud_vpc_subnet.test", "id"),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "spec", nat.PrivateSpecTypeSmall),
+					resource.TestCheckResourceAttr(rName, "spec", "Small"),
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
 					resource.TestCheckResourceAttrSet(rName, "vpc_id"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
 				),
 			},
 			{
-				Config: testAccPrivateGateway_basic_step_2(updateName, baseConfig),
+				Config: testAccPrivateGateway_update(updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(rName, "subnet_id", "huaweicloud_vpc_subnet.test", "id"),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "spec", "Medium"),
 					resource.TestCheckResourceAttr(rName, "description", ""),
-					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "baaar"),
 					resource.TestCheckResourceAttr(rName, "tags.newKey", "value"),
-					resource.TestCheckResourceAttrSet(rName, "vpc_id"),
 				),
 			},
 			{
@@ -83,13 +81,14 @@ func TestAccPrivateGateway_basic(t *testing.T) {
 	})
 }
 
-func testAccPrivateGateway_basic_step_1(name, relatedConfig string) string {
+func testAccPrivateGateway_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_nat_private_gateway" "test" {
   subnet_id             = huaweicloud_vpc_subnet.test.id
   name                  = "%[2]s"
+  spec                  = "Small"
   description           = "Created by acc test"
   enterprise_project_id = "0"
 
@@ -98,10 +97,10 @@ resource "huaweicloud_nat_private_gateway" "test" {
     key = "value"
   }
 }
-`, relatedConfig, name)
+`, common.TestBaseNetwork(name), name)
 }
 
-func testAccPrivateGateway_basic_step_2(name, relatedConfig string) string {
+func testAccPrivateGateway_update(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -116,5 +115,5 @@ resource "huaweicloud_nat_private_gateway" "test" {
     newKey = "value"
   }
 }
-`, relatedConfig, name)
+`, common.TestBaseNetwork(name), name)
 }

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_private_gateway.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_private_gateway.go
@@ -2,14 +2,14 @@ package nat
 
 import (
 	"context"
-	"log"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/chnsz/golangsdk/openstack/nat/v3/gateways"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -107,101 +107,166 @@ func ResourcePrivateGateway() *schema.Resource {
 	}
 }
 
-func buildDownLinkVpcs(subnetId string) []gateways.DownLinkVpc {
-	return []gateways.DownLinkVpc{
+func buildDownLinkVpcs(d *schema.ResourceData) []map[string]interface{} {
+	return []map[string]interface{}{
 		{
-			SubnetId: subnetId,
+			"virsubnet_id": d.Get("subnet_id"),
 		},
 	}
 }
 
+func buildCreatePrivateGatewayBodyParams(d *schema.ResourceData, epsId string) map[string]interface{} {
+	gatewayBodyParams := map[string]interface{}{
+		"name":                  d.Get("name"),
+		"description":           utils.ValueIgnoreEmpty(d.Get("description")),
+		"downlink_vpcs":         buildDownLinkVpcs(d),
+		"spec":                  utils.ValueIgnoreEmpty(d.Get("spec")),
+		"enterprise_project_id": utils.ValueIgnoreEmpty(epsId),
+		"tags":                  utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{})),
+	}
+
+	return map[string]interface{}{
+		"gateway": gatewayBodyParams,
+	}
+}
+
 func resourcePrivateGatewayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	client, err := cfg.NatV3Client(cfg.GetRegion(d))
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/private-nat/gateways"
+	)
+
+	client, err := cfg.NewServiceClient("nat", region)
 	if err != nil {
 		return diag.Errorf("error creating NAT v3 client: %s", err)
 	}
 
-	opts := gateways.CreateOpts{
-		Name:                d.Get("name").(string),
-		DownLinkVpcs:        buildDownLinkVpcs(d.Get("subnet_id").(string)),
-		Description:         d.Get("description").(string),
-		Spec:                d.Get("spec").(string),
-		EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
-		Tags:                utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreatePrivateGatewayBodyParams(d, cfg.GetEnterpriseProjectID(d))),
 	}
 
-	log.Printf("[DEBUG] The create options of the private NAT gateway is: %#v", opts)
-	resp, err := gateways.Create(client, opts)
+	resp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
 		return diag.Errorf("error creating private NAT gateway: %s", err)
 	}
-	d.SetId(resp.ID)
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	gatewayId := utils.PathSearch("gateway.id", respBody, "").(string)
+	if gatewayId == "" {
+		return diag.Errorf("error creating private NAT gateway: ID is not found in API response")
+	}
+
+	d.SetId(gatewayId)
 
 	return resourcePrivateGatewayRead(ctx, d, meta)
 }
 
+func GetPrivateGateway(client *golangsdk.ServiceClient, gatewayId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/private-nat/gateways/{gateway_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{gateway_id}", gatewayId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
 func resourcePrivateGatewayRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	natClient, err := cfg.NatV3Client(region)
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("nat", region)
 	if err != nil {
 		return diag.Errorf("error creating NAT v3 client: %s", err)
 	}
 
-	resp, err := gateways.Get(natClient, d.Id())
+	respBody, err := GetPrivateGateway(client, d.Id())
 	if err != nil {
 		// If the private NAT gateway does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving private NAT gateway")
 	}
-	mErr := multierror.Append(nil,
+	mErr := multierror.Append(
 		d.Set("region", region),
-		d.Set("subnet_id", utils.PathSearch("[0].SubnetId", resp.DownLinkVpcs, nil)),
-		d.Set("name", resp.Name),
-		d.Set("description", resp.Description),
-		d.Set("spec", resp.Spec),
-		d.Set("enterprise_project_id", resp.EnterpriseProjectId),
-		d.Set("tags", utils.TagsToMap(resp.Tags)),
-		d.Set("created_at", resp.CreatedAt),
-		d.Set("updated_at", resp.UpdatedAt),
-		d.Set("status", resp.Status),
-		d.Set("vpc_id", utils.PathSearch("[0].VpcId", resp.DownLinkVpcs, nil)),
+		d.Set("subnet_id", utils.PathSearch("gateway.downlink_vpcs[0].virsubnet_id", respBody, nil)),
+		d.Set("name", utils.PathSearch("gateway.name", respBody, nil)),
+		d.Set("description", utils.PathSearch("gateway.description", respBody, nil)),
+		d.Set("spec", utils.PathSearch("gateway.spec", respBody, nil)),
+		d.Set("enterprise_project_id", utils.PathSearch("gateway.enterprise_project_id", respBody, nil)),
+		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("gateway.tags", respBody, make([]interface{}, 0)))),
+		d.Set("created_at", utils.PathSearch("gateway.created_at", respBody, nil)),
+		d.Set("updated_at", utils.PathSearch("gateway.updated_at", respBody, nil)),
+		d.Set("status", utils.PathSearch("gateway.status", respBody, nil)),
+		d.Set("vpc_id", utils.PathSearch("gateway.downlink_vpcs[0].vpc_id", respBody, nil)),
 	)
-	if err = mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error saving private NAT gateway fields: %s", err)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdatePrivateGatewayBodyParams(d *schema.ResourceData) map[string]interface{} {
+	gatewayBodyParams := map[string]interface{}{
+		"name":        utils.ValueIgnoreEmpty(d.Get("name")),
+		"description": d.Get("description"),
+		"spec":        utils.ValueIgnoreEmpty(d.Get("spec")),
 	}
-	return nil
+
+	return map[string]interface{}{
+		"gateway": gatewayBodyParams,
+	}
 }
 
 func resourcePrivateGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	natClient, err := cfg.NatV3Client(region)
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("nat", region)
 	if err != nil {
 		return diag.Errorf("error creating NAT v3 client: %s", err)
 	}
 
-	gatewayId := d.Id()
-	if d.HasChangeExcept("tags") {
-		opts := gateways.UpdateOpts{
-			Name:        d.Get("name").(string),
-			Description: utils.String(d.Get("description").(string)),
-		}
-		if d.HasChange("spec") {
-			opts.Spec = d.Get("spec").(string)
+	if d.HasChanges("name", "description", "spec") {
+		httpUrl := "v3/{project_id}/private-nat/gateways/{gateway_id}"
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{gateway_id}", d.Id())
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody:         buildUpdatePrivateGatewayBodyParams(d),
 		}
 
-		log.Printf("[DEBUG] The update options of the private NAT gateway is: %#v", opts)
-		_, err = gateways.Update(natClient, gatewayId, opts)
+		_, err = client.Request("PUT", updatePath, &updateOpt)
 		if err != nil {
 			return diag.Errorf("error updating private NAT gateway: %s", err)
 		}
 	}
 
 	if d.HasChange("tags") {
-		err = utils.UpdateResourceTags(natClient, d, "private-nat-gateways", gatewayId)
+		natClient, err := cfg.NatV3Client(region)
 		if err != nil {
-			return diag.Errorf("error updating tags of the private NAT gateway (%s): %s", gatewayId, err)
+			return diag.Errorf("error creating NAT v3 client: %s", err)
+		}
+
+		err = utils.UpdateResourceTags(natClient, d, "private-nat-gateways", d.Id())
+		if err != nil {
+			return diag.Errorf("error updating tags of the private NAT gateway: %s", err)
 		}
 	}
 
@@ -209,14 +274,25 @@ func resourcePrivateGatewayUpdate(ctx context.Context, d *schema.ResourceData, m
 }
 
 func resourcePrivateGatewayDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	client, err := cfg.NatV3Client(cfg.GetRegion(d))
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/private-nat/gateways/{gateway_id}"
+	)
+
+	client, err := cfg.NewServiceClient("nat", region)
 	if err != nil {
 		return diag.Errorf("error creating NAT v3 client: %s", err)
 	}
 
-	gatewayId := d.Id()
-	err = gateways.Delete(client, gatewayId)
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{gateway_id}", d.Id())
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpts)
 	if err != nil {
 		// If the private NAT gateway does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error deleting private NAT gateway")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactor the private NAT gateway resource code style.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ bash test.sh "./huaweicloud/services/acceptance/nat" "TestAccPrivateGateway_basic"
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -run TestAccPrivateGateway_basic -timeout 360m -parallel 4

=== RUN   TestAccPrivateGateway_basic
=== PAUSE TestAccPrivateGateway_basic
=== CONT  TestAccPrivateGateway_basic
--- PASS: TestAccPrivateGateway_basic (73.09s)
PASS
coverage: 2.6% of statements in ./huaweicloud/...
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       73.651s coverage: 2.6% of statements in ./huaweicloud/...
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->

## UT coverage
![image](https://github.com/user-attachments/assets/d623b4cd-d64c-4a09-a3ef-2bd71ac10221)
