### PR TITLE
feat(lts/cce_access): add 'Content-Type' and new parameters and new attributes

### DIFF
--- a/docs/data-sources/lts_cce_accesses.md
+++ b/docs/data-sources/lts_cce_accesses.md
@@ -77,6 +77,31 @@ The `accesses` block supports:
 
 * `access_type` - The type of the log access.
 
+* `processor_type` - The type of the ICAgent structuring parsing.
+  + **SINGLE_LINE**
+  + **MULTI_LINE**
+  + **REGEX**
+  + **MULTI_REGEX**
+  + **SPLIT**
+  + **JSON**
+  + **NGINX**
+  + **COMPOSE**
+
+* `processors` - The list of the ICAgent structuring parsing rules.  
+  The [processors](#data_cce_accesses_processors) structure is documented below.
+
+* `demo_log` - The example log of the ICAgent structuring parsing.  
+  This parameter is available when the `processor_type` parameter is specified.
+
+* `demo_fields` - The list of the parsed fields of the example log.  
+  The [demo_fields](#data_cce_accesses_demoFields) structure is documented below.
+
+* `encoding_format` - The encoding format log file.
+  + **UTF-8**
+  + **GBK**
+
+* `incremental_collect` - Whether to collect incrementally.
+
 * `created_at` - The creation time of the CCE access, in RFC3339 format.
 
 <a name="data_accesses_elem_access_config"></a>
@@ -112,21 +137,51 @@ The `access_config` block supports:
 
 * `log_labels` - The container label log tag.
 
+* `include_labels_logical` - The logical relationship between multiple container label whitelists.
+  + **and**
+  + **or**
+
 * `include_labels` - The container label whitelist.
+
+* `exclude_labels_logical` - The logical relationship between multiple container label blacklists.
+  + **and**
+  + **or**
 
 * `exclude_labels` - The container label blacklist.
 
 * `log_envs` - The environment variable tag.
 
+* `include_envs_logical` - The logical relationship between multiple environment variable whitelists.
+  + **and**
+  + **or**
+
 * `include_envs` - The environment variable whitelist.
+
+* `exclude_envs_logical` - The logical relationship between multiple environment variable blacklist.
+  + **and**
+  + **or**
 
 * `exclude_envs` - The environment variable blacklist.
 
 * `log_k8s` - The kubernetes label log tag.
 
+* `include_k8s_labels_logical` - The logical relationship between multiple kubernetes label whitelists.
+  + **and**
+  + **or**
+
 * `include_k8s_labels` - The kubernetes label whitelist.
 
+* `exclude_k8s_labels_logical` - The logical relationship between multiple kubernetes label blacklist.
+  + **and**
+  + **or**
+
 * `exclude_k8s_labels` - The kubernetes label blacklist.
+
+* `repeat_collect` - Whether to allow repeated file collection.
+
+* `custom_key_value` - The custom key/value pairs of the CCE access.
+
+* `system_fields` - The list of system built-in fields of the CCE access.
 
 <a name="data_access_config_elem_windows_log_info"></a>
 The `windows_log_info` block supports:
@@ -169,3 +224,24 @@ The `multi_log_format` block supports:
   + **regular**: the regular expression.
 
 * `value` - The value of multi-line log format.
+
+<a name="data_cce_accesses_processors"></a>
+The `processors` block supports:
+
+* `type` - The type of the parser.
+  + **processor_regex**
+  + **processor_split_string**
+  + **processor_json**
+  + **processor_gotime**
+  + **processor_filter_regex**
+  + **processor_drop**
+  + **processor_rename**
+
+* `detail` - The configuration of the parser, in JSON format.
+
+<a name="data_cce_accesses_demoFields"></a>
+The `demo_fields` block supports:
+
+* `field_name` - The name of the parsed field.
+
+* `field_value` - The value of the parsed field.

--- a/docs/resources/lts_cce_access.md
+++ b/docs/resources/lts_cce_access.md
@@ -114,9 +114,9 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create CCE access.
   If omitted, the provider-level region will be used. Changing this creates a new resource.
 
-* `name` - (Required, String, ForceNew) Specifies the name of the CCE access. The name consists of `1` to `64`
+* `name` - (Required, String) Specifies the name of the CCE access. The name consists of `1` to `64`
   characters. Only letters, digits, underscores (_), and periods (.) are allowed, and the period cannot be the first
-  or last character. Changing this creates a new resource.
+  or last character.
 
 * `log_group_id` - (Required, String, ForceNew) Specifies the log group ID. Changing this creates a new resource.
 
@@ -134,6 +134,45 @@ The following arguments are supported:
 * `binary_collect` - (Optional, Bool) Specifies whether collect in binary format. Default is **false**.
 
 * `log_split` - (Optional, Bool) Specifies whether to split log. Default is false.
+
+* `processor_type` - (Optional, String) Specifies the type of the ICAgent structuring parsing.  
+  This parameter must be set together with the `processors` parameter.  
+  The valid values are as follows:
+  + **SINGLE_LINE**
+  + **MULTI_LINE**
+  + **REGEX**
+  + **MULTI_REGEX**
+  + **SPLIT**
+  + **JSON**
+  + **NGINX**
+  + **COMPOSE**
+
+-> If `processor_type` is specified, it does not support modification to empty.
+
+* `processors` - (Optional, List) Specifies the list of the ICAgent structuring parsing rules.  
+  The [processors](#cce_access_processors) structure is documented below.  
+  This parameter must be set together with the `processor_type` parameter.  
+  Please refer to the [Setting ICAgent Structuring Parsing Rules](https://support.huaweicloud.com/intl/en-us/usermanual-lts/lts_07_0072.html).
+
+ -> For the same log stream, If you have configured cloud structuring parsing, delete its configurations before configuring
+    ICAgent structuring parsing.
+
+* `demo_log` - (Optional, String) Specifies the example log of the ICAgent structuring parsing.  
+  This parameter is available when the `processor_type` parameter is specified.
+
+* `demo_fields` - (Optional, List) Specifies the list of the parsed fields of the example log.  
+  The [demo_fields](#cce_access_demoFields) structure is documented below.  
+  This parameter must be set together with the `demo_log` parameter.  
+  This parameter is available when the `processor_type` parameter is specified.
+
+* `encoding_format` - (Optional, String) Specifies the encoding format log file.  
+  Defaults to **UTF-8**.  
+  The valid values are as follows:
+  + **UTF-8**
+  + **GBK**
+
+* `incremental_collect` - (Optional, Bool) Specifies whether to collect incrementally.  
+  Defaults to **true**.  
 
 <a name="block_access_config"></a>
 The `access_config` block supports:
@@ -185,11 +224,25 @@ The `access_config` block supports:
   label value. For example, if you enter `app` as the key and `app_alias` as the value, when the Container label
   contains `app=lts`, `{app_alias: lts}` will be added to the log.
 
+* `include_labels_logical` - (Optional, String) Specifies the logical relationship between multiple container label
+  whitelists.  
+  Defaults to **or**.
+  The valid values are as follows:
+  + **and**
+  + **or**
+
 * `include_labels` - (Optional, Map) Specifies the container label whitelist. A maximum of `30` tags can be created.
   The key names must be unique. If labelValue is empty, all containers whose container label contains labelKey are
   matched. If labelValue is not empty, only containers whose container label contains `LabelKey=LabelValue` are
   matched. LabelKey must be fully matched, and labelValue supports regular expression matching. Multiple whitelists
   are in the OR relationship. That is, a container label can be matched as long as it meets any of the whitelists.
+
+* `exclude_labels_logical` - (Optional, String) Specifies the logical relationship between multiple container label
+  blacklists.  
+  Defaults to **or**.
+  The valid values are as follows:
+  + **and**
+  + **or**
 
 * `exclude_labels` - (Optional, Map) Specifies the container label blacklist. A maximum of `30` tags can be created.
   The key names must be unique. If labelValue is empty, all containers whose container label contains labelKey are
@@ -202,11 +255,25 @@ The `access_config` block supports:
   corresponding environment variable value. For example, if you enter `app` as the key and `app_alias` as the value,
   when the kubernetes environment variable contains `app=lts`, `{app_alias: lts}` will be added to the log.
 
+* `include_envs_logical` - (Optional, String) Specifies the logical relationship between multiple environment variable
+  whitelists.  
+  Defaults to **or**.
+  The valid values are as follows:
+  + **and**
+  + **or**
+
 * `include_envs` - (Optional, Map) Specifies the environment variable whitelist. A maximum of `30` tags can be
   created. The key names must be unique. LTS will match all containers with environment variables containing either
   an environment variable key with an empty corresponding environment variable value, or an environment variable key
   with its corresponding environment variable value. LabelKey must be fully matched, and labelValue supports regular
   expression matching.
+
+* `exclude_envs_logical` - (Optional, String) Specifies the logical relationship between multiple environment variable
+  blacklists.  
+  Defaults to **or**.
+  The valid values are as follows:
+  + **and**
+  + **or**
 
 * `exclude_envs` - (Optional, Map) Specifies the environment variable blacklist. A maximum of `30` tags can be
   created. The key names must be unique. LTS will exclude all containers with environment variables containing either
@@ -219,11 +286,25 @@ The `access_config` block supports:
   value. For example, if you enter `app` as the key and `app_alias` as the value, when the K8s label contains
   `app=lts`, `{app_alias: lts}` will be added to the log.
 
+* `include_k8s_labels_logical` - (Optional, String) Specifies the logical relationship between multiple kubernetes label
+  whitelists.  
+  Defaults to **or**.
+  The valid values are as follows:
+  + **and**
+  + **or**
+
 * `include_k8s_labels` - (Optional, Map) Specifies the kubernetes label whitelist. A maximum of `30` tags can be
   created. The key names must be unique. If labelValue is empty, all containers whose K8s label contains labelKey are
   matched. If labelValue is not empty, only containers whose K8s Label contains `LabelKey=LabelValue` are matched.
   LabelKey must be fully matched, and labelValue supports regular expression matching. Multiple whitelists are in the
   OR relationship. That is, a K8s label can be matched as long as it meets any of the whitelists.
+
+* `exclude_k8s_labels_logical` - (Optional, String) Specifies the logical relationship between multiple kubernetes label
+  blacklists.  
+  Defaults to **or**.
+  The valid values are as follows:
+  + **and**
+  + **or**
 
 * `exclude_k8s_labels` - (Optional, Map) Specifies the kubernetes label blacklist. A maximum of `30` tags can be
   created. The key names must be unique. If labelValue is empty, all containers whose K8s label contains labelKey are
@@ -231,8 +312,42 @@ The `access_config` block supports:
   LabelKey must be fully matched, and labelValue supports regular expression matching. Multiple blacklists are in the
   OR relationship. That is, a K8s Label can be excluded as long as it meets any of the blacklists.
 
+* `repeat_collect` - (Optional, Bool) Specifies whether to allow repeated file collection.  
+  Defaults to **false**.
+  + If this parameter is set to **true**, one host log file can be collected to multiple log streams.
+    This function is available only to certain ICAgent versions, please refer to the [documentation](<https://support.huaweicloud.com/intl/en-us/usermanual-lts/lts_02_0014.html#lts_02_0014__section7761151916252>).
+  + If this parameter is set to **false**, the same log file in the same host cannot be collected to different log streams.
+
+* `custom_key_value` - (Optional, Map, ForceNew) Specifies the custom key/value pairs of the CCE access.  
+  Changing this creates a new resource.
+
+* `system_fields` - (Optional, List, ForceNew) Specifies the list of system built-in fields of the CCE access.  
+  Changing this creates a new resource.  
+  If `custom_key_value` is specified, the value of `system_fields` will be automatically assigned by
+  the system as **pathfile**.  
+  If `system_fields` is specified, **pathFile** must be included.  
+  The valid values are as follows:
+  + **pathFile**
+  + **hostName**
+  + **hostId**
+  + **hostIP**
+  + **hostIPv6**
+  + **clusterId**
+  + **podName**
+  + **appName**
+  + **containerName**
+  + **nameSpace**
+  + **category**
+  + **serviceID**
+  + **podIp**
+  + **clusterName**
+  + **workloadType**
+  + **image_name**
+
  -> These parameters include `name_space_regex`, `pod_name_regex`, `container_name_regex`, `log_labels`,
-    `include_labels`, `exclude_labels`, `log_envs`, `include_envs`, `exclude_envs`, `log_k8s`, `include_k8s_labels` and
+    `include_labels_logical`, `include_labels`, `exclude_labels_logical`, `exclude_labels`, `log_envs`,
+    `include_envs_logical`, `include_envs`, `exclude_envs_logical`, `exclude_envs`, `log_k8s`,
+    `include_k8s_labels_logical`, `include_k8s_labels`, `exclude_k8s_labels_logical` and
     `exclude_k8s_labels` are available, only `path_type` is not **host_file**.
 
 <a name="block_access_config_single_log_format"></a>
@@ -287,6 +402,29 @@ The `windows_log_info` block supports:
   + When `time_offset_unit` is set to **hour**, the value ranges from `1` to `168` hours.
   + When `time_offset_unit` is set to **sec**, the value ranges from `1` to `604,800` seconds.
 
+<a name="cce_access_processors"></a>
+The `processors` block supports:
+
+* `type` - (Optional, String) Specifies the type of the parser.  
+  The valid values are as follows:
+  + **processor_regex**
+  + **processor_split_string**
+  + **processor_json**
+  + **processor_gotime**
+  + **processor_filter_regex**
+  + **processor_drop**
+  + **processor_rename**
+
+* `detail` - (Optional, String) Specifies the configuration of the parser, in JSON format.  
+  For the keys, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/api-lts/CreateAccessConfig.html#CreateAccessConfig__request_Detail).
+
+<a name="cce_access_demoFields"></a>
+The `demo_fields` block supports:
+
+* `field_name` - (Required, String) Specifies the name of the parsed field.
+
+* `field_value` - (Optional, String) Specifies the value of the parsed field.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -307,4 +445,23 @@ The CCE access can be imported using `name`, e.g.
 
 ```bash
 $ terraform import huaweicloud_lts_cce_access.test <name>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes include: `processors`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the instance. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_lts_cce_access" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      processors,
+    ]
+  }
+}
 ```

--- a/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_cce_accesses_test.go
+++ b/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_cce_accesses_test.go
@@ -34,15 +34,8 @@ func TestAccDatasourceCceAccesses_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckLTSCCEAccess(t)
-			acceptance.TestAccPreCheckLTSHostGroup(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"null": {
-				Source:            "hashicorp/null",
-				VersionConstraint: "3.2.1",
-			},
-		},
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatasourceCceAccesses_basic(name),
@@ -52,7 +45,9 @@ func TestAccDatasourceCceAccesses_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(byName, "accesses.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
 					resource.TestCheckResourceAttr(byName, "accesses.0.name", name),
 					resource.TestCheckResourceAttrPair(byName, "accesses.0.log_group_id", "huaweicloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(byName, "accesses.0.log_group_name", "huaweicloud_lts_group.test", "group_name"),
 					resource.TestCheckResourceAttrPair(byName, "accesses.0.log_stream_id", "huaweicloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttrPair(byName, "accesses.0.log_stream_name", "huaweicloud_lts_stream.test", "stream_name"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.host_group_ids.#", "1"),
 					resource.TestCheckResourceAttrPair(byName, "accesses.0.host_group_ids.0", "huaweicloud_lts_host_group.test", "id"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.cluster_id", acceptance.HW_LTS_CCE_CLUSTER_ID),
@@ -64,6 +59,10 @@ func TestAccDatasourceCceAccesses_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.name_space_regex", "test"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.pod_name_regex", "test"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.container_name_regex", "test"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.repeat_collect", "true"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.system_fields.#", "2"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.custom_key_value.%", "2"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.custom_key_value.custom_key", "custom_val"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.windows_log_info.0.categorys.#", "2"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.windows_log_info.0.event_level.#", "2"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.windows_log_info.0.time_offset_unit", "day"),
@@ -73,33 +72,51 @@ func TestAccDatasourceCceAccesses_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_labels.%", "2"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_labels.log_label_key_name", "foo"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_labels.log_label_key_value", "bar"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_labels_logical", "or"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_labels.%", "2"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_labels.include_label_key_name", "foo"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_labels.include_label_key_value", "bar"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_labels_logical", "or"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_labels.%", "2"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_labels.exclude_label_key_name", "foo"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_labels.exclude_label_key_value", "bar"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_envs.%", "2"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_envs.log_env_key_name", "foo"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_envs.log_env_key_value", "bar"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_envs_logical", "or"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_envs.%", "2"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_envs.include_env_key_name", "foo"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_envs.include_env_key_value", "bar"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_envs_logical", "or"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_envs.%", "2"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_envs.exclude_env_key_name", "foo"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_envs.exclude_env_key_value", "bar"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_k8s.%", "2"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_k8s.log_k8s_key_name", "foo"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_k8s.log_k8s_key_value", "bar"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_k8s_labels_logical", "or"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_k8s_labels.%", "2"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_k8s_labels.include_k8s_label_key_name", "foo"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_k8s_labels.include_k8s_label_key_value", "bar"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_k8s_labels_logical", "or"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_k8s_labels.%", "2"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_k8s_labels.exclude_k8s_label_key_name", "foo"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_k8s_labels.exclude_k8s_label_key_value", "bar"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.tags.%", "2"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.tags.foo", "bar"),
 					resource.TestCheckResourceAttr(byName, "accesses.0.tags.key", "value"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.binary_collect", "true"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.log_split", "true"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.demo_log", "a.log level:warn"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.processor_type", "SPLIT"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.demo_fields.#", "2"),
+					resource.TestCheckResourceAttrSet(byName, "accesses.0.demo_fields.0.field_name"),
+					resource.TestCheckResourceAttrSet(byName, "accesses.0.demo_fields.0.field_value"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.processors.#", "1"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.processors.0.type", "processor_split_string"),
+					resource.TestCheckResourceAttrSet(byName, "accesses.0.processors.0.detail"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.encoding_format", "UTF-8"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.incremental_collect", "true"),
 					resource.TestMatchResourceAttr(byName, "accesses.0.created_at",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 
@@ -120,9 +137,8 @@ func TestAccDatasourceCceAccesses_basic(t *testing.T) {
 func testAccDatasourceCceAccesses_base(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_lts_host_group" "test" {
-  name     = "%[1]s"
-  type     = "linux"
-  host_ids = split(",", "%[2]s")
+  name = "%[1]s"
+  type = "linux"
 }
 
 resource "huaweicloud_lts_group" "test" {
@@ -140,7 +156,9 @@ resource "huaweicloud_lts_cce_access" "test" {
   log_group_id   = huaweicloud_lts_group.test.id
   log_stream_id  = huaweicloud_lts_stream.test.id
   host_group_ids = [huaweicloud_lts_host_group.test.id]
-  cluster_id     = "%[3]s"
+  cluster_id     = "%[2]s"
+  binary_collect = true
+  log_split      = true
 
   access_config {
     path_type            = "container_file"
@@ -149,6 +167,14 @@ resource "huaweicloud_lts_cce_access" "test" {
     name_space_regex     = "test"
     pod_name_regex       = "test"
     container_name_regex = "test"
+    repeat_collect       = true
+
+    custom_key_value = {
+      custom_key  = "custom_val"
+      custom_key2 = "custom_val2"
+    }
+
+    system_fields = ["pathFile", "hostName"]
 
     windows_log_info {
       categorys        = ["System", "Application"]
@@ -162,47 +188,47 @@ resource "huaweicloud_lts_cce_access" "test" {
     }
 
     log_labels = {
-      log_label_key_name = "foo"
+      log_label_key_name  = "foo"
       log_label_key_value = "bar"
     }
 
     include_labels = {
-      include_label_key_name = "foo"
+      include_label_key_name  = "foo"
       include_label_key_value = "bar"
     }
 
     exclude_labels = {
-      exclude_label_key_name = "foo"
+      exclude_label_key_name  = "foo"
       exclude_label_key_value = "bar"
     }
 
     log_envs = {
-      log_env_key_name = "foo"
+      log_env_key_name  = "foo"
       log_env_key_value = "bar"
     }
 
     include_envs = {
-      include_env_key_name = "foo"
+      include_env_key_name  = "foo"
       include_env_key_value = "bar"
     }
 
     exclude_envs = {
-      exclude_env_key_name = "foo"
+      exclude_env_key_name  = "foo"
       exclude_env_key_value = "bar"
     }
 
     log_k8s = {
-      log_k8s_key_name = "foo"
+      log_k8s_key_name  = "foo"
       log_k8s_key_value = "bar"
     }
 
     include_k8s_labels = {
-      include_k8s_label_key_name = "foo"
+      include_k8s_label_key_name  = "foo"
       include_k8s_label_key_value = "bar"
     }
 
     exclude_k8s_labels = {
-      exclude_k8s_label_key_name = "foo"
+      exclude_k8s_label_key_name  = "foo"
       exclude_k8s_label_key_value = "bar"
     }
   }
@@ -211,7 +237,30 @@ resource "huaweicloud_lts_cce_access" "test" {
     foo = "bar"
     key = "value"
   }
-}`, name, acceptance.HW_LTS_HOST_IDS, acceptance.HW_LTS_CCE_CLUSTER_ID)
+
+  demo_log       = "a.log level:warn"
+  processor_type = "SPLIT"
+
+  demo_fields {
+    field_name  = "field2"
+    field_value = "level:warn"
+  }
+  demo_fields {
+    field_name  = "field1"
+    field_value = "a.log"
+  }
+
+  processors {
+    type = "processor_split_string"
+
+    detail = jsonencode({
+      "split_sep" : " ",
+      "keys" : ["field1", "field2"],
+      "keep_source" : true,
+      "keep_source_if_parse_error" : true
+    })
+  }
+}`, name, acceptance.HW_LTS_CCE_CLUSTER_ID)
 }
 
 func testAccDatasourceCceAccesses_basic(name string) string {

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_cce_access_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_cce_access_test.go
@@ -54,240 +54,171 @@ func getCceAccessConfigResourceFunc(cfg *config.Config, state *terraform.Resourc
 	return listCceAccessConfigRespBody, nil
 }
 
-func TestAccCceAccessConfig_containerFile(t *testing.T) {
-	var obj interface{}
+func TestAccCceAccessConfig_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
 
-	name := acceptance.RandomAccResourceName()
-	rName := "huaweicloud_lts_cce_access.container_file"
+		accessConfig        interface{}
+		withContainerFile   = "huaweicloud_lts_cce_access.with_container_file"
+		rcWithContainerFile = acceptance.InitResourceCheck(withContainerFile, &accessConfig, getCceAccessConfigResourceFunc)
 
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getCceAccessConfigResourceFunc,
+		withContainerStdout   = "huaweicloud_lts_cce_access.with_container_stdout"
+		rcWithContainerStdout = acceptance.InitResourceCheck(withContainerStdout, &accessConfig, getCceAccessConfigResourceFunc)
+
+		withHostFile   = "huaweicloud_lts_cce_access.with_host_file"
+		rcWithHostFile = acceptance.InitResourceCheck(withHostFile, &accessConfig, getCceAccessConfigResourceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckLTSCCEAccess(t)
-			acceptance.TestAccPreCheckLTSHostGroup(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcWithContainerFile.CheckResourceDestroy(),
+			rcWithContainerStdout.CheckResourceDestroy(),
+			rcWithHostFile.CheckResourceDestroy(),
+		),
 		Steps: []resource.TestStep{
 			{
-				Config: testCceAccessConfigContainerFile(name, ""),
+				Config: testAccCceAccessConfig_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttrSet(rName, "log_group_name"),
-					resource.TestCheckResourceAttrSet(rName, "log_stream_name"),
-					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
-					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(rName, "access_type", "K8S_CCE"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.paths.0", "/var"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.black_paths.0", "/var/a.log"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.path_type", "container_file"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.name_space_regex", "namespace"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.pod_name_regex", "podname"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.container_name_regex", "containername"),
-
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_labels.loglabelkey1", "bar1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_labels.loglabelkey2", "bar"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_labels.includeKey1", "incval1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_labels.includeKey2", "incval"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_labels.excludeKey1", "excval1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_labels.excludeKey2", "excval"),
-
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_envs.envKey1", "envval1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_envs.envKey2", "envval"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_envs.inEnvKey1", "incval1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_envs.inEnvKey2", "incval"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_envs.exEnvKey1", "excval1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_envs.exEnvKey2", "excval"),
-
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_k8s.k8sKey1", "k8sval1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_k8s.k8sKey2", "k8sval"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_k8s_labels.ink8sKey1", "ink8sval1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_k8s_labels.ink8sKey2", "ink8sval"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_k8s_labels.exk8sKey1", "exk8sval1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_k8s_labels.exk8sKey2", "exk8sval"),
+					rcWithContainerFile.CheckResourceExists(),
+					// Check Required parameters.
+					resource.TestCheckResourceAttr(withContainerFile, "name", name),
+					resource.TestCheckResourceAttrPair(withContainerFile, "log_group_id", "huaweicloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(withContainerFile, "log_stream_id", "huaweicloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.path_type", "container_file"),
+					// Check optional parameters.
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.paths.0", "/var"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.black_paths.0", "/var/a.log"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.name_space_regex", "namespace"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.pod_name_regex", "podname"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.container_name_regex", "containername"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.log_labels.loglabelkey1", "bar1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.log_labels.loglabelkey2", "bar"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_labels.includeKey1", "incval1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_labels.includeKey2", "incval"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_labels_logical", "or"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_labels.excludeKey1", "excval1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_labels.excludeKey2", "excval"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_labels_logical", "or"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.log_envs.envKey1", "envval1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.log_envs.envKey2", "envval"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_envs.inEnvKey1", "incval1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_envs.inEnvKey2", "incval"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_envs_logical", "or"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_envs.exEnvKey1", "excval1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_envs.exEnvKey2", "excval"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_envs_logical", "or"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.log_k8s.k8sKey1", "k8sval1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.log_k8s.k8sKey2", "k8sval"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_k8s_labels.ink8sKey1", "ink8sval1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_k8s_labels.ink8sKey2", "ink8sval"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_k8s_labels_logical", "or"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_k8s_labels.exk8sKey1", "exk8sval1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_k8s_labels.exk8sKey2", "exk8sval"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_k8s_labels_logical", "or"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.system_fields.#", "1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.system_fields.0", "pathFile"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.repeat_collect", "true"),
+					resource.TestCheckResourceAttrPair(withContainerFile, "host_group_ids.0", "huaweicloud_lts_host_group.test", "id"),
+					resource.TestCheckResourceAttr(withContainerFile, "tags.key", "value"),
+					resource.TestCheckResourceAttr(withContainerFile, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(withContainerFile, "log_split", "true"),
+					resource.TestCheckResourceAttrSet(withContainerFile, "demo_log"),
+					resource.TestCheckResourceAttr(withContainerFile, "demo_fields.#", "2"),
+					resource.TestCheckResourceAttrSet(withContainerFile, "demo_fields.0.field_name"),
+					resource.TestCheckResourceAttrSet(withContainerFile, "demo_fields.0.field_value"),
+					resource.TestCheckResourceAttr(withContainerFile, "processor_type", "SPLIT"),
+					resource.TestCheckResourceAttr(withContainerFile, "processors.#", "2"),
+					resource.TestCheckResourceAttr(withContainerFile, "encoding_format", "UTF-8"),
+					resource.TestCheckResourceAttr(withContainerFile, "incremental_collect", "true"),
+					// Check attributes.
+					resource.TestCheckResourceAttr(withContainerFile, "access_type", "K8S_CCE"),
+					resource.TestCheckResourceAttrSet(withContainerFile, "log_group_name"),
+					resource.TestCheckResourceAttrSet(withContainerFile, "log_stream_name"),
+					resource.TestCheckResourceAttrSet(withContainerFile, "created_at"),
+					rcWithContainerStdout.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withContainerStdout, "access_config.0.path_type", "container_stdout"),
+					resource.TestCheckResourceAttr(withContainerStdout, "access_config.0.stdout", "true"),
+					resource.TestCheckResourceAttr(withContainerStdout, "access_config.0.multi_log_format.0.mode", "time"),
+					resource.TestCheckResourceAttr(withContainerStdout, "access_config.0.multi_log_format.0.value", "YYYY-MM-DD hh:mm:ss"),
+					resource.TestCheckResourceAttr(withContainerStdout, "access_config.0.system_fields.#", "2"),
+					resource.TestCheckResourceAttr(withContainerStdout, "access_config.0.repeat_collect", "false"),
+					resource.TestCheckResourceAttr(withContainerStdout, "encoding_format", "GBK"),
+					resource.TestCheckResourceAttr(withContainerStdout, "incremental_collect", "false"),
+					rcWithHostFile.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withHostFile, "access_config.0.paths.#", "2"),
+					resource.TestCheckResourceAttr(withHostFile, "access_config.0.black_paths.#", "2"),
+					resource.TestCheckResourceAttr(withHostFile, "access_config.0.path_type", "host_file"),
 				),
 			},
 			{
-				Config: testCceAccessConfigContainerFile(name, "-update"),
+				Config: testAccCceAccessConfig_basic_step2(name, updateName),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "tags.foo", "bar-update"),
-					resource.TestCheckResourceAttr(rName, "access_type", "K8S_CCE"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.name_space_regex", "namespace-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.pod_name_regex", "podname-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.container_name_regex", "containername-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_labels.loglabelkey2", "bar-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_labels.includeKey2", "incval-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_labels.excludeKey2", "excval-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_envs.envKey2", "envval-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_envs.inEnvKey2", "incval-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_envs.exEnvKey2", "excval-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_k8s.k8sKey2", "k8sval-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_k8s_labels.ink8sKey2", "ink8sval-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_k8s_labels.exk8sKey2", "exk8sval-update"),
+					rcWithContainerFile.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withContainerFile, "name", updateName),
+					resource.TestCheckResourceAttr(withContainerFile, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.name_space_regex", "namespace_update"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.pod_name_regex", "podname_update"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.container_name_regex", "containername_update"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.log_labels.%", "1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.log_labels.loglabelkey2", "bar_update"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_labels_logical", "and"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_labels.%", "1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_labels.includeKey2", "incval_update"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_labels_logical", "and"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_labels.%", "1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_labels.excludeKey2", "excval_update"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.log_envs.%", "1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.log_envs.envKey2", "envval_update"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_envs_logical", "and"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_envs.%", "1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_envs.inEnvKey2", "incval_update"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_envs_logical", "and"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_envs.%", "1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_envs.exEnvKey2", "excval_update"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.log_k8s.%", "1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.log_k8s.k8sKey2", "k8sval_update"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_k8s_labels_logical", "and"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_k8s_labels.%", "1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.include_k8s_labels.ink8sKey2", "ink8sval_update"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_k8s_labels_logical", "and"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_k8s_labels.%", "1"),
+					resource.TestCheckResourceAttr(withContainerFile, "access_config.0.exclude_k8s_labels.exk8sKey2", "exk8sval_update"),
+					resource.TestCheckResourceAttr(withContainerFile, "log_split", "false"),
+					resource.TestCheckResourceAttr(withContainerFile, "demo_log", ""),
+					resource.TestCheckResourceAttr(withContainerFile, "demo_fields.#", "0"),
+					resource.TestCheckResourceAttr(withContainerFile, "processor_type", "SPLIT"),
+					rcWithContainerStdout.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withContainerStdout, "access_config.0.repeat_collect", "true"),
+					resource.TestCheckResourceAttr(withContainerStdout, "encoding_format", "UTF-8"),
+					resource.TestCheckResourceAttr(withContainerStdout, "incremental_collect", "true"),
+					rcWithHostFile.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withHostFile, "access_config.0.black_paths.#", "0"),
 				),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:            withContainerFile,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       testAccCceAccessConfigImportStateFunc(withContainerFile),
+				ImportStateVerifyIgnore: []string{"processors"},
+			},
+			{
+				ResourceName:      withContainerStdout,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccCceAccessConfigImportStateFunc(rName),
-			},
-		},
-	})
-}
-
-func TestAccCceAccessConfig_containerStdout(t *testing.T) {
-	var obj interface{}
-
-	name := acceptance.RandomAccResourceName()
-	rName := "huaweicloud_lts_cce_access.container_stdout"
-
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getCceAccessConfigResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckLTSCCEAccess(t)
-			acceptance.TestAccPreCheckLTSHostGroup(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testCceAccessConfigContainerStdout(name, ""),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttrSet(rName, "log_group_name"),
-					resource.TestCheckResourceAttrSet(rName, "log_stream_name"),
-					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
-					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(rName, "access_type", "K8S_CCE"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.path_type", "container_stdout"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.stdout", "true"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.name_space_regex", "namespace"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.pod_name_regex", "podname"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.container_name_regex", "containername"),
-
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_labels.loglabelkey1", "bar1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_labels.loglabelkey2", "bar"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_labels.includeKey1", "incval1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_labels.includeKey2", "incval"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_labels.excludeKey1", "excval1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_labels.excludeKey2", "excval"),
-
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_envs.envKey1", "envval1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_envs.envKey2", "envval"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_envs.inEnvKey1", "incval1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_envs.inEnvKey2", "incval"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_envs.exEnvKey1", "excval1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_envs.exEnvKey2", "excval"),
-
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_k8s.k8sKey1", "k8sval1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_k8s.k8sKey2", "k8sval"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_k8s_labels.ink8sKey1", "ink8sval1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_k8s_labels.ink8sKey2", "ink8sval"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_k8s_labels.exk8sKey1", "exk8sval1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_k8s_labels.exk8sKey2", "exk8sval"),
-				),
+				ImportStateIdFunc: testAccCceAccessConfigImportStateFunc(withContainerStdout),
 			},
 			{
-				Config: testCceAccessConfigContainerStdout(name, "-update"),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "tags.foo", "bar-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.name_space_regex", "namespace-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.pod_name_regex", "podname-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.container_name_regex", "containername-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_labels.loglabelkey2", "bar-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_labels.includeKey2", "incval-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_labels.excludeKey2", "excval-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_envs.envKey2", "envval-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_envs.inEnvKey2", "incval-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_envs.exEnvKey2", "excval-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.log_k8s.k8sKey2", "k8sval-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.include_k8s_labels.ink8sKey2", "ink8sval-update"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.exclude_k8s_labels.exk8sKey2", "exk8sval-update"),
-				),
-			},
-			{
-				ResourceName:      rName,
+				ResourceName:      withHostFile,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccCceAccessConfigImportStateFunc(rName),
-			},
-		},
-	})
-}
-
-func TestAccCceAccessConfig_hostFile(t *testing.T) {
-	var obj interface{}
-
-	name := acceptance.RandomAccResourceName()
-	rName := "huaweicloud_lts_cce_access.host_file"
-
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getCceAccessConfigResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckLTSCCEAccess(t)
-			acceptance.TestAccPreCheckLTSHostGroup(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testCceAccessConfigHostFile(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttrSet(rName, "log_group_name"),
-					resource.TestCheckResourceAttrSet(rName, "log_stream_name"),
-					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
-					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(rName, "access_type", "K8S_CCE"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.paths.#", "2"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.black_paths.#", "2"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.path_type", "host_file"),
-				),
-			},
-			{
-				Config: testCceAccessConfigHostFileUpdate(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "tags.key", "value-updated"),
-					resource.TestCheckResourceAttr(rName, "tags.owner", "terraform"),
-					resource.TestCheckResourceAttr(rName, "access_type", "K8S_CCE"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.paths.#", "1"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.paths.0", "/var/logs"),
-					resource.TestCheckResourceAttr(rName, "access_config.0.black_paths.#", "0"),
-				),
-			},
-			{
-				ResourceName:      rName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: testAccCceAccessConfigImportStateFunc(rName),
+				ImportStateIdFunc: testAccCceAccessConfigImportStateFunc(withHostFile),
 			},
 		},
 	})
@@ -308,13 +239,13 @@ func testAccCceAccessConfigImportStateFunc(rName string) resource.ImportStateIdF
 	}
 }
 
-func testCceAccessConfig_base(name string) string {
+func testAccCceAccessConfig_base(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_lts_group" "test" {
   group_name  = "%[1]s"
   ttl_in_days = 30
 }
-	  
+
 resource "huaweicloud_lts_stream" "test" {
   group_id    = huaweicloud_lts_group.test.id
   stream_name = "%[1]s"
@@ -322,31 +253,31 @@ resource "huaweicloud_lts_stream" "test" {
 }
 
 resource "huaweicloud_lts_host_group" "test" {
-  name     = "%[1]s"
-  type     = "linux"
-  host_ids = split(",", "%[2]s")
+  name = "%[1]s"
+  type = "linux"
 }
-`, name, acceptance.HW_LTS_HOST_IDS)
+`, name)
 }
 
-func testCceAccessConfigContainerFile(name, suffix string) string {
+func testAccCceAccessConfig_basic_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_lts_cce_access" "container_file" {
+resource "huaweicloud_lts_cce_access" "with_container_file" {
   name           = "%[2]s"
   log_group_id   = huaweicloud_lts_group.test.id
   log_stream_id  = huaweicloud_lts_stream.test.id
   host_group_ids = [huaweicloud_lts_host_group.test.id]
   cluster_id     = "%[3]s"
+  log_split      = true
 
   access_config {
     path_type            = "container_file"
     paths                = ["/var"]
     black_paths          = ["/var/a.log"]
-    name_space_regex     = "namespace%[4]s"
-    pod_name_regex       = "podname%[4]s"
-    container_name_regex = "containername%[4]s"
+    name_space_regex     = "namespace"
+    pod_name_regex       = "podname"
+    container_name_regex = "containername"
 
     windows_log_info {
       categorys        = ["System", "Application"]
@@ -361,151 +292,121 @@ resource "huaweicloud_lts_cce_access" "container_file" {
 
     log_labels = {
       loglabelkey1 = "bar1"
-      loglabelkey2 = "bar%[4]s"
+      loglabelkey2 = "bar"
     }
 
     include_labels = {
       includeKey1 = "incval1"
-      includeKey2 = "incval%[4]s"
+      includeKey2 = "incval"
     }
 
     exclude_labels = {
       excludeKey1 = "excval1"
-      excludeKey2 = "excval%[4]s"
+      excludeKey2 = "excval"
     }
 
     log_envs = {
       envKey1 = "envval1"
-      envKey2 = "envval%[4]s"
+      envKey2 = "envval"
     }
 
     include_envs = {
       inEnvKey1 = "incval1"
-      inEnvKey2 = "incval%[4]s"
+      inEnvKey2 = "incval"
     }
 
     exclude_envs = {
       exEnvKey1 = "excval1"
-      exEnvKey2 = "excval%[4]s"
+      exEnvKey2 = "excval"
     }
 
     log_k8s = {
       k8sKey1 = "k8sval1"
-      k8sKey2 = "k8sval%[4]s"
+      k8sKey2 = "k8sval"
     }
 
     include_k8s_labels = {
       ink8sKey1 = "ink8sval1"
-      ink8sKey2 = "ink8sval%[4]s"
+      ink8sKey2 = "ink8sval"
     }
 
     exclude_k8s_labels = {
       exk8sKey1 = "exk8sval1"
-      exk8sKey2 = "exk8sval%[4]s"
+      exk8sKey2 = "exk8sval"
     }
+
+    custom_key_value = {
+      customkey = "custom_val"
+    }
+  }
+
+  demo_log       = "2025-04-28 10:59:07.000 a.log:1 level:warn|error"
+  processor_type = "SPLIT"
+
+  demo_fields {
+    field_name  = "field2"
+    field_value = "error"
+  }
+  demo_fields {
+    field_name  = "field1"
+    field_value = "2025-04-28 10:59:07.000 a.log:1 level:warn"
+  }
+
+  processors {
+    type = "processor_filter_regex"
+
+    detail = jsonencode({
+      "include" : {
+        "name1" : "^terraform"
+      },
+      "exclude" : {
+        "black" : "test"
+      }
+    })
+  }
+  processors {
+    type = "processor_split_string"
+
+    detail = jsonencode({
+      "split_sep" : "|",
+      "keys" : ["field1", "field2"],
+      "keep_source" : false,
+      "keep_source_if_parse_error" : false
+    })
   }
 
   tags = {
     key = "value"
-    foo = "bar%[4]s"
+    foo = "bar"
   }
 }
-`, testCceAccessConfig_base(name), name, acceptance.HW_LTS_CCE_CLUSTER_ID, suffix)
-}
 
-func testCceAccessConfigContainerStdout(name, suffix string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_lts_cce_access" "container_stdout" {
-  name           = "%[2]s"
-  log_group_id   = huaweicloud_lts_group.test.id
-  log_stream_id  = huaweicloud_lts_stream.test.id
-  host_group_ids = [huaweicloud_lts_host_group.test.id]
-  cluster_id     = "%[3]s"
+resource "huaweicloud_lts_cce_access" "with_container_stdout" {
+  name                = "%[2]s_container_file"
+  log_group_id        = huaweicloud_lts_group.test.id
+  log_stream_id       = huaweicloud_lts_stream.test.id
+  cluster_id          = "%[3]s"
+  encoding_format     = "GBK"
+  incremental_collect = false
 
   access_config {
-    path_type            = "container_stdout"
-    stdout               = true
-    name_space_regex     = "namespace%[4]s"
-    pod_name_regex       = "podname%[4]s"
-    container_name_regex = "containername%[4]s"
+    path_type      = "container_stdout"
+    stdout         = true
+    repeat_collect = false
+    system_fields  = ["pathFile", "hostName"]
 
-    windows_log_info {
-      categorys        = ["System", "Application"]
-      event_level      = ["warning", "error"]
-      time_offset_unit = "day"
-      time_offset      = 7
-    }
-
-    single_log_format {
-      mode = "system"
-    }
-
-    log_labels = {
-      loglabelkey1 = "bar1"
-      loglabelkey2 = "bar%[4]s"
-    }
-
-    include_labels = {
-      includeKey1 = "incval1"
-      includeKey2 = "incval%[4]s"
-    }
-
-    exclude_labels = {
-      excludeKey1 = "excval1"
-      excludeKey2 = "excval%[4]s"
-    }
-
-    log_envs = {
-      envKey1 = "envval1"
-      envKey2 = "envval%[4]s"
-    }
-
-    include_envs = {
-      inEnvKey1 = "incval1"
-      inEnvKey2 = "incval%[4]s"
-    }
-
-    exclude_envs = {
-      exEnvKey1 = "excval1"
-      exEnvKey2 = "excval%[4]s"
-    }
-
-    log_k8s = {
-      k8sKey1 = "k8sval1"
-      k8sKey2 = "k8sval%[4]s"
-    }
-
-    include_k8s_labels = {
-      ink8sKey1 = "ink8sval1"
-      ink8sKey2 = "ink8sval%[4]s"
-    }
-
-    exclude_k8s_labels = {
-      exk8sKey1 = "exk8sval1"
-      exk8sKey2 = "exk8sval%[4]s"
+    multi_log_format  {
+      mode  = "time"
+      value = "YYYY-MM-DD hh:mm:ss"
     }
   }
-
-  tags = {
-    key = "value"
-    foo = "bar%[4]s"
-  }
-}
-`, testCceAccessConfig_base(name), name, acceptance.HW_LTS_CCE_CLUSTER_ID, suffix)
 }
 
-func testCceAccessConfigHostFile(name string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_lts_cce_access" "host_file" {
-  name           = "%[2]s"
-  log_group_id   = huaweicloud_lts_group.test.id
-  log_stream_id  = huaweicloud_lts_stream.test.id
-  host_group_ids = [huaweicloud_lts_host_group.test.id]
-  cluster_id     = "%[3]s"
+resource "huaweicloud_lts_cce_access" "with_host_file" {
+  name          = "%[2]s_host_file"
+  log_group_id  = huaweicloud_lts_group.test.id
+  log_stream_id = huaweicloud_lts_stream.test.id
+  cluster_id    = "%[3]s"
 
   access_config {
     path_type   = "host_file"
@@ -516,39 +417,130 @@ resource "huaweicloud_lts_cce_access" "host_file" {
       mode = "system"
     }
   }
-
-  tags = {
-    key = "value"
-    foo = "bar"
-  }
 }
-`, testCceAccessConfig_base(name), name, acceptance.HW_LTS_CCE_CLUSTER_ID)
+`, testAccCceAccessConfig_base(name), name, acceptance.HW_LTS_CCE_CLUSTER_ID)
 }
 
-func testCceAccessConfigHostFileUpdate(name string) string {
+func testAccCceAccessConfig_basic_step2(name, updateName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_lts_cce_access" "host_file" {
+resource "huaweicloud_lts_cce_access" "with_container_file" {
   name           = "%[2]s"
   log_group_id   = huaweicloud_lts_group.test.id
   log_stream_id  = huaweicloud_lts_stream.test.id
   host_group_ids = [huaweicloud_lts_host_group.test.id]
   cluster_id     = "%[3]s"
+  log_split      = false
+
+  access_config {
+    path_type                  = "container_file"
+    paths                      = ["/var"]
+    black_paths                = ["/var/a.log"]
+    name_space_regex           = "namespace_update"
+    pod_name_regex             = "podname_update"
+    container_name_regex       = "containername_update"
+    exclude_envs_logical       = "and"
+    include_envs_logical       = "and"
+    exclude_labels_logical     = "and"
+    include_labels_logical     = "and"
+    exclude_k8s_labels_logical = "and"
+    include_k8s_labels_logical = "and"
+
+    windows_log_info {
+      categorys        = ["System", "Application"]
+      event_level      = ["warning", "error"]
+      time_offset_unit = "day"
+      time_offset      = 7
+    }
+
+    single_log_format {
+      mode = "system"
+    }
+
+    log_labels = {
+      loglabelkey2 = "bar_update"
+    }
+
+    include_labels = {
+      includeKey2 = "incval_update"
+    }
+
+    exclude_labels = {
+      excludeKey2 = "excval_update"
+    }
+
+    log_envs = {
+      envKey2 = "envval_update"
+    }
+
+    include_envs = {
+      inEnvKey2 = "incval_update"
+    }
+
+    exclude_envs = {
+      exEnvKey2 = "excval_update"
+    }
+
+    log_k8s = {
+      k8sKey2 = "k8sval_update"
+    }
+
+    include_k8s_labels = {
+      ink8sKey2 = "ink8sval_update"
+    }
+
+    exclude_k8s_labels = {
+      exk8sKey2 = "exk8sval_update"
+    }
+
+    custom_key_value = {
+      customkey = "custom_val"
+    }
+  }
+
+  processor_type = "SPLIT"
+  processors {}
+
+  tags = {
+    foo = "bar_update"
+  }
+}
+
+resource "huaweicloud_lts_cce_access" "with_container_stdout" {
+  name                = "%[2]s_container_file"
+  log_group_id        = huaweicloud_lts_group.test.id
+  log_stream_id       = huaweicloud_lts_stream.test.id
+  cluster_id          = "%[3]s"
+  encoding_format     = "UTF-8"
+  incremental_collect = true
+
+  access_config {
+    path_type      = "container_stdout"
+    stdout         = true
+    repeat_collect = true
+
+    multi_log_format  {
+      mode  = "time"
+      value = "YYYY-MM-DD hh:mm:ss"
+    }
+  }
+}
+
+resource "huaweicloud_lts_cce_access" "with_host_file" {
+  name          = "%[2]s_host_file"
+  log_group_id  = huaweicloud_lts_group.test.id
+  log_stream_id = huaweicloud_lts_stream.test.id
+  cluster_id    = "%[3]s"
 
   access_config {
     path_type = "host_file"
-    paths     = ["/var/logs"]
+    paths     = ["/var", "/temp"]
 
     single_log_format {
       mode = "system"
     }
   }
-
-  tags = {
-    key   = "value-updated"
-    owner = "terraform"
-  }
 }
-`, testCceAccessConfig_base(name), name, acceptance.HW_LTS_CCE_CLUSTER_ID)
+`, testAccCceAccessConfig_base(name), updateName, acceptance.HW_LTS_CCE_CLUSTER_ID)
 }

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_cce_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_cce_access.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -41,7 +42,6 @@ func ResourceCceAccessConfig() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The name of the CCE access.`,
 			},
 			"log_group_id": {
@@ -88,6 +88,71 @@ func ResourceCceAccessConfig() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: `Whether to split log. Default is false.`,
+			},
+			// The API does not support setting `processor_type` to empty.
+			"processor_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"processors"},
+				Description:  `The type of the ICAgent structuring parsing.`,
+			},
+			"processors": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				RequiredWith: []string{"processor_type"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The type of the parser.`,
+						},
+						"detail": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsJSON,
+							Description:  `The configuration of the parser, in JSON format.`,
+						},
+					},
+				},
+				Description: `The list of the ICAgent structuring parsing rules.`,
+			},
+			"demo_log": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The example log of the ICAgent structuring parsing.`,
+			},
+			"demo_fields": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"field_name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The name of the parsed field.`,
+						},
+						"field_value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The value of the parsed field.`,
+						},
+					},
+				},
+				Description: `The list of the parsed fields of the example log`,
+			},
+			"encoding_format": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The encoding format log file.`,
+			},
+			// If not specified, the API defaults to true.
+			"incremental_collect": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Whether to collect logs incrementally.`,
 			},
 			"access_type": {
 				Type:        schema.TypeString,
@@ -188,11 +253,23 @@ func cceAccessConfigDeatilSchema() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `The container label log tag.`,
 			},
