### PR TITLE
refactor(nat): refactor the private DNAT rule resource code style

### DIFF
--- a/docs/resources/nat_private_dnat_rule.md
+++ b/docs/resources/nat_private_dnat_rule.md
@@ -2,7 +2,8 @@
 subcategory: "NAT Gateway (NAT)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_nat_private_dnat_rule"
-description: ""
+description: |-
+  Manages a DNAT rule resource of the **private** NAT within HuaweiCloud.
 ---
 
 # huaweicloud_nat_private_dnat_rule
@@ -164,5 +165,5 @@ In addition to all arguments above, the following attributes are exported:
 DNAT rules can be imported using their `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_nat_private_dnat_rule.test 19e3f4ed-fde0-406a-828d-7e0482400da9
+$ terraform import huaweicloud_nat_private_dnat_rule.test <id>
 ```

--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_dnat_rule_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_dnat_rule_test.go
@@ -7,27 +7,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/nat/v3/dnats"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/nat"
 )
 
 func getPrivateDnatRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := cfg.NatV3Client(acceptance.HW_REGION_NAME)
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("nat", region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating NAT v3 client: %s", err)
 	}
 
-	return dnats.Get(client, state.Primary.ID)
+	return nat.GetPrivateDnatRule(client, state.Primary.ID)
 }
 
 // The backend forwarding object is the ECS instance.
 func TestAccPrivateDnatRule_basic(t *testing.T) {
 	var (
-		obj dnats.Rule
-
+		obj   interface{}
 		rName = "huaweicloud_nat_private_dnat_rule.test"
 		name  = acceptance.RandomAccResourceNameWithDash()
 	)
@@ -49,15 +48,12 @@ func TestAccPrivateDnatRule_basic(t *testing.T) {
 				Config: testAccPrivateDnatRule_basic_step_1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(rName, "gateway_id",
-						"huaweicloud_nat_private_gateway.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id", "huaweicloud_nat_private_gateway.test", "id"),
 					resource.TestCheckResourceAttr(rName, "protocol", "tcp"),
-					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
-						"huaweicloud_nat_private_transit_ip.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id", "huaweicloud_nat_private_transit_ip.test", "id"),
 					resource.TestCheckResourceAttr(rName, "transit_service_port", "1000"),
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
-					resource.TestCheckResourceAttrPair(rName, "backend_interface_id",
-						"huaweicloud_compute_instance.test", "network.0.port"),
+					resource.TestCheckResourceAttrPair(rName, "backend_interface_id", "huaweicloud_compute_instance.test", "network.0.port"),
 					resource.TestCheckResourceAttr(rName, "internal_service_port", "2000"),
 					resource.TestCheckResourceAttrSet(rName, "backend_type"),
 					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
@@ -138,10 +134,6 @@ resource "huaweicloud_compute_instance" "test" {
   network {
     uuid = huaweicloud_vpc_subnet.test.id
   }
-
-  tags = {
-    foo = "bar"
-  }
 }
 
 resource "huaweicloud_nat_private_gateway" "test" {
@@ -155,7 +147,6 @@ resource "huaweicloud_nat_private_gateway" "test" {
 func testAccPrivateDnatRule_basic_step_1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
-
 %[2]s
 
 resource "huaweicloud_nat_private_dnat_rule" "test" {
@@ -173,7 +164,6 @@ resource "huaweicloud_nat_private_dnat_rule" "test" {
 func testAccPrivateDnatRule_basic_step_2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
-
 %[2]s
 
 resource "huaweicloud_nat_private_dnat_rule" "test" {
@@ -190,7 +180,6 @@ resource "huaweicloud_nat_private_dnat_rule" "test" {
 func testAccPrivateDnatRule_basic_step_3(name string) string {
 	return fmt.Sprintf(`
 %[1]s
-
 %[2]s
 
 resource "huaweicloud_nat_private_dnat_rule" "test" {
@@ -205,8 +194,7 @@ resource "huaweicloud_nat_private_dnat_rule" "test" {
 // The backend forwarding object is the ELB loadbalancer.
 func TestAccPrivateDnatRule_elbBackend(t *testing.T) {
 	var (
-		obj dnats.Rule
-
+		obj   interface{}
 		rName = "huaweicloud_nat_private_dnat_rule.test"
 		name  = acceptance.RandomAccResourceNameWithDash()
 	)
@@ -228,15 +216,12 @@ func TestAccPrivateDnatRule_elbBackend(t *testing.T) {
 				Config: testAccPrivateDnatRule_elbBackend_step_1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(rName, "gateway_id",
-						"huaweicloud_nat_private_gateway.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id", "huaweicloud_nat_private_gateway.test", "id"),
 					resource.TestCheckResourceAttr(rName, "protocol", "tcp"),
-					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
-						"huaweicloud_nat_private_transit_ip.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id", "huaweicloud_nat_private_transit_ip.test", "id"),
 					resource.TestCheckResourceAttr(rName, "transit_service_port", "1000"),
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
-					resource.TestCheckResourceAttrPair(rName, "backend_interface_id",
-						"data.huaweicloud_networking_port.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "backend_interface_id", "huaweicloud_elb_loadbalancer.test", "ipv4_port_id"),
 					resource.TestCheckResourceAttr(rName, "internal_service_port", "2000"),
 					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
 				),
@@ -284,81 +269,10 @@ func testAccPrivateDnatRule_elbBackend_base(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-%[2]s
-
-resource "huaweicloud_network_acl" "test" {
-  name = "%[3]s"
-
-  subnets = [
-    huaweicloud_vpc_subnet.test.id
-  ]
-
-  inbound_rules = [
-    huaweicloud_network_acl_rule.test.id
-  ]
-}
-
-resource "huaweicloud_network_acl_rule" "test" {
-  name                   = "%[3]s"
-  protocol               = "tcp"
-  action                 = "allow"
-  source_ip_address      = huaweicloud_vpc.test.cidr
-  source_port            = "8080"
-  destination_ip_address = "0.0.0.0/0"
-  destination_port       = "8081"
-}
-
-resource "huaweicloud_networking_secgroup_rule" "in_v4_icmp_all" {
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  ethertype         = "IPv4"
-  direction         = "ingress"
-  protocol          = "icmp"
-  remote_ip_prefix  = "0.0.0.0/0"
-}
-
-resource "huaweicloud_networking_secgroup_rule" "in_v4_elb_member" {
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  ethertype         = "IPv4"
-  direction         = "ingress"
-  protocol          = "tcp"
-  ports             = "80,8081"
-  remote_ip_prefix  = huaweicloud_vpc.test.cidr
-}
-
-resource "huaweicloud_networking_secgroup_rule" "in_v4_all_group" {
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  ethertype         = "IPv4"
-  direction         = "ingress"
-  remote_group_id   = huaweicloud_networking_secgroup.test.id
-}
-
-resource "huaweicloud_networking_secgroup_rule" "out_v4_all" {
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  ethertype         = "IPv4"
-  direction         = "egress"
-  remote_ip_prefix  = "0.0.0.0/0"
-}
-
-resource "huaweicloud_vpc_eip" "test" {
-  publicip {
-    type = "5_bgp"
-  }
-
-  bandwidth {
-    name        = "%[3]s"
-    size        = 5
-    share_type  = "PER"
-    charge_mode = "traffic"
-  }
-}
-
-resource "huaweicloud_compute_eip_associate" "test" {
-  public_ip   = huaweicloud_vpc_eip.test.address
-  instance_id = huaweicloud_compute_instance.test.id
-}
+data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_elb_loadbalancer" "test" {
-  name           = "%[3]s"
+  name           = "%[2]s"
   vpc_id         = huaweicloud_vpc.test.id
   ipv4_subnet_id = huaweicloud_vpc_subnet.test.subnet_id
 
@@ -367,54 +281,18 @@ resource "huaweicloud_elb_loadbalancer" "test" {
   ]
 }
 
-resource "huaweicloud_elb_listener" "test" {
-  name            = "%[3]s"
-  protocol        = "HTTP"
-  protocol_port   = 8080
-  loadbalancer_id = huaweicloud_elb_loadbalancer.test.id
-
-  idle_timeout     = 60
-  request_timeout  = 60
-  response_timeout = 60
+resource "huaweicloud_nat_private_gateway" "test" {
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  name                  = "%[2]s"
+  enterprise_project_id = "0"
 }
-
-resource "huaweicloud_elb_pool" "test" {
-  protocol    = "HTTP"
-  lb_method   = "ROUND_ROBIN"
-  listener_id = huaweicloud_elb_listener.test.id
-
-  persistence {
-    type = "HTTP_COOKIE"
-  }
-}
-
-resource "huaweicloud_elb_monitor" "test" {
-  protocol    = "HTTP"
-  interval    = 20
-  timeout     = 15
-  max_retries = 10
-  url_path    = "/"
-  port        = 8080
-  pool_id     = huaweicloud_elb_pool.test.id
-}
-
-resource "huaweicloud_elb_member" "test" {
-  address       = huaweicloud_compute_instance.test.access_ip_v4
-  protocol_port = 8080
-  pool_id       = huaweicloud_elb_pool.test.id
-  subnet_id     = huaweicloud_vpc_subnet.test.subnet_id
-}
-
-data "huaweicloud_networking_port" "test" {
-  network_id = huaweicloud_vpc_subnet.test.id
-  fixed_ip   = huaweicloud_elb_loadbalancer.test.ipv4_address
-}
-`, testAccPrivateDnatRule_ecsPart(name), testAccPrivateDnatRule_transitIpConfig(name), name)
+`, common.TestBaseNetwork(name), name)
 }
 
 func testAccPrivateDnatRule_elbBackend_step_1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
+%[2]s
 
 resource "huaweicloud_nat_private_dnat_rule" "test" {
   gateway_id            = huaweicloud_nat_private_gateway.test.id
@@ -422,45 +300,46 @@ resource "huaweicloud_nat_private_dnat_rule" "test" {
   description           = "Created by acc test"
   transit_ip_id         = huaweicloud_nat_private_transit_ip.test.id
   transit_service_port  = 1000
-  backend_interface_id  = data.huaweicloud_networking_port.test.id
+  backend_interface_id  = huaweicloud_elb_loadbalancer.test.ipv4_port_id
   internal_service_port = 2000
 }
-`, testAccPrivateDnatRule_elbBackend_base(name))
+`, testAccPrivateDnatRule_elbBackend_base(name), testAccPrivateDnatRule_transitIpConfig(name))
 }
 
 func testAccPrivateDnatRule_elbBackend_step_2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
+%[2]s
 
 resource "huaweicloud_nat_private_dnat_rule" "test" {
   gateway_id            = huaweicloud_nat_private_gateway.test.id
   protocol              = "udp"
   transit_ip_id         = huaweicloud_nat_private_transit_ip.test.id
   transit_service_port  = 3000
-  backend_interface_id  = data.huaweicloud_networking_port.test.id
+  backend_interface_id  = huaweicloud_elb_loadbalancer.test.ipv4_port_id
   internal_service_port = 4000
 }
-`, testAccPrivateDnatRule_elbBackend_base(name))
+`, testAccPrivateDnatRule_elbBackend_base(name), testAccPrivateDnatRule_transitIpConfig(name))
 }
 
 func testAccPrivateDnatRule_elbBackend_step_3(name string) string {
 	return fmt.Sprintf(`
 %[1]s
+%[2]s
 
 resource "huaweicloud_nat_private_dnat_rule" "test" {
   gateway_id           = huaweicloud_nat_private_gateway.test.id
   protocol             = "any"
   transit_ip_id        = huaweicloud_nat_private_transit_ip.test.id
-  backend_interface_id = data.huaweicloud_networking_port.test.id
+  backend_interface_id = huaweicloud_elb_loadbalancer.test.ipv4_port_id
 }
-`, testAccPrivateDnatRule_elbBackend_base(name))
+`, testAccPrivateDnatRule_elbBackend_base(name), testAccPrivateDnatRule_transitIpConfig(name))
 }
 
 // The backend forwarding object is the VIP.
 func TestAccPrivateDnatRule_vipBackend(t *testing.T) {
 	var (
-		obj dnats.Rule
-
+		obj   interface{}
 		rName = "huaweicloud_nat_private_dnat_rule.test"
 		name  = acceptance.RandomAccResourceNameWithDash()
 	)
@@ -482,15 +361,12 @@ func TestAccPrivateDnatRule_vipBackend(t *testing.T) {
 				Config: testAccPrivateDnatRule_vipBackend_step_1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(rName, "gateway_id",
-						"huaweicloud_nat_private_gateway.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id", "huaweicloud_nat_private_gateway.test", "id"),
 					resource.TestCheckResourceAttr(rName, "protocol", "tcp"),
-					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
-						"huaweicloud_nat_private_transit_ip.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id", "huaweicloud_nat_private_transit_ip.test", "id"),
 					resource.TestCheckResourceAttr(rName, "transit_service_port", "1000"),
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
-					resource.TestCheckResourceAttrPair(rName, "backend_interface_id",
-						"huaweicloud_networking_vip.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "backend_interface_id", "huaweicloud_networking_vip.test", "id"),
 					resource.TestCheckResourceAttr(rName, "internal_service_port", "2000"),
 					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
 				),
@@ -537,7 +413,6 @@ func TestAccPrivateDnatRule_vipBackend(t *testing.T) {
 func testAccPrivateDnatRule_vipBackend_base(name string) string {
 	return fmt.Sprintf(`
 %[1]s
-
 %[2]s
 
 resource "huaweicloud_nat_private_gateway" "test" {
@@ -599,8 +474,7 @@ resource "huaweicloud_nat_private_dnat_rule" "test" {
 
 func TestAccPrivateDnatRule_customIpAddress(t *testing.T) {
 	var (
-		obj dnats.Rule
-
+		obj   interface{}
 		rName = "huaweicloud_nat_private_dnat_rule.test"
 		name  = acceptance.RandomAccResourceNameWithDash()
 	)
@@ -622,11 +496,9 @@ func TestAccPrivateDnatRule_customIpAddress(t *testing.T) {
 				Config: testAccPrivateDnatRule_customIpAddress_step_1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(rName, "gateway_id",
-						"huaweicloud_nat_private_gateway.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id", "huaweicloud_nat_private_gateway.test", "id"),
 					resource.TestCheckResourceAttr(rName, "protocol", "any"),
-					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
-						"huaweicloud_nat_private_transit_ip.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id", "huaweicloud_nat_private_transit_ip.test", "id"),
 					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
 				),
 			},
@@ -684,7 +556,6 @@ func TestAccPrivateDnatRule_customIpAddress(t *testing.T) {
 func testAccPrivateDnatRule_customIpAddress_base(name string) string {
 	return fmt.Sprintf(`
 %[1]s
-
 %[2]s
 
 resource "huaweicloud_nat_private_gateway" "test" {

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_private_dnat_rule.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_private_dnat_rule.go
@@ -3,14 +3,14 @@ package nat
 import (
 	"context"
 	"fmt"
-	"log"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/chnsz/golangsdk/openstack/nat/v3/dnats"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -109,122 +109,208 @@ func ResourcePrivateDnatRule() *schema.Resource {
 	}
 }
 
+func buildCreatePrivateDnatRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	dnatRuleBodyParams := map[string]interface{}{
+		"gateway_id":            d.Get("gateway_id"),
+		"transit_ip_id":         d.Get("transit_ip_id"),
+		"protocol":              utils.ValueIgnoreEmpty(d.Get("protocol")),
+		"network_interface_id":  utils.ValueIgnoreEmpty(d.Get("backend_interface_id")),
+		"private_ip_address":    utils.ValueIgnoreEmpty(d.Get("backend_private_ip")),
+		"internal_service_port": convertIntToStr(d.Get("internal_service_port").(int)),
+		"transit_service_port":  convertIntToStr(d.Get("transit_service_port").(int)),
+		"description":           utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+
+	return map[string]interface{}{
+		"dnat_rule": dnatRuleBodyParams,
+	}
+}
+
+func convertIntToStr(param int) string {
+	return fmt.Sprintf("%v", param)
+}
+
 func resourcePrivateDnatRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	client, err := cfg.NatV3Client(cfg.GetRegion(d))
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/private-nat/dnat-rules"
+	)
+
+	client, err := cfg.NewServiceClient("nat", region)
 	if err != nil {
 		return diag.Errorf("error creating NAT v3 client: %s", err)
 	}
 
-	opts := dnats.CreateOpts{
-		GatewayId:           d.Get("gateway_id").(string),
-		Protocol:            d.Get("protocol").(string),
-		Description:         d.Get("description").(string),
-		NetworkInterfaceId:  d.Get("backend_interface_id").(string),
-		PrivateIpAddress:    d.Get("backend_private_ip").(string),
-		InternalServicePort: strconv.Itoa(d.Get("internal_service_port").(int)),
-		TransitIpId:         d.Get("transit_ip_id").(string),
-		TransitServicePort:  strconv.Itoa(d.Get("transit_service_port").(int)),
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreatePrivateDnatRuleBodyParams(d)),
 	}
 
-	log.Printf("[DEBUG] The create options of the DNAT rule (Private NAT) is: %#v", opts)
-	resp, err := dnats.Create(client, opts)
+	resp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
-		return diag.Errorf("error creating DNAT rule (Private NAT): %s", err)
+		return diag.Errorf("error creating private DNAT rule: %s", err)
 	}
-	d.SetId(resp.ID)
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	ruleId := utils.PathSearch("dnat_rule.id", respBody, "").(string)
+	if ruleId == "" {
+		return diag.Errorf("error creating private DNAT rule: ID is not found in API response")
+	}
+
+	d.SetId(ruleId)
 
 	return resourcePrivateDnatRuleRead(ctx, d, meta)
 }
 
+func GetPrivateDnatRule(client *golangsdk.ServiceClient, ruleId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/private-nat/dnat-rules/{dnat_rule_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{dnat_rule_id}", ruleId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
 func resourcePrivateDnatRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.NatV3Client(region)
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("nat", region)
 	if err != nil {
 		return diag.Errorf("error creating NAT v3 client: %s", err)
 	}
 
-	resp, err := dnats.Get(client, d.Id())
+	respBody, err := GetPrivateDnatRule(client, d.Id())
 	if err != nil {
 		// If the private DNAT rule does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving private DNAT rule")
 	}
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("gateway_id", resp.GatewayId),
-		d.Set("transit_ip_id", resp.TransitIpId),
-		d.Set("description", resp.Description),
-		d.Set("backend_interface_id", resp.NetworkInterfaceId),
-		d.Set("protocol", resp.Protocol),
-		d.Set("backend_private_ip", resp.PrivateIpAddress),
-		d.Set("backend_type", resp.Type),
-		d.Set("created_at", resp.CreatedAt),
-		d.Set("updated_at", resp.UpdatedAt),
-		d.Set("enterprise_project_id", resp.EnterpriseProjectId),
+		d.Set("gateway_id", utils.PathSearch("dnat_rule.gateway_id", respBody, nil)),
+		d.Set("transit_ip_id", utils.PathSearch("dnat_rule.transit_ip_id", respBody, nil)),
+		d.Set("description", utils.PathSearch("dnat_rule.description", respBody, nil)),
+		d.Set("backend_interface_id", utils.PathSearch("dnat_rule.network_interface_id", respBody, nil)),
+		d.Set("protocol", utils.PathSearch("dnat_rule.protocol", respBody, nil)),
+		d.Set("backend_private_ip", utils.PathSearch("dnat_rule.private_ip_address", respBody, nil)),
+		d.Set("backend_type", utils.PathSearch("dnat_rule.type", respBody, nil)),
+		d.Set("created_at", utils.PathSearch("dnat_rule.created_at", respBody, nil)),
+		d.Set("updated_at", utils.PathSearch("dnat_rule.updated_at", respBody, nil)),
+		d.Set("enterprise_project_id", utils.PathSearch("dnat_rule.enterprise_project_id", respBody, nil)),
 	)
 
+	internalPort := utils.PathSearch("dnat_rule.internal_service_port", respBody, "").(string)
+	transitPort := utils.PathSearch("dnat_rule.transit_service_port", respBody, "").(string)
+
 	// Parse the internal service port
-	if internalServicePort, err := strconv.Atoi(resp.InternalServicePort); err != nil {
+	if internalServicePort, err := strconv.Atoi(internalPort); err != nil {
 		mErr = multierror.Append(mErr, fmt.Errorf("invalid format for internal service port, want 'string', but '%T'",
-			resp.InternalServicePort))
+			internalPort))
 	} else if internalServicePort != 0 {
 		mErr = multierror.Append(mErr, d.Set("internal_service_port", internalServicePort))
 	}
 
 	// Parse the transit service port
-	if transitServicePort, err := strconv.Atoi(resp.TransitServicePort); err != nil {
-		mErr = multierror.Append(mErr, fmt.Errorf("invalid format for transit service port, want 'string', but '%T'",
-			resp.TransitServicePort))
+	if transitServicePort, err := strconv.Atoi(transitPort); err != nil {
+		mErr = multierror.Append(mErr, fmt.Errorf("invalid format for internal service port, want 'string', but '%T'",
+			transitPort))
 	} else if transitServicePort != 0 {
 		mErr = multierror.Append(mErr, d.Set("transit_service_port", transitServicePort))
 	}
 
-	if err = mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error saving resource fields of the DNAT rule (Private NAT): %s", err)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdatePrivateDnatRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	dnatRuleBodyParams := map[string]interface{}{
+		"transit_ip_id":         d.Get("transit_ip_id"),
+		"protocol":              utils.ValueIgnoreEmpty(d.Get("protocol")),
+		"internal_service_port": convertIntToStr(d.Get("internal_service_port").(int)),
+		"transit_service_port":  convertIntToStr(d.Get("transit_service_port").(int)),
+		"description":           d.Get("description"),
 	}
-	return nil
+
+	return dnatRuleBodyParams
+}
+
+func updatePrivateDnatRule(client *golangsdk.ServiceClient, ruleId string, dnatRuleBodyParams map[string]interface{}) error {
+	httpUrl := "v3/{project_id}/private-nat/dnat-rules/{dnat_rule_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{dnat_rule_id}", ruleId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"dnat_rule": dnatRuleBodyParams,
+		},
+	}
+	_, err := client.Request("PUT", updatePath, &opt)
+	return err
 }
 
 func resourcePrivateDnatRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.NatV3Client(region)
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("nat", region)
 	if err != nil {
 		return diag.Errorf("error creating NAT v3 client: %s", err)
 	}
 
-	ruleId := d.Id()
-	opts := dnats.UpdateOpts{
-		Protocol:            d.Get("protocol").(string),
-		Description:         utils.String(d.Get("description").(string)),
-		InternalServicePort: strconv.Itoa(d.Get("internal_service_port").(int)),
-		TransitIpId:         d.Get("transit_ip_id").(string),
-		TransitServicePort:  strconv.Itoa(d.Get("transit_service_port").(int)),
-	}
+	updateOpt := buildUpdatePrivateDnatRuleBodyParams(d)
 	if d.HasChange("backend_private_ip") {
-		opts.PrivateIpAddress = d.Get("backend_private_ip").(string)
+		updateOpt["private_ip_address"] = utils.ValueIgnoreEmpty(d.Get("backend_private_ip"))
 	} else if d.HasChange("backend_interface_id") {
-		opts.NetworkInterfaceId = d.Get("backend_interface_id").(string)
+		updateOpt["network_interface_id"] = utils.ValueIgnoreEmpty(d.Get("backend_interface_id"))
 	}
 
-	_, err = dnats.Update(client, ruleId, opts)
+	err = updatePrivateDnatRule(client, d.Id(), updateOpt)
 	if err != nil {
-		return diag.Errorf("error updating DNAT rule (Private NAT) (%s): %s", ruleId, err)
+		return diag.Errorf("error updating private DNAT rule: %s", err)
 	}
 
 	return resourcePrivateDnatRuleRead(ctx, d, meta)
 }
 
 func resourcePrivateDnatRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	client, err := cfg.NatV3Client(cfg.GetRegion(d))
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/private-nat/dnat-rules/{dnat_rule_id}"
+	)
+
+	client, err := cfg.NewServiceClient("nat", region)
 	if err != nil {
 		return diag.Errorf("error creating NAT v3 client: %s", err)
 	}
 
