### PR TITLE
chore(servicestage): change the API usage for components querying

### DIFF
--- a/docs/data-sources/servicestagev3_components.md
+++ b/docs/data-sources/servicestagev3_components.md
@@ -12,6 +12,14 @@ Use this data source to query the list of components under specified application
 
 ## Example Usage
 
+### Query all components under specified region
+
+```hcl
+data "huaweicloud_servicestagev3_components" "test" {}
+```
+
+### Query all components under specified application via its ID
+
 ```hcl
 variable "application_id" {}
 
@@ -27,7 +35,7 @@ The following arguments are supported:
 * `region` - (Optional, String) Specifies the region where the components are located.  
   If omitted, the provider-level region will be used.
 
-* `application_id` - (Required, String) Specifies the ID of the application to which the components belong.
+* `application_id` - (Optional, String) Specifies the ID of the application to which the components belong.
 
 ## Attribute Reference
 
@@ -58,9 +66,6 @@ The `components` block supports:
 * `refer_resources` - The configuration of the reference resources.  
   The [refer_resources](#servicestage_v3_components_refer_resources) structure is documented below.
 
-* `build` - The build configuration of the component, in JSON format.  
-  For the keys, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/api-servicestage/servicestage_06_0076.html#servicestage_06_0076__en-us_topic_0220056060_table7559740).
-
 * `external_accesses` - The configuration of the external accesses.  
   The [external_accesses](#servicestage_v3_components_external_accesses) structure is documented below.
 
@@ -75,10 +80,6 @@ The `components` block supports:
   + **PENDING**
   + **UNKNOWN**
   + **PARTIALLY_FAILED**
-
-* `created_at` - The creation time of the component, in RFC3339 format.
-
-* `updated_at` - The latest update time of the component, in RFC3339 format.
 
 <a name="servicestage_v3_components_runtime_stack"></a>
 The `runtime_stack` block supports:

--- a/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestagev3_components_test.go
+++ b/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestagev3_components_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
@@ -14,8 +15,13 @@ func TestAccDataV3Components_basic(t *testing.T) {
 	var (
 		name = acceptance.RandomAccResourceNameWithDash()
 
-		all = "data.huaweicloud_servicestagev3_components.test"
+		all = "data.huaweicloud_servicestagev3_components.all"
 		dc  = acceptance.InitDataSourceCheck(all)
+
+		byApplicationId           = "data.huaweicloud_servicestagev3_components.by_application_id"
+		dcByApplicationId         = acceptance.InitDataSourceCheck(byApplicationId)
+		byNotFoundApplicationId   = "data.huaweicloud_servicestagev3_components.by_not_found_application_id"
+		dcByNotFoundApplicationId = acceptance.InitDataSourceCheck(byNotFoundApplicationId)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -23,9 +29,11 @@ func TestAccDataV3Components_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			// Make sure at least one of node exist.
 			acceptance.TestAccPreCheckCceClusterId(t)
-			// Make sure the networks of the CCE cluster and the CSE engine are same.
+			// Make sure the networks of the CCE cluster and the CSE engine and the ELB loadbalancer are same.
 			acceptance.TestAccPreCheckCSEMicroserviceEngineID(t)
-			acceptance.TestAccPreCheckImsImageUrl(t)
+			acceptance.TestAccPreCheckElbLoadbalancerID(t)
+			// At least one of JAR package need to be provided.
+			acceptance.TestAccPreCheckServiceStageJarPkgStorageURLs(t, 1)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -41,11 +49,13 @@ func TestAccDataV3Components_basic(t *testing.T) {
 					resource.TestCheckOutput("is_component_source_set_and_valid", "true"),
 					resource.TestCheckOutput("is_component_version_set_and_valid", "true"),
 					resource.TestCheckOutput("is_component_refer_resources_set_and_valid", "true"),
-					resource.TestCheckOutput("is_component_build_set_and_valid", "true"),
 					resource.TestCheckOutput("is_component_tags_set_and_valid", "true"),
 					resource.TestCheckOutput("is_component_status_set", "true"),
-					resource.TestCheckOutput("is_component_created_at_set_and_valid", "true"),
-					resource.TestCheckOutput("is_component_updated_at_set_and_valid", "true"),
+					dcByApplicationId.CheckResourceExists(),
+					resource.TestMatchResourceAttr(byApplicationId, "components.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckOutput("is_application_id_filter_param_useful", "true"),
+					dcByNotFoundApplicationId.CheckResourceExists(),
+					resource.TestCheckOutput("is_not_found_application_id_filter_param_useful", "true"),
 				),
 			},
 		},
@@ -53,10 +63,18 @@ func TestAccDataV3Components_basic(t *testing.T) {
 }
 
 func testAccDataV3Components_basic(name string) string {
+	randUUID, _ := uuid.GenerateUUID()
+
 	return fmt.Sprintf(`
 %[1]s
 