+			"include_labels_logical": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The logical relationship between multiple container label whitelists.`,
+			},
 			"include_labels": {
 				Type:        schema.TypeMap,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `The container label whitelist.`,
+			},
+			"exclude_labels_logical": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The logical relationship between multiple container label blacklists.`,
 			},
 			"exclude_labels": {
 				Type:        schema.TypeMap,
@@ -206,11 +283,23 @@ func cceAccessConfigDeatilSchema() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `The environment variable tag.`,
 			},
+			"include_envs_logical": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The logical relationship between multiple environment variable whitelists.`,
+			},
 			"include_envs": {
 				Type:        schema.TypeMap,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `The environment variable whitelist.`,
+			},
+			"exclude_envs_logical": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The logical relationship between multiple environment variable blacklists.`,
 			},
 			"exclude_envs": {
 				Type:        schema.TypeMap,
@@ -224,17 +313,51 @@ func cceAccessConfigDeatilSchema() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `The kubernetes label log tag.`,
 			},
+			"include_k8s_labels_logical": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The logical relationship between multiple kubernetes label whitelists.`,
+			},
 			"include_k8s_labels": {
 				Type:        schema.TypeMap,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `The kubernetes label whitelist.`,
 			},
+			"exclude_k8s_labels_logical": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The logical relationship between multiple kubernetes label blacklists.`,
+			},
 			"exclude_k8s_labels": {
 				Type:        schema.TypeMap,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `The kubernetes label blacklist.`,
+			},
+			// If not specified, the API defaults to true.
+			"repeat_collect": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Whether to allow repeated file collection.`,
+			},
+			"custom_key_value": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The custom key/value pairs.`,
+			},
+			"system_fields": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of system built-in fields of the CCE access.`,
 			},
 		},
 	}
@@ -298,8 +421,29 @@ func buildCreateCceAccessConfigBodyParams(d *schema.ResourceData) map[string]int
 		"cluster_id":           d.Get("cluster_id"),
 		"binary_collect":       utils.ValueIgnoreEmpty(d.Get("binary_collect")),
 		"log_split":            utils.ValueIgnoreEmpty(d.Get("log_split")),
+		"processor_type":       utils.ValueIgnoreEmpty(d.Get("processor_type")),
+		"processors":           buildHostAccessProcessors(d.Get("processors").([]interface{})),
+		"demo_log":             utils.ValueIgnoreEmpty(d.Get("demo_log")),
+		"demo_fields":          buildCceAccessDemoFields(d.Get("demo_fields").(*schema.Set)),
+		"encoding_format":      utils.ValueIgnoreEmpty(d.Get("encoding_format")),
+		"incremental_collect":  d.Get("incremental_collect"),
 	}
 	return bodyParams
+}
+
+func buildCceAccessDemoFields(demoFields *schema.Set) []map[string]interface{} {
+	if demoFields.Len() < 1 {
+		return nil
+	}
+	result := make([]map[string]interface{}, 0, demoFields.Len())
+	for _, demoField := range demoFields.List() {
+		result = append(result, map[string]interface{}{
+			"field_name":  utils.ValueIgnoreEmpty(utils.PathSearch("field_name", demoField, nil)),
+			"field_value": utils.ValueIgnoreEmpty(utils.PathSearch("field_value", demoField, nil)),
+		})
+	}
+
+	return result
 }
 
 func buildCceAccessConfigDeatilRequestBody(rawParams interface{}) map[string]interface{} {
@@ -316,25 +460,34 @@ func buildCceAccessConfigDeatilRequestBody(rawParams interface{}) map[string]int
 	}
 
 	params := map[string]interface{}{
-		"pathType":           raw["path_type"],
-		"paths":              utils.ValueIgnoreEmpty(raw["paths"].(*schema.Set).List()),
-		"black_paths":        utils.ValueIgnoreEmpty(raw["black_paths"].(*schema.Set).List()),
-		"format":             buildHostAccessConfigFormatRequestBody(raw),
-		"windows_log_info":   buildHostAccessConfigWindowsLogInfoRequestBody(raw["windows_log_info"]),
-		"stdout":             utils.ValueIgnoreEmpty(raw["stdout"]),
-		"stderr":             utils.ValueIgnoreEmpty(raw["stderr"]),
-		"namespaceRegex":     utils.ValueIgnoreEmpty(raw["name_space_regex"]),
-		"podNameRegex":       utils.ValueIgnoreEmpty(raw["pod_name_regex"]),
-		"containerNameRegex": utils.ValueIgnoreEmpty(raw["container_name_regex"]),
-		"logLabels":          raw["log_labels"],
-		"includeLabels":      raw["include_labels"],
-		"excludeLabels":      raw["exclude_labels"],
-		"logEnvs":            raw["log_envs"],
-		"includeEnvs":        raw["include_envs"],
-		"excludeEnvs":        raw["exclude_envs"],
-		"logK8s":             raw["log_k8s"],
-		"includeK8sLabels":   raw["include_k8s_labels"],
-		"excludeK8sLabels":   raw["exclude_k8s_labels"],
+		"pathType":                raw["path_type"],
+		"paths":                   utils.ValueIgnoreEmpty(raw["paths"].(*schema.Set).List()),
+		"black_paths":             utils.ValueIgnoreEmpty(raw["black_paths"].(*schema.Set).List()),
+		"format":                  buildHostAccessConfigFormatRequestBody(raw),
+		"windows_log_info":        buildHostAccessConfigWindowsLogInfoRequestBody(raw["windows_log_info"]),
+		"stdout":                  utils.ValueIgnoreEmpty(raw["stdout"]),
+		"stderr":                  utils.ValueIgnoreEmpty(raw["stderr"]),
+		"namespaceRegex":          utils.ValueIgnoreEmpty(raw["name_space_regex"]),
+		"podNameRegex":            utils.ValueIgnoreEmpty(raw["pod_name_regex"]),
+		"containerNameRegex":      utils.ValueIgnoreEmpty(raw["container_name_regex"]),
+		"logLabels":               raw["log_labels"],
+		"includeLabelsLogical":    utils.ValueIgnoreEmpty(raw["include_labels_logical"]),
+		"includeLabels":           raw["include_labels"],
+		"excludeLabelsLogical":    utils.ValueIgnoreEmpty(raw["exclude_labels_logical"]),
+		"excludeLabels":           raw["exclude_labels"],
+		"logEnvs":                 raw["log_envs"],
+		"includeEnvsLogical":      utils.ValueIgnoreEmpty(raw["include_envs_logical"]),
+		"includeEnvs":             raw["include_envs"],
+		"excludeEnvsLogical":      utils.ValueIgnoreEmpty(raw["exclude_envs_logical"]),
+		"excludeEnvs":             raw["exclude_envs"],
+		"logK8s":                  raw["log_k8s"],
+		"includeK8sLabelsLogical": utils.ValueIgnoreEmpty(raw["include_k8s_labels_logical"]),
+		"includeK8sLabels":        raw["include_k8s_labels"],
+		"excludeK8sLabelsLogical": utils.ValueIgnoreEmpty(raw["exclude_k8s_labels_logical"]),
+		"excludeK8sLabels":        raw["exclude_k8s_labels"],
+		"repeat_collect":          raw["repeat_collect"],
+		"custom_key_value":        raw["custom_key_value"],
+		"system_fields":           utils.ValueIgnoreEmpty(raw["system_fields"].(*schema.Set).List()),
 	}
 	return params
 }
@@ -383,18 +536,27 @@ func resourceCceAccessConfigRead(_ context.Context, d *schema.ResourceData, meta
 	created := utils.PathSearch("create_time", listCceAccessConfigRespBody, float64(0)).(float64)
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
+		// Required parameters.
 		d.Set("name", utils.PathSearch("access_config_name", listCceAccessConfigRespBody, nil)),
-		d.Set("access_type", utils.PathSearch("access_config_type", listCceAccessConfigRespBody, nil)),
 		d.Set("log_group_id", utils.PathSearch("log_info.log_group_id", listCceAccessConfigRespBody, nil)),
 		d.Set("log_stream_id", utils.PathSearch("log_info.log_stream_id", listCceAccessConfigRespBody, nil)),
-		d.Set("log_group_name", utils.PathSearch("log_info.log_group_name", listCceAccessConfigRespBody, nil)),
-		d.Set("log_stream_name", utils.PathSearch("log_info.log_stream_name", listCceAccessConfigRespBody, nil)),
-		d.Set("host_group_ids", utils.PathSearch("host_group_info.host_group_id_list", listCceAccessConfigRespBody, nil)),
-		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("access_config_tag", listCceAccessConfigRespBody, nil))),
 		d.Set("access_config", flattenCceAccessConfigDetail(listCceAccessConfigRespBody)),
 		d.Set("cluster_id", utils.PathSearch("cluster_id", listCceAccessConfigRespBody, nil)),
+		// Optional parameters.
+		d.Set("host_group_ids", utils.PathSearch("host_group_info.host_group_id_list", listCceAccessConfigRespBody, nil)),
+		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("access_config_tag", listCceAccessConfigRespBody, nil))),
 		d.Set("binary_collect", utils.PathSearch("binary_collect", listCceAccessConfigRespBody, nil)),
 		d.Set("log_split", utils.PathSearch("log_split", listCceAccessConfigRespBody, nil)),
+		d.Set("processor_type", utils.PathSearch("processor_type", listCceAccessConfigRespBody, nil)),
+		d.Set("demo_log", utils.PathSearch("demo_log", listCceAccessConfigRespBody, nil)),
+		d.Set("demo_fields",
+			flattenCceAccessDemoFields(utils.PathSearch("demo_fields", listCceAccessConfigRespBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("encoding_format", utils.PathSearch("encoding_format", listCceAccessConfigRespBody, nil)),
+		d.Set("incremental_collect", utils.PathSearch("incremental_collect", listCceAccessConfigRespBody, nil)),
+		// Attributes.
+		d.Set("access_type", utils.PathSearch("access_config_type", listCceAccessConfigRespBody, nil)),
+		d.Set("log_group_name", utils.PathSearch("log_info.log_group_name", listCceAccessConfigRespBody, nil)),
+		d.Set("log_stream_name", utils.PathSearch("log_info.log_stream_name", listCceAccessConfigRespBody, nil)),
 		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(created)/1000, false)),
 	)
 
@@ -404,37 +566,68 @@ func resourceCceAccessConfigRead(_ context.Context, d *schema.ResourceData, meta
 func flattenCceAccessConfigDetail(resp interface{}) []map[string]interface{} {
 	return []map[string]interface{}{
 		{
-			"path_type":            utils.PathSearch("access_config_detail.pathType", resp, nil),
-			"paths":                utils.PathSearch("access_config_detail.paths", resp, nil),
-			"black_paths":          utils.PathSearch("access_config_detail.black_paths", resp, nil),
-			"single_log_format":    flattenHostAccessConfigLogFormat(utils.PathSearch("access_config_detail.format.single", resp, nil)),
-			"multi_log_format":     flattenHostAccessConfigLogFormat(utils.PathSearch("access_config_detail.format.multi", resp, nil)),
-			"windows_log_info":     flattenHostAccessConfigWindowsLogInfo(utils.PathSearch("access_config_detail.windows_log_info", resp, nil)),
-			"stdout":               utils.PathSearch("access_config_detail.stdout", resp, nil),
-			"stderr":               utils.PathSearch("access_config_detail.stderr", resp, nil),
-			"name_space_regex":     utils.PathSearch("access_config_detail.namespaceRegex", resp, nil),
-			"pod_name_regex":       utils.PathSearch("access_config_detail.podNameRegex", resp, nil),
-			"container_name_regex": utils.PathSearch("access_config_detail.containerNameRegex", resp, nil),
-			"log_labels":           utils.PathSearch("access_config_detail.logLabels", resp, nil),
-			"include_labels":       utils.PathSearch("access_config_detail.includeLabels", resp, nil),
-			"exclude_labels":       utils.PathSearch("access_config_detail.excludeLabels", resp, nil),
-			"log_envs":             utils.PathSearch("access_config_detail.logEnvs", resp, nil),
-			"include_envs":         utils.PathSearch("access_config_detail.includeEnvs", resp, nil),
-			"exclude_envs":         utils.PathSearch("access_config_detail.excludeEnvs", resp, nil),
-			"log_k8s":              utils.PathSearch("access_config_detail.logK8s", resp, nil),
-			"include_k8s_labels":   utils.PathSearch("access_config_detail.includeK8sLabels", resp, nil),
-			"exclude_k8s_labels":   utils.PathSearch("access_config_detail.excludeK8sLabels", resp, nil),
+			"path_type":                  utils.PathSearch("access_config_detail.pathType", resp, nil),
+			"paths":                      utils.PathSearch("access_config_detail.paths", resp, nil),
+			"black_paths":                utils.PathSearch("access_config_detail.black_paths", resp, nil),
+			"single_log_format":          flattenHostAccessConfigLogFormat(utils.PathSearch("access_config_detail.format.single", resp, nil)),
+			"multi_log_format":           flattenHostAccessConfigLogFormat(utils.PathSearch("access_config_detail.format.multi", resp, nil)),
+			"windows_log_info":           flattenHostAccessConfigWindowsLogInfo(utils.PathSearch("access_config_detail.windows_log_info", resp, nil)),
+			"stdout":                     utils.PathSearch("access_config_detail.stdout", resp, nil),
+			"stderr":                     utils.PathSearch("access_config_detail.stderr", resp, nil),
+			"name_space_regex":           utils.PathSearch("access_config_detail.namespaceRegex", resp, nil),
+			"pod_name_regex":             utils.PathSearch("access_config_detail.podNameRegex", resp, nil),
+			"container_name_regex":       utils.PathSearch("access_config_detail.containerNameRegex", resp, nil),
+			"log_labels":                 utils.PathSearch("access_config_detail.logLabels", resp, nil),
+			"include_labels_logical":     utils.PathSearch("access_config_detail.includeLabelsLogical", resp, nil),
+			"include_labels":             utils.PathSearch("access_config_detail.includeLabels", resp, nil),
+			"exclude_labels_logical":     utils.PathSearch("access_config_detail.excludeLabelsLogical", resp, nil),
+			"exclude_labels":             utils.PathSearch("access_config_detail.excludeLabels", resp, nil),
+			"log_envs":                   utils.PathSearch("access_config_detail.logEnvs", resp, nil),
+			"include_envs_logical":       utils.PathSearch("access_config_detail.includeEnvsLogical", resp, nil),
+			"include_envs":               utils.PathSearch("access_config_detail.includeEnvs", resp, nil),
+			"exclude_envs_logical":       utils.PathSearch("access_config_detail.excludeEnvsLogical", resp, nil),
+			"exclude_envs":               utils.PathSearch("access_config_detail.excludeEnvs", resp, nil),
+			"log_k8s":                    utils.PathSearch("access_config_detail.logK8s", resp, nil),
+			"include_k8s_labels_logical": utils.PathSearch("access_config_detail.includeK8sLabelsLogical", resp, nil),
+			"include_k8s_labels":         utils.PathSearch("access_config_detail.includeK8sLabels", resp, nil),
+			"exclude_k8s_labels_logical": utils.PathSearch("access_config_detail.excludeK8sLabelsLogical", resp, nil),
+			"exclude_k8s_labels":         utils.PathSearch("access_config_detail.excludeK8sLabels", resp, nil),
+			"custom_key_value":           utils.PathSearch("access_config_detail.custom_key_value", resp, nil),
+			"repeat_collect":             utils.PathSearch("access_config_detail.repeat_collect", resp, nil),
+			"system_fields":              utils.PathSearch("access_config_detail.system_fields", resp, nil),
 		},
 	}
 }
 
+func flattenCceAccessDemoFields(demoFields []interface{}) []map[string]interface{} {
+	if len(demoFields) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(demoFields))
+	for i, demoField := range demoFields {
+		result[i] = map[string]interface{}{
+			"field_name":  utils.PathSearch("field_name", demoField, nil),
+			"field_value": utils.PathSearch("field_value", demoField, nil),
+		}
+	}
+	return result
+}
+
 func resourceCceAccessConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	updateCceAccessConfigChanges := []string{
+		"name",
 		"access_config",
 		"host_group_ids",
 		"tags",
 		"binary_collect",
 		"log_split",
+		"processor_type",
+		"processors",
+		"demo_log",
+		"demo_fields",
+		"encoding_format",
+		"incremental_collect",
 	}
 
 	if d.HasChanges(updateCceAccessConfigChanges...) {
@@ -459,7 +652,7 @@ func resourceCceAccessConfigUpdate(ctx context.Context, d *schema.ResourceData, 
 			},
 		}
 
-		updateCceAccessConfigOpt.JSONBody = utils.RemoveNil(buildUpdateCceAccessConfigBodyParams(d))
+		updateCceAccessConfigOpt.JSONBody = buildUpdateCceAccessConfigBodyParams(d)
 		_, err = ltsClient.Request("PUT", updateCceAccessConfigPath, &updateCceAccessConfigOpt)
 		if err != nil {
 			return diag.Errorf("error updating CCE access config: %s", err)
@@ -469,16 +662,58 @@ func resourceCceAccessConfigUpdate(ctx context.Context, d *schema.ResourceData, 
 }
 
 func buildUpdateCceAccessConfigBodyParams(d *schema.ResourceData) map[string]interface{} {
+	// The demo_log and `demo_fields` cannot be ignored, otherwise it cannot be modified to empty.
 	bodyParams := map[string]interface{}{
 		"access_config_id":     d.Id(),
+		"access_config_name":   d.Get("name"),
 		"access_config_detail": buildCceAccessConfigDeatilRequestBody(d.Get("access_config")),
 		"host_group_info":      buildHostGroupInfoRequestBody(d),
 		"access_config_tag":    utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
 		"cluster_id":           d.Get("cluster_id"),
 		"binary_collect":       utils.ValueIgnoreEmpty(d.Get("binary_collect")),
 		"log_split":            utils.ValueIgnoreEmpty(d.Get("log_split")),
+		"processor_type":       utils.ValueIgnoreEmpty(d.Get("processor_type")),
+		"demo_log":             d.Get("demo_log"),
+		"encoding_format":      utils.ValueIgnoreEmpty(d.Get("encoding_format")),
+		"incremental_collect":  d.Get("incremental_collect"),
 	}
+
+	bodyParams = utils.RemoveNil(bodyParams)
+	// `processors` and `demo_fields` not be ignored, therwise it cannot be modified to empty.
+	bodyParams["processors"] = buildUpdateCceAccessProcessors(d.Get("processors").([]interface{}))
+	bodyParams["demo_fields"] = buildUpdateCceAccessDemoFields(d.Get("demo_fields").(*schema.Set))
+
 	return bodyParams
+}
+
+func buildUpdateCceAccessDemoFields(demoFields *schema.Set) []map[string]interface{} {
+	fields := buildHostAccessDemoFields(demoFields)
+	if fields == nil {
+		return []map[string]interface{}{}
+	}
+
+	return fields
+}
+
+func buildUpdateCceAccessProcessors(processors []interface{}) []map[string]interface{} {
+	if len(processors) < 1 || processors[0] == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(processors))
+	for _, processor := range processors {
+		processorType := utils.PathSearch("type", processor, "").(string)
+		detail := utils.PathSearch("detail", processor, "").(string)
+		if processorType == "" && detail == "" {
+			continue
+		}
+		result = append(result, map[string]interface{}{
+			"type":   processorType,
+			"detail": utils.StringToJson(detail),
+		})
+	}
+
+	return result
 }
 
 func cceAccessConfigResourceImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_cce_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_cce_access.go
@@ -258,6 +258,9 @@ func resourceCceAccessConfigCreate(ctx context.Context, d *schema.ResourceData, 
 
 	createCceAccessConfigOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=UTF-8",
+		},
 	}
 	createCceAccessConfigOpt.JSONBody = utils.RemoveNil(buildCreateCceAccessConfigBodyParams(d))
 	createCceAccessConfigResp, err := ltsClient.Request("POST", createCceAccessConfigPath, &createCceAccessConfigOpt)
@@ -353,6 +356,9 @@ func resourceCceAccessConfigRead(_ context.Context, d *schema.ResourceData, meta
 
 	listCceAccessConfigOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=UTF-8",
+		},
 	}
 
 	name := d.Get("name").(string)
@@ -448,6 +454,9 @@ func resourceCceAccessConfigUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		updateCceAccessConfigOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json;charset=UTF-8",
+			},
 		}
 
 		updateCceAccessConfigOpt.JSONBody = utils.RemoveNil(buildUpdateCceAccessConfigBodyParams(d))
@@ -497,6 +506,9 @@ func refreshCceAccessID(ltsClient *golangsdk.ServiceClient, d *schema.ResourceDa
 
 	listCceAccessConfigOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=UTF-8",
+		},
 	}
 
 	name := d.Get("name").(string)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Add `Content-Type` for the APIs.
2. The resource supports new paramster and modify name.
+ Add parameters:
  + processor_type
  + processors
  + demo_log
  + demo_fields
  + encoding_format
  + incremental_collect
  + access_config.custom_key_value
  + access_config.system_fields
  + access_config.repeat_collect
  + access_config.exclude_envs_logical
  + access_configexclude_k8s_labels_logical
  + access_configexclude_labels_logical
  + access_configinclude_envs_logical
  + access_configinclude_k8s_labels_logical
  + access_configinclude_labels_logical

+ Support to modify the `name`  parameter.
3. Add new attributes for data source:
  + accesses.processor_type
  + accesses.processors
  + accesses.demo_log
  + accesses.demo_fields
  + accesses.encoding_format
  + accesses.incremental_collect
  + accesses.access_config.custom_key_value
  + accesses.access_config.system_fields
  + accesses.access_config.repeat_collect
  + accesses.access_config.exclude_envs_logical
  + accesses.access_configexclude_k8s_labels_logical
  + accesses.access_configexclude_labels_logical
  + accesses.access_configinclude_envs_logical
  + accesses.access_configinclude_k8s_labels_logical
  + accesses.access_configinclude_labels_logical

Due to API reasons, the `custom_key_value` and `system_fields` parameters cannot be modified empty and will be connected after the backend is repaired.
![image](https://github.com/user-attachments/assets/9a9a26e7-e82e-4485-825c-7c3d55ed6da6)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lts -f TestAccDatasourceCceAccesses_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccDatasourceCceAccesses_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourceCceAccesses_basic
=== PAUSE TestAccDatasourceCceAccesses_basic
=== CONT  TestAccDatasourceCceAccesses_basic
--- PASS: TestAccDatasourceCceAccesses_basic (28.17s)
PASS
coverage: 13.4% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       28.664s coverage: 13.4% of statements in ./huaweicloud/services/lts
```
```
./scripts/coverage.sh -o lts -f TestAccCceAccessConfig_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccCceAccessConfig_basic -timeout 360m -parallel 10
=== RUN   TestAccCceAccessConfig_basic
=== PAUSE TestAccCceAccessConfig_basic
=== CONT  TestAccCceAccessConfig_basic
--- PASS: TestAccCceAccessConfig_basic (63.52s)
PASS
coverage: 14.5% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       64.200s coverage: 14.5% of statements in ./huaweicloud/services/lts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
