### PR TITLE
feat(servicestage): add new data source to query inner runtime stacks

### DIFF
--- a/docs/data-sources/servicestagev3_inner_runtime_stacks.md
+++ b/docs/data-sources/servicestagev3_inner_runtime_stacks.md
@@ -1,0 +1,45 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestagev3_inner_runtime_stacks"
+description: |-
+  Use this data source to query the list of inner runtime stacks within HuaweiCloud.
+---
+
+# huaweicloud_servicestagev3_inner_runtime_stacks
+
+Use this data source to query the list of inner runtime stacks within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_servicestagev3_inner_runtime_stacks" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the inner runtime stacks are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID, in UUID format.
+
+* `runtime_stacks` - All inner runtime stack details.  
+  The [runtime_stacks](#servicestage_v3_inner_runtime_stacks) structure is documented below.
+
+<a name="servicestage_v3_inner_runtime_stacks"></a>
+The `runtime_stacks` block supports:
+
+* `type` - The type of the inner runtime stack.
+  + **Nodejs**
+  + **Java**
+  + **Tomcat**
+  + **Python**
+  + **Php**
+
+* `url` - The image URL of the inner runtime stack.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1221,11 +1221,12 @@ func Provider() *schema.Provider {
 			// Querying by Ver.2 APIs
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),
 			// Querying by Ver.3 APIs
-			"huaweicloud_servicestagev3_applications":      servicestage.DataSourceV3Applications(),
-			"huaweicloud_servicestagev3_components":        servicestage.DataSourceV3Components(),
-			"huaweicloud_servicestagev3_component_records": servicestage.DataSourceV3ComponentRecords(),
-			"huaweicloud_servicestagev3_environments":      servicestage.DataSourceV3Environments(),
-			"huaweicloud_servicestagev3_runtime_stacks":    servicestage.DataSourceV3RuntimeStacks(),
+			"huaweicloud_servicestagev3_applications":         servicestage.DataSourceV3Applications(),
+			"huaweicloud_servicestagev3_components":           servicestage.DataSourceV3Components(),
+			"huaweicloud_servicestagev3_component_records":    servicestage.DataSourceV3ComponentRecords(),
+			"huaweicloud_servicestagev3_environments":         servicestage.DataSourceV3Environments(),
+			"huaweicloud_servicestagev3_inner_runtime_stacks": servicestage.DataSourceV3InnerRuntimeStacks(),
+			"huaweicloud_servicestagev3_runtime_stacks":       servicestage.DataSourceV3RuntimeStacks(),
 
 			"huaweicloud_smn_topics":              smn.DataSourceTopics(),
 			"huaweicloud_smn_message_templates":   smn.DataSourceSmnMessageTemplates(),

--- a/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestagev3_inner_runtime_stacks_test.go
+++ b/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestagev3_inner_runtime_stacks_test.go
@@ -1,0 +1,35 @@
+package servicestage
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataV3InnerRuntimeStacks_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_servicestagev3_inner_runtime_stacks.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataV3InnerRuntimeStacks_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "runtime_stacks.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "runtime_stacks.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "runtime_stacks.0.url"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataV3InnerRuntimeStacks_basic = `data "huaweicloud_servicestagev3_inner_runtime_stacks" "test" {}`

--- a/huaweicloud/services/servicestage/data_source_huaweicloud_servicestagev3_inner_runtime_stacks.go
+++ b/huaweicloud/services/servicestage/data_source_huaweicloud_servicestagev3_inner_runtime_stacks.go
@@ -1,0 +1,119 @@
+package servicestage
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ServiceStage GET /v3/{project_id}/cas/innerimages
+func DataSourceV3InnerRuntimeStacks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV3InnerRuntimeStacksRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the inner runtime stacks are located.`,
+			},
+			"runtime_stacks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the inner runtime stack.`,
+						},
+						"url": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The image URL of the inner runtime stack.`,
+						},
+					},
+				},
+				Description: "All inner runtime stack details.",
+			},
+		},
+	}
+}
+
+func listV3InnerRuntimeStacks(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	httpUrl := "v3/{project_id}/cas/innerimages"
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+	return utils.PathSearch("runtime_stacks", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenV3InnerRuntimeStacks(runtimeStacks []interface{}) []map[string]interface{} {
+	if len(runtimeStacks) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(runtimeStacks))
+	for _, runtimeStack := range runtimeStacks {
+		result = append(result, map[string]interface{}{
+			"type": utils.PathSearch("type", runtimeStack, nil),
+			"url":  utils.PathSearch("url", runtimeStack, nil),
+		})
+	}
+	return result
+}
+
+func dataSourceV3InnerRuntimeStacksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	innerRuntimeStacks, err := listV3InnerRuntimeStacks(client)
+	if err != nil {
+		return diag.Errorf("error getting inner runtime stacks: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("runtime_stacks", flattenV3InnerRuntimeStacks(innerRuntimeStacks)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new data source to query inner runtime stacks.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query inner runtime stacks
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o servicestage -f TestAccDataV3InnerRuntimeStacks_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccDataV3InnerRuntimeStacks_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV3InnerRuntimeStacks_basic
=== PAUSE TestAccDataV3InnerRuntimeStacks_basic
=== CONT  TestAccDataV3InnerRuntimeStacks_basic
--- PASS: TestAccDataV3InnerRuntimeStacks_basic (17.60s)
PASS
coverage: 3.3% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      17.679s coverage: 3.3% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
