### PR TITLE
feat(lts/sql_alarm_rule): add new parameters and use 'notification_save_rule' instead of 'notification_rule'

### DIFF
--- a/docs/resources/lts_sql_alarm_rule.md
+++ b/docs/resources/lts_sql_alarm_rule.md
@@ -61,12 +61,12 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies the description of the SQL alarm rule.
 
-* `send_notifications` - (Optional, Bool, ForceNew) Specifies whether to send notifications.
-  Changing this parameter will create a new resource.
+* `send_notifications` - (Optional, Bool) Specifies whether to send notifications.  
+  Defaults to **false**.
 
-* `notification_rule` - (Optional, List, ForceNew) Specifies the notification rule.
-  Changing this parameter will create a new resource.
-  The [NotificationRule](#SQLAlarmRule_NotificationRule) structure is documented below.
+* `notification_save_rule` - (Optional, List) Specifies the notification rule.  
+  The [NotificationRule](#SQLAlarmRule_NotificationRule) structure is documented below.  
+  This parameter is available only when `send_notifications` parameter is set to **true**.
 
 * `trigger_condition_count` - (Optional, Int) Specifies the count to trigger the alarm.
   Defaults to `1`.
@@ -130,38 +130,29 @@ The `Frequency` block supports:
 <a name="SQLAlarmRule_NotificationRule"></a>
 The `NotificationRule` block supports:
 
-* `template_name` - (Required, String, ForceNew) Specifies the notification template name.
-  Changing this parameter will create a new resource.
+* `template_name` - (Required, String) Specifies the notification template name.
 
-* `language` - (Required, String, ForceNew) Specifies the notification language.
+* `language` - (Required, String) Specifies the notification language.
   The value can be **zh-cn** and **en-us**.
-  Changing this parameter will create a new resource.
 
-* `user_name` - (Required, String, ForceNew) Specifies the user name.
-  Changing this parameter will create a new resource.
+* `user_name` - (Required, String) Specifies the user name.
 
-* `topics` - (Required, List, ForceNew) Specifies the SMN topics.
+* `topics` - (Required, List) Specifies the SMN topics.
   The [Topic](#SQLAlarmRule_Topic) structure is documented below.
-  Changing this parameter will create a new resource.
 
-* `timezone` - (Optional, String, ForceNew) Specifies the timezone.
-  Changing this parameter will create a new resource.
+* `timezone` - (Optional, String) Specifies the timezone.
 
 <a name="SQLAlarmRule_Topic"></a>
 The `NotificationRuleTopic` block supports:
 
-* `name` - (Required, String, ForceNew) Specifies the topic name.
-  Changing this parameter will create a new resource.
+* `name` - (Required, String) Specifies the topic name.
 
-* `topic_urn` - (Required, String, ForceNew) Specifies the topic URN.
-  Changing this parameter will create a new resource.
+* `topic_urn` - (Required, String) Specifies the topic URN.
 
-* `display_name` - (Optional, String, ForceNew) Specifies the display name.
+* `display_name` - (Optional, String) Specifies the display name.
   This will be shown as the sender of the message.
-  Changing this parameter will create a new resource.
 
-* `push_policy` - (Optional, String, ForceNew) Specifies the push policy.
-  Changing this parameter will create a new resource.
+* `push_policy` - (Optional, Int) Specifies the push policy.
 
 ## Attribute Reference
 
@@ -184,7 +175,7 @@ $ terraform import huaweicloud_lts_sql_alarm_rule.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response. The missing attributes include: `notification_rule`.
+API response. The missing attributes include: `notification_save_rule.0.user_name` and `notification_save_rule.0.timezone`.
 It is generally recommended running `terraform plan` after importing a certificate.
 You can then decide if changes should be applied to the certificate, or the resource definition should be updated to
 align with the certificate. Also you can ignore changes as below.
@@ -195,7 +186,7 @@ resource "huaweicloud_lts_sql_alarm_rule" "test" {
 
   lifecycle {
     ignore_changes = [
-      notification_rule,
+      notification_save_rule.0.user_name, notification_save_rule.0.timezone,
     ]
   }
 }

--- a/docs/resources/lts_sql_alarm_rule.md
+++ b/docs/resources/lts_sql_alarm_rule.md
@@ -64,6 +64,11 @@ The following arguments are supported:
 * `send_notifications` - (Optional, Bool) Specifies whether to send notifications.  
   Defaults to **false**.
 
+* `alarm_action_rule_name` - (Optional, String) Specifies the name of the alarm action rule associated with
+  the SQL alarm rule.  
+  This parameter is available only when `send_notifications` parameter is set to **true** and cannot be used
+  together with `notification_save_rule` parameter.
+
 * `notification_save_rule` - (Optional, List) Specifies the notification rule.  
   The [NotificationRule](#SQLAlarmRule_NotificationRule) structure is documented below.  
   This parameter is available only when `send_notifications` parameter is set to **true**.
@@ -74,10 +79,30 @@ The following arguments are supported:
 * `trigger_condition_frequency` - (Optional, Int) Specifies the frequency to trigger the alarm.
   Defaults to `1`.
 
-* `send_recovery_notifications` - (Optional, Bool) Specifies whether to send recovery notifications.
+* `send_recovery_notifications` - (Optional, Bool) Specifies whether to send recovery notifications.  
+  Defaults to **false**
 
 * `recovery_frequency` - (Optional, Int) Specifies the frequency to recover the alarm.
   Defaults to `3`.
+
+* `alarm_rule_alias` - (Optional, String) Specifies the alias name of the SQL alarm rule.  
+  The maximum lanegth is `128` characters, only Chinese characters, letters, digits, hyphens (-) and underscores (_)
+  are allowed.  
+  The name cannot start with and end with a hyphen or a underscore.
+
+* `notification_frequency` - (Optional, Int) Specifies the notification frequency of the SQL alarm rule,
+  in minutes.  
+  Defaults to `0`, `0` means immediately notification.  
+  This parameter is available only when `send_notifications` parameter is set to **true**.
+  The valid values are as follows:
+  + **0**
+  + **5**
+  + **10**
+  + **15**
+  + **30**
+  + **60**
+  + **180**
+  + **360**
 
 * `status` - (Optional, String) Specifies the status. The value can be: **RUNNING** and **STOPPING**.
   Defaults to **RUNNING**
@@ -100,7 +125,12 @@ The `SQLRequests` block supports:
   + When the `search_time_range_unit` is **minute**, the value ranges from `1` to `60`;
   + When the `search_time_range_unit` is **hour**, the value ranges from `1` to `24`;
 
-* `is_time_range_relative` - (Optional, Bool) Specifies the SQL request is relative to time range.
+* `is_time_range_relative` - (Optional, Bool) Specifies the SQL request is relative to time range.  
+  Defaults to **false**.
+
+* `log_group_name` - (Optional, String) Specifies the name of the log group.
+
+* `log_stream_name` - (Optional, String) Specifies the name of the log stream.
 
 <a name="SQLAlarmRule_Frequency"></a>
 The `Frequency` block supports:

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_sql_alarm_rule_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_sql_alarm_rule_test.go
@@ -2,67 +2,33 @@ package lts
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lts"
 )
 
 func getSQLAlarmRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	region := acceptance.HW_REGION_NAME
-	// getSQLAlarmRule: Query the LTS SQLAlarmRule detail
-	var (
-		getSQLAlarmRuleHttpUrl = "v2/{project_id}/lts/alarms/sql-alarm-rule"
-		getSQLAlarmRuleProduct = "lts"
-	)
-	getSQLAlarmRuleClient, err := cfg.NewServiceClient(getSQLAlarmRuleProduct, region)
+	getSQLAlarmRuleClient, err := cfg.NewServiceClient("lts", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating LTS client: %s", err)
 	}
 
-	getSQLAlarmRulePath := getSQLAlarmRuleClient.Endpoint + getSQLAlarmRuleHttpUrl
-	getSQLAlarmRulePath = strings.ReplaceAll(getSQLAlarmRulePath, "{project_id}", getSQLAlarmRuleClient.ProjectID)
-
-	getSQLAlarmRuleOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: map[string]string{"Content-Type": "application/json"},
-	}
-
-	getSQLAlarmRuleResp, err := getSQLAlarmRuleClient.Request("GET", getSQLAlarmRulePath, &getSQLAlarmRuleOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving SQL alarm rule: %s", err)
-	}
-
-	getSQLAlarmRuleRespBody, err := utils.FlattenResponse(getSQLAlarmRuleResp)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving SQL alarm rule: %s", err)
-	}
-
-	jsonPath := fmt.Sprintf("sql_alarm_rules[?sql_alarm_rule_id =='%s']|[0]", state.Primary.ID)
-	getSQLAlarmRuleRespBody = utils.PathSearch(jsonPath, getSQLAlarmRuleRespBody, nil)
-	if getSQLAlarmRuleRespBody == nil {
-		return nil, golangsdk.ErrDefault404{}
-	}
-	return getSQLAlarmRuleRespBody, nil
+	return lts.GetSQLAlarmRuleById(getSQLAlarmRuleClient, state.Primary.ID)
 }
 
 func TestAccSQLAlarmRule_basic(t *testing.T) {
 	var (
-		name     = acceptance.RandomAccResourceName()
-		password = acceptance.RandomPassword()
+		name      = acceptance.RandomAccResourceName()
+		aliasName = acceptance.RandomAccResourceName()
+		password  = acceptance.RandomPassword()
 
 		obj                interface{}
-		rName              = "huaweicloud_lts_sql_alarm_rule.test"
+		rName              = "huaweicloud_lts_sql_alarm_rule.with_action_alarm_rule_name"
 		withNotiSaveRule   = "huaweicloud_lts_sql_alarm_rule.with_notification_save_rule"
 		rc                 = acceptance.InitResourceCheck(rName, &obj, getSQLAlarmRuleResourceFunc)
 		rcWithNotiSaveRule = acceptance.InitResourceCheck(withNotiSaveRule, &obj, getSQLAlarmRuleResourceFunc)
@@ -72,6 +38,7 @@ func TestAccSQLAlarmRule_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPrecheckDomainId(t)
+			acceptance.TestAccPreCheckLtsAlarmActionRuleName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
@@ -80,24 +47,48 @@ func TestAccSQLAlarmRule_basic(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSQLAlarmRule_basic_step1(name, password),
+				Config: testAccSQLAlarmRule_basic_step1(name, password, aliasName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "description", "created by terraform"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.type", "HOURLY"),
+					resource.TestCheckResourceAttr(rName, "condition_expression", "t>0"),
+					resource.TestCheckResourceAttr(rName, "alarm_level", "CRITICAL"),
+					resource.TestCheckResourceAttr(rName, "sql_requests.0.title", name),
+					resource.TestCheckResourceAttr(rName, "sql_requests.0.sql", "select count(*) as t"),
 					resource.TestCheckResourceAttrPair(rName, "sql_requests.0.log_group_id",
 						"huaweicloud_lts_group.test.0", "id"),
 					resource.TestCheckResourceAttrPair(rName, "sql_requests.0.log_stream_id",
 						"huaweicloud_lts_stream.test.0", "id"),
-					resource.TestCheckResourceAttr(rName, "frequency.0.type", "HOURLY"),
-					resource.TestCheckResourceAttr(rName, "condition_expression", "t>0"),
-					resource.TestCheckResourceAttr(rName, "alarm_level", "CRITICAL"),
+					resource.TestCheckResourceAttr(rName, "sql_requests.0.search_time_range_unit", "minute"),
+					resource.TestCheckResourceAttr(rName, "sql_requests.0.search_time_range", "5"),
 					// Check optional parameters.
+					resource.TestCheckResourceAttrPair(rName, "sql_requests.0.log_stream_name",
+						"huaweicloud_lts_stream.test.0", "stream_name"),
+					resource.TestCheckResourceAttrPair(rName, "sql_requests.0.log_group_name",
+						"huaweicloud_lts_group.test.0", "group_name"),
+					resource.TestCheckResourceAttr(rName, "description", "created by terraform"),
+					resource.TestCheckResourceAttr(rName, "send_notifications", "true"),
+					resource.TestCheckResourceAttr(rName, "trigger_condition_count", "1"),
+					resource.TestCheckResourceAttr(rName, "trigger_condition_frequency", "1"),
+					resource.TestCheckResourceAttr(rName, "send_recovery_notifications", "false"),
+					resource.TestCheckResourceAttr(rName, "recovery_frequency", "3"),
+					resource.TestCheckResourceAttr(rName, "notification_frequency", "0"),
+					resource.TestCheckResourceAttr(rName, "alarm_rule_alias", name),
+					resource.TestCheckResourceAttr(rName, "alarm_action_rule_name", acceptance.HW_LTS_ALARM_ACTION_RULE_NAME),
 					resource.TestCheckResourceAttr(rName, "status", "STOPPING"),
+					// Check Attributes.
+					resource.TestCheckResourceAttrSet(rName, "domain_id"),
 					resource.TestCheckResourceAttrSet(rName, "created_at"),
 
 					rcWithNotiSaveRule.CheckResourceExists(),
 					resource.TestCheckResourceAttr(withNotiSaveRule, "send_notifications", "true"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "trigger_condition_count", "2"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "trigger_condition_frequency", "3"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "send_recovery_notifications", "true"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "recovery_frequency", "4"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "notification_frequency", "15"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "alarm_rule_alias", aliasName),
 					resource.TestCheckResourceAttr(withNotiSaveRule, "notification_save_rule.0.template_name", "sql_template"),
 					resource.TestCheckResourceAttr(withNotiSaveRule, "notification_save_rule.0.topics.#", "1"),
 					resource.TestCheckResourceAttrPair(withNotiSaveRule, "notification_save_rule.0.topics.0.name",
@@ -111,15 +102,33 @@ func TestAccSQLAlarmRule_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSQLAlarmRule_basic_step2(name, password),
+				Config: testAccSQLAlarmRule_basic_step2(name, password, aliasName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "condition_expression", "t>2"),
 					resource.TestCheckResourceAttr(rName, "alarm_level", "INFO"),
+					resource.TestCheckResourceAttr(rName, "sql_requests.0.title", name+"_sql"),
+					resource.TestCheckResourceAttr(rName, "sql_requests.0.sql", "select *"),
+					resource.TestCheckResourceAttrPair(rName, "sql_requests.0.log_group_id",
+						"huaweicloud_lts_group.test.1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "sql_requests.0.log_stream_id",
+						"huaweicloud_lts_stream.test.1", "id"),
+					resource.TestCheckResourceAttr(rName, "sql_requests.0.search_time_range_unit", "hour"),
+					resource.TestCheckResourceAttr(rName, "sql_requests.0.search_time_range", "10"),
+					resource.TestCheckResourceAttr(rName, "sql_requests.0.is_time_range_relative", "true"),
 					resource.TestCheckResourceAttr(rName, "frequency.0.type", "DAILY"),
 					resource.TestCheckResourceAttr(rName, "frequency.0.hour_of_day", "6"),
 					// Check Optional parameter.
+					resource.TestCheckResourceAttr(rName, "trigger_condition_count", "6"),
+					resource.TestCheckResourceAttr(rName, "trigger_condition_frequency", "6"),
+					resource.TestCheckResourceAttr(rName, "send_recovery_notifications", "true"),
+					resource.TestCheckResourceAttr(rName, "recovery_frequency", "5"),
+					resource.TestCheckResourceAttr(rName, "notification_frequency", "30"),
+					resource.TestCheckResourceAttrPair(rName, "sql_requests.0.log_stream_name",
+						"huaweicloud_lts_stream.test.1", "stream_name"),
+					resource.TestCheckResourceAttrPair(rName, "sql_requests.0.log_group_name",
+						"huaweicloud_lts_group.test.1", "group_name"),
 					resource.TestCheckResourceAttr(rName, "notification_save_rule.0.template_name", "sql_template"),
 					resource.TestCheckResourceAttr(rName, "notification_save_rule.0.topics.#", "1"),
 					resource.TestCheckResourceAttrPair(rName, "notification_save_rule.0.topics.0.name",
@@ -133,26 +142,36 @@ func TestAccSQLAlarmRule_basic(t *testing.T) {
 					// Check attributes.
 					resource.TestCheckResourceAttrSet(rName, "updated_at"),
 					rcWithNotiSaveRule.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "notification_save_rule.0.template_name", "sql_template"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "frequency.0.type", "CRON"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "frequency.0.cron_expression", "0 18 * * *"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "send_recovery_notifications", "false"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "notification_save_rule.0.template_name", "sql_template"),
 					resource.TestCheckResourceAttr(withNotiSaveRule, "notification_save_rule.0.topics.#", "2"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "alarm_rule_alias", aliasName+"_update"),
 				),
 			},
 			{
 				Config: testAccSQLAlarmRule_basic_step3(name, password),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					rcWithNotiSaveRule.CheckResourceExists(),
-					resource.TestCheckResourceAttr(withNotiSaveRule, "send_notifications", "false"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.type", "WEEKLY"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.hour_of_day", "6"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.day_of_week", "2"),
+					resource.TestCheckResourceAttr(rName, "send_notifications", "true"),
+					resource.TestCheckResourceAttr(rName, "alarm_action_rule_name", acceptance.HW_LTS_ALARM_ACTION_RULE_NAME),
 					resource.TestCheckResourceAttr(rName, "notification_save_rule.#", "0"),
+					rcWithNotiSaveRule.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "frequency.0.type", "FIXED_RATE"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "frequency.0.fixed_rate_unit", "minute"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "frequency.0.fixed_rate", "30"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "send_notifications", "false"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "notification_save_rule.#", "0"),
 				),
 			},
 			{
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"notification_rule",
-				},
 			},
 			{
 				ResourceName:            withNotiSaveRule,
@@ -175,19 +194,21 @@ locals {
 `, testAlarmRule_base(name, password), name)
 }
 
-func testAccSQLAlarmRule_basic_step1(name, password string) string {
+func testAccSQLAlarmRule_basic_step1(name, password, aliasName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_lts_sql_alarm_rule" "test" {
-  name                 = "%[2]s"
-  description          = "created by terraform"
-  condition_expression = "t>0"
-  alarm_level          = "CRITICAL"
-  status               = "STOPPING"
+resource "huaweicloud_lts_sql_alarm_rule" "with_action_alarm_rule_name" {
+  name                   = "%[2]s"
+  description            = "created by terraform"
+  condition_expression   = "t>0"
+  alarm_level            = "CRITICAL"
+  send_notifications     = true
+  alarm_action_rule_name = "%[4]s"
+  status                 = "STOPPING"
 
   sql_requests {
-    title                  = "%[2]s_sql"
+    title                  = "%[2]s"
     sql                    = "select count(*) as t"
     log_group_id           = huaweicloud_lts_group.test[0].id
     log_stream_id          = huaweicloud_lts_stream.test[0].id
@@ -201,18 +222,26 @@ resource "huaweicloud_lts_sql_alarm_rule" "test" {
 }
 
 resource "huaweicloud_lts_sql_alarm_rule" "with_notification_save_rule" {
-  name                 = "%[2]s_notification"
-  condition_expression = "t>0"
-  alarm_level          = "MINOR"
-  send_notifications   = true
-  
+  name                        = "%[2]s_sql"
+  condition_expression        = "t>0"
+  alarm_level                 = "MINOR"
+  send_notifications          = true
+  trigger_condition_count     = 2
+  trigger_condition_frequency = 3
+  send_recovery_notifications = true
+  recovery_frequency          = 4
+  notification_frequency      = 15
+  alarm_rule_alias            = "%[3]s"
+
   sql_requests {
-    title                  = "%[2]s_sql"
+    title                  = "%[2]s"
     sql                    = "select count(*) as t"
     log_group_id           = huaweicloud_lts_group.test[0].id
     log_stream_id          = huaweicloud_lts_stream.test[0].id
     search_time_range_unit = "minute"
     search_time_range      = 5
+    log_group_name         = huaweicloud_lts_group.test[0].group_name
+    log_stream_name        = huaweicloud_lts_stream.test[0].stream_name
   }
 
   frequency {
@@ -232,27 +261,35 @@ resource "huaweicloud_lts_sql_alarm_rule" "with_notification_save_rule" {
     }
   }
 }
-`, testAccSQLAlarmRule_base(name, password), name)
+`, testAccSQLAlarmRule_base(name, password), name, aliasName, acceptance.HW_LTS_ALARM_ACTION_RULE_NAME)
 }
 
-func testAccSQLAlarmRule_basic_step2(name, password string) string {
+func testAccSQLAlarmRule_basic_step2(name, password, aliasName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_lts_sql_alarm_rule" "test" {
-  name                 = "%[2]s"
-  condition_expression = "t>2"
-  alarm_level          = "INFO"
-  send_notifications   = true
-  status               = "RUNNING"
+resource "huaweicloud_lts_sql_alarm_rule" "with_action_alarm_rule_name" {
+  name                        = "%[2]s"
+  condition_expression        = "t>2"
+  alarm_level                 = "INFO"
+  trigger_condition_count     = 6
+  trigger_condition_frequency = 6
+  send_recovery_notifications = true
+  recovery_frequency          = 5
+  send_notifications          = true
+  notification_frequency      = 30
+  status                      = "RUNNING"
 
   sql_requests {
     title                  = "%[2]s_sql"
-    sql                    = "select count(*) as t"
-    log_group_id           = huaweicloud_lts_group.test[0].id
-    log_stream_id          = huaweicloud_lts_stream.test[0].id
-    search_time_range_unit = "minute"
-    search_time_range      = 5
+    sql                    = "select *"
+    log_group_id           = huaweicloud_lts_group.test[1].id
+    log_stream_id          = huaweicloud_lts_stream.test[1].id
+    search_time_range_unit = "hour"
+    search_time_range      = 10
+    is_time_range_relative = true
+    log_group_name         = huaweicloud_lts_group.test[1].group_name
+    log_stream_name        = huaweicloud_lts_stream.test[1].stream_name
   }
 
   frequency {
@@ -260,13 +297,12 @@ resource "huaweicloud_lts_sql_alarm_rule" "test" {
     hour_of_day = 6
   }
 
-  # Verify the 'keywords_alarm_send_code' is '2' in the modification logic.
+  # Verify the 'sql_alarm_send_code' is '1' in the modification logic.
   notification_save_rule {
     template_name = local.sql_template_name
     user_name     = huaweicloud_identity_user.test.name
     language      = "en-us"
 
-	# Verify the 'keywords_alarm_send_code' is '2' in the modification logic.
     topics {
       name      = huaweicloud_smn_topic.test[0].name
       topic_urn = huaweicloud_smn_topic.test[0].topic_urn
@@ -279,7 +315,8 @@ resource "huaweicloud_lts_sql_alarm_rule" "with_notification_save_rule" {
   condition_expression = "t>0"
   alarm_level          = "MINOR"
   send_notifications   = true
-  
+  alarm_rule_alias     = "%[3]s_update"
+
   sql_requests {
     title                  = "%[2]s_sql"
     sql                    = "select count(*) as t"
@@ -287,10 +324,13 @@ resource "huaweicloud_lts_sql_alarm_rule" "with_notification_save_rule" {
     log_stream_id          = huaweicloud_lts_stream.test[0].id
     search_time_range_unit = "minute"
     search_time_range      = 5
+    log_group_name         = huaweicloud_lts_group.test[0].group_name
+    log_stream_name        = huaweicloud_lts_stream.test[0].stream_name
   }
 
   frequency {
-    type = "HOURLY"
+    type            = "CRON"
+    cron_expression = "0 18 * * *"
   }
 
   notification_save_rule {
@@ -298,7 +338,7 @@ resource "huaweicloud_lts_sql_alarm_rule" "with_notification_save_rule" {
     user_name     = huaweicloud_identity_user.test.name
     language      = "en-us"
 
-	# Verify the 'keywords_alarm_send_code' is '2' in the modification logic.
+    # Verify the 'sql_alarm_send_code' is '2' in the modification logic.
     topics {
       name         = huaweicloud_smn_topic.test[0].name
       topic_urn    = huaweicloud_smn_topic.test[0].topic_urn
@@ -311,31 +351,40 @@ resource "huaweicloud_lts_sql_alarm_rule" "with_notification_save_rule" {
     }
   }
 }
-`, testAccSQLAlarmRule_base(name, password), name)
+`, testAccSQLAlarmRule_base(name, password), name, aliasName)
 }
 
 func testAccSQLAlarmRule_basic_step3(name, password string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_lts_sql_alarm_rule" "test" {
-  name                 = "%[2]s"
-  condition_expression = "t>2"
-  alarm_level          = "INFO"
-  status               = "RUNNING"
+resource "huaweicloud_lts_sql_alarm_rule" "with_action_alarm_rule_name" {
+  name                        = "%[2]s"
+  condition_expression        = "t>2"
+  alarm_level                 = "INFO"
+  trigger_condition_count     = 6
+  trigger_condition_frequency = 6
+  recovery_frequency          = 5
+  send_notifications          = true
+  notification_frequency      = 30
+  alarm_action_rule_name      = "%[3]s"
 
   sql_requests {
     title                  = "%[2]s_sql"
-    sql                    = "select count(*) as t"
-    log_group_id           = huaweicloud_lts_group.test[0].id
-    log_stream_id          = huaweicloud_lts_stream.test[0].id
-    search_time_range_unit = "minute"
-    search_time_range      = 5
+    sql                    = "select *"
+    log_group_id           = huaweicloud_lts_group.test[1].id
+    log_stream_id          = huaweicloud_lts_stream.test[1].id
+    search_time_range_unit = "hour"
+    search_time_range      = 10
+    is_time_range_relative = true
+    log_group_name         = huaweicloud_lts_group.test[1].group_name
+    log_stream_name        = huaweicloud_lts_stream.test[1].stream_name
   }
 
   frequency {
-    type        = "DAILY"
+    type        = "WEEKLY"
     hour_of_day = 6
+    day_of_week = 2
   }
 }
 
@@ -343,7 +392,7 @@ resource "huaweicloud_lts_sql_alarm_rule" "with_notification_save_rule" {
   name                 = "%[2]s_notification"
   condition_expression = "t>0"
   alarm_level          = "MINOR"
-  
+
   sql_requests {
     title                  = "%[2]s_sql"
     sql                    = "select count(*) as t"
@@ -354,10 +403,12 @@ resource "huaweicloud_lts_sql_alarm_rule" "with_notification_save_rule" {
   }
 
   frequency {
-    type = "HOURLY"
+    type            = "FIXED_RATE"
+    fixed_rate_unit = "minute"
+    fixed_rate      = "30"
   }
 
-  # Remove 'notification_save_rule', verify the 'keywords_alarm_send_code' is '3' in the modification logic.
+  # Remove 'notification_save_rule', verify the 'sql_alarm_send_code' is '3' in the modification logic.
 }
-`, testAccSQLAlarmRule_base(name, password), name)
+`, testAccSQLAlarmRule_base(name, password), name, acceptance.HW_LTS_ALARM_ACTION_RULE_NAME)
 }

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_sql_alarm_rule_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_sql_alarm_rule_test.go
@@ -58,61 +58,92 @@ func getSQLAlarmRuleResourceFunc(cfg *config.Config, state *terraform.ResourceSt
 
 func TestAccSQLAlarmRule_basic(t *testing.T) {
 	var (
-		obj      interface{}
 		name     = acceptance.RandomAccResourceName()
-		rName    = "huaweicloud_lts_sql_alarm_rule.test"
 		password = acceptance.RandomPassword()
-	)
 
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getSQLAlarmRuleResourceFunc,
+		obj                interface{}
+		rName              = "huaweicloud_lts_sql_alarm_rule.test"
+		withNotiSaveRule   = "huaweicloud_lts_sql_alarm_rule.with_notification_save_rule"
+		rc                 = acceptance.InitResourceCheck(rName, &obj, getSQLAlarmRuleResourceFunc)
+		rcWithNotiSaveRule = acceptance.InitResourceCheck(withNotiSaveRule, &obj, getSQLAlarmRuleResourceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDomainId(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rc.CheckResourceDestroy(),
+			rcWithNotiSaveRule.CheckResourceDestroy(),
+		),
 		Steps: []resource.TestStep{
 			{
-				Config: testSQLAlarmRule_basic(name, password),
+				Config: testAccSQLAlarmRule_basic_step1(name, password),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "description", "created by terraform"),
+					resource.TestCheckResourceAttrPair(rName, "sql_requests.0.log_group_id",
+						"huaweicloud_lts_group.test.0", "id"),
+					resource.TestCheckResourceAttrPair(rName, "sql_requests.0.log_stream_id",
+						"huaweicloud_lts_stream.test.0", "id"),
+					resource.TestCheckResourceAttr(rName, "frequency.0.type", "HOURLY"),
 					resource.TestCheckResourceAttr(rName, "condition_expression", "t>0"),
 					resource.TestCheckResourceAttr(rName, "alarm_level", "CRITICAL"),
+					// Check optional parameters.
 					resource.TestCheckResourceAttr(rName, "status", "STOPPING"),
-					resource.TestCheckResourceAttr(rName, "frequency.0.type", "HOURLY"),
-					resource.TestCheckResourceAttrPair(rName, "sql_requests.0.log_group_id",
-						"huaweicloud_lts_group.test", "id"),
-					resource.TestCheckResourceAttrPair(rName, "sql_requests.0.log_stream_id",
-						"huaweicloud_lts_stream.test", "id"),
-					resource.TestCheckResourceAttr(rName, "notification_rule.0.language", "en-us"),
-					resource.TestCheckResourceAttrPair(rName, "notification_rule.0.template_name",
-						"huaweicloud_lts_notification_template.test", "name"),
-					resource.TestCheckResourceAttrPair(rName, "notification_rule.0.user_name",
-						"huaweicloud_identity_user.test", "name"),
-					resource.TestCheckResourceAttrPair(rName, "notification_rule.0.topics.0.name",
-						"huaweicloud_smn_topic.test", "name"),
-					resource.TestCheckResourceAttrPair(rName, "notification_rule.0.topics.0.topic_urn",
-						"huaweicloud_smn_topic.test", "topic_urn"),
 					resource.TestCheckResourceAttrSet(rName, "created_at"),
+
+					rcWithNotiSaveRule.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "send_notifications", "true"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "notification_save_rule.0.template_name", "sql_template"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "notification_save_rule.0.topics.#", "1"),
+					resource.TestCheckResourceAttrPair(withNotiSaveRule, "notification_save_rule.0.topics.0.name",
+						"huaweicloud_smn_topic.test.0", "name"),
+					resource.TestCheckResourceAttrPair(withNotiSaveRule, "notification_save_rule.0.topics.0.topic_urn",
+						"huaweicloud_smn_topic.test.0", "topic_urn"),
+					resource.TestCheckResourceAttrPair(withNotiSaveRule, "notification_save_rule.0.topics.0.display_name",
+						"huaweicloud_smn_topic.test.0", "display_name"),
+					resource.TestCheckResourceAttrPair(withNotiSaveRule, "notification_save_rule.0.topics.0.push_policy",
+						"huaweicloud_smn_topic.test.0", "push_policy"),
 				),
 			},
 			{
-				Config: testSQLAlarmRule_basic_update(name, password),
+				Config: testAccSQLAlarmRule_basic_step2(name, password),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "description", ""),
 					resource.TestCheckResourceAttr(rName, "condition_expression", "t>2"),
 					resource.TestCheckResourceAttr(rName, "alarm_level", "INFO"),
-					resource.TestCheckResourceAttr(rName, "status", "RUNNING"),
 					resource.TestCheckResourceAttr(rName, "frequency.0.type", "DAILY"),
 					resource.TestCheckResourceAttr(rName, "frequency.0.hour_of_day", "6"),
+					// Check Optional parameter.
+					resource.TestCheckResourceAttr(rName, "notification_save_rule.0.template_name", "sql_template"),
+					resource.TestCheckResourceAttr(rName, "notification_save_rule.0.topics.#", "1"),
+					resource.TestCheckResourceAttrPair(rName, "notification_save_rule.0.topics.0.name",
+						"huaweicloud_smn_topic.test.0", "name"),
+					resource.TestCheckResourceAttrPair(rName, "notification_save_rule.0.topics.0.topic_urn",
+						"huaweicloud_smn_topic.test.0", "topic_urn"),
+					resource.TestCheckResourceAttr(rName, "notification_save_rule.0.topics.0.display_name", ""),
+					resource.TestCheckResourceAttr(rName, "notification_save_rule.0.topics.0.push_policy", "0"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "status", "RUNNING"),
+					// Check attributes.
 					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					rcWithNotiSaveRule.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "notification_save_rule.0.template_name", "sql_template"),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "notification_save_rule.0.topics.#", "2"),
+				),
+			},
+			{
+				Config: testAccSQLAlarmRule_basic_step3(name, password),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					rcWithNotiSaveRule.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withNotiSaveRule, "send_notifications", "false"),
+					resource.TestCheckResourceAttr(rName, "notification_save_rule.#", "0"),
 				),
 			},
 			{
@@ -123,11 +154,28 @@ func TestAccSQLAlarmRule_basic(t *testing.T) {
 					"notification_rule",
 				},
 			},
+			{
+				ResourceName:            withNotiSaveRule,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"notification_save_rule.0.user_name", "notification_save_rule.0.timezone"},
+			},
 		},
 	})
 }
 
-func testSQLAlarmRule_basic(name, password string) string {
+func testAccSQLAlarmRule_base(name, password string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# 'sql_template' is the default template provided by the system.
+locals {
+  sql_template_name = [for v in data.huaweicloud_lts_notification_templates.test.templates[*].name :v if v == "sql_template"][0]
+}
+`, testAlarmRule_base(name, password), name)
+}
+
+func testAccSQLAlarmRule_basic_step1(name, password string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -141,8 +189,28 @@ resource "huaweicloud_lts_sql_alarm_rule" "test" {
   sql_requests {
     title                  = "%[2]s_sql"
     sql                    = "select count(*) as t"
-    log_group_id           = huaweicloud_lts_group.test.id
-    log_stream_id          = huaweicloud_lts_stream.test.id
+    log_group_id           = huaweicloud_lts_group.test[0].id
+    log_stream_id          = huaweicloud_lts_stream.test[0].id
+    search_time_range_unit = "minute"
+    search_time_range      = 5
+  }
+
+  frequency {
+    type = "HOURLY"
+  }
+}
+
+resource "huaweicloud_lts_sql_alarm_rule" "with_notification_save_rule" {
+  name                 = "%[2]s_notification"
+  condition_expression = "t>0"
+  alarm_level          = "MINOR"
+  send_notifications   = true
+  
+  sql_requests {
+    title                  = "%[2]s_sql"
+    sql                    = "select count(*) as t"
+    log_group_id           = huaweicloud_lts_group.test[0].id
+    log_stream_id          = huaweicloud_lts_stream.test[0].id
     search_time_range_unit = "minute"
     search_time_range      = 5
   }
@@ -151,21 +219,102 @@ resource "huaweicloud_lts_sql_alarm_rule" "test" {
     type = "HOURLY"
   }
 
-  notification_rule {
-    template_name = huaweicloud_lts_notification_template.test.name
+  notification_save_rule {
+    template_name = local.sql_template_name
     user_name     = huaweicloud_identity_user.test.name
     language      = "en-us"
 
     topics {
-      name      = huaweicloud_smn_topic.test.name
-      topic_urn = huaweicloud_smn_topic.test.topic_urn
+      name         = huaweicloud_smn_topic.test[0].name
+      topic_urn    = huaweicloud_smn_topic.test[0].topic_urn
+      display_name = huaweicloud_smn_topic.test[0].display_name
+      push_policy  = huaweicloud_smn_topic.test[0].push_policy
     }
   }
 }
-`, testAlarmRule_base(name, password), name)
+`, testAccSQLAlarmRule_base(name, password), name)
 }
 
