### PR TITLE
refactor(vod): refactor vod category resource with general code style

### DIFF
--- a/huaweicloud/services/vod/resource_huaweicloud_vod_media_category.go
+++ b/huaweicloud/services/vod/resource_huaweicloud_vod_media_category.go
@@ -2,14 +2,16 @@ package vod
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	vod "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vod/v1/model"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -56,9 +58,21 @@ func ResourceMediaCategory() *schema.Resource {
 	}
 }
 
+func buildCreateMediaCategoryBodyParams(d *schema.ResourceData, parentId int64) map[string]interface{} {
+	return map[string]interface{}{
+		"name":      d.Get("name"),
+		"parent_id": parentId,
+	}
+}
+
 func resourceMediaCategoryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.HcVodV1Client(config.GetRegion(d))
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1.0/{project_id}/asset/category"
+		product = "vod"
+	)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
 		return diag.Errorf("error creating VOD client: %s", err)
 	}
@@ -68,71 +82,100 @@ func resourceMediaCategoryCreate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	createOpts := vod.CreateCategoryReq{
-		Name:     d.Get("name").(string),
-		ParentId: utils.Int32(int32(parentId)),
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildCreateMediaCategoryBodyParams(d, parentId),
 	}
 
-	createReq := vod.CreateAssetCategoryRequest{
-		Body: &createOpts,
-	}
-
-	resp, err := client.CreateAssetCategory(&createReq)
+	resp, err := client.Request("POST", requestPath, &requestOpt)
 	if err != nil {
 		return diag.Errorf("error creating VOD media category: %s", err)
 	}
 
-	d.SetId(strconv.FormatInt(int64(*resp.Id), 10))
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("id", respBody, nil)
+	if id == nil {
+		return diag.Errorf("error creating VOD media category: ID is not found in API response")
+	}
+
+	d.SetId(strconv.FormatInt(int64(id.(float64)), 10))
 
 	return resourceMediaCategoryRead(ctx, d, meta)
 }
 
-func resourceMediaCategoryRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.HcVodV1Client(config.GetRegion(d))
-	if err != nil {
-		return diag.Errorf("error creating VOD client: %s", err)
-	}
-
-	id, err := strconv.ParseInt(d.Id(), 10, 32)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	resp, err := client.ListAssetCategory(&vod.ListAssetCategoryRequest{Id: int32(id)})
-	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving VOD media category")
-	}
-
-	categoryList := *resp.Body
-	if len(categoryList) == 0 {
-		log.Printf("unable to retrieve VOD media category: %d", id)
-		d.SetId("")
-		return nil
-	}
-	category := categoryList[0]
-
-	children, err := utils.JsonMarshal(category.Children)
+func flattenChildrenAttribute(categoryResp interface{}) string {
+	children, err := utils.JsonMarshal(utils.PathSearch("children", categoryResp, nil))
 	if err != nil {
 		log.Printf("error marshaling children: %s", err)
 	}
 
-	mErr := multierror.Append(nil,
-		d.Set("region", config.GetRegion(d)),
-		d.Set("name", category.Name),
-		d.Set("children", string(children)),
-	)
+	return string(children)
+}
 
-	if err = mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error setting VOD media category fields: %s", err)
+func resourceMediaCategoryRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1.0/{project_id}/asset/category"
+		product = "vod"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating VOD client: %s", err)
 	}
 
-	return nil
+	requestPath := client.Endpoint + httpUrl
+	requestPath += fmt.Sprintf("?id=%s", d.Id())
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving VOD media category")
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	categoryResp := utils.PathSearch("[0]", respBody, nil)
+	if categoryResp == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", categoryResp, nil)),
+		d.Set("children", flattenChildrenAttribute(categoryResp)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdateMediaCategoryBodyParams(d *schema.ResourceData, id int64) map[string]interface{} {
+	return map[string]interface{}{
+		"name": d.Get("name"),
+		"id":   id,
+	}
 }
 
 func resourceMediaCategoryUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.HcVodV1Client(config.GetRegion(d))
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1.0/{project_id}/asset/category"
+		product = "vod"
+	)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
 		return diag.Errorf("error creating VOD client: %s", err)
 	}
@@ -142,16 +185,14 @@ func resourceMediaCategoryUpdate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	updateOpts := vod.UpdateCategoryReq{
-		Name: d.Get("name").(string),
-		Id:   int32(id),
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildUpdateMediaCategoryBodyParams(d, id),
 	}
 
-	updateReq := vod.UpdateAssetCategoryRequest{
-		Body: &updateOpts,
-	}
-
-	_, err = client.UpdateAssetCategory(&updateReq)
+	_, err = client.Request("PUT", requestPath, &requestOpt)
 	if err != nil {
 		return diag.Errorf("error updating VOD media category: %s", err)
 	}
@@ -160,18 +201,25 @@ func resourceMediaCategoryUpdate(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceMediaCategoryDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.HcVodV1Client(config.GetRegion(d))
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1.0/{project_id}/asset/category"
+		product = "vod"
+	)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
 		return diag.Errorf("error creating VOD client: %s", err)
 	}
 
-	id, err := strconv.ParseInt(d.Id(), 10, 32)
-	if err != nil {
-		return diag.FromErr(err)
+	requestPath := client.Endpoint + httpUrl
+	requestPath += fmt.Sprintf("?id=%s", d.Id())
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
 
-	_, err = client.DeleteAssetCategory(&vod.DeleteAssetCategoryRequest{Id: int32(id)})
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
 	if err != nil {
 		return diag.Errorf("error deleting VOD media category: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactor vod category resource with general code style.
![image](https://github.com/user-attachments/assets/90e29338-663d-4acf-b699-6408264523f8)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/vod' TESTARGS='-run TestAccMediaCategory_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vod -v -run TestAccMediaCategory_basic -timeout 360m -parallel 4
=== RUN   TestAccMediaCategory_basic
=== PAUSE TestAccMediaCategory_basic
=== CONT  TestAccMediaCategory_basic
--- PASS: TestAccMediaCategory_basic (15.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vod       15.822s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/a3fe3912-fc99-4ffc-827b-7e937eaff636)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
