### PR TITLE
feat(VPC): add params to vpc subnet resource

### DIFF
--- a/docs/resources/vpc_subnet.md
+++ b/docs/resources/vpc_subnet.md
@@ -53,8 +53,10 @@ resource "huaweicloud_vpc_subnet" "subnet_with_dhcp" {
   vpc_id            = huaweicloud_vpc.vpc.id
   availability_zone = var.availability_zone
 
-  dhcp_lease_time    = "24h"
-  ntp_server_address = "10.100.0.33,10.100.0.34"
+  dhcp_lease_time      = "24h"
+  dhcp_ipv6_lease_time = "4h"
+  ntp_server_address   = "10.100.0.33,10.100.0.34"
+  dhcp_domain_name     = "test.domainnanme"
 }
 
  ```
@@ -106,6 +108,15 @@ The following arguments are supported:
 * `dhcp_lease_time` - (Optional, String) Specifies the DHCP lease expiration time. The value can be -1, which indicates
   unlimited lease time, or Number+h. the number ranges from 1 to 30,000. For example, the value can be 5h. The default
   value is 24h.
+
+* `dhcp_ipv6_lease_time` - (Optional, String) Specifies the DHCP lease expiration time of the IPv6 subnet. The value can
+  be -1, which indicates unlimited lease time, or Number+h. the number ranges from 1 to 175200. For example, the value
+  can be 5h. The default value is 2h.
+
+* `dhcp_domain_name` - (Optional, String) Specifies the domain name configured for DNS and is used to obtain the IP address
+  from the DNS server. A domain name can contain only letters, digits, and hyphens (-) and cannot start or end with a
+  hyphen (-). Each domain name contains at least two labels separated by periods (.). Max total: 254 characters. Max
+  label: 63 characters.
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the subnet.
 

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_subnet_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_subnet_test.go
@@ -131,6 +131,8 @@ func TestAccVpcSubnetV1_dhcp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "dhcp_lease_time", "48h"),
 					resource.TestCheckResourceAttr(resourceName, "ntp_server_address", "10.100.0.33"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_ipv6_lease_time", "4h"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_domain_name", "test.domainname"),
 				),
 			},
 			{
@@ -139,6 +141,8 @@ func TestAccVpcSubnetV1_dhcp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "dhcp_lease_time", "72h"),
 					resource.TestCheckResourceAttr(resourceName, "ntp_server_address", "10.100.0.33,10.100.0.34"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_ipv6_lease_time", "8h"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_domain_name", "test.domainname.update"),
 				),
 			},
 		},
@@ -278,10 +282,13 @@ resource "huaweicloud_vpc_subnet" "test" {
   cidr              = "192.168.0.0/24"
   gateway_ip        = "192.168.0.1"
   vpc_id            = huaweicloud_vpc.test.id
+  ipv6_enable       = true
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
 
-  dhcp_lease_time    = "48h"
-  ntp_server_address = "10.100.0.33"
+  dhcp_lease_time      = "48h"
+  ntp_server_address   = "10.100.0.33"
+  dhcp_ipv6_lease_time = "4h"
+  dhcp_domain_name     = "test.domainname"
 }
 `, testAccVpcSubnet_base(rName), rName)
 }
@@ -295,10 +302,13 @@ resource "huaweicloud_vpc_subnet" "test" {
   cidr              = "192.168.0.0/24"
   gateway_ip        = "192.168.0.1"
   vpc_id            = huaweicloud_vpc.test.id
+  ipv6_enable       = true
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
 
-  dhcp_lease_time    = "72h"
-  ntp_server_address = "10.100.0.33,10.100.0.34"
+  dhcp_lease_time      = "72h"
+  ntp_server_address   = "10.100.0.33,10.100.0.34"
+  dhcp_ipv6_lease_time = "8h"
+  dhcp_domain_name     = "test.domainname.update"
 }
 `, testAccVpcSubnet_base(rName), rName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add params to vpc subnet resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add params to vpc subnet resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

make testacc TEST=./huaweicloud/services/acceptance/vpc/ TESTARGS='-run TestAccVpcSubnetV1_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/ -v -run TestAccVpcSubnetV1_ -timeout 360m -parallel 4
=== RUN   TestAccVpcSubnetV1_basic
=== PAUSE TestAccVpcSubnetV1_basic
=== RUN   TestAccVpcSubnetV1_ipv6
=== PAUSE TestAccVpcSubnetV1_ipv6
=== RUN   TestAccVpcSubnetV1_dhcp
=== PAUSE TestAccVpcSubnetV1_dhcp
=== CONT  TestAccVpcSubnetV1_basic
=== CONT  TestAccVpcSubnetV1_dhcp
=== CONT  TestAccVpcSubnetV1_ipv6
--- PASS: TestAccVpcSubnetV1_basic (112.22s)
--- PASS: TestAccVpcSubnetV1_dhcp (112.59s)
--- PASS: TestAccVpcSubnetV1_ipv6 (121.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       121.910s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
