### PR TITLE
feat(servicestage): supports new resource to manage runtime stacks

### DIFF
--- a/docs/resources/servicestagev3_runtime_stack.md
+++ b/docs/resources/servicestagev3_runtime_stack.md
@@ -1,0 +1,91 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestagev3_runtime_stack"
+description: |-
+  Manages a custom runtime stack resource within HuaweiCloud.
+---
+
+# huaweicloud_servicestagev3_runtime_stack
+
+Manages a custom runtime stack resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "runtime_stack_name" {}
+variable "java_sdk_obs_storage_url" {}
+
+resource "huaweicloud_servicestagev3_runtime_stack" "test" {
+  name        = var.runtime_stack_name
+  deploy_mode = "virtualmachine"
+  type        = "Java"
+  version     = "1.0.1"
+  spec        = jsonencode({
+    "parameters": {
+      "jdk_url": var.java_sdk_obs_storage_url
+    }
+  })
+  description = "Created by terraform script"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the application is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the runtime stack.  
+  The valid length is limited from `2` to `64`, only letters, digits, slash (/), hyphens (-) and underscores (_) are
+  allowed. The name must start with a letter and end with a letter or a digit.
+
+* `deploy_mode` - (Required, String, NonUpdatable) Specifies the deploy mode of the runtime stack.
+  The valid value is **virtualmachine**.
+
+* `type` - (Required, String, NonUpdatable) Specifies the type of the runtime stack.
+  The valid values are as follows:
+  + **Java**
+  + **Tomcat**
+
+* `version` - (Required, String) Specifies the version of the runtime stack.
+  The valid format is **{number}.{number}.{number}**, e.g. **1.0.1**.
+
+* `spec` - (Optional, String) Specifies the configuration of runtime stack, in JSON format.
+  For the structure, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/api-servicestage/servicestage_06_0229.html#servicestage_06_0229__table51321252171513).
+
+* `description` - (Optional, String) Specifies the description of the runtime stack.  
+  The value can contain a maximum of `512` characters.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, in UUID format.
+
+* `status` - The current status of the runtime stack.
+
+* `creator` - The creator name of the runtime stack.
+
+* `created_at` - The creation time of the runtime stack, in RFC3339 format.
+
+* `updated_at` - The latest update time of the runtime stack, in RFC3339 format.
+
+* `component_count` - The number of components associated with the runtime stack.
+
+## Import
+
+Runtime stacks can be imported using their `name` or `id`, e.g.
+
+### Import a runtime stack using its name
+
+```bash
+$ terraform import huaweicloud_servicestagev3_runtime_stack.test <name>
+```
+
+### Import a runtime stack using its ID
+
+```bash
+$ terraform import huaweicloud_servicestagev3_runtime_stack.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2321,6 +2321,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_servicestagev3_configuration_group":       servicestage.ResourceV3ConfigurationGroup(),
 			"huaweicloud_servicestagev3_environment":               servicestage.ResourceV3Environment(),
 			"huaweicloud_servicestagev3_environment_associate":     servicestage.ResourceV3EnvironmentAssociate(),
+			"huaweicloud_servicestagev3_runtime_stack":             servicestage.ResourceV3RuntimeStack(),
 
 			"huaweicloud_sfs_turbo":            sfsturbo.ResourceSFSTurbo(),
 			"huaweicloud_sfs_turbo_dir":        sfsturbo.ResourceSfsTurboDir(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -587,6 +587,7 @@ var (
 	HW_SMN_SUBSCRIBED_TOPIC_URN = os.Getenv("HW_SMN_SUBSCRIBED_TOPIC_URN")
 
 	HW_SERVICESTAGE_JAR_PKG_STORAGE_URLS = os.Getenv("HW_SERVICESTAGE_JAR_PKG_STORAGE_URLS")
+	HW_SERVICESTAGE_ZIP_STORAGE_URLS     = os.Getenv("HW_SERVICESTAGE_ZIP_STORAGE_URLS")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -3115,5 +3116,12 @@ func TestAccPreCheckIMSImageMetadataID(t *testing.T) {
 func TestAccPreCheckServiceStageJarPkgStorageURLs(t *testing.T, n int) {
 	if len(strings.Split(HW_SERVICESTAGE_JAR_PKG_STORAGE_URLS, ",")) < n {
 		t.Skipf("at least %d URLs for HW_SERVICESTAGE_JAR_PKG_STORAGE_URLS must be set, separated by a comma (,)", n)
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckServiceStageZipStorageURLs(t *testing.T, n int) {
+	if len(strings.Split(HW_SERVICESTAGE_ZIP_STORAGE_URLS, ",")) < n {
+		t.Skipf("at least %d URLs for HW_SERVICESTAGE_ZIP_STORAGE_URLS must be set, separated by a comma (,)", n)
 	}
 }

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_runtime_stack_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_runtime_stack_test.go
@@ -1,0 +1,144 @@
+package servicestage
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/servicestage"
+)
+
+func getV3RuntimeStackFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("servicestage", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ServiceStage client: %s", err)
+	}
+	return servicestage.GetV3RuntimeStackById(client, state.Primary.ID)
+}
+
+func TestAccV3RuntimeStack_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceName = "huaweicloud_servicestagev3_runtime_stack.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getV3RuntimeStackFunc)
+
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// At least two ZIP files must be provided.
+			acceptance.TestAccPreCheckServiceStageZipStorageURLs(t, 2)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV3RuntimeStack_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "deploy_mode", "virtualmachine"),
+					resource.TestCheckResourceAttr(resourceName, "type", "Java"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1.0.1"),
+					resource.TestCheckResourceAttrSet(resourceName, "spec"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "creator"),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(resourceName, "component_count"),
+				),
+			},
+			{
+				Config: testAccV3RuntimeStack_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "deploy_mode", "virtualmachine"),
+					resource.TestCheckResourceAttr(resourceName, "type", "Java"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1.0.2"),
+					resource.TestCheckResourceAttrSet(resourceName, "spec"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "creator"),
+					resource.TestMatchResourceAttr(resourceName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(resourceName, "component_count"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"spec_origin",
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccV3RuntimeStackImportStateFunc(resourceName),
+				ImportStateVerifyIgnore: []string{
+					"spec_origin",
+				},
+			},
+		},
+	})
+}
+
+func testAccV3RuntimeStackImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+		if rs.Primary.Attributes["name"] == "" {
+			return "", fmt.Errorf("invalid format specified for runtime stack name ('%s')",
+				rs.Primary.Attributes["name"])
+		}
+		return rs.Primary.Attributes["name"], nil
+	}
+}
+
+func testAccV3RuntimeStack_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_servicestagev3_runtime_stack" "test" {
+  name        = "%[1]s"
+  deploy_mode = "virtualmachine"
+  type        = "Java"
+  version     = "1.0.1"
+  spec        = jsonencode({
+    "parameters": {
+      "jdk_url": try(element(split(",", "%[2]s"), 0), "")
+    }
+  })
+  description = "Created by terraform script"
+}
+`, name, acceptance.HW_SERVICESTAGE_ZIP_STORAGE_URLS)
+}
+
+func testAccV3RuntimeStack_basic_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_servicestagev3_runtime_stack" "test" {
+  name        = "%[1]s"
+  deploy_mode = "virtualmachine"
+  type        = "Java"
+  version     = "1.0.2"
+  spec        = jsonencode({
+    "parameters": {
+      "jdk_url": try(element(split(",", "%[2]s"), 1), "")
+    }
+  })
+}
+`, name, acceptance.HW_SERVICESTAGE_ZIP_STORAGE_URLS)
+}

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_runtime_stack.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_runtime_stack.go
@@ -1,0 +1,357 @@
+package servicestage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	runtimeStackJsonObjectParamKeys = []string{
+		"spec",
+	}
+	runtimeStackNonUpdatableParams = []string{
+		"deploy_mode",
+		"type",
+	}
+)
+
+// @API ServiceStage POST /v3/{project_id}/cas/runtimestacks
+// @API ServiceStage GET /v3/{project_id}/cas/runtimestacks/{runtimestack_id}
+// @API ServiceStage PUT /v3/{project_id}/cas/runtimestacks/{runtimestack_id}
+// @API ServiceStage DELETE /v3/{project_id}/cas/runtimestacks/{runtimestack_id}
+// @API ServiceStage GET /v3/{project_id}/cas/runtimestacks
+func ResourceV3RuntimeStack() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceV3RuntimeStackCreate,
+		ReadContext:   resourceV3RuntimeStackRead,
+		UpdateContext: resourceV3RuntimeStackUpdate,
+		DeleteContext: resourceV3RuntimeStackDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceV3RuntimeStackImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(runtimeStackNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the runtime stack is located.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the runtime stack.`,
+			},
+			"deploy_mode": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The deploy mode of the runtime stack.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the runtime stack.`,
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The version of the runtime stack.`,
+			},
+			"spec": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateFunc:     validation.StringIsJSON,
+				DiffSuppressFunc: utils.SuppressObjectDiffs(),
+				Description:      `The configuration of runtime stack, in JSON format.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the runtime stack.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current status of the runtime stack.`,
+			},
+			"creator": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator name of the runtime stack.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the runtime stack, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the runtime stack, in RFC3339 format.`,
+			},
+			"component_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of components associated with the runtime stack.`,
+			},
+			// Internal parameters/attributes.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"spec_origin": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`The script configuration value of this change is also the original value used for comparison with
+the new value next time the change is made. The corresponding parameter name is 'spec'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func buildV3RuntimeStackCreateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"deploy_mode": d.Get("deploy_mode"),
+		"type":        d.Get("type"),
+		"version":     d.Get("version"),
+		"spec":        utils.StringToJson(d.Get("spec").(string)),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+}
+
+func resourceV3RuntimeStackCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/cas/runtimestacks"
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: utils.RemoveNil(buildV3RuntimeStackCreateBodyParams(d)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating runtime stack: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	runtimeStackId := utils.PathSearch("id", respBody, "").(string)
+	if runtimeStackId == "" {
+		return diag.Errorf("failed to find the runtime stack ID from the API response")
+	}
+	d.SetId(runtimeStackId)
+
+	// If the request is successful, obtain the values ​​of all JSON parameters first and save them to the
+	// corresponding '_origin' attributes for subsequent determination and construction of the request body during
+	// next updates.
+	err = utils.RefreshObjectParamOriginValues(d, runtimeStackJsonObjectParamKeys)
+	if err != nil {
+		return diag.Errorf("unable to refresh the origin values: %s", err)
+	}
+
+	return resourceV3RuntimeStackRead(ctx, d, meta)
+}
+
+func GetV3RuntimeStackById(client *golangsdk.ServiceClient, runtimeStackId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/cas/runtimestacks/{runtimestack_id}"
+
+	queryPath := client.Endpoint + httpUrl
+	queryPath = strings.ReplaceAll(queryPath, "{project_id}", client.ProjectID)
+	queryPath = strings.ReplaceAll(queryPath, "{runtimestack_id}", runtimeStackId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	requestResp, err := client.Request("GET", queryPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceV3RuntimeStackRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		runtimeStackId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	runtimeStack, err := GetV3RuntimeStackById(client, runtimeStackId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error querying runtime stack (%s)", runtimeStackId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", runtimeStack, nil)),
+		d.Set("deploy_mode", utils.PathSearch("deploy_mode", runtimeStack, nil)),
+		d.Set("type", utils.PathSearch("type", runtimeStack, nil)),
+		d.Set("version", utils.PathSearch("version", runtimeStack, nil)),
+		d.Set("spec", utils.JsonToString(utils.PathSearch("spec", runtimeStack, nil))),
+		d.Set("description", utils.PathSearch("description", runtimeStack, nil)),
+		d.Set("status", utils.PathSearch("status", runtimeStack, nil)),
+		d.Set("creator", utils.PathSearch("creator", runtimeStack, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", runtimeStack, float64(0)).(float64))/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time", runtimeStack, float64(0)).(float64))/1000, false)),
+		d.Set("component_count", utils.PathSearch("component_count", runtimeStack, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildV3RuntimeStackUpdateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"deploy_mode": d.Get("deploy_mode"),
+		"type":        d.Get("type"),
+		"version":     d.Get("version"),
+		"spec":        utils.StringToJson(d.Get("spec").(string)),
+		"description": d.Get("description"),
+	}
+}
+
+func resourceV3RuntimeStackUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		runtimeStackId = d.Id()
+		httpUrl        = "v3/{project_id}/cas/runtimestacks/{runtimestack_id}"
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{runtimestack_id}", runtimeStackId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: utils.RemoveNil(buildV3RuntimeStackUpdateBodyParams(d)),
+	}
+
+	_, err = client.Request("PUT", updatePath, &opt)
+	if err != nil {
+		return diag.Errorf("error updating runtime stack (%s): %s", runtimeStackId, err)
+	}
+
+	// If the request is successful, obtain the values ​​of all JSON parameters first and save them to the
+	// corresponding '_origin' attributes for subsequent determination and construction of the request body during
+	// next updates.
+	err = utils.RefreshObjectParamOriginValues(d, runtimeStackJsonObjectParamKeys)
+	if err != nil {
+		return diag.Errorf("unable to refresh the origin values: %s", err)
+	}
+
+	return resourceV3RuntimeStackRead(ctx, d, meta)
+}
+
+func resourceV3RuntimeStackDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		runtimeStackId = d.Id()
+		httpUrl        = "v3/{project_id}/cas/runtimestacks/{runtimestack_id}"
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{runtimestack_id}", runtimeStackId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: utils.RemoveNil(buildV3RuntimeStackCreateBodyParams(d)),
+	}
+
+	_, err = client.Request("DELETE", deletePath, &opt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting runtime stack (%s)", runtimeStackId))
+	}
+	return nil
+}
+
+func resourceV3RuntimeStackImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+
+	if !utils.IsUUID(importedId) {
+		var (
+			cfg    = meta.(*config.Config)
+			region = cfg.GetRegion(d)
+		)
+		client, err := cfg.NewServiceClient("servicestage", region)
+		if err != nil {
+			return nil, fmt.Errorf("error creating ServiceStage client: %s", err)
+		}
+		runtimeStacks, err := listV3RuntimeStacks(client)
+		if err != nil {
+			return nil, err
+		}
+		runtimeStackId := utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0].id", importedId), runtimeStacks, "").(string)
+		if runtimeStackId == "" {
+			return nil, fmt.Errorf("unable to find the runtime stack by its name (%s)", importedId)
+		}
+		d.SetId(runtimeStackId)
+	}
+
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource to manage runtime stack using ver.3 APIs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to manage runtime stack using ver.3 APIs.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o servicestage -f TestAccV3RuntimeStack_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccV3RuntimeStack_basic -timeout 360m -parallel 10
=== RUN   TestAccV3RuntimeStack_basic
=== PAUSE TestAccV3RuntimeStack_basic
=== CONT  TestAccV3RuntimeStack_basic
--- PASS: TestAccV3RuntimeStack_basic (22.85s)
PASS
coverage: 6.2% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      23.059s coverage: 6.2% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/94cbe391-d62f-4c29-a267-c181281624b9)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![image](https://github.com/user-attachments/assets/ceafe98b-4f74-4b2a-bfaa-1c03ba182b28)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
