### PR TITLE
feat(modelarts): Add new data source to query resource pools

### DIFF
--- a/docs/data-sources/modelartsv2_resource_pools.md
+++ b/docs/data-sources/modelartsv2_resource_pools.md
@@ -1,0 +1,194 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelartsv2_resource_pools"
+description: |-
+  Use this data source to get list of ModelArts resource pools within HuaweiCloud.
+---
+
+# huaweicloud_modelartsv2_resource_pools
+
+Use this data source to get list of ModelArts resource pools within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_modelartsv2_resource_pools" "test" {
+  status = "created"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Optional, String) The workspace ID to which the resource pool belongs.
+
+* `status` - (Optional, String) The status of the resource pool to be queried.  
+  The valid values are as follows:
+  + **created**
+  + **failed**
+  + **creating**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `resource_pools` - All resource pools that matched filter parameters.  
+  The [resource_pools](#modelarts_resource_pools) structure is documented below.
+
+<a name="modelarts_resource_pools"></a>
+The `resource_pools` block supports:
+
+* `metadata` - The metadata configuration of the resource pool.  
+  The [metadata](#modelarts_resource_pool_metadata) structure is documented below.
+
+* `name` - The name of the resource pool.
+
+* `scope` - The list of job types supported by the resource pool.
+
+* `resources` - The list of resource specifications in the resource pool.  
+  The [resources](#modelarts_resource_pool_resources) structure is documented below.
+
+* `network_id` - The ModelArts network ID of the resource pool.
+
+* `prefix` - The prefix of the user-defined node name of the resource pool.
+
+* `vpc_id` - The ID of the VPC to which the resource pool belongs.
+
+* `subnet_id` - The network ID of the subnet to which the resource pool belongs.
+
+* `clusters` - The list of the CCE clusters.  
+  The [clusters](#modelarts_resource_pool_clusters) structure is documented below.
+
+* `user_login` - The user login info of the resource pool.  
+  The [user_login](#modelarts_resource_pool_user_login) structure is documented below.
+
+* `workspace_id` - The workspace ID of the resource pool.
+  + **0**: Default workspace.
+
+* `description` - The description of the resource pool.
+
+* `charging_mode` - The charging mode of the resource pool.
+  + **prePaid**: The yearly/monthly billing mode.
+
+* `status` - The status of the resource pool.
+
+* `resource_pool_id` - The resource ID of the resource pool.
+
+<a name="modelarts_resource_pool_metadata"></a>
+The `metadata` block supports:
+
+* `annotations` - The annotations of the resource pool.
+
+* `labels` - The labels of the resource pool.
+
+* `created_at` - The creation time of the resource pool, in RFC3339 format.
+
+<a name="modelarts_resource_pool_resources"></a>
+The `resources` block supports:
+
+* `flavor_id` - The resource flavor ID.
+
+* `count` - The number of resources of the corresponding flavors.
+
+* `node_pool` - The name of resource pool nodes.
+
+* `max_count` - The max number of resources of the corresponding flavors.
+
+* `vpc_id` - The ID of the VPC to which the the resource pool nodes belong.
+
+* `subnet_id` - The network ID of a subnet to which the the resource pool nodes belong.
+
+* `security_group_ids` - The security group IDs to which the the resource pool nodes belong.
+
+* `azs` - The availability zones for the resource pool nodes.
+  The [azs](#modelarts_resource_pool_resource_azs) structure is documented below.
+
+* `taints` - The taints added to resource pool nodes.  
+  The [taints](#modelarts_resource_pool_resource_taints) structure is documented below.
+
+* `labels` - The labels of resource pool nodes.
+
+* `tags` - The key/value pairs to associate with the resource pool nodes.
+
+* `extend_params` - The extend parameters of the resource pool nodes.
+
+* `root_volume` - The root volume of the resource pool nodes.  
+  The [root_volume](#modelarts_resource_pool_resource_root_volume) structure is documented below.
+
+* `data_volumes` - The list of data volumes of the resource pool nodes.  
+  The [data_volumes](#modelarts_resource_pool_resource_data_volumes) structure is documented below.
+
+* `volume_group_configs` - The extend configurations of the volume groups.  
+  The [volume_group_configs](#modelarts_resource_pool_resource_volume_group_configs) structure is documented below.
+
+<a name="modelarts_resource_pool_resource_azs"></a>
+The `azs` block supports:
+
+* `az` - The AZ name.
+
+* `count` - The number of nodes for the corresponding AZ
+
+<a name="modelarts_resource_pool_resource_taints"></a>
+The `taints` block supports:
+
+* `key` - The key of the taint.
+
+* `value` - The value of the taint.
+
+* `effect` - The effect of the taint.
+
+<a name="modelarts_resource_pool_resource_root_volume"></a>
+The `root_volume` block supports:
+
+* `volume_type` - The type of the root volume.
+
+* `size` - The size of the root volume.
+
+<a name="modelarts_resource_pool_resource_data_volumes"></a>
+The `root_volume` block supports:
+
+* `volume_type` - The type of the data volume.
+
+* `size` - The size of the data volume.
+
+* `extend_params` - The extend parameters of the data volume.
+
+* `count` - The count of the current data volume configuration.
+
+<a name="modelarts_resource_pool_resource_volume_group_configs"></a>
+The `volume_group_configs` block supports:
+
+* `volume_group` - The name of the volume group.
+
+* `docker_thin_pool` - The percentage of container volumes to data volumes on resource pool nodes.
+
+* `lvm_config` - The configuration of the LVM management.  
+  The [lvm_config](#modelarts_resource_pool_group_config_lvm_config) structure is documented below.
+
+* `types` - The list of storage types of the volume group.
+
+<a name="modelarts_resource_pool_group_config_lvm_config"></a>
+The `lvm_config` block supports:
+
+* `lv_type` - The LVM write mode.
+
+* `path` - The volume mount path.
+
+<a name="modelarts_resource_pool_clusters"></a>
+The `clusters` block supports:
+
+* `provider_id` - The ID of the CCE cluster that resource pool used.
+
+* `name` - The name of the CCE cluster that resource pool used.
+
+<a name="modelarts_resource_pool_user_login"></a>
+The `user_login` block supports:
+
+* `key_pair_name` - The key pair name of the login user.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1113,6 +1113,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_workspaces":       modelarts.DataSourceWorkspaces(),
 			"huaweicloud_modelarts_services":         modelarts.DataSourceServices(),
 			"huaweicloud_modelarts_resource_flavors": modelarts.DataSourceResourceFlavors(),
+			// Resource management via V2 APIs.
+			"huaweicloud_modelartsv2_resource_pools": modelarts.DataSourceV2ResourcePools(),
 
 			"huaweicloud_mapreduce_clusters": mrs.DataSourceMrsClusters(),
 

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelartsv2_resource_pools_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelartsv2_resource_pools_test.go
@@ -1,0 +1,58 @@
+package modelarts
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this acceptance test, please support at least one of resource pool.
+func TestAccDataSourceV2ResourcePools_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_modelartsv2_resource_pools.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byWorkspaceId   = "data.huaweicloud_modelartsv2_resource_pools.by_workspace_id"
+		dcByWorkspaceId = acceptance.InitDataSourceCheck(byWorkspaceId)
+
+		byStatus   = "data.huaweicloud_modelartsv2_resource_pools.by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceV2ResourcePools_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "resource_pools.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByWorkspaceId.CheckResourceExists(),
+					resource.TestCheckOutput("is_workspace_id_filter_useful", "true"),
+					dcByStatus.CheckResourceExists(),
+					resource.TestMatchResourceAttr(byStatus, "resource_pools.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceV2ResourcePools_basic string = `
+data "huaweicloud_modelartsv2_resource_pools" "all" {}
+
+data "huaweicloud_modelartsv2_resource_pools" "by_workspace_id" {
+  workspace_id = "0"
+}
+
+output "is_workspace_id_filter_useful" {
+  value = alltrue([for o in data.huaweicloud_modelartsv2_resource_pools.by_workspace_id.resource_pools: o.workspace_id == "0"])
+}
+
+data "huaweicloud_modelartsv2_resource_pools" "by_status" {
+  status = "created"
+}
+`

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_resource_pools.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_resource_pools.go
@@ -1,0 +1,618 @@
+package modelarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ServiceStage GET /v2/{project_id}/pools
+func DataSourceV2ResourcePools() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV2ResourcePoolsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the resource pools are located.`,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The workspace ID to which the resource pool belongs.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The status of the resource pools to be queried.`,
+			},
+			"resource_pools": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"metadata": {
+							Type:        schema.TypeList,
+							Elem:        dataV2ResourcePoolMetadataSchema(),
+							Computed:    true,
+							Description: `The metadata configuration of the resource pool.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the resource pool.`,
+						},
+						"scope": {
+							Type:        schema.TypeList,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Computed:    true,
+							Description: `The list of job types supported by the resource pool.`,
+						},
+						"resources": {
+							Type:        schema.TypeList,
+							Elem:        dataV2ResourcePoolResourceSchema(),
+							Computed:    true,
+							Description: `The list of resource specifications in the resource pool.`,
+						},
+						"network_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ModelArts network ID of the resource pool.`,
+						},
+						"prefix": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The prefix of the user-defined node name of the resource pool.`,
+						},
+						"vpc_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the VPC to which the resource pool belongs.`,
+						},
+						"subnet_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The network ID of the subnet to which the resource pool belongs.`,
+						},
+						"clusters": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        dataV2ResourcePoolClustersSchema(),
+							Description: `The list of the CCE clusters.`,
+						},
+						"user_login": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        dataV2ResourcePoolUserLoginSchema(),
+							Description: `The user login info of the resource pool.`,
+						},
+						"workspace_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The workspace ID of the resource pool.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the resource pool.`,
+						},
+						"charging_mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The charging mode of the resource pool.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the resource pool.`,
+						},
+						"resource_pool_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The resource ID of the resource pool.`,
+						},
+					},
+				},
+				Description: "All application details.",
+			},
+		},
+	}
+}
+
+func dataV2ResourcePoolMetadataSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"annotations": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The annotations of the resource pool.`,
+			},
+			"labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The labels of the resource pool.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the resource pool, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func dataV2ResourcePoolResourceSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"flavor_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The resource flavor ID.`,
+			},
+			"count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of resources of the corresponding flavors.`,
+			},
+			"node_pool": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of resource pool nodes.`,
+			},
+			"max_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The max number of resources of the corresponding flavors.`,
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the VPC to which the the resource pool nodes belong.`,
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The network ID of a subnet to which the the resource pool nodes belong.`,
+			},
+			"security_group_ids": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The security group IDs to which the the resource pool nodes belong.`,
+			},
+			"azs": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2ResourcePoolResourceAzsSchema(),
+				Description: `The availability zones for the resource pool nodes.`,
+			},
+			"taints": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2ResourcePoolResourceTaintsSchema(),
+				Description: `The taints added to resource pool nodes.`,
+			},
+			"labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The labels of resource pool nodes.`,
+			},
+			"tags": common.TagsComputedSchema(
+				`The key/value pairs to associate with the resource pool nodes.`,
+			),
+			"extend_params": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The extend parameters of the resource pool nodes.`,
+			},
+			"root_volume": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2ResourcePoolResourceRootVolumeSchema(),
+				Description: `The root volume of the resource pool nodes.`,
+			},
+			"data_volumes": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2ResourcePoolResourceDataVolumesSchema(),
+				Description: `The list of data volumes of the resource pool nodes.`,
+			},
+			"volume_group_configs": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        dataV2ResourcePoolResourceVolumeGroupConfigsSchema(),
+				Description: `The extend configurations of the volume groups.`,
+			},
+		},
+	}
+}
+
+func dataV2ResourcePoolResourceAzsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"az": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The AZ name.`,
+			},
+			"count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of nodes for the corresponding AZ.`,
+			},
+		},
+	}
+}
+
+func dataV2ResourcePoolResourceTaintsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The key of the taint.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The value of the taint.`,
+			},
+			"effect": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The effect of the taint.`,
+			},
+		},
+	}
+}
+
+func dataV2ResourcePoolResourceRootVolumeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"volume_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the root volume.`,
+			},
+			"size": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The size of the root volume.`,
+			},
+		},
+	}
+}
+
+func dataV2ResourcePoolResourceDataVolumesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"volume_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the data volume.`,
+			},
+			"size": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The size of the data volume.`,
+			},
+			"extend_params": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The extend parameters of the data volume.`,
+			},
+			"count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The count of the current data volume configuration.`,
+			},
+		},
+	}
+}
+
+func dataV2ResourcePoolResourceVolumeGroupConfigsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"volume_group": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the volume group.`,
+			},
+			"docker_thin_pool": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The percentage of container volumes to data volumes on resource pool nodes.`,
+			},
+			"lvm_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"lv_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The LVM write mode.`,
+						},
+						"path": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The volume mount path.`,
+						},
+					},
+				},
+				Description: `The configuration of the LVM management.`,
+			},
+			"types": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of storage types of the volume group.`,
+			},
+		},
+	}
+}
+
+func dataV2ResourcePoolClustersSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"provider_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the CCE cluster that resource pool used.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the CCE cluster that resource pool used.`,
+			},
+		},
+	}
+}
+
+func dataV2ResourcePoolUserLoginSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key_pair_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The key pair name of the login user.`,
+			},
+		},
+	}
+}
+
+func buildV2ResourcePoolsQueryParams(d *schema.ResourceData) string {
+	result := ""
+
+	if workspaceId, ok := d.GetOk("workspace_id"); ok {
+		result += fmt.Sprintf("&workspaceId=%v", workspaceId)
+	}
+
+	if status, ok := d.GetOk("status"); ok {
+		result += fmt.Sprintf("&status=%v", status)
+	}
+
+	if result == "" {
+		return result
+	}
+	return "?" + result[1:]
+}
+
+func listV2ResourcePools(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/pools"
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildV2ResourcePoolsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenV2ResourcePoolMetadata(metadata interface{}) []map[string]interface{} {
+	if metadata == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"annotations": utils.PathSearch("annotations", metadata, make(map[string]interface{})),
+			"labels":      utils.PathSearch("labels", metadata, make(map[string]interface{})),
+			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("creationTimestamp",
+				metadata, "").(string))/1000, false),
+		},
+	}
+}
+
+func flattenV2ResourcePoolResourceAzs(azList []interface{}) []map[string]interface{} {
+	if len(azList) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(azList))
+	for _, az := range azList {
+		result = append(result, map[string]interface{}{
+			"az":    utils.PathSearch("az", az, nil),
+			"count": utils.PathSearch("count", az, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenV2ResourcePoolResourceTaints(taints []interface{}) []map[string]interface{} {
+	if len(taints) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(taints))
+	for _, taint := range taints {
+		result = append(result, map[string]interface{}{
+			"key":    utils.PathSearch("key", taint, nil),
+			"value":  utils.PathSearch("value", taint, nil),
+			"effect": utils.PathSearch("effect", taint, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenV2ResourcePoolResources(resources []interface{}) []map[string]interface{} {
+	if len(resources) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(resources))
+	for _, resource := range resources {
+		result = append(result, map[string]interface{}{
+			"flavor_id":          utils.PathSearch("flavor", resource, nil),
+			"count":              utils.PathSearch("count", resource, nil),
+			"max_count":          utils.PathSearch("maxCount", resource, nil),
+			"node_pool":          utils.PathSearch("nodePool", resource, nil),
+			"vpc_id":             utils.PathSearch("network.vpc", resource, nil),
+			"subnet_id":          utils.PathSearch("network.subnet", resource, nil),
+			"security_group_ids": utils.PathSearch("network.securityGroups", resource, nil),
+			"azs":                flattenV2ResourcePoolResourceAzs(utils.PathSearch("azs", resource, make([]interface{}, 0)).([]interface{})),
+			"taints":             flattenV2ResourcePoolResourceTaints(utils.PathSearch("taints", resource, make([]interface{}, 0)).([]interface{})),
+			"labels":             utils.PathSearch("labels", resource, nil),
+			"tags":               flattenResourcePoolResourcesTags(resource),
+			"extend_params":      utils.JsonToString(utils.PathSearch("extendParams", resource, nil)),
+			"root_volume":        flattenResourcePoolResourcesRootVolume(utils.PathSearch("rootVolume", resource, nil)),
+			"data_volumes": flattenResourcePoolResourcesDataVolumes(utils.PathSearch("dataVolumes",
+				resource, make([]interface{}, 0)).([]interface{})),
+			"volume_group_configs": flattenResourcePoolResourcesVolumeGroupConfigs(utils.PathSearch("volumeGroupConfigs",
+				resource, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func flattenV2ResourcePoolClusters(clusters []interface{}) []map[string]interface{} {
+	if len(clusters) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(clusters))
+	for _, cluster := range clusters {
+		result = append(result, map[string]interface{}{
+			"provider_id": utils.PathSearch("providerId", cluster, nil),
+			"name":        utils.PathSearch("name", cluster, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenV2ResourcePoolUserLogin(userLogin interface{}) []map[string]interface{} {
+	if userLogin == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"key_pair_name": utils.PathSearch("keyPairName", userLogin, nil),
+		},
+	}
+}
+
+func flattenV2ResourcePoolChargingMode(chargingMode string) interface{} {
+	if chargingMode == "1" {
+		return "prePaid"
+	}
+
+	return nil
+}
+
+func flattenV2ResourcePools(resourcePools []interface{}) []map[string]interface{} {
+	if len(resourcePools) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(resourcePools))
+	for _, resourcePool := range resourcePools {
+		result = append(result, map[string]interface{}{
+			"metadata": flattenV2ResourcePoolMetadata(utils.PathSearch("metadata", resourcePool, nil)),
+			"name":     utils.PathSearch(`metadata.labels."os.modelarts/name"`, resourcePool, nil),
+			"scope":    utils.PathSearch("spec.scope", resourcePool, nil),
+			"resources": flattenV2ResourcePoolResources(utils.PathSearch("spec.resources",
+				resourcePool, make([]interface{}, 0)).([]interface{})),
+			"network_id": utils.PathSearch("spec.network.name", resourcePool, nil),
+			"prefix":     utils.PathSearch(`metadata.labels."os.modelarts/node.prefix"`, resourcePool, nil),
+			"vpc_id":     utils.PathSearch("spec.network.vpcId", resourcePool, nil),
+			"subnet_id":  utils.PathSearch("spec.network.subnetId", resourcePool, nil),
+			"clusters": flattenV2ResourcePoolClusters(utils.PathSearch("spec.clusters",
+				resourcePool, make([]interface{}, 0)).([]interface{})),
+			"user_login":   flattenV2ResourcePoolUserLogin(utils.PathSearch("spec.userLogin", resourcePool, nil)),
+			"workspace_id": utils.PathSearch(`metadata.labels."os.modelarts/workspace.id"`, resourcePool, nil),
+			"description":  utils.PathSearch(`metadata.annotations."os.modelarts/description"`, resourcePool, nil),
+			"charging_mode": flattenV2ResourcePoolChargingMode(utils.PathSearch(`metadata.annotations."os.modelarts/billing.mode"`,
+				resourcePool, "").(string)),
+			"status":           utils.PathSearch("status.phase", resourcePool, nil),
+			"resource_pool_id": utils.PathSearch(`metadata.labels."os.modelarts/resource.id"`, resourcePool, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceV2ResourcePoolsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	resourcePools, err := listV2ResourcePools(client, d)
+	if err != nil {
+		return diag.Errorf("error getting resource pools: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("resource_pools", flattenV2ResourcePools(resourcePools)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool.go
@@ -337,13 +337,11 @@ func modelartsResourcePoolResourcesAzsSchema() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"az": {
 				Type:        schema.TypeString,
-				Optional:    true,
 				Computed:    true,
 				Description: `The AZ name.`,
 			},
 			"count": {
 				Type:        schema.TypeInt,
-				Optional:    true,
 				Computed:    true,
 				Description: `Number of nodes.`,
 			},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new data source to query resource pools and supports two filter parameters:
- workspace_id
- status

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query resource pools
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccDataSourceV2ResourcePools_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDataSourceV2ResourcePools_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceV2ResourcePools_basic
=== PAUSE TestAccDataSourceV2ResourcePools_basic
=== CONT  TestAccDataSourceV2ResourcePools_basic
--- PASS: TestAccDataSourceV2ResourcePools_basic (12.63s)
PASS
coverage: 6.7% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 12.712s coverage: 6.7% of statements in ./huaweicloud/services/modelarts
```

![image](https://github.com/user-attachments/assets/1fddaea6-e987-4e75-be0b-e886e97c4b31)

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
