### PR TITLE
feat(evs): evs volume datasource support new fields

### DIFF
--- a/docs/data-sources/evs_volumes.md
+++ b/docs/data-sources/evs_volumes.md
@@ -16,6 +16,8 @@ variable "target_server" {}
 
 data "huaweicloud_evs_volumes" "test" {
   server_id = var.target_server
+  ids       = urlencode("['XXX','XXX']")
+  metadata  = urlencode("{\"hw:passthrough\": \"true\"}")
 }
 ```
 
@@ -57,6 +59,30 @@ The following arguments are supported:
   + **VPN**
 
 * `tags` - (Optional, Map) Specifies the included key/value pairs which associated with the desired disk.
+
+* `dedicated_storage_id` - (Optional, String) Specifies the dedicated storage pool ID. All disks in the dedicated storage
+  pool can be filtered by exact match.
+
+* `dedicated_storage_name` - (Optional, String) Specifies the dedicated storage pool name. All disks in the dedicated
+  storage pool can be filtered by fuzzy match.
+
+* `ids` - (Optional, String) Specifies the disk IDs. The value is in the ids=['id1','id2',...,'idx'] format.
+  In the response, the `ids` value contains valid disk IDs only. Invalid disk IDs are ignored.
+  The details about a maximum of `60` disks can be queried. If `volume_id` and `ids` are both specified in the request,
+  `volume_id` will be ignored.
+  Please pay attention to escape special characters before use. Please refer to the usage of example.
+
+* `metadata` - (Optional, String) Specifies the disk metadata.
+  Please pay attention to escape special characters before use. Please refer to the usage of example.
+
+* `service_type` - (Optional, String) Specifies the service type. Supported services are **EVS**, **DSS**, and **DESS**.
+
+* `sort_dir` - (Optional, String) Specifies the result sorting order. The default value is **desc**.
+  + **desc**: The descending order.
+  + **asc**: The ascending order.
+
+* `sort_key` - (Optional, String) Specifies the keyword based on which the returned results are sorted.
+  The value can be **id**, **status**, **size**, or **created_at**, and the default value is **created_at**.
 
 ## Attribute Reference
 
@@ -111,6 +137,64 @@ The `volumes` block supports:
 
 * `wwn` - The unique identifier used when attaching the disk.
 
+* `dedicated_storage_id` - The ID of the dedicated storage pool housing the disk.
+
+* `dedicated_storage_name` - The name of the dedicated storage pool housing the disk.
+
+* `iops_attribute` - The disk IOPS information. This attribute appears only for a general purpose SSD V2 or an extreme
+  SSD V2 disk. The [iops_attribute](#iops_attribute_struct) structure is documented below.
+
+* `throughput_attribute` - The disk throughput information. This attribute appears only for a general purpose SSD V2 disk.
+  The [throughput_attribute](#throughput_attribute_struct) structure is documented below.
+
+* `links` - The disk URI. The [links](#links_struct) structure is documented below.
+
+* `metadata` - The key-value pair disk metadata. Valid key-value pairs are as follows:
+  + **__system__cmkid**: The encryption CMK ID in metadata. This attribute is used together with **__system__encrypted**
+    for encryption.
+  + **__system__encrypted**: The encryption field in metadata. The value can be `0` (no encryption) or `1` (encryption).
+    If this attribute is not specified, the encryption attribute of the disk is the same as that of the data source.
+    If the disk is not created from a data source, the disk is not encrypted by default.
+  + **full_clone**: The creation method when the disk is created from a snapshot. `0`: linked clone. `1`: full clone.
+  + **hw:passthrough**: If this attribute value is **true**, the disk device type is SCSI, which allows ECS OSs to directly
+    access the underlying storage media and supports SCSI reservation commands. If this attribute is set to **false**,
+    the disk device type is VBD, which is also the default type. VBD supports only simple SCSI read/write commands.
+    If this attribute is not specified, the disk device type is VBD.
+  + **orderID**: The attribute that describes the disk billing mode in metadata. If this attribute has a value, the disk
+    is billed on a yearly/monthly basis. If this attribute is empty, the disk is billed on a pay-per-use basis.
+
+* `serial_number` - The disk serial number. This field is returned only for non-HyperMetro SCSI disks and is used for
+  disk mapping in the VM.
+
+* `snapshot_id` - The snapshot ID. This attribute has a value if the disk is created from a snapshot.
+
+* `volume_image_metadata` - The metadata of the disk image.
+
+<a name="links_struct"></a>
+The `links` block supports:
+
+* `href` - The corresponding shortcut link.
+
+* `rel` - The shortcut link marker name.
+
+<a name="throughput_attribute_struct"></a>
+The `throughput_attribute` block supports:
+
+* `frozened` - The frozen tag.
+
+* `id` - The throughput ID.
+
+* `total_val` - The throughput.
+
+<a name="iops_attribute_struct"></a>
+The `iops_attribute` block supports:
+
+* `frozened` - The frozen tag.
+
+* `id` - The ID of the disk IOPS.
+
+* `total_val` - The IOPS.
+
 The `attachments` block supports:
 
 * `id` - The ID of the attached resource in UUID format.
@@ -122,3 +206,9 @@ The `attachments` block supports:
 * `device_name` - The device name to which the disk is attached.
 
 * `server_id` - The ID of the server to which the disk is attached.
+
+* `host_name` - The name of the physical host housing the cloud server to which the disk is attached.
+
+* `attached_volume_id` - The ID of the attached disk.
+
+* `volume_id` - The disk ID.

--- a/huaweicloud/services/acceptance/evs/data_source_huaweicloud_evs_volumes_test.go
+++ b/huaweicloud/services/acceptance/evs/data_source_huaweicloud_evs_volumes_test.go
@@ -24,11 +24,28 @@ func TestAccEvsVolumesDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "volumes.#", "5"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.availability_zone"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.bootable"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.create_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.links.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.metadata.%"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.service_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.shareable"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.update_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.volume_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.wwn"),
 
 					resource.TestCheckOutput("is_volume_id_filter_useful", "true"),
 					resource.TestCheckOutput("is_name_filter_useful", "true"),
 					resource.TestCheckOutput("is_availability_zone_filter_useful", "true"),
 					resource.TestCheckOutput("is_enterprise_project_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_ids_filter_useful", "true"),
+					resource.TestCheckOutput("is_metadata_filter_useful", "true"),
+					resource.TestCheckOutput("is_service_type_filter_useful", "true"),
+					resource.TestCheckOutput("is_sort_filter_useful", "true"),
 				),
 			},
 		},
@@ -161,6 +178,84 @@ output "is_enterprise_project_id_filter_useful" {
   value = length(data.huaweicloud_evs_volumes.enterprise_project_id_filter.volumes) > 0 && alltrue(
     [for v in data.huaweicloud_evs_volumes.enterprise_project_id_filter.volumes[*].enterprise_project_id : v == local.enterprise_project_id]
   )
+}
+
+# Filter using ids
+locals {
+  volume_id1 = data.huaweicloud_evs_volumes.test.volumes.0.id
+  volume_id2 = data.huaweicloud_evs_volumes.test.volumes.1.id
+  ids        = format("['%%s','%%s']", local.volume_id1, local.volume_id2)
+}
+
+data "huaweicloud_evs_volumes" "ids_filter" {
+  ids = urlencode(local.ids)
+}
+
+output "is_ids_filter_useful" {
+  value = length(data.huaweicloud_evs_volumes.ids_filter.volumes) == 2 && alltrue(
+    [for v in data.huaweicloud_evs_volumes.ids_filter.volumes[*].id : v == local.volume_id1 || v == local.volume_id2]
+  )
+}
+
+# Filter using metadata
+locals {
+  metadata = urlencode("{\"hw:passthrough\": \"true\"}")
+}
+
+data "huaweicloud_evs_volumes" "metadata_filter" {
+  depends_on = [huaweicloud_compute_volume_attach.test]
+
+  metadata = local.metadata
+}
+
+output "is_metadata_filter_useful" {
+  value = length(data.huaweicloud_evs_volumes.metadata_filter.volumes) > 0 && alltrue(
+    [for v in data.huaweicloud_evs_volumes.metadata_filter.volumes[*].metadata : lookup(v, "hw:passthrough", "false") == "true"]
+  )
+}
+
+# Filter using service_type
+locals {
+  service_type = data.huaweicloud_evs_volumes.test.volumes.0.service_type
+}
+
+data "huaweicloud_evs_volumes" "service_type_filter" {
+  service_type = local.service_type
+}
+
+output "is_service_type_filter_useful" {
+  value = length(data.huaweicloud_evs_volumes.service_type_filter.volumes) > 0 && alltrue(
+    [for v in data.huaweicloud_evs_volumes.service_type_filter.volumes[*].service_type : v == local.service_type]
+  )
+}
+
+# Filter using sort_dir and sort_key
+locals {
+  sort_key = "created_at"
+}
+
+data "huaweicloud_evs_volumes" "sort_asc_filter" {
+  depends_on = [huaweicloud_compute_volume_attach.test]
+
+  sort_key = local.sort_key
+  sort_dir = "asc"
+}
+
+data "huaweicloud_evs_volumes" "sort_desc_filter" {
+   depends_on = [huaweicloud_compute_volume_attach.test]
+
+  sort_key = local.sort_key
+  sort_dir = "desc"
+}
+
+locals {
+  asc_first_id = data.huaweicloud_evs_volumes.sort_asc_filter.volumes[0].id
+  desc_length  = length(data.huaweicloud_evs_volumes.sort_desc_filter.volumes)
+  desc_last_id = data.huaweicloud_evs_volumes.sort_desc_filter.volumes[local.desc_length - 1].id
+}
+
+output "is_sort_filter_useful" {
+  value = local.desc_length > 0 && local.asc_first_id == local.desc_last_id
 }
 `, testAccEvsVolumesDataSource_base(rName))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Evs volume datasource support new fields.
![image](https://github.com/user-attachments/assets/6076399a-1e34-458c-973e-213b4ade3258)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run TestAccEvsVolumesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolumesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsVolumesDataSource_basic
=== PAUSE TestAccEvsVolumesDataSource_basic
=== CONT  TestAccEvsVolumesDataSource_basic
--- PASS: TestAccEvsVolumesDataSource_basic (350.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       350.332s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
