### PR TITLE
feat(evs): create v3 volume transfer resource

### DIFF
--- a/docs/resources/evsv3_volume_transfer.md
+++ b/docs/resources/evsv3_volume_transfer.md
@@ -1,0 +1,95 @@
+---
+subcategory: "Elastic Volume Service (EVS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_evsv3_volume_transfer"
+description: |-
+  Manages an EVS volume transfer (V3) resource within HuaweiCloud.
+---
+
+# huaweicloud_evsv3_volume_transfer
+
+Manages an EVS volume transfer resource within HuaweiCloud.
+
+-> The transfer can only be created when the EVS volume is in the **available** state, other constraints that do not
+   support transfer are as follows:
+   <br/>1. Volumes with the prePaid billing mode do not support transfer.
+   <br/>2. Frozen volumes do not support transfer.
+   <br/>3. Encrypted volumes do not support transfer.
+   <br/>4. Volumes with corresponding backups and snapshots do not support transfer.
+   <br/>5. Volumes with backup policies do not support transfer.
+   <br/>6. Volumes on DSS (Dedicated Storage Service) do not support transfer.
+   <br/>7. Volumes on DESS (Dedicated Enterprise Storage Service) do not support transfer.
+   <br/>8. EVS system disk does not support transfer.
+
+## Example Usage
+
+```hcl
+variable "volume_id" {}
+variable "name" {}
+
+resource "huaweicloud_evsv3_volume_transfer" "test" {
+  volume_id = var.volume_id
+  name      = var.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `volume_id` - (Required, String, NonUpdatable) Specifies the volume ID to be transferred.
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the volume transfer record.
+  Supports a maximum of `64` characters.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `auth_key` - The identity authentication key for volume transfer.
+
+  -> The `auth_key` field is used to accept the volume transfer, after the volume transfer is successfully accepted,
+     the volume transfer resource will no longer exist.
+
+* `created_at` - The creation time of the volume transfer record, in RFC3339 format.
+
+* `links` - The links to the cloud disk transfer record.
+  The [links](#links_struct) structure is documented below.
+
+<a name="links_struct"></a>
+The `links` block supports:
+
+* `href` - The corresponding shortcut link.
+
+* `rel` - The shortcut link marker name.
+
+## Import
+
+Volumes can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_evsv3_volume_transfer.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `auth_key`.
+It is generally recommended running terraform plan after importing the resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_evsv3_volume_transfer" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      auth_key, 
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1912,6 +1912,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_evs_volume":                   evs.ResourceEvsVolume(),
 			"huaweicloud_evs_snapshot_rollback":        evs.ResourceSnapshotRollBack(),
 			"huaweicloud_evs_volume_transfer":          evs.ResourceVolumeTransfer(),
+			"huaweicloud_evsv3_volume_transfer":        evs.ResourceV3VolumeTransfer(),
 			"huaweicloud_evs_volume_transfer_accepter": evs.ResourceVolumeTransferAccepter(),
 
 			"huaweicloud_fgs_application":                fgs.ResourceApplication(),

--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evsv3_volume_transfer_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evsv3_volume_transfer_test.go
@@ -1,0 +1,110 @@
+package evs
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getV3VolumeTransferFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		id      = state.Primary.ID
+		httpUrl = "v3/{project_id}/os-volume-transfer/{transfer_id}"
+		product = "evs"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating EVS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{transfer_id}", id)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving EVS v3 volume transfer: %s", err)
+	}
+	return utils.FlattenResponse(resp)
+}
+func TestAccV3VolumeTransfer_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_evsv3_volume_transfer.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getV3VolumeTransferFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV3VolumeTransfer_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "volume_id", "huaweicloud_evs_volume.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "auth_key"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "links.#"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"auth_key",
+				},
+			},
+		},
+	})
+}
+
+func testAccV3VolumeTransfer_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  name              = "%s"
+  description       = "Created by acc test"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  volume_type       = "SAS"
+  size              = 12
+}
+`, name)
+}
+
+func testAccV3VolumeTransfer_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_evsv3_volume_transfer" "test" {
+  volume_id = huaweicloud_evs_volume.test.id
+  name      = "%[2]s"
+}
+`, testAccV3VolumeTransfer_base(name), name)
+}

--- a/huaweicloud/services/evs/resource_huaweicloud_evsv3_volume_transfer.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evsv3_volume_transfer.go
@@ -1,0 +1,241 @@
+package evs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var v3TransferNonUpdatableParams = []string{"volume_id", "name"}
+
+// @API EVS POST /v3/{project_id}/os-volume-transfer
+// @API EVS GET /v3/{project_id}/os-volume-transfer/{transfer_id}
+// @API EVS DELETE /v3/{project_id}/os-volume-transfer/{transfer_id}
+func ResourceV3VolumeTransfer() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceV3VolumeTransferCreate,
+		ReadContext:   resourceV3VolumeTransferRead,
+		UpdateContext: resourceV3VolumeTransferUpdate,
+		DeleteContext: resourceV3VolumeTransferDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(v3TransferNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"auth_key": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Computed:  true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"links": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     v3TransferLinksComputeSchema(),
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func v3TransferLinksComputeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"href": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"rel": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCreateV3TransferBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"transfer": map[string]interface{}{
+			"name":      d.Get("name"),
+			"volume_id": d.Get("volume_id"),
+		},
+	}
+}
+
+func resourceV3VolumeTransferCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/os-volume-transfer"
+		product = "evs"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildCreateV3TransferBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating EVS v3 volume transfer: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	transferId := utils.PathSearch("transfer.id", respBody, "").(string)
+	if transferId == "" {
+		return diag.Errorf("error creating EVS v3 volume transfer: ID is not found in API response")
+	}
+
+	d.SetId(transferId)
+	// The `auth_key` field is an important attribute and will only be returned when calling the create API.
+	// So it is necessary to make a no null judgment and set value here.
+	authKey := utils.PathSearch("transfer.auth_key", respBody, "").(string)
+	if authKey == "" {
+		return diag.Errorf("error creating EVS v3 volume transfer: auth_key is not found in API response")
+	}
+
+	if err := d.Set("auth_key", authKey); err != nil {
+		return diag.Errorf("error setting attribute `auth_key` after creating EVS v3 volume transfer: %s", err)
+	}
+
+	return resourceV3VolumeTransferRead(ctx, d, meta)
+}
+
+func flattenV3TransferLinksAttribute(respBody interface{}) []interface{} {
+	links := utils.PathSearch("transfer.links", respBody, make([]interface{}, 0)).([]interface{})
+	if len(links) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(links))
+	for _, v := range links {
+		rst = append(rst, map[string]interface{}{
+			"href": utils.PathSearch("href", v, nil),
+			"rel":  utils.PathSearch("rel", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func resourceV3VolumeTransferRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		mErr    *multierror.Error
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/os-volume-transfer/{transfer_id}"
+		product = "evs"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{transfer_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		// When the resource does not exist, calling the query API will return a `404` status code.
+		return common.CheckDeletedDiag(d, err, "error retrieving EVS v3 volume transfer")
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("volume_id", utils.PathSearch("transfer.volume_id", respBody, nil)),
+		d.Set("name", utils.PathSearch("transfer.name", respBody, nil)),
+		d.Set("links", flattenV3TransferLinksAttribute(respBody)),
+		d.Set("created_at", utils.PathSearch("transfer.created_at", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceV3VolumeTransferUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceV3VolumeTransferDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/os-volume-transfer/{transfer_id}"
+		product = "evs"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{transfer_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		// When the resource does not exist, calling the delete API will return a `404` status code.
+		return common.CheckDeletedDiag(d, err, "error deleting EVS v3 volume transfer")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Create v3 volume transfer resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run TestAccV3VolumeTransfer_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccV3VolumeTransfer_basic -timeout 360m -parallel 4
=== RUN   TestAccV3VolumeTransfer_basic
=== PAUSE TestAccV3VolumeTransfer_basic
=== CONT  TestAccV3VolumeTransfer_basic
--- PASS: TestAccV3VolumeTransfer_basic (49.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       49.675s
```

* [X] Documentation updated.
* [X] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/dbd23a5f-1f8b-47d3-8f20-7afdbe735fd2)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![image](https://github.com/user-attachments/assets/850d9389-3fb0-4ad9-9b7c-4ed0c906efcc)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
