### PR TITLE
feat(lts/host_access): the resource supports new paramster and attributes and add Content-Type

### DIFF
--- a/docs/resources/lts_host_access.md
+++ b/docs/resources/lts_host_access.md
@@ -41,9 +41,8 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `name` - (Required, String, ForceNew) Specifies the host access name. The name consists of `1` to `64` characters.
+* `name` - (Required, String) Specifies the host access name. The name consists of `1` to `64` characters.
   Only letters, digits, underscores (_), and periods (.) are allowed, and the period cannot be the first or last character.
-  Changing this parameter will create a new resource.
 
 * `log_group_id` - (Required, String, ForceNew) Specifies the log group ID.
   Changing this parameter will create a new resource.
@@ -86,6 +85,24 @@ The following arguments are supported:
   This parameter must be set together with the `demo_log` parameter.  
   This parameter is available when the `processor_type` parameter is specified.
 
+* `binary_collect` - (Optional, Bool, ForceNew) Specifies whether to allow collection of binary log files.  
+  Defaults to **false**.  
+  Changing this parameter will create a new resource.
+
+* `encoding_format` - (Optional, String) Specifies the encoding format log file.  
+  Defaults to **UTF-8**.  
+  The valid values are as follows:
+  + **UTF-8**
+  + **GBK**
+
+* `incremental_collect` - (Optional, Bool) Specifies whether to collect incrementally.  
+  Defaults to **true**.  
+  When incremental collection a new file, ICAgent reads the file from the end of the file.  
+  When full collection a new file, ICAgent reads the file from the beginning of the file.
+
+* `log_split` - (Optional, Bool) Specifies whether to enable log splitting.  
+  Defaults to **false**.
+
 <a name="HostAccessConfigDeatil"></a>
 The `access_config` block supports:
 
