### PR TITLE
refactor(ims): refactor `ims_image_export` resource code style

### DIFF
--- a/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_image_export_test.go
+++ b/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_image_export_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
 func TestAccImageExport_basic(t *testing.T) {
@@ -52,6 +53,43 @@ func TestAccImageExport_with_isQuickExport(t *testing.T) {
 	})
 }
 
+func testAccImageExport_base(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s"
+  image_name         = "Ubuntu 18.04 server 64bit"
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+}
+
+resource "huaweicloud_ims_ecs_system_image" "test" {
+  name        = "%[2]s"
+  instance_id = huaweicloud_compute_instance.test.id
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, common.TestBaseNetwork(rName), rName)
+}
+
 func testAccImageExport_basic() string {
 	rName := acceptance.RandomAccResourceName()
 	rNameSuffix := acctest.RandString(4)
@@ -64,7 +102,7 @@ resource "huaweicloud_ims_image_export" "test" {
   bucket_url  = "%[2]s_%[3]s"
   file_format = "qcow2"
 }
-`, testAccEcsSystemImage_basic(rName), acceptance.HW_IMS_IMAGE_URL, rNameSuffix)
+`, testAccImageExport_base(rName), acceptance.HW_IMS_IMAGE_URL, rNameSuffix)
 }
 
 func testAccImageExport_with_isQuickExport() string {
@@ -79,5 +117,5 @@ resource "huaweicloud_ims_image_export" "test" {
   bucket_url      = "%[2]s_%[3]s"
   is_quick_export = true
 }
-`, testAccEcsSystemImage_basic(rName), acceptance.HW_IMS_IMAGE_URL, rNameSuffix)
+`, testAccImageExport_base(rName), acceptance.HW_IMS_IMAGE_URL, rNameSuffix)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

refactor `ims_image_export` resource code style

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

refactor `ims_image_export` resource code style

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccImageExport_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccImageExport_ -timeout 360m -parallel 4
=== RUN   TestAccImageExport_basic
=== PAUSE TestAccImageExport_basic
=== RUN   TestAccImageExport_with_isQuickExport
=== PAUSE TestAccImageExport_with_isQuickExport
=== CONT  TestAccImageExport_basic
=== CONT  TestAccImageExport_with_isQuickExport
--- PASS: TestAccImageExport_with_isQuickExport (473.79s)
--- PASS: TestAccImageExport_basic (701.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       701.797s

```
![image](https://github.com/user-attachments/assets/4b68c8c7-6362-4061-9475-d2b53329e3b0)


* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
