### PR TITLE
feat(eps): add new data source to query eps quotas

### DIFF
--- a/docs/data-sources/enterprise_project_quotas.md
+++ b/docs/data-sources/enterprise_project_quotas.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Enterprise Project Management Service (EPS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_enterprise_project_quotas"
+description: |-
+  Use this data source to get the list of quotas of EPS resources within HuaweiCloud.
+---
+
+# huaweicloud_enterprise_project_quotas
+
+Use this data source to get the list of quotas of EPS resources within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_enterprise_project_quotas" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource quotas.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `quotas` - The list of the resource quotas.
+  The [quotas](#eps_quotas) structure is documented below.
+
+<a name="eps_quotas"></a>
+The `quotas` block supports:
+
+* `quota` - The total number of the resource quota.
+
+* `type` - The resource type corresponding to quota.
+
+* `used` - The used quota number.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -846,8 +846,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_eg_event_channels":        eg.DataSourceEventChannels(),
 			"huaweicloud_eg_event_sources":         eg.DataSourceEventSources(),
 
-			"huaweicloud_enterprise_project":  eps.DataSourceEnterpriseProject(),
-			"huaweicloud_enterprise_projects": eps.DataSourceEnterpriseProjects(),
+			"huaweicloud_enterprise_project":        eps.DataSourceEnterpriseProject(),
+			"huaweicloud_enterprise_projects":       eps.DataSourceEnterpriseProjects(),
+			"huaweicloud_enterprise_project_quotas": eps.DataSourceQuotas(),
 
 			"huaweicloud_er_associations":       er.DataSourceAssociations(),
 			"huaweicloud_er_attachments":        er.DataSourceAttachments(),

--- a/huaweicloud/services/acceptance/eps/data_source_huaweicloud_enterprise_project_quotas_test.go
+++ b/huaweicloud/services/acceptance/eps/data_source_huaweicloud_enterprise_project_quotas_test.go
@@ -1,0 +1,57 @@
+package eps
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataEnterpriseProjectQuotas_basic(t *testing.T) {
+	all := "data.huaweicloud_enterprise_project_quotas.test"
+	dc := acceptance.InitDataSourceCheck(all)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataEnterpriseProjectQuotas_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "quotas.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckOutput("is_eps_quota_configured", "true"),
+					resource.TestCheckOutput("is_type_configured", "true"),
+					resource.TestCheckOutput("is_quota_used_number_configured", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataEnterpriseProjectQuotas_basic = `
+data "huaweicloud_enterprise_project_quotas" "test" {}
+
+locals {
+  enterprise_project_quota = try(element([for o in data.huaweicloud_enterprise_project_quotas.test.quotas: o if
+    o.type == "enterprise_project"], 0), null)
+}
+
+output "is_eps_quota_configured" {
+  value = local.enterprise_project_quota != null
+}
+
+output "is_total_quota_number_configured" {
+  value = lookup(local.enterprise_project_quota, "quota") > 0
+}
+
+output "is_type_configured" {
+  value = lookup(local.enterprise_project_quota, "type") != ""
+}
+
+output "is_quota_used_number_configured" {
+  value = lookup(local.enterprise_project_quota, "used") > 0
+}
+`

--- a/huaweicloud/services/eps/data_source_huaweicloud_enterprise_project_quotas.go
+++ b/huaweicloud/services/eps/data_source_huaweicloud_enterprise_project_quotas.go
@@ -1,0 +1,129 @@
+package eps
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EPS GET /v1.0/enterprise-projects/quotas
+func DataSourceQuotas() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceQuotasRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region in which to query the resource quotas.`,
+			},
+
+			// Attributes.
+			"quotas": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"quota": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The total number of the resource quota.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The resource type corresponding to quota.`,
+						},
+						"used": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The used quota number.`,
+						},
+					},
+				},
+				Description: `The list of the resource quotas.`,
+			},
+		},
+	}
+}
+
+func listResourceQuotas(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	httpUrl := "v1.0/enterprise-projects/quotas"
+	listPath := client.Endpoint + httpUrl
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("quotas.resources", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenResourceQuotas(resources []interface{}) []map[string]interface{} {
+	if len(resources) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(resources))
+	for _, resource := range resources {
+		result = append(result, map[string]interface{}{
+			"quota": utils.PathSearch("quota", resource, nil),
+			"type":  utils.PathSearch("type", resource, nil),
+			"used":  utils.PathSearch("used", resource, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("eps", region)
+	if err != nil {
+		return diag.Errorf("error creating EPS client: %s", err)
+	}
+
+	staticRoutes, err := listResourceQuotas(client)
+	if err != nil {
+		return diag.Errorf("error querying resource quotas: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("quotas", flattenResourceQuotas(staticRoutes)),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving data source fields of the EPS resource quotas: %s", mErr)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new data source to query eps quotas.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query eps quotas.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o eps -f TestAccDataEnterpriseProjectQuotas_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eps" -v -coverprofile="./huaweicloud/services/acceptance/eps/eps_coverage.cov" -coverpkg="./huaweicloud/services/eps" -run TestAccDataEnterpriseProjectQuotas_basic -timeout 360m -parallel 10
=== RUN   TestAccDataEnterpriseProjectQuotas_basic
=== PAUSE TestAccDataEnterpriseProjectQuotas_basic
=== CONT  TestAccDataEnterpriseProjectQuotas_basic
--- PASS: TestAccDataEnterpriseProjectQuotas_basic (9.39s)
PASS
coverage: 16.9% of statements in ./huaweicloud/services/eps
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eps       9.507s  coverage: 16.9% of statements in ./huaweicloud/services/eps
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
