### PR TITLE
feat(evs): create v3 volume transfers datasource

### DIFF
--- a/docs/data-sources/evsv3_volume_transfers.md
+++ b/docs/data-sources/evsv3_volume_transfers.md
@@ -1,0 +1,53 @@
+---
+subcategory: "Elastic Volume Service (EVS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_evsv3_volume_transfers"
+description: |-
+  Use this data source to get the list of EVS volume transfers (V3) within HuaweiCloud.
+---
+
+# huaweicloud_evsv3_volume_transfers
+
+Use this data source to get the list of EVS volume transfers (V3) within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_evsv3_volume_transfers" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `transfers` - The list of volume transfers.
+
+  The [transfers](#transfers_struct) structure is documented below.
+
+<a name="transfers_struct"></a>
+The `transfers` block supports:
+
+* `id` - The volume transfer ID.
+
+* `name` - The volume transfer name.
+
+* `volume_id` - The volume ID.
+
+* `links` - The links to the cloud disk transfer record.
+  The [links](#links_struct) structure is documented below.
+
+<a name="links_struct"></a>
+The `links` block supports:
+
+* `href` - The corresponding shortcut link.
+
+* `rel` - The shortcut link marker name.

--- a/docs/resources/evsv3_volume_transfer.md
+++ b/docs/resources/evsv3_volume_transfer.md
@@ -8,7 +8,7 @@ description: |-
 
 # huaweicloud_evsv3_volume_transfer
 
-Manages an EVS volume transfer resource within HuaweiCloud.
+Manages an EVS volume transfer (V3) resource within HuaweiCloud.
 
 -> The transfer can only be created when the EVS volume is in the **available** state, other constraints that do not
    support transfer are as follows:

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -863,6 +863,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_evs_availability_zones": evs.DataSourceEvsAvailabilityZones(),
 			"huaweicloud_evs_volume_types":       evs.DataSourceEvsVolumeTypes(),
 			"huaweicloud_evs_volume_transfers":   evs.DataSourceEvsVolumeTransfers(),
+			"huaweicloud_evsv3_volume_transfers": evs.DataSourceEvsV3VolumeTransfers(),
 			"huaweicloud_evs_tags":               evs.DataSourceEvsTags(),
 			"huaweicloud_evs_quotas":             evs.DataSourceEvsQuotas(),
 

--- a/huaweicloud/services/acceptance/evs/data_source_huaweicloud_evsv3_volume_transfers_test.go
+++ b/huaweicloud/services/acceptance/evs/data_source_huaweicloud_evsv3_volume_transfers_test.go
@@ -1,0 +1,46 @@
+package evs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceEvsV3VolumeTransfers_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_evsv3_volume_transfers.test"
+	name := acceptance.RandomAccResourceNameWithDash()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceEvsV3VolumeTransfers_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "transfers.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "transfers.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "transfers.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "transfers.0.volume_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "transfers.0.links.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceEvsV3VolumeTransfers_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_evsv3_volume_transfers" "test" {
+  depends_on = [huaweicloud_evsv3_volume_transfer.test]
+}
+`, testAccV3VolumeTransfer_basic(name))
+}

--- a/huaweicloud/services/evs/data_source_huaweicloud_evsv3_volume_transfers.go
+++ b/huaweicloud/services/evs/data_source_huaweicloud_evsv3_volume_transfers.go
@@ -1,0 +1,174 @@
+package evs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EVS GET /v3/{project_id}/os-volume-transfer
+func DataSourceEvsV3VolumeTransfers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEvsV3VolumeTransfersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"transfers": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of volume transfers.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The volume transfer ID.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The volume transfer name.`,
+						},
+						"volume_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The volume ID.`,
+						},
+						"links": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        datasourceV3TransferLinksSchema(),
+							Description: `The links to the cloud disk transfer record.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func datasourceV3TransferLinksSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"href": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The corresponding shortcut link.`,
+			},
+			"rel": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The shortcut link marker name.`,
+			},
+		},
+	}
+}
+
+func buildV3TransfersQueryPath(requestPath string, offset int) string {
+	if offset == 0 {
+		return requestPath
+	}
+
+	return fmt.Sprintf("%s?offset=%d", requestPath, offset)
+}
+
+func dataSourceEvsV3VolumeTransfersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		httpUrl      = "v3/{project_id}/os-volume-transfer"
+		product      = "evs"
+		offset       = 0
+		allTransfers []interface{}
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		resp, err := client.Request("GET", buildV3TransfersQueryPath(requestPath, offset), &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving EVS v3 volume transfers: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		transfers := utils.PathSearch("transfers", respBody, make([]interface{}, 0)).([]interface{})
+		if len(transfers) == 0 {
+			break
+		}
+
+		allTransfers = append(allTransfers, transfers...)
+		offset += len(transfers)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("transfers", flattenDatasourceV3VolumeTransfers(allTransfers)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDatasourceV3VolumeTransfers(allTransfers []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(allTransfers))
+	for _, v := range allTransfers {
+		rst = append(rst, map[string]interface{}{
+			"id":        utils.PathSearch("id", v, nil),
+			"name":      utils.PathSearch("name", v, nil),
+			"volume_id": utils.PathSearch("volume_id", v, nil),
+			"links":     flattenDatasourceV3TransferLinks(v),
+		})
+	}
+
+	return rst
+}
+
+func flattenDatasourceV3TransferLinks(respBody interface{}) []interface{} {
+	links := utils.PathSearch("links", respBody, make([]interface{}, 0)).([]interface{})
+	if len(links) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(links))
+	for _, v := range links {
+		rst = append(rst, map[string]interface{}{
+			"href": utils.PathSearch("href", v, nil),
+			"rel":  utils.PathSearch("rel", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Create v3 volume transfers datasource.
![image](https://github.com/user-attachments/assets/fcd4e3f6-e074-4614-b7b3-c971b6f98a8d)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run TestAccDataSourceEvsV3VolumeTransfers_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccDataSourceEvsV3VolumeTransfers_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceEvsV3VolumeTransfers_basic
=== PAUSE TestAccDataSourceEvsV3VolumeTransfers_basic
=== CONT  TestAccDataSourceEvsV3VolumeTransfers_basic
--- PASS: TestAccDataSourceEvsV3VolumeTransfers_basic (69.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       69.271s
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
