### PR TITLE
feat(nat): the transit IP supports new field and attribute

### DIFF
--- a/docs/data-sources/nat_private_transit_ips.md
+++ b/docs/data-sources/nat_private_transit_ips.md
@@ -2,7 +2,8 @@
 subcategory: "NAT Gateway (NAT)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_nat_private_transit_ips"
-description: ""
+description: |-
+  Use this data source to get the list of transit IPs.
 ---
 
 # huaweicloud_nat_private_transit_ips
@@ -41,6 +42,8 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the transit
   IPs belong.
 
+* `transit_subnet_id` - (Optional, List) Specifies the ID of the transit subnet.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -62,6 +65,8 @@ The `transit_ips` block supports:
 * `tags` - The key/value pairs to associate with the transit IP.
 
 * `gateway_id` - The ID of the private NAT gateway to which the transit IP belongs.
+
+* `status` - The status of the transit IP.
 
 * `created_at` - The creation time of the transit IP.
 

--- a/docs/resources/nat_private_transit_ip.md
+++ b/docs/resources/nat_private_transit_ip.md
@@ -57,6 +57,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `gateway_id` - The ID of the private NAT gateway to which the transit IP belongs.
 
+* `status` - The status of the transit IP.
+
 * `created_at` - The creation time of the transit IP for private NAT.
 
 * `updated_at` - The latest update time of the transit IP for private NAT.

--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_transit_ip_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_transit_ip_test.go
@@ -52,6 +52,7 @@ func TestAccPrivateTransitIp_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
 					resource.TestCheckResourceAttrSet(rName, "created_at"),
 					resource.TestCheckResourceAttrSet(rName, "updated_at"),
 				),

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_private_transit_ip.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_private_transit_ip.go
@@ -64,6 +64,11 @@ func ResourcePrivateTransitIp() *schema.Resource {
 				Computed:    true,
 				Description: "The network interface ID of the transit IP for private NAT.",
 			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The status of the transit IP.",
+			},
 			"gateway_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -176,6 +181,7 @@ func resourcePrivateTransitIpRead(_ context.Context, d *schema.ResourceData, met
 		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("transit_ip.tags", respBody, make([]interface{}, 0)))),
 		d.Set("gateway_id", utils.PathSearch("transit_ip.gateway_id", respBody, nil)),
 		d.Set("network_interface_id", utils.PathSearch("transit_ip.network_interface_id", respBody, nil)),
+		d.Set("status", utils.PathSearch("transit_ip.status", respBody, nil)),
 		d.Set("created_at", utils.PathSearch("transit_ip.created_at", respBody, nil)),
 		d.Set("updated_at", utils.PathSearch("transit_ip.updated_at", respBody, nil)),
 	)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The transit IP supports new field and attribute.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateTransitIp_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateTransitIp_basic -timeout 360m -parallel 4
=== RUN   TestAccPrivateTransitIp_basic
=== PAUSE TestAccPrivateTransitIp_basic
=== CONT  TestAccPrivateTransitIp_basic
--- PASS: TestAccPrivateTransitIp_basic (72.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       72.111s
```
```
 make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccDatasourcePrivateTransitIps_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccDatasourcePrivateTransitIps_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourcePrivateTransitIps_basic
=== PAUSE TestAccDatasourcePrivateTransitIps_basic
=== CONT  TestAccDatasourcePrivateTransitIps_basic
--- PASS: TestAccDatasourcePrivateTransitIps_basic (58.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       58.115s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
