### PR TITLE
feat(CCE): cce node pool resource add param partition

### DIFF
--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -401,6 +401,10 @@ The following arguments are supported:
   which is supported by clusters of v1.23.6-r0 to v1.25 or clusters of v1.25.2-r0 or later versions.
   The [object](#hostname_config) structure is documented below.
 
+* `partition` - (Optional, String, NonUpdatable) Specifies the partition to which the node belongs. Value options:
+  + **center**: center cloud.
+  + The availability zone ID of the edge station.
+
 <a name="extension_nics"></a>
 The `extension_nics` block supports:
 

--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -363,6 +363,10 @@ The following arguments are supported:
   which is supported by clusters of v1.23.6-r0 to v1.25 or clusters of v1.25.2-r0 or later versions.
   The [object](#hostname_config) structure is documented below.
 
+* `partition` - (Optional, String, NonUpdatable) Specifies the partition to which the node belongs. Value options:
+  + **center**: center cloud.
+  + The availability zone ID of the edge station.
+
 * `extension_scale_groups` - (Optional, List) Specifies the configurations of extended scaling groups in the node pool.
   The [object](#extension_scale_groups) structure is documented below.
 

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node.go
@@ -298,6 +298,10 @@ func ResourceNode() *schema.Resource {
 					},
 				},
 			},
+			"partition": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -349,11 +353,6 @@ func ResourceNode() *schema.Resource {
 				Type:       schema.TypeString,
 				Optional:   true,
 				Deprecated: "will be removed after v1.26.0",
-			},
-			"partition": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "schema: Internal",
 			},
 		},
 	}

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
@@ -49,7 +49,7 @@ var nodePoolNonUpdatableParams = []string{
 	"extend_params.*.agency_name", "extend_params.*.kube_reserved_mem", "extend_params.*.system_reserved_mem",
 	"extend_params.*.security_reinforcement_type", "extend_params.*.market_type", "extend_params.*.spot_price",
 	"security_groups", "pod_security_groups", "ecs_group_id", "hostname_config", "hostname_config.*.type",
-	"max_pods", "preinstall", "postinstall", "extend_param",
+	"max_pods", "preinstall", "postinstall", "extend_param", "partition",
 }
 
 func ResourceNodePool() *schema.Resource {
@@ -244,6 +244,10 @@ func ResourceNodePool() *schema.Resource {
 						},
 					},
 				},
+			},
+			"partition": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
@@ -542,6 +546,10 @@ func buildNodePoolCreateOpts(d *schema.ResourceData, cfg *config.Config) (*nodep
 		createOpts.Spec.NodeTemplate.RunTime = &nodes.RunTimeSpec{
 			Name: v.(string),
 		}
+	}
+
+	if v, ok := d.GetOk("partition"); ok {
+		createOpts.Spec.NodeTemplate.Partition = v.(string)
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  cce node pool resource add param partition
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  cce node pool resource add param partition
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