@@ -117,6 +134,27 @@ The `access_config` block supports:
 
 * `windows_log_info` - (Optional, List) Specifies the configuration of Windows event logs.
   The [windows_log_info](#HostAccessConfigWindowsLogInfo) structure is documented below.
+
+* `custom_key_value` - (Optional, Map, ForceNew) Specifies the custom key/value pairs of the host access.  
+  Changing this parameter will create a new resource.
+
+* `system_fields` - (Optional, List, ForceNew) Specifies the list of system built-in fields of the host access.  
+  Changing this parameter will create a new resource.  
+  If `custom_key_value` is specified, the value of `system_fields` will be automatically assigned by
+  the system as **pathfile**.  
+  If `system_fields` is specified, **pathFile** must be included.  
+  The valid values are as follows:
+  + **pathFile**
+  + **hostName**
+  + **hostId**
+  + **hostIP**
+  + **hostIPv6**
+
+* `repeat_collect` - (Optional, Bool) Specifies whether to allow repeated flie collection.  
+  Defaults to **false**.
+  + If this parameter is set to **true**, one host log file can be collected to multiple log streams.
+    This function is available only to certain ICAgent versions, please refer to the [documentation](<https://support.huaweicloud.com/intl/en-us/usermanual-lts/lts_02_0014.html#lts_02_0014__section7761151916252>).
+  + If this parameter is set to **false**, the same log file in the same host cannot be collected to different log streams.
 
 <a name="HostAccessConfigSingleLogFormat"></a>
 The `single_log_format` blocks supports:
@@ -201,6 +239,8 @@ In addition to all arguments above, the following attributes are exported:
 * `log_group_name` - The log group name.
 
 * `log_stream_name` - The log stream name.
+
+* `created_at` - The creation time of the host access, in RFC3339 format.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_host_access_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_host_access_test.go
@@ -2,6 +2,7 @@ package lts
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -55,15 +56,17 @@ func getHostAccessConfigResourceFunc(cfg *config.Config, state *terraform.Resour
 }
 
 func TestAccHostAccessConfig_basic(t *testing.T) {
-	var obj interface{}
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
 
-	name := acceptance.RandomAccResourceName()
-	rName := "huaweicloud_lts_host_access.test"
-
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getHostAccessConfigResourceFunc,
+		hostAccess interface{}
+		rName      = "huaweicloud_lts_host_access.test"
+		rc         = acceptance.InitResourceCheck(
+			rName,
+			&hostAccess,
+			getHostAccessConfigResourceFunc,
+		)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -75,28 +78,45 @@ func TestAccHostAccessConfig_basic(t *testing.T) {
 				Config: testHostAccessConfig_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
+					// Check required Parameter.
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "access_config.0.paths.#", "2"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.black_paths.#", "2"),
-					resource.TestCheckResourceAttr(rName, "host_group_ids.#", "0"),
-					resource.TestCheckResourceAttr(rName, "access_type", "AGENT"),
-					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
-					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttrPair(rName, "log_group_id", "huaweicloud_lts_group.test", "id"),
 					resource.TestCheckResourceAttrPair(rName, "log_stream_id", "huaweicloud_lts_stream.test", "id"),
-					resource.TestCheckResourceAttrSet(rName, "log_group_name"),
-					resource.TestCheckResourceAttrSet(rName, "log_stream_name"),
+					resource.TestCheckResourceAttr(rName, "access_config.0.paths.#", "2"),
+					// Check optional Parameter.
+					resource.TestCheckResourceAttr(rName, "access_config.0.black_paths.#", "2"),
+					resource.TestCheckResourceAttr(rName, "access_config.0.repeat_collect", "false"),
+					resource.TestCheckResourceAttr(rName, "access_config.0.custom_key_value.%", "1"),
+					resource.TestCheckResourceAttr(rName, "access_config.0.custom_key_value.flag", "terraform"),
+					resource.TestCheckResourceAttr(rName, "access_config.0.system_fields.0", "pathFile"),
+					resource.TestCheckResourceAttr(rName, "host_group_ids.#", "0"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttrSet(rName, "demo_log"),
 					resource.TestCheckResourceAttr(rName, "demo_fields.#", "2"),
 					resource.TestCheckResourceAttr(rName, "processor_type", "SPLIT"),
+					resource.TestCheckResourceAttr(rName, "binary_collect", "true"),
+					resource.TestCheckResourceAttr(rName, "encoding_format", "GBK"),
+					resource.TestCheckResourceAttr(rName, "incremental_collect", "false"),
+					resource.TestCheckResourceAttr(rName, "log_split", "true"),
+					// Check attributes.
+					resource.TestCheckResourceAttr(rName, "access_type", "AGENT"),
+					resource.TestCheckResourceAttrSet(rName, "log_group_name"),
+					resource.TestCheckResourceAttrSet(rName, "log_stream_name"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
 			{
-				Config: testHostAccessConfig_basic_step2(name),
+				Config: testHostAccessConfig_basic_step2(name, updateName),
 				Check: resource.ComposeTestCheckFunc(
+					// Check required Parameter.
+					resource.TestCheckResourceAttr(rName, "name", updateName),
 					resource.TestCheckResourceAttr(rName, "access_config.0.paths.#", "1"),
 					resource.TestCheckResourceAttr(rName, "access_config.0.paths.0", "/var/log/*/*.log"),
+					// Check optional Parameter.
 					resource.TestCheckResourceAttr(rName, "access_config.0.black_paths.0", "/var/log/*/a.log"),
+					resource.TestCheckResourceAttr(rName, "access_config.0.repeat_collect", "true"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value-updated"),
 					resource.TestCheckResourceAttr(rName, "tags.owner", "terraform"),
 					resource.TestCheckResourceAttr(rName, "host_group_ids.#", "1"),
@@ -106,6 +126,9 @@ func TestAccHostAccessConfig_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "demo_fields.0.name", "field1"),
 					resource.TestCheckResourceAttr(rName, "demo_fields.0.value", "level:warn1"),
 					resource.TestCheckResourceAttr(rName, "processor_type", "SPLIT"),
+					resource.TestCheckResourceAttr(rName, "encoding_format", "UTF-8"),
+					resource.TestCheckResourceAttr(rName, "incremental_collect", "true"),
+					resource.TestCheckResourceAttr(rName, "log_split", "false"),
 				),
 			},
 			{
@@ -140,17 +163,24 @@ func TestAccHostAccessConfig_windows(t *testing.T) {
 				Config: testHostAccessConfig_windows_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
+					// Check required parameters.
 					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "log_group_id", "huaweicloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "log_stream_id", "huaweicloud_lts_stream.test", "id"),
 					resource.TestCheckResourceAttr(rName, "access_config.0.paths.0", "D:\\data\\log\\*"),
+					// Check optional parameters.
 					resource.TestCheckResourceAttr(rName, "access_config.0.black_paths.0", "D:\\data\\log\\a.log"),
 					resource.TestCheckResourceAttr(rName, "access_config.0.windows_log_info.0.time_offset", "7"),
 					resource.TestCheckResourceAttr(rName, "access_config.0.windows_log_info.0.time_offset_unit", "day"),
 					resource.TestCheckResourceAttr(rName, "host_group_ids.#", "1"),
-					resource.TestCheckResourceAttr(rName, "access_type", "AGENT"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttrPair(rName, "log_group_id", "huaweicloud_lts_group.test", "id"),
-					resource.TestCheckResourceAttrPair(rName, "log_stream_id", "huaweicloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttr(rName, "binary_collect", "false"),
+					resource.TestCheckResourceAttr(rName, "encoding_format", "UTF-8"),
+					resource.TestCheckResourceAttr(rName, "incremental_collect", "true"),
+					resource.TestCheckResourceAttr(rName, "log_split", "false"),
+					// Check attributes.
+					resource.TestCheckResourceAttr(rName, "access_type", "AGENT"),
 					resource.TestCheckResourceAttrSet(rName, "log_group_name"),
 					resource.TestCheckResourceAttrSet(rName, "log_stream_name"),
 				),
@@ -210,11 +240,16 @@ resource "huaweicloud_lts_host_access" "test" {
   log_stream_id = huaweicloud_lts_stream.test.id
 
   access_config {
-    paths       = ["/var/temp", "/var/log/*"]
-    black_paths = ["/var/temp", "/var/log/*/a.log"]
+    paths          = ["/var/temp", "/var/log/*"]
+    black_paths    = ["/var/temp", "/var/log/*/a.log"]
+    repeat_collect = false
 
     single_log_format {
       mode = "system"
+    }
+
+    custom_key_value = {
+      "flag": "terraform"
     }
   }
 
@@ -256,11 +291,16 @@ resource "huaweicloud_lts_host_access" "test" {
       "keep_source_if_parse_error": false
     })
   }
+
+  binary_collect      = true
+  encoding_format     = "GBK"
+  incremental_collect = false
+  log_split           = true
 }
 `, testHostAccessConfig_base(name), name)
 }
 
-func testHostAccessConfig_basic_step2(name string) string {
+func testHostAccessConfig_basic_step2(name, updateName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -283,6 +323,10 @@ resource "huaweicloud_lts_host_access" "test" {
     multi_log_format {
       mode  = "time"
       value = "YYYY-MM-DD hh:mm:ss"
+    }
+
+    custom_key_value = {
+      "flag": "terraform"
     }
   }
 
@@ -309,8 +353,11 @@ resource "huaweicloud_lts_host_access" "test" {
       "keep_source_if_parse_error": true
     })
   }
+
+  encoding_format  = "UTF-8"
+  binary_collect   = true
 }
-`, testHostAccessConfig_base(name), name)
+`, testHostAccessConfig_base(name), updateName)
 }
 
 func testHostAccessConfig_windows_basic(name string) string {

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_host_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_host_access.go
@@ -259,6 +259,9 @@ func resourceHostAccessConfigCreate(ctx context.Context, d *schema.ResourceData,
 
 	createHostAccessConfigOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=UTF-8",
+		},
 	}
 
 	createHostAccessConfigOpt.JSONBody = utils.RemoveNil(buildCreateHostAccessConfigBodyParams(d))
@@ -453,6 +456,9 @@ func resourceHostAccessConfigRead(_ context.Context, d *schema.ResourceData, met
 
 	listHostAccessConfigOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=UTF-8",
+		},
 	}
 
 	name := d.Get("name").(string)
@@ -585,6 +591,9 @@ func resourceHostAccessConfigUpdate(ctx context.Context, d *schema.ResourceData,
 
 		updateHostAccessConfigOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json;charset=UTF-8",
+			},
 		}
 
 		updateHostAccessConfigOpt.JSONBody = utils.RemoveNil(buildUpdateHostAccessConfigBodyParams(d))
@@ -638,6 +647,9 @@ func resourceHostAccessConfigDelete(_ context.Context, d *schema.ResourceData, m
 
 	deleteHostAccessConfigOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=UTF-8",
+		},
 	}
 
 	deleteHostAccessConfigOpt.JSONBody = buildDeleteHostAccessConfigBodyParams(d)

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_host_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_host_access.go
@@ -49,7 +49,6 @@ func ResourceHostAccessConfig() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"log_group_id": {
 				Type:     schema.TypeString,
@@ -125,6 +124,30 @@ func ResourceHostAccessConfig() *schema.Resource {
 				},
 				Description: `The list of the parsed fields of the example log`,
 			},
+			"binary_collect": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Whether to allow collection of binary log files.`,
+			},
+			"encoding_format": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The encoding format log file.`,
+			},
+			// If not specified, the API defaults to true.
+			"incremental_collect": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Whether to collect logs incrementally.`,
+			},
+			"log_split": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to enable log splitting.`,
+			},
 			"access_type": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -136,6 +159,11 @@ func ResourceHostAccessConfig() *schema.Resource {
 			"log_stream_name": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the host access, in RFC3339 format.`,
 			},
 		},
 	}
@@ -176,6 +204,27 @@ func hostAccessConfigDeatilSchema(parent string) *schema.Resource {
 				Elem:     hostAccessConfigWindowsLogInfoSchema(),
 				Optional: true,
 				Computed: true,
+			},
+			"custom_key_value": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The custom key/value pairs of the host access.`,
+			},
+			"system_fields": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of system built-in fields of the host access.`,
+			},
+			"repeat_collect": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Whether to allow repeated flie collection.`,
 			},
 		},
 	}
@@ -301,6 +350,10 @@ func buildCreateHostAccessConfigBodyParams(d *schema.ResourceData) map[string]in
 		"processors":           buildHostAccessProcessors(d.Get("processors").([]interface{})),
 		"demo_log":             utils.ValueIgnoreEmpty(d.Get("demo_log")),
 		"demo_fields":          buildHostAccessDemoFields(d.Get("demo_fields").(*schema.Set)),
+		"binary_collect":       d.Get("binary_collect"),
+		"encoding_format":      utils.ValueIgnoreEmpty(d.Get("encoding_format")),
+		"incremental_collect":  d.Get("incremental_collect"),
+		"log_split":            d.Get("log_split"),
 	}
 	return bodyParams
 }
@@ -330,6 +383,9 @@ func buildHostAccessConfigDeatilRequestBody(rawParams interface{}) map[string]in
 			"black_paths":      utils.ValueIgnoreEmpty(raw["black_paths"].(*schema.Set).List()),
 			"format":           buildHostAccessConfigFormatRequestBody(raw),
 			"windows_log_info": buildHostAccessConfigWindowsLogInfoRequestBody(raw["windows_log_info"]),
+			"custom_key_value": utils.ValueIgnoreEmpty(raw["custom_key_value"]),
+			"system_fields":    utils.ValueIgnoreEmpty(raw["system_fields"].(*schema.Set).List()),
+			"repeat_collect":   raw["repeat_collect"],
 		}
 		return params
 	}
@@ -490,11 +546,8 @@ func resourceHostAccessConfigRead(_ context.Context, d *schema.ResourceData, met
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
 		d.Set("name", utils.PathSearch("access_config_name", listHostAccessConfigRespBody, nil)),
-		d.Set("access_type", utils.PathSearch("access_config_type", listHostAccessConfigRespBody, nil)),
 		d.Set("log_group_id", utils.PathSearch("log_info.log_group_id", listHostAccessConfigRespBody, nil)),
 		d.Set("log_stream_id", utils.PathSearch("log_info.log_stream_id", listHostAccessConfigRespBody, nil)),
-		d.Set("log_group_name", utils.PathSearch("log_info.log_group_name", listHostAccessConfigRespBody, nil)),
-		d.Set("log_stream_name", utils.PathSearch("log_info.log_stream_name", listHostAccessConfigRespBody, nil)),
 		d.Set("host_group_ids", utils.PathSearch("host_group_info.host_group_id_list", listHostAccessConfigRespBody, nil)),
 		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("access_config_tag", listHostAccessConfigRespBody, nil))),
 		d.Set("access_config", flattenHostAccessConfigDetail(listHostAccessConfigRespBody)),
@@ -502,7 +555,16 @@ func resourceHostAccessConfigRead(_ context.Context, d *schema.ResourceData, met
 		d.Set("demo_log", utils.PathSearch("demo_log", listHostAccessConfigRespBody, nil)),
 		d.Set("demo_fields",
 			flattenHostAccessDemoFields(utils.PathSearch("demo_fields", listHostAccessConfigRespBody, make([]interface{}, 0)).([]interface{}))),
-	)
+		d.Set("binary_collect", utils.PathSearch("binary_collect", listHostAccessConfigRespBody, nil)),
+		d.Set("encoding_format", utils.PathSearch("encoding_format", listHostAccessConfigRespBody, nil)),
+		d.Set("incremental_collect", utils.PathSearch("incremental_collect", listHostAccessConfigRespBody, nil)),
+		d.Set("log_split", utils.PathSearch("log_split", listHostAccessConfigRespBody, nil)),
+		// Attributes.
+		d.Set("access_type", utils.PathSearch("access_config_type", listHostAccessConfigRespBody, nil)),
+		d.Set("log_group_name", utils.PathSearch("log_info.log_group_name", listHostAccessConfigRespBody, nil)),
+		d.Set("log_stream_name", utils.PathSearch("log_info.log_stream_name", listHostAccessConfigRespBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", listHostAccessConfigRespBody,
+			float64(0)).(float64))/1000, false)))
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
@@ -515,6 +577,9 @@ func flattenHostAccessConfigDetail(resp interface{}) []map[string]interface{} {
 			"single_log_format": flattenHostAccessConfigLogFormat(utils.PathSearch("access_config_detail.format.single", resp, nil)),
 			"multi_log_format":  flattenHostAccessConfigLogFormat(utils.PathSearch("access_config_detail.format.multi", resp, nil)),
 			"windows_log_info":  flattenHostAccessConfigWindowsLogInfo(utils.PathSearch("access_config_detail.windows_log_info", resp, nil)),
+			"custom_key_value":  utils.PathSearch("access_config_detail.custom_key_value", resp, nil),
+			"system_fields":     utils.PathSearch("access_config_detail.system_fields", resp, nil),
+			"repeat_collect":    utils.PathSearch("access_config_detail.repeat_collect", resp, nil),
 		},
 	}
 }
@@ -567,6 +632,7 @@ func resourceHostAccessConfigUpdate(ctx context.Context, d *schema.ResourceData,
 	region := cfg.GetRegion(d)
 
 	updateHostAccessConfigChanges := []string{
+		"name",
 		"access_config",
 		"host_group_ids",
 		"tags",
@@ -574,6 +640,9 @@ func resourceHostAccessConfigUpdate(ctx context.Context, d *schema.ResourceData,
 		"processors",
 		"demo_log",
 		"demo_fields",
+		"encoding_format",
+		"incremental_collect",
+		"log_split",
 	}
 
 	if d.HasChanges(updateHostAccessConfigChanges...) {
@@ -618,15 +687,34 @@ func buildUpdateHostGroupInfoRequestBody(d *schema.ResourceData) map[string]inte
 func buildUpdateHostAccessConfigBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"access_config_id":     d.Id(),
-		"access_config_detail": buildHostAccessConfigDeatilRequestBody(d.Get("access_config")),
+		"access_config_name":   d.Get("name"),
+		"access_config_detail": buildUpdateHostAccessConfigDeatilRequestBody(d.Get("access_config").([]interface{})),
 		"host_group_info":      buildUpdateHostGroupInfoRequestBody(d),
 		"access_config_tag":    utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
 		"processor_type":       utils.ValueIgnoreEmpty(d.Get("processor_type")),
 		"processors":           utils.ValueIgnoreEmpty(buildHostAccessProcessors(d.Get("processors").([]interface{}))),
 		"demo_log":             utils.ValueIgnoreEmpty(d.Get("demo_log")),
 		"demo_fields":          utils.ValueIgnoreEmpty(buildHostAccessDemoFields(d.Get("demo_fields").(*schema.Set))),
+		"encoding_format":      utils.ValueIgnoreEmpty(d.Get("encoding_format")),
+		"incremental_collect":  d.Get("incremental_collect"),
+		"log_split":            d.Get("log_split"),
 	}
 	return bodyParams
+}
+
+func buildUpdateHostAccessConfigDeatilRequestBody(accessConfig []interface{}) map[string]interface{} {
+	if len(accessConfig) == 0 {
+		return nil
+	}
+
+	raw := accessConfig[0].(map[string]interface{})
+	return map[string]interface{}{
+		"paths":            utils.ValueIgnoreEmpty(raw["paths"].(*schema.Set).List()),
+		"black_paths":      utils.ValueIgnoreEmpty(raw["black_paths"].(*schema.Set).List()),
+		"format":           buildHostAccessConfigFormatRequestBody(raw),
+		"windows_log_info": buildHostAccessConfigWindowsLogInfoRequestBody(raw["windows_log_info"]),
+		"repeat_collect":   raw["repeat_collect"],
+	}
 }
 
 func resourceHostAccessConfigDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Add `Content-Type` to the interfaces. 
2. The resource supports new paramster and attributes.
+ Add parameters: `binary_collect`, `encoding_format`, `incremental_collect`, `log_split`,  `custom_key_value`,  `system_fields`, `repeat_collect`. Due to API reasons, the `binary_collect`,  `custom_key_value` and  `system_fields` parameters cannot be modified and will be connected after the backend is repaired.
+ new attributes: `created _at`.
+ support to modify the `name ` parameter.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
 1. add `Content-Type` to the interfaces. 
 2. the resource supports new paramster and attributes.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o lts -f TestAccHostAccessConfig_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccHostAccessConfig_ -timeout 360m -parallel 10
=== RUN   TestAccHostAccessConfig_basic
=== PAUSE TestAccHostAccessConfig_basic
=== RUN   TestAccHostAccessConfig_windows
=== PAUSE TestAccHostAccessConfig_windows
=== CONT  TestAccHostAccessConfig_basic
=== CONT  TestAccHostAccessConfig_windows
--- PASS: TestAccHostAccessConfig_windows (31.51s)
--- PASS: TestAccHostAccessConfig_basic (51.55s)
PASS
coverage: 14.9% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       51.675s coverage: 14.9% of statements in ./huaweicloud/services/lts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
