### PR TITLE
feat(eps): add new resource to operate enterprise project

### DIFF
--- a/docs/resources/enterprise_project_action.md
+++ b/docs/resources/enterprise_project_action.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Enterprise Project Management Service (EPS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_enterprise_project_action"
+description: |-
+ Use this resource to operate the enterprise project within HuaweiCloud.
+---
+
+# huaweicloud_enterprise_project_action
+
+Use this resource to operate the enterprise project within HuaweiCloud.
+
+-> This resource is only a one-time action resource for operating the enterprise project. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "enterprise_project_id" {}
+
+resource "huaweicloud_enterprise_project_action" "test" {
+  enterprise_project_id = var.enterprise_project_id
+  action                = "disable"
+}
+```
+
+## Argument Reference
+
+* `enterprise_project_id` - (Required, String, NonUpdatable) Specifies the ID of enterprise project to be operated.
+
+* `action` - (Required, String, NonUpdatable) Specifies the action type.  
+  The valid values are as follows:
+  + **enable**
+  + **disable**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2219,6 +2219,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_elb_security_policy":              elb.ResourceSecurityPolicy(),
 
 			"huaweicloud_enterprise_project":           eps.ResourceEnterpriseProject(),
+			"huaweicloud_enterprise_project_action":    eps.ResourceAction(),
 			"huaweicloud_enterprise_project_authority": eps.ResourceAuthority(),
 
 			"huaweicloud_er_association":         er.ResourceAssociation(),

--- a/huaweicloud/services/acceptance/eps/resource_huaweicloud_enterprise_project_action_test.go
+++ b/huaweicloud/services/acceptance/eps/resource_huaweicloud_enterprise_project_action_test.go
@@ -1,0 +1,50 @@
+package eps
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccAction_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare an enterprise project and the status is enable.
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAction_basic_step1(),
+			},
+			{
+				Config: testAccAction_basic_step2(),
+			},
+		},
+	})
+}
+
+func testAccAction_basic_step1() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_enterprise_project_action" "disable" {
+  enterprise_project_id = "%[1]s"
+  action                = "disable"
+}
+`, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST)
+}
+
+func testAccAction_basic_step2() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_enterprise_project_action" "enable" {
+  enterprise_project_id = "%[1]s"
+  action                = "enable"
+}
+`, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/eps/resource_huaweicloud_enterprise_project_action.go
+++ b/huaweicloud/services/eps/resource_huaweicloud_enterprise_project_action.go
@@ -1,0 +1,111 @@
+package eps
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var actionNonUpdatableParams = []string{
+	"enterprise_project_id",
+	"action",
+}
+
+// @API ER POST /v1.0/enterprise-projects/{enterprise_project_id}/action
+func ResourceAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceActionCreate,
+		UpdateContext: resourceActionUpdate,
+		ReadContext:   resourceActionRead,
+		DeleteContext: resourceActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(actionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of enterprise project to be operated.`,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The action type.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceActionCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("eps", cfg.Region)
+	if err != nil {
+		return diag.Errorf("error creating EPS client: %s", err)
+	}
+
+	var (
+		httpUrl = "v1.0/enterprise-projects/{enterprise_project_id}/action"
+		epsId   = d.Get("enterprise_project_id").(string)
+		action  = d.Get("action").(string)
+	)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{enterprise_project_id}", epsId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		OkCodes: []int{204},
+		JSONBody: map[string]interface{}{
+			"action": action,
+		},
+	}
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("unable to %s the enterprise project (%s): %s", action, epsId, err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	return nil
+}
+
+func resourceActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceActionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for operating the enterprise project. Deleting this
+resource will not clear the corresponding request record, but will only remove the resource information from the tfstate
+file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource to operate enterprise project.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to operate enterprise project
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o eps -f TestAccAction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eps" -v -coverprofile="./huaweicloud/services/acceptance/eps/eps_coverage.cov" -coverpkg="./huaweicloud/services/eps" -run TestAccAction_basic -timeout 360m -parallel 10
=== RUN   TestAccAction_basic
=== PAUSE TestAccAction_basic
=== CONT  TestAccAction_basic
--- PASS: TestAccAction_basic (24.12s)
PASS
coverage: 13.6% of statements in ./huaweicloud/services/eps
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eps       24.199s coverage: 13.6% of statements in ./huaweicloud/services/eps
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
