### PR TITLE
feat(er): supports new resource to update the attachment infos

### DIFF
--- a/docs/resources/er_attachment_update.md
+++ b/docs/resources/er_attachment_update.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Enterprise Router (ER)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_er_attachment_update"
+description: |-
+  Use this resource to update the basic attachment information within HuaweiCloud.
+---
+
+# huaweicloud_er_attachment_update
+
+Use this resource to update the basic attachment information within HuaweiCloud.
+
+-> This resource is only a one-time action resource for updating the attachment. Deleting this resource will not restore
+   the corresponding attachment configuration, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "attachment_id" {}
+variable "new_attachment_name" {}
+
+resource "huaweicloud_er_attachment_update" "test" {
+  instance_id   = var.instance_id
+  attachment_id = var.attachment_id
+  name          = var.new_attachment_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the shared ER instance.
+
+* `attachment_id` - (Required, String, NonUpdatable) Specifies the ID of the attachment to be accept or reject.
+
+* `name` - (Optional, String) Specifies the new name of the attachment.
+  The valid length is limited from `1` to `64` characters, only English letters, Chinese characters, digits,
+  underscore (_), hyphens (-) and dots (.) allowed.
+
+* `description` - (Optional, String) Specifies the new name of the attachment.
+  The valid length is limited from `1` to `255`, and the angle brackets (< and >) are not allowed.
+  The description do not restore with an empty value whether this parameter value is omitted or set empty.
+
+-> At least one of parameter `name` and parameter `description` must be set.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1913,6 +1913,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_er_association":         er.ResourceAssociation(),
 			"huaweicloud_er_attachment_accepter": er.ResourceAttachmentAccepter(),
+			"huaweicloud_er_attachment_update":   er.ResourceAttachmentUpdate(),
 			"huaweicloud_er_instance":            er.ResourceInstance(),
 			"huaweicloud_er_propagation":         er.ResourcePropagation(),
 			"huaweicloud_er_route_table":         er.ResourceRouteTable(),

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_attachment_update_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_attachment_update_test.go
@@ -1,0 +1,170 @@
+package er
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er"
+)
+
+func getAttachmentFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("er", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Instance Client: %s", err)
+	}
+	return er.GetAttachmentById(client, state.Primary.Attributes["instance_id"],
+		state.Primary.Attributes["attachment_id"])
+}
+
+func TestAccAttachmentUpdate_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceName = "huaweicloud_er_attachment_update.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getAttachmentFunc)
+
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		baseConfig = testAccAttachmentUpdate_base()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAttachmentUpdate_basic_step1(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id",
+						"huaweicloud_er_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "attachment_id",
+						"huaweicloud_er_vpc_attachment.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "name",
+						"huaweicloud_er_vpc_attachment.test", "name"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by attachment update resource"),
+				),
+			},
+			{
+				Config: testAccAttachmentUpdate_basic_step2(baseConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id",
+						"huaweicloud_er_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "attachment_id",
+						"huaweicloud_er_vpc_attachment.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by attachment update resource"),
+				),
+			},
+			{
+				Config: testAccAttachmentUpdate_basic_step3(baseConfig, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id",
+						"huaweicloud_er_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "attachment_id",
+						"huaweicloud_er_vpc_attachment.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by attachment update resource"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAttachmentUpdate_base() string {
+	var (
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+	)
+
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_er_instance" "test" {
+  availability_zones = try(slice(data.huaweicloud_availability_zones.test.names, 0, 1), []) # only one az has.
+  name               = "%[1]s"
+  asn                = %[2]d
+
+  lifecycle {
+    ignore_changes = [
+      availability_zones,
+    ]
+  }
+}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id     = huaweicloud_vpc.test.id
+  name       = "%[1]s"
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 0)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 0), 1)
+}
+
+resource "huaweicloud_er_vpc_attachment" "test" {
+  instance_id = huaweicloud_er_instance.test.id
+  vpc_id      = huaweicloud_vpc.test.id # huaweicloud_vpc_subnet.test.vpc_id
+  subnet_id   = huaweicloud_vpc_subnet.test.id
+  name        = "%[1]s"
+
+  lifecycle {
+    ignore_changes = [
+      name,
+      description,
+    ]
+  }
+}
+`, name, bgpAsNum)
+}
+
+func testAccAttachmentUpdate_basic_step1(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_er_attachment_update" "test" {
+  instance_id   = huaweicloud_er_instance.test.id
+  attachment_id = huaweicloud_er_vpc_attachment.test.id
+  description   = "Created by attachment update resource"
+}
+`, baseConfig)
+}
+
+func testAccAttachmentUpdate_basic_step2(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_er_attachment_update" "test" {
+  instance_id   = huaweicloud_er_instance.test.id
+  attachment_id = huaweicloud_er_vpc_attachment.test.id
+  name          = "%[2]s"
+}
+`, baseConfig, name)
+}
+
+func testAccAttachmentUpdate_basic_step3(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_er_attachment_update" "test" {
+  instance_id   = huaweicloud_er_instance.test.id
+  attachment_id = huaweicloud_er_vpc_attachment.test.id
+  name          = "%[2]s"
+  description   = "Updated by attachment update resource"
+}
+`, baseConfig, name)
+}

