### PR TITLE
feat(servicestage): add new resource to do component refresh action

### DIFF
--- a/docs/resources/servicestagev3_component_refresh.md
+++ b/docs/resources/servicestagev3_component_refresh.md
@@ -1,0 +1,44 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestagev3_component_refresh"
+description: |-
+  Use this resource to refresh ServiceStage component within HuaweiCloud.
+---
+
+# huaweicloud_servicestagev3_component_refresh
+
+Use this resource to refresh ServiceStage component within HuaweiCloud.
+
+-> This resource is only a one-time action resource for doing component refresh. Deleting this resource will not clear
+   the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "application_id" {}
+variable "component_id" {}
+
+resource "huaweicloud_servicestagev3_component_refresh" "test" {
+  application_id = var.application_id
+  component_id   = var.component_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the component to be refreshed is located.  
+  If omitted, the provider-level region will be used.
+  Changing this will create a new resource.
+
+* `application_id` - (Required, String, NonUpdatable) Specifies the application ID to which the componnet belongs.  
+
+* `component_id` - (Required, String, NonUpdatable) Specifies the ID of the component to be refreshed.  
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2318,6 +2318,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_servicestagev3_component":                 servicestage.ResourceV3Component(),
 			"huaweicloud_servicestagev3_configuration":             servicestage.ResourceV3Configuration(),
 			"huaweicloud_servicestagev3_component_action":          servicestage.ResourceV3ComponentAction(),
+			"huaweicloud_servicestagev3_component_refresh":         servicestage.ResourceV3ComponentRefresh(),
 			"huaweicloud_servicestagev3_configuration_group":       servicestage.ResourceV3ConfigurationGroup(),
 			"huaweicloud_servicestagev3_environment":               servicestage.ResourceV3Environment(),
 			"huaweicloud_servicestagev3_environment_associate":     servicestage.ResourceV3EnvironmentAssociate(),

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_component_refresh_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_component_refresh_test.go
@@ -1,0 +1,42 @@
+package servicestage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccV3ComponentRefresh_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Make sure at least one of node exist.
+			acceptance.TestAccPreCheckCceClusterId(t)
+			// At least one of JAR package must be provided.
+			acceptance.TestAccPreCheckServiceStageJarPkgStorageURLs(t, 1)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV3ComponentRefresh_basic_step1(),
+			},
+		},
+	})
+}
+
+func testAccV3ComponentRefresh_basic_step1() string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestagev3_component_refresh" "test" {
+  application_id = huaweicloud_servicestagev3_application.test.id
+  component_id   = huaweicloud_servicestagev3_component.test.id
+}
+`, testAccV3ComponentAction_basic_base())
+}

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_component_refresh.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_component_refresh.go
@@ -1,0 +1,119 @@
+package servicestage
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var v3ComponentRefreshNonUpdatableParams = []string{
+	"application_id",
+	"component_id",
+}
+
+// @API ServiceStage PUT /v3/{project_id}/cas/applications/{application_id}/components/{component_id}/refresh
+func ResourceV3ComponentRefresh() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceV3ComponentRefreshCreate,
+		ReadContext:   resourceV3ComponentRefreshRead,
+		UpdateContext: resourceV3ComponentRefreshUpdate,
+		DeleteContext: resourceV3ComponentRefreshDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(v3ComponentRefreshNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the component to be refreshed is located.`,
+			},
+			// Required parameters.
+			"application_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The application ID to which the componnet belongs.`,
+			},
+			"component_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the component to be refreshed.`,
+			},
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceV3ComponentRefreshCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		httpUrl       = "v3/{project_id}/cas/applications/{application_id}/components/{component_id}/refresh"
+		applicationId = d.Get("application_id").(string)
+		componentId   = d.Get("component_id").(string)
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{application_id}", applicationId)
+	createPath = strings.ReplaceAll(createPath, "{component_id}", componentId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	_, err = client.Request("PUT", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error executing component action: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	return resourceComponentActionRead(ctx, d, meta)
+}
+
+func resourceV3ComponentRefreshRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceV3ComponentRefreshUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceV3ComponentRefreshDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for doing component refresh. Deleting this resource
+will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource to do component refresh action
![image](https://github.com/user-attachments/assets/ea878d39-4fd8-487d-9e9a-874e73f5ded1)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to do component refresh action.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o servicestage -f TestAccV3ComponentRefresh_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccV3ComponentRefresh_basic -timeout 360m -parallel 10
=== RUN   TestAccV3ComponentRefresh_basic
=== PAUSE TestAccV3ComponentRefresh_basic
=== CONT  TestAccV3ComponentRefresh_basic
--- PASS: TestAccV3ComponentRefresh_basic (307.79s)
PASS
coverage: 20.2% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      307.871s        coverage: 20.2% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