-	ruleId := d.Id()
-	err = dnats.Delete(client, ruleId)
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{dnat_rule_id}", d.Id())
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpts)
 	if err != nil {
 		// If the private DNAT rule does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error deleting private DNAT rule")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactor the private DNAT rule resource code style.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateDnatRule_vipBackend"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateDnatRule_vipBackend -timeout 360m -parallel 4
=== RUN   TestAccPrivateDnatRule_vipBackend
=== PAUSE TestAccPrivateDnatRule_vipBackend
=== CONT  TestAccPrivateDnatRule_vipBackend
--- PASS: TestAccPrivateDnatRule_vipBackend (97.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       97.786s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateDnatRule_customIpAddress"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateDnatRule_customIpAddress -timeout 360m -parallel 4
=== RUN   TestAccPrivateDnatRule_customIpAddress
=== PAUSE TestAccPrivateDnatRule_customIpAddress
=== CONT  TestAccPrivateDnatRule_customIpAddress
--- PASS: TestAccPrivateDnatRule_customIpAddress (107.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       107.465s
```
```
$ bash test.sh "./huaweicloud/services/acceptance/nat" "TestAccPrivateDnatRule_basic"
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -run TestAccPrivateDnatRule_basic -timeout 360m -parallel 4

=== RUN   TestAccPrivateDnatRule_basic
=== PAUSE TestAccPrivateDnatRule_basic
=== CONT  TestAccPrivateDnatRule_basic
--- PASS: TestAccPrivateDnatRule_basic (228.69s)
PASS
coverage: 2.9% of statements in ./huaweicloud/...
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       229.335s        coverage: 2.9% of statements in ./huaweicloud/...
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
## UT coverage
![image](https://github.com/user-attachments/assets/5d80df34-5fc8-4573-ad6c-6e8fc231777d)
