### PR TITLE
refactor(vod): refactor vod asset resource with general code style

### DIFF
--- a/docs/resources/vod_media_asset.md
+++ b/docs/resources/vod_media_asset.md
@@ -160,6 +160,12 @@ In addition to all arguments above, the following attributes are exported:
 
 * `category_name` - The category name of the media asset.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `delete` - Defaults to `60` seconds.
+
 ## Import
 
 The media asset can be imported using the `id`, e.g.

--- a/huaweicloud/services/acceptance/vod/resource_huaweicloud_vod_media_asset_test.go
+++ b/huaweicloud/services/acceptance/vod/resource_huaweicloud_vod_media_asset_test.go
@@ -7,27 +7,28 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	vod "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vod/v1/model"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vod"
 )
 
 func getResourceAsset(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcVodV1Client(acceptance.HW_REGION_NAME)
+	var (
+		region  = acceptance.HW_REGION_NAME
+		product = "vod"
+	)
+
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating VOD client: %s", err)
 	}
 
-	return client.ShowAssetDetail(&vod.ShowAssetDetailRequest{AssetId: state.Primary.ID})
+	return vod.ReadMediaAssetDetail(client, state.Primary.ID)
 }
 
-func TestAccMediaAsset_basic(t *testing.T) {
-	var asset vod.ShowAssetDetailResponse
+func TestAccMediaAsset_obs(t *testing.T) {
+	var asset interface{}
 	rName := acceptance.RandomAccResourceNameWithDash()
-	updateName := rName + "-update"
-	description := "test video"
-	descriptionUpdate := "test video update"
 	resourceName := "huaweicloud_vod_media_asset.test"
 
 	rc := acceptance.InitResourceCheck(
@@ -42,27 +43,61 @@ func TestAccMediaAsset_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMediaAsset_basic(testAccMediaAsset_base(rName), rName, description),
+				Config: testAccMediaAsset_obs(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "media_type", "MP4"),
-					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
 					resource.TestCheckResourceAttr(resourceName, "labels", "test_label_1,test_lable_2,test_label_3"),
-					resource.TestCheckResourceAttr(resourceName, "category_id", "-1"),
-					resource.TestCheckResourceAttr(resourceName, "media_name", acceptance.HW_VOD_MEDIA_ASSET_FILE),
+					resource.TestCheckResourceAttrPair(resourceName, "input_bucket",
+						"huaweicloud_obs_bucket.test", "bucket"),
+					resource.TestCheckResourceAttrPair(resourceName, "input_path",
+						"huaweicloud_obs_bucket_object.test", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "category_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "category_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "media_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "thumbnail.#"),
 				),
 			},
 			{
-				Config: testAccMediaAsset_basic(testAccMediaAsset_base(rName), updateName, descriptionUpdate),
+				Config: testAccMediaAsset_obs_update1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", rName)),
 					resource.TestCheckResourceAttr(resourceName, "media_type", "MP4"),
-					resource.TestCheckResourceAttr(resourceName, "description", descriptionUpdate),
-					resource.TestCheckResourceAttr(resourceName, "labels", "test_label_1,test_lable_2,test_label_3"),
-					resource.TestCheckResourceAttr(resourceName, "category_id", "-1"),
-					resource.TestCheckResourceAttr(resourceName, "media_name", acceptance.HW_VOD_MEDIA_ASSET_FILE),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description update"),
+					resource.TestCheckResourceAttr(resourceName, "labels", "test_label_1,test_lable_2"),
+					resource.TestCheckResourceAttr(resourceName, "publish", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "category_id",
+						"huaweicloud_vod_media_category.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "input_bucket",
+						"huaweicloud_obs_bucket.test", "bucket"),
+					resource.TestCheckResourceAttrPair(resourceName, "input_path",
+						"huaweicloud_obs_bucket_object.test", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "category_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "media_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "thumbnail.#"),
+				),
+			},
+			{
+				Config: testAccMediaAsset_obs_update2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", rName)),
+					resource.TestCheckResourceAttr(resourceName, "media_type", "MP4"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "labels", "test_label_1,test_lable_2"),
+					resource.TestCheckResourceAttr(resourceName, "publish", "false"),
+					resource.TestCheckResourceAttrPair(resourceName, "category_id",
+						"huaweicloud_vod_media_category.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "input_bucket",
+						"huaweicloud_obs_bucket.test", "bucket"),
+					resource.TestCheckResourceAttrPair(resourceName, "input_path",
+						"huaweicloud_obs_bucket_object.test", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "category_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "media_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "thumbnail.#"),
 				),
 			},
 			{
@@ -70,14 +105,14 @@ func TestAccMediaAsset_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"input_bucket", "input_path", "thumbnail",
+					"input_bucket", "input_path", "thumbnail", "publish",
 				},
 			},
 		},
 	})
 }
 
