### PR TITLE
feat(servicestage): supports new data source to query component used resources

### DIFF
--- a/docs/data-sources/servicestagev3_component_used_resources.md
+++ b/docs/data-sources/servicestagev3_component_used_resources.md
@@ -1,0 +1,51 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestagev3_component_used_resources"
+description: |-
+  Use this data source to query the list of component used resources within HuaweiCloud.
+---
+
+# huaweicloud_servicestagev3_component_used_resources
+
+Use this data source to query the component used resources within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_servicestagev3_component_used_resources" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the components are located.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID, in UUID format.
+
+* `applications` - The application list that component used.
+  The [applications](#servicestage_v3_component_used_applications) structure is documented below.
+
+* `enterprise_projects` - The ID list of the enterprise projects that component used.
+
+* `environments` - The environment list that component used.
+  The [environments](#servicestage_v3_component_used_environments) structure is documented below.
+
+<a name="servicestage_v3_component_used_applications"></a>
+The `applications` block supports:
+
+* `id` - The ID of the application that component used.
+
+* `label` - The name of the application that component used.
+
+<a name="servicestage_v3_component_used_environments"></a>
+The `environments` block supports:
+
+* `id` - The ID of the environment that component used.
+
+* `label` - The name of the environment that component used.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1222,12 +1222,13 @@ func Provider() *schema.Provider {
 			// Querying by Ver.2 APIs
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),
 			// Querying by Ver.3 APIs
-			"huaweicloud_servicestagev3_applications":         servicestage.DataSourceV3Applications(),
-			"huaweicloud_servicestagev3_components":           servicestage.DataSourceV3Components(),
-			"huaweicloud_servicestagev3_component_records":    servicestage.DataSourceV3ComponentRecords(),
-			"huaweicloud_servicestagev3_environments":         servicestage.DataSourceV3Environments(),
-			"huaweicloud_servicestagev3_inner_runtime_stacks": servicestage.DataSourceV3InnerRuntimeStacks(),
-			"huaweicloud_servicestagev3_runtime_stacks":       servicestage.DataSourceV3RuntimeStacks(),
+			"huaweicloud_servicestagev3_applications":             servicestage.DataSourceV3Applications(),
+			"huaweicloud_servicestagev3_components":               servicestage.DataSourceV3Components(),
+			"huaweicloud_servicestagev3_component_records":        servicestage.DataSourceV3ComponentRecords(),
+			"huaweicloud_servicestagev3_component_used_resources": servicestage.DataSourceV3ComponentUsedResources(),
+			"huaweicloud_servicestagev3_environments":             servicestage.DataSourceV3Environments(),
+			"huaweicloud_servicestagev3_inner_runtime_stacks":     servicestage.DataSourceV3InnerRuntimeStacks(),
+			"huaweicloud_servicestagev3_runtime_stacks":           servicestage.DataSourceV3RuntimeStacks(),
 
 			"huaweicloud_smn_topics":              smn.DataSourceTopics(),
 			"huaweicloud_smn_message_templates":   smn.DataSourceSmnMessageTemplates(),

--- a/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestagev3_component_used_resources_test.go
+++ b/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestagev3_component_used_resources_test.go
@@ -1,0 +1,127 @@
+package servicestage
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataV3ComponentUsedResources_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		all = "data.huaweicloud_servicestagev3_component_used_resources.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Make sure at least one of node exist.
+			acceptance.TestAccPreCheckCceClusterId(t)
+			acceptance.TestAccPreCheckImageUrl(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataV3ComponentUsedResources_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "applications.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckResourceAttrSet(all, "applications.0.id"),
+					resource.TestCheckResourceAttrSet(all, "applications.0.label"),
+					resource.TestMatchResourceAttr(all, "enterprise_projects.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestMatchResourceAttr(all, "environments.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckResourceAttrSet(all, "environments.0.id"),
+					resource.TestCheckResourceAttrSet(all, "environments.0.label"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataV3ComponentUsedResources_basic(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_cce_clusters" "test" {
+  cluster_id = "%[1]s"
+}
+
+resource "huaweicloud_servicestagev3_application" "test" {
+  name                  = "%[2]s"
+  enterprise_project_id = "0"
+}
+
+resource "huaweicloud_servicestagev3_environment" "test" {
+  name                  = "%[2]s"
+  vpc_id                = try(data.huaweicloud_cce_clusters.test.clusters[0].vpc_id, "")
+  enterprise_project_id = "0"
+}
+
+resource "huaweicloud_servicestagev3_environment_associate" "test" {
+  environment_id = huaweicloud_servicestagev3_environment.test.id
+
+  resources {
+    type = "cce"
+    id   = try(data.huaweicloud_cce_clusters.test.clusters[0].id, "")
+  }
+}
+
+data "huaweicloud_servicestagev3_runtime_stacks" "test" {}
+
+locals {
+  docker_runtime_stack = try([for o in data.huaweicloud_servicestagev3_runtime_stacks.test.runtime_stacks:
+    o if o.type == "Docker" && o.deploy_mode == "container"][0], {})
+}
+
+resource "huaweicloud_servicestagev3_component" "test" {
+  depends_on = [
+    huaweicloud_servicestagev3_environment_associate.test
+  ]
+
+  application_id = huaweicloud_servicestagev3_application.test.id
+  environment_id = huaweicloud_servicestagev3_environment.test.id
+  name           = "%[2]s"
+
+  runtime_stack {
+    deploy_mode = try(local.docker_runtime_stack.deploy_mode, "container")
+    type        = try(local.docker_runtime_stack.type, "Docker")
+    name        = try(local.docker_runtime_stack.name, "Docker")
+    version     = try(local.docker_runtime_stack.version, null)
+  }
+
+  source = jsonencode({
+    "auth": "iam",
+    "kind": "image",
+    "storage": "swr",
+    "url": "%[3]s"
+  })
+
+  version = "1.0.1"
+  replica = 2
+
+  refer_resources {
+    id         = try(data.huaweicloud_cce_clusters.test.clusters[0].id, "")
+    type       = "cce"
+    parameters = jsonencode({
+      "namespace": "default",
+      "type": "VirtualMachine"
+    })
+  }
+
+  limit_cpu      = 0.5
+  limit_memory   = 1
+  request_cpu    = 0.5
+  request_memory = 1
+}
+
+data "huaweicloud_servicestagev3_component_used_resources" "test" {
+  depends_on = [
+    huaweicloud_servicestagev3_component.test,
+  ]
+}
+`, acceptance.HW_CCE_CLUSTER_ID, name, acceptance.HW_BUILD_IMAGE_URL)
+}

--- a/huaweicloud/services/servicestage/data_source_huaweicloud_servicestagev3_component_used_resources.go
+++ b/huaweicloud/services/servicestage/data_source_huaweicloud_servicestagev3_component_used_resources.go
@@ -1,0 +1,144 @@
+package servicestage
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ServiceStage GET /v3/{project_id}/cas/components/filterOptions
+func DataSourceV3ComponentUsedResources() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV3ComponentUsedResourcesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the components are located.`,
+			},
+			"applications": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the application that component used.`,
+						},
+						"label": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the application that component used.`,
+						},
+					},
+				},
+				Description: `The list of applications that component used.`,
+			},
+			"enterprise_projects": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The ID list of the enterprise projects that component used.`,
+			},
+			"environments": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the environment that component used.`,
+						},
+						"label": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the environment that component used.`,
+						},
+					},
+				},
+				Description: `The list of environments that component used.`,
+			},
+		},
+	}
+}
+
+func listV3ComponentUsedResources(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v3/{project_id}/cas/components/filterOptions"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func flattenV3ComponentUsedResourcesInfo(objInfos []interface{}) []map[string]interface{} {
+	if len(objInfos) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(objInfos))
+	for _, obj := range objInfos {
+		result = append(result, map[string]interface{}{
+			"id":    utils.PathSearch("id", obj, nil),
+			"label": utils.PathSearch("label", obj, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceV3ComponentUsedResourcesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	filterOptions, err := listV3ComponentUsedResources(client)
+	if err != nil {
+		return diag.Errorf("error getting component used resources: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("applications", flattenV3ComponentUsedResourcesInfo(utils.PathSearch("filter_options.applications",
+			filterOptions, make([]interface{}, 0)).([]interface{}))),
+		d.Set("enterprise_projects", utils.PathSearch("filter_options.enterprise_projects",
+			filterOptions, make([]interface{}, 0))),
+		d.Set("environments", flattenV3ComponentUsedResourcesInfo(utils.PathSearch("filter_options.environments",
+			filterOptions, make([]interface{}, 0)).([]interface{}))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New data source supported for the ServiceStage component used resources querying:
- used applications
- used environments
- used enterprise project

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new data source to query component used resources.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o servicestage -f TestAccDataV3ComponentFilterOptions_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccDataV3ComponentFilterOptions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV3ComponentFilterOptions_basic
=== PAUSE TestAccDataV3ComponentFilterOptions_basic
=== CONT  TestAccDataV3ComponentFilterOptions_basic
--- PASS: TestAccDataV3ComponentFilterOptions_basic (44.43s)
PASS
coverage: 20.4% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      44.496s coverage: 20.4% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