-func testSQLAlarmRule_basic_update(name, password string) string {
+func testAccSQLAlarmRule_basic_step2(name, password string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_lts_sql_alarm_rule" "test" {
+  name                 = "%[2]s"
+  condition_expression = "t>2"
+  alarm_level          = "INFO"
+  send_notifications   = true
+  status               = "RUNNING"
+
+  sql_requests {
+    title                  = "%[2]s_sql"
+    sql                    = "select count(*) as t"
+    log_group_id           = huaweicloud_lts_group.test[0].id
+    log_stream_id          = huaweicloud_lts_stream.test[0].id
+    search_time_range_unit = "minute"
+    search_time_range      = 5
+  }
+
+  frequency {
+    type        = "DAILY"
+    hour_of_day = 6
+  }
+
+  # Verify the 'keywords_alarm_send_code' is '2' in the modification logic.
+  notification_save_rule {
+    template_name = local.sql_template_name
+    user_name     = huaweicloud_identity_user.test.name
+    language      = "en-us"
+
+	# Verify the 'keywords_alarm_send_code' is '2' in the modification logic.
+    topics {
+      name      = huaweicloud_smn_topic.test[0].name
+      topic_urn = huaweicloud_smn_topic.test[0].topic_urn
+    }
+  }
+}
+
+resource "huaweicloud_lts_sql_alarm_rule" "with_notification_save_rule" {
+  name                 = "%[2]s_notification"
+  condition_expression = "t>0"
+  alarm_level          = "MINOR"
+  send_notifications   = true
+  
+  sql_requests {
+    title                  = "%[2]s_sql"
+    sql                    = "select count(*) as t"
+    log_group_id           = huaweicloud_lts_group.test[0].id
+    log_stream_id          = huaweicloud_lts_stream.test[0].id
+    search_time_range_unit = "minute"
+    search_time_range      = 5
+  }
+
+  frequency {
+    type = "HOURLY"
+  }
+
+  notification_save_rule {
+    template_name = local.sql_template_name
+    user_name     = huaweicloud_identity_user.test.name
+    language      = "en-us"
+
+	# Verify the 'keywords_alarm_send_code' is '2' in the modification logic.
+    topics {
+      name         = huaweicloud_smn_topic.test[0].name
+      topic_urn    = huaweicloud_smn_topic.test[0].topic_urn
+      display_name = huaweicloud_smn_topic.test[0].display_name
+      push_policy  = huaweicloud_smn_topic.test[0].push_policy
+    }
+    topics {
+      name      = huaweicloud_smn_topic.test[1].name
+      topic_urn = huaweicloud_smn_topic.test[1].topic_urn
+    }
+  }
+}
+`, testAccSQLAlarmRule_base(name, password), name)
+}
+
+func testAccSQLAlarmRule_basic_step3(name, password string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -178,8 +327,8 @@ resource "huaweicloud_lts_sql_alarm_rule" "test" {
   sql_requests {
     title                  = "%[2]s_sql"
     sql                    = "select count(*) as t"
-    log_group_id           = huaweicloud_lts_group.test.id
-    log_stream_id          = huaweicloud_lts_stream.test.id
+    log_group_id           = huaweicloud_lts_group.test[0].id
+    log_stream_id          = huaweicloud_lts_stream.test[0].id
     search_time_range_unit = "minute"
     search_time_range      = 5
   }
@@ -188,17 +337,27 @@ resource "huaweicloud_lts_sql_alarm_rule" "test" {
     type        = "DAILY"
     hour_of_day = 6
   }
-
-  notification_rule {
-    template_name = huaweicloud_lts_notification_template.test.name
-    user_name     = huaweicloud_identity_user.test.name
-    language      = "en-us"
-
-    topics {
-      name      = huaweicloud_smn_topic.test.name
-      topic_urn = huaweicloud_smn_topic.test.topic_urn
-    }
-  }
 }
-`, testAlarmRule_base(name, password), name)
+
+resource "huaweicloud_lts_sql_alarm_rule" "with_notification_save_rule" {
+  name                 = "%[2]s_notification"
+  condition_expression = "t>0"
+  alarm_level          = "MINOR"
+  
+  sql_requests {
+    title                  = "%[2]s_sql"
+    sql                    = "select count(*) as t"
+    log_group_id           = huaweicloud_lts_group.test[0].id
+    log_stream_id          = huaweicloud_lts_stream.test[0].id
+    search_time_range_unit = "minute"
+    search_time_range      = 5
+  }
+
+  frequency {
+    type = "HOURLY"
+  }
+
+  # Remove 'notification_save_rule', verify the 'keywords_alarm_send_code' is '3' in the modification logic.
+}
+`, testAccSQLAlarmRule_base(name, password), name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Use `notification_save_rule` instead of `notification_rule` parameter and `send_notifications` paramter supports modification.
2. Add new parameters.
+ new paramster: `alarm_action_rule_name`, `alarm_rule_alias`, `notification_frequency`, `sql_requests.log_group_name`, `sql_requests.log_stream_name`.
+ The `send_notifications` parameter supports modify.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new parameters and use 'notification_save_rule' instead of 'notification_rule'.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
./scripts/coverage.sh -o lts -f TestAccSQLAlarmRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccSQLAlarmRule_basic -timeout 360m -parallel 10
=== RUN   TestAccSQLAlarmRule_basic
=== PAUSE TestAccSQLAlarmRule_basic
=== CONT  TestAccSQLAlarmRule_basic
--- PASS: TestAccSQLAlarmRule_basic (62.75s)
PASS
coverage: 12.8% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       62.876s coverage: 12.8% of statements in ./huaweicloud/services/lts

./scripts/coverage.sh -o lts -f TestAccKeywordsAlarmRule_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccKeywordsAlarmRule_ -timeout 360m -parallel 10
=== RUN   TestAccKeywordsAlarmRule_basic
=== PAUSE TestAccKeywordsAlarmRule_basic
=== CONT  TestAccKeywordsAlarmRule_basic
--- PASS: TestAccKeywordsAlarmRule_basic (75.84s)
PASS
coverage: 13.0% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       76.005s coverage: 13.0% of statements in ./huaweicloud/services/lts
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/0de9be9a-cf48-4d8a-94e8-892658a54511)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