-func testAccMediaAsset_base(rName string) string {
+func testAccMediaAsset_obs_base(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_obs_bucket" "test" {
   bucket = "%s"
@@ -91,16 +126,16 @@ resource "huaweicloud_obs_bucket_object" "test" {
 }`, rName, acceptance.HW_VOD_MEDIA_ASSET_FILE)
 }
 
-func testAccMediaAsset_basic(baseConfig, rName, description string) string {
+func testAccMediaAsset_obs(rName string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_vod_media_asset" "test" {
-  name         = "%s"
+  name         = "%[2]s"
   media_type   = "MP4"
   input_bucket = huaweicloud_obs_bucket.test.bucket
   input_path   = huaweicloud_obs_bucket_object.test.id
-  description  = "%s"
+  description  = "test description"
   labels       = "test_label_1,test_lable_2,test_label_3"
 
   thumbnail {
@@ -108,5 +143,195 @@ resource "huaweicloud_vod_media_asset" "test" {
     time = 1
   }
 }
-`, baseConfig, rName, description)
+`, testAccMediaAsset_obs_base(rName), rName)
+}
+
+func testAccMediaAsset_obs_update1(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_vod_media_category" "test" {
+  name = "%[2]s"
+}
+
+resource "huaweicloud_vod_media_asset" "test" {
+  name         = "%[2]s_update"
+  media_type   = "MP4"
+  input_bucket = huaweicloud_obs_bucket.test.bucket
+  input_path   = huaweicloud_obs_bucket_object.test.id
+  description  = "test description update"
+  category_id  = huaweicloud_vod_media_category.test.id
+  labels       = "test_label_1,test_lable_2"
+  publish      = true
+
+  thumbnail {
+    type = "time"
+    time = 1
+  }
+}
+`, testAccMediaAsset_obs_base(rName), rName)
+}
+
+func testAccMediaAsset_obs_update2(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_vod_media_category" "test" {
+  name = "%[2]s"
+}
+
+resource "huaweicloud_vod_media_asset" "test" {
+  name         = "%[2]s_update"
+  media_type   = "MP4"
+  input_bucket = huaweicloud_obs_bucket.test.bucket
+  input_path   = huaweicloud_obs_bucket_object.test.id
+  category_id  = huaweicloud_vod_media_category.test.id
+  labels       = "test_label_1,test_lable_2"
+  publish      = false
+
+  thumbnail {
+    type = "time"
+    time = 1
+  }
+}
+`, testAccMediaAsset_obs_base(rName), rName)
+}
+
+func TestAccMediaAsset_url(t *testing.T) {
+	var asset interface{}
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_vod_media_asset.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&asset,
+		getResourceAsset,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheckVODMediaAsset(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMediaAsset_url(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "media_type", "MP4"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "url", "http://demo/test_video.mp4"),
+					resource.TestCheckResourceAttr(resourceName, "labels", "test_label_1,test_lable_2,test_label_3"),
+					resource.TestCheckResourceAttrSet(resourceName, "category_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "category_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "media_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "thumbnail.#"),
+				),
+			},
+			{
+				Config: testAccMediaAsset_obs_url1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", rName)),
+					resource.TestCheckResourceAttr(resourceName, "media_type", "MP4"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description update"),
+					resource.TestCheckResourceAttr(resourceName, "url", "http://demo/test_video.mp4"),
+					resource.TestCheckResourceAttr(resourceName, "labels", "test_label_1,test_lable_2"),
+					resource.TestCheckResourceAttr(resourceName, "publish", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "category_id",
+						"huaweicloud_vod_media_category.test", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "category_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "media_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "thumbnail.#"),
+				),
+			},
+			{
+				Config: testAccMediaAsset_obs_url2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", rName)),
+					resource.TestCheckResourceAttr(resourceName, "media_type", "MP4"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "url", "http://demo/test_video.mp4"),
+					resource.TestCheckResourceAttr(resourceName, "labels", "test_label_1,test_lable_2"),
+					resource.TestCheckResourceAttr(resourceName, "publish", "false"),
+					resource.TestCheckResourceAttrPair(resourceName, "category_id",
+						"huaweicloud_vod_media_category.test", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "category_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "media_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "thumbnail.#"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"url", "thumbnail", "publish",
+				},
+			},
+		},
+	})
+}
+
+func testAccMediaAsset_url(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vod_media_asset" "test" {
+  name        = "%[1]s"
+  media_type  = "MP4"
+  url         = "http://demo/test_video.mp4"
+  description = "test description"
+  labels      = "test_label_1,test_lable_2,test_label_3"
+
+  thumbnail {
+    type = "time"
+    time = 1
+  }
+}
+`, rName)
+}
+
+func testAccMediaAsset_obs_url1(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vod_media_category" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_vod_media_asset" "test" {
+  name        = "%[1]s_update"
+  media_type  = "MP4"
+  url         = "http://demo/test_video.mp4"
+  description = "test description update"
+  category_id = huaweicloud_vod_media_category.test.id
+  labels      = "test_label_1,test_lable_2"
+  publish     = true
+
+  thumbnail {
+    type = "time"
+    time = 1
+  }
+}
+`, rName)
+}
+
+func testAccMediaAsset_obs_url2(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vod_media_category" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_vod_media_asset" "test" {
+  name        = "%[1]s_update"
+  media_type  = "MP4"
+  url         = "http://demo/test_video.mp4"
+  category_id = huaweicloud_vod_media_category.test.id
+  labels      = "test_label_1,test_lable_2"
+  publish     = false
+
+  thumbnail {
+    type = "time"
+    time = 1
+  }
+}
+`, rName)
 }

