### PR TITLE
feat(ga): the listener support new attributes

### DIFF
--- a/docs/data-sources/ga_listeners.md
+++ b/docs/data-sources/ga_listeners.md
@@ -2,7 +2,8 @@
 subcategory: "Global Accelerator (GA)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_ga_listeners"
-description: ""
+description: |-
+  Use this data source to get the list of listeners.
 ---
 
 # huaweicloud_ga_listeners
@@ -74,9 +75,21 @@ The `listeners` block supports:
 
 * `updated_at` - The latest update time of the listener.
 
+* `frozen_info` - The frozen details of cloud services or resources.
+  The [frozen_info](#Listeners_frozen_info) structure is documented below.
+
 <a name="listener_port_ranges"></a>
 The `port_ranges` block supports:
 
 * `from_port` - The listening to start port of the listener.
 
 * `to_port` - The listening to end port of the listener.
+
+<a name="Listeners_frozen_info"></a>
+The `frozen_info` block supports:
+
+* `status` - The status of a cloud service or resource.
+
+* `effect` - The status of the resource after being forzen.
+
+* `scene` - The service scenario.

--- a/docs/resources/ga_listener.md
+++ b/docs/resources/ga_listener.md
@@ -2,7 +2,8 @@
 subcategory: "Global Accelerator (GA)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_ga_listener"
-description: ""
+description: |-
+  Manages a GA listener resource within HuaweiCloud.
 ---
 
 # huaweicloud_ga_listener
@@ -83,7 +84,34 @@ In addition to all arguments above, the following attributes are exported:
 * `created_at` - Indicates when the listener was created.
 
 * `updated_at` - Indicates when the listener was updated.
-  
+
+* `frozen_info` - The frozen details of cloud services or resources.
+  The [frozen_info](#Listener_frozen_info) structure is documented below.
+
+<a name="Listener_frozen_info"></a>
+The `frozen_info` block supports:
+
+* `status` - The status of a cloud service or resource.
+  The valid values are as follows:
+  + `0`: unfrozen/normal (The cloud service will recover after being unfrozen.)
+  + `1`: frozen (Resources and data will be retained, but the cloud service cannot be used.)
+  + `2`: deleted/terminated (Both resources and data will be cleared.)
+
+* `effect` - The status of the resource after being forzen.
+  The valid values are as follows:
+  + `1` (default): The resource is frozen and can be released.
+  + `2`: The resource is frozen and cannot be released.
+  + `3`: The resource is frozen and cannot be renewed.
+
+* `scene` - The service scenario.
+  The valid values are as follows:
+  + **ARREAR**: The cloud service is in arrears, including expiration of yearly/monthly resources and fee deduction
+    failure of pay-per-use resources.
+  + **POLICE**: The cloud service is frozen for public security.
+  + **ILLEGAL**: The cloud service is frozen due to violation of laws and regulations.
+  + **VERIFY**: The cloud service is frozen because the user fails to pass the real-name authentication.
+  + **PARTNER**: A partner freezes their customer's resources.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:

--- a/huaweicloud/services/ga/data_source_huaweicloud_ga_listeners.go
+++ b/huaweicloud/services/ga/data_source_huaweicloud_ga_listeners.go
@@ -129,6 +129,31 @@ func listenersSchema() *schema.Resource {
 				Computed:    true,
 				Description: "The latest update time of the listener.",
 			},
+			"frozen_info": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The frozen details of cloud services or resources.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"status": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The status of a cloud service or resource.`,
+						},
+						"effect": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The status of the resource after being forzen.`,
+						},
+						"scene": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The service scenario.`,
+						},
+					},
+				},
+			},
 		},
 	}
 	return &sc
@@ -205,6 +230,7 @@ func flattenListListenersResponseBody(resp interface{}) []interface{} {
 			"tags":            utils.FlattenTagsToMap(utils.PathSearch("tags", v, nil)),
 			"created_at":      utils.PathSearch("created_at", v, nil),
 			"updated_at":      utils.PathSearch("updated_at", v, nil),
+			"frozen_info":     flattenListenerFrozenInfos(utils.PathSearch("frozen_info", v, nil)),
 		})
 	}
 	return rst
@@ -220,6 +246,20 @@ func flattenPortRanges(raw interface{}) []map[string]interface{} {
 		}
 	}
 	return result
+}
+
+func flattenListenerFrozenInfos(resp interface{}) []map[string]interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	frozenInfo := map[string]interface{}{
+		"status": utils.PathSearch("status", resp, nil),
+		"effect": utils.PathSearch("effect", resp, nil),
+		"scene":  utils.PathSearch("scene", resp, []string{}),
+	}
+
+	return []map[string]interface{}{frozenInfo}
 }
 
 func filterListListenersResponseBody(all []interface{}, d *schema.ResourceData) []interface{} {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The listener support new attributes.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ga" TESTARGS="-run TestAccListener_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ga -v -run TestAccListener_basic -timeout 360m -parallel 4
=== RUN   TestAccListener_basic
=== PAUSE TestAccListener_basic
=== CONT  TestAccListener_basic
--- PASS: TestAccListener_basic (104.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga        104.175s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/ga" TESTARGS="-run TestAccDatasourceListeners_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ga -v -run TestAccDatasourceListeners_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceListeners_basic
=== PAUSE TestAccDatasourceListeners_basic
=== CONT  TestAccDatasourceListeners_basic
--- PASS: TestAccDatasourceListeners_basic (77.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga        78.073s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