--- a/huaweicloud/services/er/resource_huaweicloud_er_attachment_update.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_attachment_update.go
@@ -1,0 +1,209 @@
+package er
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var attachmenUpdateNonUpdatableParams = []string{
+	"instance_id",
+	"attachment_id",
+}
+
+// @API ER PUT /v3/{project_id}/enterprise-router/{er_id}/attachments/{attachment_id}
+// @API ER GET /v3/{project_id}/enterprise-router/{er_id}/attachments/{attachment_id}
+func ResourceAttachmentUpdate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAttachmentUpdateCreate,
+		UpdateContext: resourceAttachmentUpdateUpdate,
+		ReadContext:   resourceAttachmentUpdateRead,
+		DeleteContext: resourceAttachmentUpdateDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(attachmenUpdateNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the attachment is located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the ER instance.`,
+			},
+			"attachment_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the attachment to be updated.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The new name of the attachment.`,
+				AtLeastOneOf: []string{
+					"description",
+				},
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The new description of the attachment.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func doAttachmentUpdate(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl      = "v3/{project_id}/enterprise-router/{er_id}/attachments/{attachment_id}"
+		instanceId   = d.Get("instance_id").(string)
+		attachmentId = d.Get("attachment_id").(string)
+	)
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{er_id}", instanceId)
+	updatePath = strings.ReplaceAll(updatePath, "{attachment_id}", attachmentId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"attachment": map[string]interface{}{
+				"name":        utils.ValueIgnoreEmpty(d.Get("name")),
+				"description": utils.ValueIgnoreEmpty(d.Get("description")),
+			},
+		},
+	}
+	_, err := client.Request("PUT", updatePath, &opt)
+	return err
+}
+
+func resourceAttachmentUpdateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("er", region)
+	if err != nil {
+		return diag.Errorf("error creating ER client: %s", err)
+	}
+
+	err = doAttachmentUpdate(client, d)
+	if err != nil {
+		return diag.Errorf("error updating attachment information: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	return resourceAttachmentUpdateRead(ctx, d, meta)
+}
+
+func GetAttachmentById(client *golangsdk.ServiceClient, instanceId, attachmentId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/enterprise-router/{er_id}/attachments/{attachment_id}"
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{er_id}", instanceId)
+	getPath = strings.ReplaceAll(getPath, "{attachment_id}", attachmentId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceAttachmentUpdateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		instanceId   = d.Get("instance_id").(string)
+		attachmentId = d.Get("attachment_id").(string)
+	)
+	client, err := cfg.NewServiceClient("er", region)
+	if err != nil {
+		return diag.Errorf("error creating ER client: %s", err)
+	}
+
+	attachment, err := GetAttachmentById(client, instanceId, attachmentId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error getting attachment information")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("attachment.name", attachment, nil)),
+		d.Set("description", utils.PathSearch("attachment.description", attachment, nil)),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving data source fields of the ER resource tags: %s", mErr)
+	}
+	return nil
+}
+
+func resourceAttachmentUpdateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("er", region)
+	if err != nil {
+		return diag.Errorf("error creating ER client: %s", err)
+	}
+
+	err = doAttachmentUpdate(client, d)
+	if err != nil {
+		return diag.Errorf("error updating attachment information: %s", err)
+	}
+
+	return resourceAttachmentUpdateRead(ctx, d, meta)
+}
+
+func resourceAttachmentUpdateDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for updating the attachment. Deleting this resource
+will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource to do attachment update operation.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Supports new resource to update the attachment infos.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o er -f TestAccAttachmentUpdate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/er" -v -coverprofile="./huaweicloud/services/acceptance/er/er_coverage.cov" -coverpkg="./huaweicloud/services/er" -run TestAccAttachmentUpdate_basic -timeout 360m -parallel 10
=== RUN   TestAccAttachmentUpdate_basic
=== PAUSE TestAccAttachmentUpdate_basic
=== CONT  TestAccAttachmentUpdate_basic
--- PASS: TestAccAttachmentUpdate_basic (123.58s)
PASS
coverage: 15.5% of statements in ./huaweicloud/services/er
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        123.698s        coverage: 15.5% of statements in ./huaweicloud/services/er
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/ed4840a6-ffa1-497f-86a5-93360fb16cfd)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