--- a/huaweicloud/services/vod/resource_huaweicloud_vod_media_asset.go
+++ b/huaweicloud/services/vod/resource_huaweicloud_vod_media_asset.go
@@ -2,15 +2,18 @@ package vod
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	v1 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vod/v1"
-	vod "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vod/v1/model"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -33,6 +36,10 @@ func ResourceMediaAsset() *schema.Resource {
 		DeleteContext: resourceMediaAssetDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(60 * time.Second),
 		},
 
 		//request and response parameters
@@ -204,268 +211,404 @@ func ResourceMediaAsset() *schema.Resource {
 	}
 }
 
-func buildReviewOpts(reviewTemplateId string) *vod.Review {
-	if reviewTemplateId == "" {
+func buildVodMediaAssetByUrlReviewBodyParams(d *schema.ResourceData) map[string]interface{} {
+	templateID := d.Get("review_template_id").(string)
+	if templateID == "" {
 		return nil
 	}
 
-	return &vod.Review{
-		TemplateId: reviewTemplateId,
+	return map[string]interface{}{
+		"template_id": templateID,
 	}
 }
 
-func buildThumbnailOpts(rawThumbnail []interface{}) *vod.Thumbnail {
-	if len(rawThumbnail) != 1 {
+func buildVodMediaAssetByUrlThumbnailBodyParams(d *schema.ResourceData) map[string]interface{} {
+	rawArray := d.Get("thumbnail").([]interface{})
+	if len(rawArray) == 0 {
 		return nil
 	}
-
-	thumbnail := rawThumbnail[0].(map[string]interface{})
-
-	var thumbnailType vod.ThumbnailType
-	if thumbnail["type"].(string) == "time" {
-		thumbnailType = vod.GetThumbnailTypeEnum().TIME
+	rawMap := rawArray[0].(map[string]interface{})
+	return map[string]interface{}{
+		"type":           rawMap["type"],
+		"time":           utils.ValueIgnoreEmpty(rawMap["time"]),
+		"dots":           rawMap["dots"],
+		"cover_position": utils.ValueIgnoreEmpty(rawMap["cover_position"]),
+		"format":         utils.ValueIgnoreEmpty(rawMap["format"]),
+		"aspect_ratio":   utils.ValueIgnoreEmpty(rawMap["aspect_ratio"]),
+		"max_length":     utils.ValueIgnoreEmpty(rawMap["max_length"]),
 	}
-	if thumbnail["type"].(string) == "dots" {
-		thumbnailType = vod.GetThumbnailTypeEnum().DOTS
-	}
-
-	thumbnailOpts := vod.Thumbnail{
-		Type:          thumbnailType,
-		Time:          utils.Int32IgnoreEmpty(int32(thumbnail["time"].(int))),
-		Dots:          utils.ExpandToInt32ListPointer(thumbnail["dots"].([]interface{})),
-		CoverPosition: utils.Int32IgnoreEmpty(int32(thumbnail["cover_position"].(int))),
-		Format:        utils.Int32IgnoreEmpty(int32(thumbnail["format"].(int))),
-		AspectRatio:   utils.Int32IgnoreEmpty(int32(thumbnail["aspect_ratio"].(int))),
-		MaxLength:     utils.Int32IgnoreEmpty(int32(thumbnail["max_length"].(int))),
-	}
-
-	return &thumbnailOpts
 }
 
-func createMediaAssetByUrl(client *v1.VodClient, d *schema.ResourceData) (string, error) {
-	var videoType vod.UploadMetaDataByUrlVideoType
-	if err := videoType.UnmarshalJSON([]byte(d.Get("media_type").(string))); err != nil {
-		return "", fmt.Errorf("error parsing the argument media_type: %s", err)
-	}
-
-	createOpts := vod.UploadMetaDataByUrl{
-		VideoType:         videoType,
-		Title:             d.Get("name").(string),
-		Url:               d.Get("url").(string),
-		Description:       utils.StringIgnoreEmpty(d.Get("description").(string)),
-		CategoryId:        utils.Int32IgnoreEmpty(int32(d.Get("category_id").(int))),
-		Tags:              utils.StringIgnoreEmpty(d.Get("labels").(string)),
-		TemplateGroupName: utils.StringIgnoreEmpty(d.Get("template_group_name").(string)),
-		WorkflowName:      utils.StringIgnoreEmpty(d.Get("workflow_name").(string)),
-		Review:            buildReviewOpts(d.Get("review_template_id").(string)),
-		Thumbnail:         buildThumbnailOpts(d.Get("thumbnail").([]interface{})),
-	}
-
+func buildVodMediaAssetByUrlAutoPublishParam(d *schema.ResourceData) int {
 	if d.Get("publish").(bool) {
-		createOpts.AutoPublish = utils.Int32(int32(1))
-	} else {
-		createOpts.AutoPublish = utils.Int32(int32(0))
+		return 1
 	}
+
+	return 0
+}
+
+func buildVodMediaAssetByUrlAutoEncryptParam(d *schema.ResourceData) interface{} {
 	if d.Get("auto_encrypt").(bool) {
-		createOpts.AutoEncrypt = utils.Int32(int32(1))
-	}
-	if d.Get("auto_preload").(bool) {
-		createOpts.AutoPreheat = utils.Int32(int32(1))
-	}
-
-	uploadList := vod.UploadMetaDataByUrlReq{
-		UploadMetadatas: []vod.UploadMetaDataByUrl{createOpts},
-	}
-	createReq := vod.UploadMetaDataByUrlRequest{
-		Body: &uploadList,
-	}
-	resp, err := client.UploadMetaDataByUrl(&createReq)
-	if err != nil {
-		return "", fmt.Errorf("error creating VOD media asset: %s", err)
-	}
-
-	if resp.UploadAssets == nil {
-		return "", fmt.Errorf("unable to find the asset after uploading")
-	}
-	assets := *resp.UploadAssets
-	if len(assets) == 0 || assets[0].AssetId == nil {
-		return "", fmt.Errorf("unable to find the asset after uploading")
-	}
-	return *assets[0].AssetId, nil
-}
-
-func createMediaAssetFromObs(client *v1.VodClient, d *schema.ResourceData, region string) (string, error) {
-	bucketAuthOpts := vod.UpdateBucketAuthorizedReq{
-		Bucket:    d.Get("input_bucket").(string),
-		Operation: "1",
-	}
-
-	bucketAuthReq := vod.UpdateBucketAuthorizedRequest{
-		Body: &bucketAuthOpts,
-	}
-	_, err := client.UpdateBucketAuthorized(&bucketAuthReq)
-	if err != nil {
-		return "", fmt.Errorf("error authorizing the OBS bucket to VOD: %s", err)
-	}
-
-	var videoType vod.PublishAssetFromObsReqVideoType
-	if err = videoType.UnmarshalJSON([]byte(d.Get("media_type").(string))); err != nil {
-		return "", fmt.Errorf("error parsing the argument media_type: %s", err)
-	}
-
-	createOpts := vod.PublishAssetFromObsReq{
-		VideoType:         videoType,
-		Title:             d.Get("name").(string),
-		Description:       utils.StringIgnoreEmpty(d.Get("description").(string)),
-		CategoryId:        utils.Int32IgnoreEmpty(int32(d.Get("category_id").(int))),
-		Tags:              utils.StringIgnoreEmpty(d.Get("labels").(string)),
-		TemplateGroupName: utils.StringIgnoreEmpty(d.Get("template_group_name").(string)),
-		WorkflowName:      utils.StringIgnoreEmpty(d.Get("workflow_name").(string)),
-		Review:            buildReviewOpts(d.Get("review_template_id").(string)),
-		Thumbnail:         buildThumbnailOpts(d.Get("thumbnail").([]interface{})),
-		Input: &vod.FileAddr{
-			Bucket:   d.Get("input_bucket").(string),
-			Object:   d.Get("input_path").(string),
-			Location: region,
-		},
-		OutputBucket: utils.StringIgnoreEmpty(d.Get("output_bucket").(string)),
-		OutputPath:   utils.StringIgnoreEmpty(d.Get("output_path").(string)),
-		StorageMode:  utils.Int32IgnoreEmpty(int32(d.Get("storage_mode").(int))),
-	}
-
-	if d.Get("publish").(bool) {
-		createOpts.AutoPublish = utils.Int32(int32(1))
-	} else {
-		createOpts.AutoPublish = utils.Int32(int32(0))
-	}
-	if d.Get("auto_encrypt").(bool) {
-		createOpts.AutoEncrypt = utils.Int32(int32(1))
-	}
-	if d.Get("auto_preload").(bool) {
-		createOpts.AutoPreheat = utils.Int32(int32(1))
-	}
-
-	createReq := vod.PublishAssetFromObsRequest{
-		Body: &createOpts,
-	}
-
-	resp, err := client.PublishAssetFromObs(&createReq)
-	if err != nil {
-		return "", fmt.Errorf("error creating VOD media asset: %s", err)
-	}
-
-	if resp.AssetId == nil {
-		return "", fmt.Errorf("unable to find the asset after uploading")
-	}
-
-	return *resp.AssetId, nil
-}
-
-func resourceMediaAssetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.HcVodV1Client(config.GetRegion(d))
-	if err != nil {
-		return diag.Errorf("error creating VOD client: %s", err)
-	}
-
-	var AssetID string
-	if _, ok := d.GetOk("url"); ok {
-		AssetID, err = createMediaAssetByUrl(client, d)
-		if err != nil {
-			diag.FromErr(err)
-		}
-	} else {
-		AssetID, err = createMediaAssetFromObs(client, d, config.GetRegion(d))
-		if err != nil {
-			diag.FromErr(err)
-		}
-	}
-
-	d.SetId(AssetID)
-	return resourceMediaAssetRead(ctx, d, meta)
-}
-
-func resourceMediaAssetRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.HcVodV1Client(config.GetRegion(d))
-	if err != nil {
-		return diag.Errorf("error creating VOD client: %s", err)
-	}
-
-	resp, err := client.ShowAssetDetail(&vod.ShowAssetDetailRequest{AssetId: d.Id()})
-	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving VOD media asset")
-	}
-
-	mErr := multierror.Append(nil,
-		d.Set("region", config.GetRegion(d)),
-		d.Set("name", resp.BaseInfo.Title),
-		d.Set("media_name", resp.BaseInfo.VideoName),
-		d.Set("description", resp.BaseInfo.Description),
-		d.Set("category_id", resp.BaseInfo.CategoryId),
-		d.Set("category_name", resp.BaseInfo.CategoryName),
-		d.Set("media_type", resp.BaseInfo.VideoType),
-		d.Set("labels", resp.BaseInfo.Tags),
-		d.Set("media_url", resp.BaseInfo.VideoUrl),
-	)
-
-	if sourcePath := resp.BaseInfo.SourcePath; sourcePath != nil {
-		mErr = multierror.Append(mErr,
-			d.Set("input_bucket", sourcePath.Bucket),
-			d.Set("input_path", sourcePath.Object),
-		)
-	}
-
-	if outputPath := resp.BaseInfo.OutputPath; outputPath != nil {
-		mErr = multierror.Append(mErr,
-			d.Set("output_bucket", outputPath.Bucket),
-			d.Set("output_path", outputPath.Object),
-		)
-	}
-
-	if err = mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error setting VOD media asset fields: %s", err)
+		return 1
 	}
 
 	return nil
 }
 
+func buildVodMediaAssetByUrlAutoPreheatParam(d *schema.ResourceData) interface{} {
+	if d.Get("auto_preload").(bool) {
+		return 1
+	}
+
+	return nil
+}
+
+func buildVodMediaAssetByUrlBodyParams(d *schema.ResourceData) map[string]interface{} {
+	metadataObject := map[string]interface{}{
+		"video_type":          d.Get("media_type"),
+		"title":               d.Get("name"),
+		"url":                 d.Get("url"),
+		"description":         utils.ValueIgnoreEmpty(d.Get("description")),
+		"category_id":         utils.ValueIgnoreEmpty(d.Get("category_id")),
+		"tags":                utils.ValueIgnoreEmpty(d.Get("labels")),
+		"template_group_name": utils.ValueIgnoreEmpty(d.Get("template_group_name")),
+		"workflow_name":       utils.ValueIgnoreEmpty(d.Get("workflow_name")),
+		"review":              buildVodMediaAssetByUrlReviewBodyParams(d),
+		"thumbnail":           buildVodMediaAssetByUrlThumbnailBodyParams(d),
+		"auto_publish":        buildVodMediaAssetByUrlAutoPublishParam(d),
+		"auto_encrypt":        buildVodMediaAssetByUrlAutoEncryptParam(d),
+		"auto_preheat":        buildVodMediaAssetByUrlAutoPreheatParam(d),
+	}
+
+	return map[string]interface{}{
+		"upload_metadatas": []map[string]interface{}{metadataObject},
+	}
+}
+
+func createVodMediaAssetByUrl(client *golangsdk.ServiceClient, d *schema.ResourceData) (string, error) {
+	requestPath := client.Endpoint + "v1.0/{project_id}/asset/upload_by_url"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildVodMediaAssetByUrlBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return "", err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return "", err
+	}
+
+	assetID := utils.PathSearch("upload_assets|[0].asset_id", respBody, "").(string)
+	if assetID == "" {
+		return "", errors.New("asset_id is not found in API response")
+	}
+
+	return assetID, nil
+}
+
+func buildAuthorizeAssetBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"bucket":    d.Get("input_bucket"),
+		"operation": "1",
+	}
+}
+
+func authorizeAsset(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v1.0/{project_id}/asset/authority"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildAuthorizeAssetBodyParams(d),
+	}
+
+	_, err := client.Request("PUT", requestPath, &requestOpt)
+	return err
+}
+
+func buildVodMediaAssetByObsReviewBodyParams(d *schema.ResourceData) map[string]interface{} {
+	templateID := d.Get("review_template_id").(string)
+	if templateID == "" {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"template_id": templateID,
+	}
+}
+
+func buildVodMediaAssetByObsThumbnailBodyParams(d *schema.ResourceData) map[string]interface{} {
+	rawArray := d.Get("thumbnail").([]interface{})
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap := rawArray[0].(map[string]interface{})
+	return map[string]interface{}{
+		"type":           rawMap["type"],
+		"time":           utils.ValueIgnoreEmpty(rawMap["time"]),
+		"dots":           rawMap["dots"],
+		"cover_position": utils.ValueIgnoreEmpty(rawMap["cover_position"]),
+		"format":         utils.ValueIgnoreEmpty(rawMap["format"]),
+		"aspect_ratio":   utils.ValueIgnoreEmpty(rawMap["aspect_ratio"]),
+		"max_length":     utils.ValueIgnoreEmpty(rawMap["max_length"]),
+	}
+}
+
+func buildVodMediaAssetByObsInputBodyParams(d *schema.ResourceData, region string) map[string]interface{} {
+	return map[string]interface{}{
+		"bucket":   d.Get("input_bucket"),
+		"object":   d.Get("input_path"),
+		"location": region,
+	}
+}
+
+func buildVodMediaAssetByObsAutoPublishBodyParams(d *schema.ResourceData) int {
+	if d.Get("publish").(bool) {
+		return 1
+	}
+
+	return 0
+}
+
+func buildVodMediaAssetByObsAutoEncryptBodyParams(d *schema.ResourceData) interface{} {
+	if d.Get("auto_encrypt").(bool) {
+		return 1
+	}
+
+	return nil
+}
+
+func buildVodMediaAssetByObsAutoPreheatBodyParams(d *schema.ResourceData) interface{} {
+	if d.Get("auto_preload").(bool) {
+		return 1
+	}
+
+	return nil
+}
+
+func buildVodMediaAssetByObsBodyParams(d *schema.ResourceData, region string) map[string]interface{} {
+	return map[string]interface{}{
+		"video_type":          d.Get("media_type"),
+		"title":               d.Get("name"),
+		"description":         utils.ValueIgnoreEmpty(d.Get("description")),
+		"category_id":         utils.ValueIgnoreEmpty(d.Get("category_id")),
+		"tags":                utils.ValueIgnoreEmpty(d.Get("labels")),
+		"template_group_name": utils.ValueIgnoreEmpty(d.Get("template_group_name")),
+		"workflow_name":       utils.ValueIgnoreEmpty(d.Get("workflow_name")),
+		"review":              utils.ValueIgnoreEmpty(buildVodMediaAssetByObsReviewBodyParams(d)),
+		"thumbnail":           buildVodMediaAssetByObsThumbnailBodyParams(d),
+		"input":               buildVodMediaAssetByObsInputBodyParams(d, region),
+		"output_bucket":       utils.ValueIgnoreEmpty(d.Get("output_bucket")),
+		"output_path":         utils.ValueIgnoreEmpty(d.Get("output_path")),
+		"storage_mode":        utils.ValueIgnoreEmpty(d.Get("storage_mode")),
+		"auto_publish":        buildVodMediaAssetByObsAutoPublishBodyParams(d),
+		"auto_encrypt":        buildVodMediaAssetByObsAutoEncryptBodyParams(d),
+		"auto_preheat":        buildVodMediaAssetByObsAutoPreheatBodyParams(d),
+	}
+}
+
+func createVodMediaAssetByObs(client *golangsdk.ServiceClient, d *schema.ResourceData, region string) (string, error) {
+	if err := authorizeAsset(client, d); err != nil {
+		return "", fmt.Errorf("error authorizing the OBS bucket to VOD: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v1.0/{project_id}/asset/reproduction"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildVodMediaAssetByObsBodyParams(d, region)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return "", err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return "", err
+	}
+
+	assetID := utils.PathSearch("asset_id", respBody, "").(string)
+	if assetID == "" {
+		return "", errors.New("asset_id is not found in API response")
+	}
+
+	return assetID, nil
+}
+
+func resourceMediaAssetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "vod"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating VOD client: %s", err)
+	}
+
+	var assetID string
+	if _, ok := d.GetOk("url"); ok {
+		assetID, err = createVodMediaAssetByUrl(client, d)
+		if err != nil {
+			return diag.Errorf("error creating VOD media asset by URL: %s", err)
+		}
+	} else {
+		assetID, err = createVodMediaAssetByObs(client, d, region)
+		if err != nil {
+			return diag.Errorf("error creating VOD media asset by OBS: %s", err)
+		}
+	}
+
+	d.SetId(assetID)
+	return resourceMediaAssetRead(ctx, d, meta)
+}
+
+func ReadMediaAssetDetail(client *golangsdk.ServiceClient, assetID string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1.0/{project_id}/asset/details"
+	requestPath += fmt.Sprintf("?asset_id=%s", assetID)
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceMediaAssetRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "vod"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating VOD client: %s", err)
+	}
+
+	respBody, err := ReadMediaAssetDetail(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving VOD media asset")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("base_info.title", respBody, nil)),
+		d.Set("media_name", utils.PathSearch("base_info.video_name", respBody, nil)),
+		d.Set("description", utils.PathSearch("base_info.description", respBody, nil)),
+		d.Set("category_id", utils.PathSearch("base_info.category_id", respBody, nil)),
+		d.Set("category_name", utils.PathSearch("base_info.category_name", respBody, nil)),
+		d.Set("media_type", utils.PathSearch("base_info.video_type", respBody, nil)),
+		d.Set("labels", utils.PathSearch("base_info.tags", respBody, nil)),
+		d.Set("media_url", utils.PathSearch("base_info.video_url", respBody, nil)),
+	)
+
+	sourcePath := utils.PathSearch("base_info.source_path", respBody, nil)
+	if sourcePath != nil {
+		mErr = multierror.Append(mErr,
+			d.Set("input_bucket", utils.PathSearch("bucket", sourcePath, nil)),
+			d.Set("input_path", utils.PathSearch("object", sourcePath, nil)),
+		)
+	}
+
+	outputPath := utils.PathSearch("base_info.output_path", respBody, nil)
+	if outputPath != nil {
+		mErr = multierror.Append(mErr,
+			d.Set("output_bucket", utils.PathSearch("bucket", outputPath, nil)),
+			d.Set("output_path", utils.PathSearch("object", outputPath, nil)),
+		)
+	}
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdateAssetMetaBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"asset_id":    d.Id(),
+		"title":       d.Get("name"),
+		"description": d.Get("description"),
+		"category_id": d.Get("category_id"),
+		"tags":        d.Get("labels"),
+	}
+}
+
+func updateAssetMeta(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v1.0/{project_id}/asset/info"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes:          []int{200, 201, 204},
+		JSONBody:         buildUpdateAssetMetaBodyParams(d),
+	}
+
+	_, err := client.Request("PUT", requestPath, &requestOpt)
+	return err
+}
+
+func publishAssets(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v1.0/{project_id}/asset/status/publish"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"asset_id": []string{d.Id()},
+		},
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	return err
+}
+
+func unPublishAssets(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v1.0/{project_id}/asset/status/unpublish"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"asset_id": []string{d.Id()},
+		},
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	return err
+}
+
 func resourceMediaAssetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.HcVodV1Client(config.GetRegion(d))
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "vod"
+	)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
 		return diag.Errorf("error creating VOD client: %s", err)
 	}
 
 	if d.HasChanges("name", "description", "category_id", "labels") {
-		updateOpts := vod.UpdateAssetMetaReq{
-			AssetId:     d.Id(),
-			Title:       utils.String(d.Get("name").(string)),
-			Description: utils.String(d.Get("description").(string)),
-			CategoryId:  utils.Int32(int32(d.Get("category_id").(int))),
-			Tags:        utils.String(d.Get("labels").(string)),
-		}
-
-		updateReq := vod.UpdateAssetMetaRequest{
-			Body: &updateOpts,
-		}
-
-		_, err = client.UpdateAssetMeta(&updateReq)
-		if err != nil {
+		if err := updateAssetMeta(client, d); err != nil {
 			return diag.Errorf("error updating VOD media asset: %s", err)
 		}
 	}
 
 	if d.HasChange("publish") {
 		if d.Get("publish").(bool) {
-			_, err = client.PublishAssets(&vod.PublishAssetsRequest{Body: &vod.PublishAssetReq{AssetId: []string{d.Id()}}})
-			if err != nil {
+			if err := publishAssets(client, d); err != nil {
 				return diag.Errorf("error publishing VOD media asset: %s", err)
 			}
 		} else {
-			_, err = client.UnpublishAssets(&vod.UnpublishAssetsRequest{Body: &vod.PublishAssetReq{AssetId: []string{d.Id()}}})
-			if err != nil {
-				return diag.Errorf("error unpublishing VOD media asset: %s", err)
+			if err := unPublishAssets(client, d); err != nil {
+				return diag.Errorf("error un-publishing VOD media asset: %s", err)
 			}
 		}
 	}
@@ -473,16 +616,58 @@ func resourceMediaAssetUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return resourceMediaAssetRead(ctx, d, meta)
 }
 
-func resourceMediaAssetDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.HcVodV1Client(config.GetRegion(d))
+func waitingForMediaAssetDelete(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			respBody, err := ReadMediaAssetDetail(client, d.Id())
+			if err != nil {
+				var errDefault404 golangsdk.ErrDefault404
+				if errors.As(err, &errDefault404) {
+					return "deleted", "COMPLETED", nil
+				}
+				return nil, "ERROR", err
+			}
+
+			return respBody, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceMediaAssetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "vod"
+		httpUrl = "v1.0/{project_id}/asset"
+	)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
 		return diag.Errorf("error creating VOD client: %s", err)
 	}
 
-	_, err = client.DeleteAssets(&vod.DeleteAssetsRequest{AssetId: []string{d.Id()}})
+	requestPath := client.Endpoint + httpUrl
+	requestPath += fmt.Sprintf("?asset_id=%s", d.Id())
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
 	if err != nil {
 		return diag.Errorf("error deleting VOD media asset: %s", err)
+	}
+
+	if err := waitingForMediaAssetDelete(ctx, client, d, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.Errorf("error waiting for VOD media asset (%s) deleted: %s", d.Id(), err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactor vod asset resource with general code style.
![image](https://github.com/user-attachments/assets/40175c32-c5ba-45c9-bc02-d2c38695d39d)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Use the old code package to create resources, then switch to the new code package and execute `terraform plan`. It is found that there is no prompt for resource changes, so it can be considered that this resource reconstruction has no impact on the existing resources.
![image](https://github.com/user-attachments/assets/8fbed72e-7e9d-46e2-893b-1a04a74f6778)



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/vod' TESTARGS='-run TestAccMediaAsset_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vod -v -run TestAccMediaAsset_ -timeout 360m -parallel 4
=== RUN   TestAccMediaAsset_obs
=== PAUSE TestAccMediaAsset_obs
=== RUN   TestAccMediaAsset_url
=== PAUSE TestAccMediaAsset_url
=== CONT  TestAccMediaAsset_obs
=== CONT  TestAccMediaAsset_url
--- PASS: TestAccMediaAsset_url (29.54s)
--- PASS: TestAccMediaAsset_obs (36.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vod       36.608s
```

* [x] Documentation updated.
* [ ] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/a129bd8a-adcc-40f0-922f-cd39d77e17d2)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