-data "huaweicloud_servicestagev3_components" "test" {
+data "huaweicloud_servicestagev3_components" "all" {
+  depends_on = [
+    huaweicloud_servicestagev3_component.test
+  ]
+}
+
+data "huaweicloud_servicestagev3_components" "by_application_id" {
   depends_on = [
     huaweicloud_servicestagev3_component.test
   ]
@@ -64,68 +82,74 @@ data "huaweicloud_servicestagev3_components" "test" {
   application_id = huaweicloud_servicestagev3_application.test.id
 }
 
+data "huaweicloud_servicestagev3_components" "by_not_found_application_id" {
+  depends_on = [
+    huaweicloud_servicestagev3_component.test
+  ]
+
+  application_id = "%[2]s"
+}
+
 locals {
-  component_id            = huaweicloud_servicestagev3_component.test.id
-  component_filter_result = try([
-    for v in data.huaweicloud_servicestagev3_components.test.components : v if v.id == local.component_id
+  component_id                    = huaweicloud_servicestagev3_component.test.id
+  manully_filter_component_result = try([
+    for v in data.huaweicloud_servicestagev3_components.all.components : v if v.id == local.component_id
+  ][0], null)
+  application_id_filter_result    = try([
+    for v in data.huaweicloud_servicestagev3_components.by_application_id.components : v if v.id == local.component_id
   ][0], null)
 }
 
 output "is_component_id_set_and_valid" {
-  value = local.component_filter_result != null
+  value = local.manully_filter_component_result.id != null
 }
 
 output "is_environment_id_set_and_valid" {
-  value = try(local.component_filter_result.environment_id == huaweicloud_servicestagev3_environment.test.id, false)
+  value = try(local.manully_filter_component_result.environment_id == huaweicloud_servicestagev3_environment.test.id, false)
 }
 
 output "is_component_name_set_and_valid" {
-  value = try(local.component_filter_result.name == huaweicloud_servicestagev3_component.test.name, false)
+  value = try(local.manully_filter_component_result.name == huaweicloud_servicestagev3_component.test.name, false)
 }
 
 output "is_component_runtime_stack_set_and_valid" {
-  value = try(length(local.component_filter_result.runtime_stack) > 0 && alltrue([
-	  local.component_filter_result.runtime_stack[0].name == huaweicloud_servicestagev3_component.test.runtime_stack[0].name,
-	  local.component_filter_result.runtime_stack[0].type == huaweicloud_servicestagev3_component.test.runtime_stack[0].type,
-	  local.component_filter_result.runtime_stack[0].deploy_mode == huaweicloud_servicestagev3_component.test.runtime_stack[0].deploy_mode,
-	  local.component_filter_result.runtime_stack[0].version == huaweicloud_servicestagev3_component.test.runtime_stack[0].version,
+  value = try(length(local.manully_filter_component_result.runtime_stack) > 0 && alltrue([
+    local.manully_filter_component_result.runtime_stack[0].name == huaweicloud_servicestagev3_component.test.runtime_stack[0].name,
+    local.manully_filter_component_result.runtime_stack[0].type == huaweicloud_servicestagev3_component.test.runtime_stack[0].type,
+    local.manully_filter_component_result.runtime_stack[0].deploy_mode == huaweicloud_servicestagev3_component.test.runtime_stack[0].deploy_mode,
+    local.manully_filter_component_result.runtime_stack[0].version == huaweicloud_servicestagev3_component.test.runtime_stack[0].version,
   ]))
 }
 
 output "is_component_source_set_and_valid" {
-  value = try(local.component_filter_result.source == huaweicloud_servicestagev3_component.test.source, false)
+  value = try(local.manully_filter_component_result.source == huaweicloud_servicestagev3_component.test.source, false)
 }
 
 output "is_component_version_set_and_valid" {
-  value = try(local.component_filter_result.version == huaweicloud_servicestagev3_component.test.version, false)
+  value = try(local.manully_filter_component_result.version == huaweicloud_servicestagev3_component.test.version, false)
 }
 
 output "is_component_refer_resources_set_and_valid" {
-  value = try(length(local.component_filter_result.refer_resources) == length(huaweicloud_servicestagev3_component.test.refer_resources), false)
-}
-
-output "is_component_build_set_and_valid" {
-  value = try(local.component_filter_result.build == huaweicloud_servicestagev3_component.test.build, false)
+  value = try(length(local.manully_filter_component_result.refer_resources) == length(huaweicloud_servicestagev3_component.test.refer_resources),
+    false)
 }
 
 output "is_component_tags_set_and_valid" {
   value = try(length(setintersection(matchkeys(values(huaweicloud_servicestagev3_component.test.tags),
-    keys(huaweicloud_servicestagev3_component.test.tags), keys(local.component_filter_result.tags)),
-    values(local.component_filter_result.tags))) == length(local.component_filter_result.tags), false)
+    keys(huaweicloud_servicestagev3_component.test.tags), keys(local.manully_filter_component_result.tags)),
+    values(local.manully_filter_component_result.tags))) == length(local.manully_filter_component_result.tags), false)
 }
 
 output "is_component_status_set" {
-  value = local.component_filter_result.status != ""
+  value = local.manully_filter_component_result.status != ""
 }
 
-output "is_component_created_at_set_and_valid" {
-  value = try(length(regexall("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
-    local.component_filter_result.created_at)) > 0, false)
+output "is_application_id_filter_param_useful" {
+  value = length(local.application_id_filter_result) > 0
 }
 
-output "is_component_updated_at_set_and_valid" {
-  value = try(length(regexall("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
-    local.component_filter_result.updated_at)) > 0, false)
+output "is_not_found_application_id_filter_param_useful" {
+  value = length(data.huaweicloud_servicestagev3_components.by_not_found_application_id.components) == 0
 }
-`, testAccV3Component_basic_step1(name))
+`, testAccV3Component_basic_step1(name), randUUID)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Using 'Obtaining All Components' API to instead of the 'Obtaining All Components of an Application' API.
The attributes return are same for these APIs.
Three attributes are deprecated from the doucment:
- build
- create_time
- update_time

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. change the API usage for components querying.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o servicestage -f TestAccDataV3Components_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccDataV3Components_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV3Components_basic
=== PAUSE TestAccDataV3Components_basic
=== CONT  TestAccDataV3Components_basic
--- PASS: TestAccDataV3Components_basic (391.89s)
PASS
coverage: 25.1% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      391.961s        coverage: 25.1% of statements in ./huaweicloud/services/servicestage
```

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
