### PR TITLE
chore(nat): remove the validateFunc from the NAT resource

### DIFF
--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_gateway_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_gateway_test.go
@@ -49,7 +49,7 @@ func TestAccPublicGateway_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "spec", string(nat.PublicSpecTypeSmall)),
+					resource.TestCheckResourceAttr(rName, "spec", "1"),
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
 					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
 					resource.TestCheckResourceAttr(rName, "session_conf.0.tcp_session_expire_time", "1000"),
@@ -68,7 +68,7 @@ func TestAccPublicGateway_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
-					resource.TestCheckResourceAttr(rName, "spec", string(nat.PublicSpecTypeMedium)),
+					resource.TestCheckResourceAttr(rName, "spec", "2"),
 					resource.TestCheckResourceAttr(rName, "description", ""),
 					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
 					resource.TestCheckResourceAttr(rName, "session_conf.0.tcp_session_expire_time", "900"),
@@ -168,7 +168,7 @@ func TestAccPublicGateway_prepaid(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "spec", string(nat.PublicSpecTypeSmall)),
+					resource.TestCheckResourceAttr(rName, "spec", "1"),
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
 					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
@@ -188,7 +188,7 @@ func TestAccPublicGateway_prepaid(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "spec", string(nat.PublicSpecTypeSmall)),
+					resource.TestCheckResourceAttr(rName, "spec", "1"),
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
 					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),

--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_natv3_gateway_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_natv3_gateway_test.go
@@ -49,7 +49,7 @@ func TestAccPublicGatewayV3_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "spec", string(nat.PublicSpecTypeSmall)),
+					resource.TestCheckResourceAttr(rName, "spec", "1"),
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
 					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
 					resource.TestCheckResourceAttr(rName, "session_conf.0.tcp_session_expire_time", "1000"),
@@ -68,7 +68,7 @@ func TestAccPublicGatewayV3_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
-					resource.TestCheckResourceAttr(rName, "spec", string(nat.PublicSpecTypeMedium)),
+					resource.TestCheckResourceAttr(rName, "spec", "2"),
 					resource.TestCheckResourceAttr(rName, "description", ""),
 					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
 					resource.TestCheckResourceAttr(rName, "session_conf.0.tcp_session_expire_time", "900"),
@@ -168,7 +168,7 @@ func TestAccPublicGatewayV3_prepaid(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "spec", string(nat.PublicSpecTypeSmall)),
+					resource.TestCheckResourceAttr(rName, "spec", "1"),
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
 					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
@@ -188,7 +188,7 @@ func TestAccPublicGatewayV3_prepaid(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "spec", string(nat.PublicSpecTypeSmall)),
+					resource.TestCheckResourceAttr(rName, "spec", "1"),
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
 					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_gateway.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_gateway.go
@@ -20,17 +20,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-type (
-	PublicSpecType string
-)
-
-const (
-	PublicSpecTypeSmall      PublicSpecType = "1"
-	PublicSpecTypeMedium     PublicSpecType = "2"
-	PublicSpecTypeLarge      PublicSpecType = "3"
-	PublicSpecTypeExtraLarge PublicSpecType = "4"
-)
-
 // @API NAT POST /v2/{project_id}/nat_gateways
 // @API NAT GET /v2/{project_id}/nat_gateways/{nat_gateway_id}
 // @API NAT PUT /v2/{project_id}/nat_gateways/{nat_gateway_id}

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_private_gateway.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_private_gateway.go
@@ -7,20 +7,12 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-)
-
-const (
-	PrivateSpecTypeSmall      string = "Small"
-	PrivateSpecTypeMedium     string = "Medium"
-	PrivateSpecTypeLarge      string = "Large"
-	PrivateSpecTypeExtraLarge string = "Extra-Large"
 )
 
 // @API NAT POST /v3/{project_id}/private-nat/gateways
@@ -68,12 +60,6 @@ func ResourcePrivateGateway() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: "The specification of the private NAT gateway.",
-				ValidateFunc: validation.StringInSlice([]string{
-					PrivateSpecTypeSmall,
-					PrivateSpecTypeMedium,
-					PrivateSpecTypeLarge,
-					PrivateSpecTypeExtraLarge,
-				}, false),
 			},
 			"enterprise_project_id": {
 				Type:        schema.TypeString,

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_snat_rule.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_snat_rule.go
@@ -11,20 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-)
-
-type SourceType int
-
-const (
-	SourceTypeVpc SourceType = 0
-	SourceTypeDc  SourceType = 1
 )
 
 // @API NAT POST /v2/{project_id}/snat_rules
@@ -78,11 +70,7 @@ func ResourcePublicSnatRule() *schema.Resource {
 				Description: "schema: Required; The ID of the gateway to which the SNAT rule belongs.",
 			},
 			"source_type": {
-				Type: schema.TypeInt,
-				ValidateFunc: validation.IntInSlice([]int{
-					int(SourceTypeVpc),
-					int(SourceTypeDc),
-				}),
+				Type:        schema.TypeInt,
 				Optional:    true,
 				ForceNew:    true,
 				Description: "The resource type of the SNAT rule.",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove the validateFunc from the NAT resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPublicGateway_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccPublicGateway_basic
=== PAUSE TestAccPublicGateway_basic
=== CONT  TestAccPublicGateway_basic
--- PASS: TestAccPublicGateway_basic (94.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       94.287s
```
```
 make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateGateway_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccPrivateGateway_basic
=== PAUSE TestAccPrivateGateway_basic
=== CONT  TestAccPrivateGateway_basic
--- PASS: TestAccPrivateGateway_basic (73.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       73.490s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPublicSnatRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicSnatRule_basic -timeout 360m -parallel 4
=== RUN   TestAccPublicSnatRule_basic
=== PAUSE TestAccPublicSnatRule_basic
=== CONT  TestAccPublicSnatRule_basic
--- PASS: TestAccPublicSnatRule_basic (95.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       95.767s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPublicGatewayV3_prepaid"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicGatewayV3_prepaid -timeout 360m -parallel 4
=== RUN   TestAccPublicGatewayV3_prepaid
=== PAUSE TestAccPublicGatewayV3_prepaid
=== CONT  TestAccPublicGatewayV3_prepaid
--- PASS: TestAccPublicGatewayV3_prepaid (151.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       151.316s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
