### PR TITLE
feat(ga): the health check supports new attributes

### DIFF
--- a/docs/data-sources/ga_health_checks.md
+++ b/docs/data-sources/ga_health_checks.md
@@ -2,7 +2,8 @@
 subcategory: "Global Accelerator (GA)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_ga_health_checks"
-description: ""
+description: |-
+  Use this data source to get the list of health checks.
 ---
 
 # huaweicloud_ga_health_checks
@@ -71,3 +72,15 @@ The `health_checks` block supports:
 * `created_at` - The creation time of the health check.
 
 * `updated_at` - The latest update time of the health check.
+
+* `frozen_info` - The frozen details of cloud services or resources.
+  The [frozen_info](#health_checks_frozen_info) structure is documented below.
+
+<a name="health_checks_frozen_info"></a>
+The `frozen_info` block supports:
+
+* `status` - The status of a cloud service or resource.
+
+* `effect` - The status of the resource after being forzen.
+
+* `scene` - The service scenario.

--- a/docs/resources/ga_health_check.md
+++ b/docs/resources/ga_health_check.md
@@ -2,7 +2,8 @@
 subcategory: "Global Accelerator (GA)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_ga_health_check"
-description: ""
+description: |-
+  Manages a GA health check resource within HuaweiCloud.
 ---
 
 # huaweicloud_ga_health_check
@@ -70,6 +71,33 @@ In addition to all arguments above, the following attributes are exported:
 * `created_at` - Indicates when the health check was configured.
 
 * `updated_at` - Indicates when the health check was updated.
+
+* `frozen_info` - The frozen details of cloud services or resources.
+  The [frozen_info](#health_check_frozen_info) structure is documented below.
+
+<a name="health_check_frozen_info"></a>
+The `frozen_info` block supports:
+
+* `status` - The status of a cloud service or resource.
+  The valid values are as follows:
+  + `0`: unfrozen/normal (The cloud service will recover after being unfrozen.)
+  + `1`: frozen (Resources and data will be retained, but the cloud service cannot be used.)
+  + `2`: deleted/terminated (Both resources and data will be cleared.)
+
+* `effect` - The status of the resource after being forzen.
+  The valid values are as follows:
+  + `1` (default): The resource is frozen and can be released.
+  + `2`: The resource is frozen and cannot be released.
+  + `3`: The resource is frozen and cannot be renewed.
+
+* `scene` - The service scenario.
+  The valid values are as follows:
+  + **ARREAR**: The cloud service is in arrears, including expiration of yearly/monthly resources and fee deduction
+    failure of pay-per-use resources.
+  + **POLICE**: The cloud service is frozen for public security.
+  + **ILLEGAL**: The cloud service is frozen due to violation of laws and regulations.
+  + **VERIFY**: The cloud service is frozen because the user fails to pass the real-name authentication.
+  + **PARTNER**: A partner freezes their customer's resources.
 
 ## Timeouts
 

--- a/huaweicloud/services/ga/data_source_huaweicloud_ga_health_checks.go
+++ b/huaweicloud/services/ga/data_source_huaweicloud_ga_health_checks.go
@@ -114,6 +114,31 @@ func healthChecksSchema() *schema.Resource {
 				Computed:    true,
 				Description: "The latest update time of the health check.",
 			},
+			"frozen_info": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The frozen details of cloud services or resources.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"status": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The status of a cloud service or resource.`,
+						},
+						"effect": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The status of the resource after being forzen.`,
+						},
+						"scene": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The service scenario.`,
+						},
+					},
+				},
+			},
 		},
 	}
 	return &sc
@@ -211,9 +236,24 @@ func flattenListHealthChecksResponseBody(resp interface{}) []interface{} {
 			"enabled":           utils.PathSearch("enabled", v, nil),
 			"created_at":        utils.PathSearch("created_at", v, nil),
 			"updated_at":        utils.PathSearch("updated_at", v, nil),
+			"frozen_info":       flattenHealthChecksFrozenInfo(utils.PathSearch("frozen_info", v, nil)),
 		})
 	}
 	return rst
+}
+
+func flattenHealthChecksFrozenInfo(resp interface{}) []map[string]interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	frozenInfo := map[string]interface{}{
+		"status": utils.PathSearch("status", resp, nil),
+		"effect": utils.PathSearch("effect", resp, nil),
+		"scene":  utils.PathSearch("scene", resp, []string{}),
+	}
+
+	return []map[string]interface{}{frozenInfo}
 }
 
 func buildListHealthChecksQueryParams(d *schema.ResourceData) string {

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_health_check.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_health_check.go
@@ -106,6 +106,31 @@ func ResourceHealthCheck() *schema.Resource {
 				Computed:    true,
 				Description: `Indicates when the health check was updated. `,
 			},
+			"frozen_info": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The frozen details of cloud services or resources.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"status": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The status of a cloud service or resource.`,
+						},
+						"effect": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The status of the resource after being forzen.`,
+						},
+						"scene": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The service scenario.`,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -261,9 +286,24 @@ func resourceHealthCheckRead(_ context.Context, d *schema.ResourceData, meta int
 		d.Set("status", utils.PathSearch("health_check.status", respBody, nil)),
 		d.Set("timeout", utils.PathSearch("health_check.timeout", respBody, nil)),
 		d.Set("updated_at", utils.PathSearch("health_check.updated_at", respBody, nil)),
+		d.Set("frozen_info", flattenHealthCheckFrozenInfo(utils.PathSearch("health_check.frozen_info", respBody, nil))),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenHealthCheckFrozenInfo(resp interface{}) []map[string]interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	frozenInfo := map[string]interface{}{
+		"status": utils.PathSearch("status", resp, nil),
+		"effect": utils.PathSearch("effect", resp, nil),
+		"scene":  utils.PathSearch("scene", resp, []string{}),
+	}
+
+	return []map[string]interface{}{frozenInfo}
 }
 
 func resourceHealthCheckUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The health check supports new attributes.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ga" TESTARGS="-run TestAccHealthCheck_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ga -v -run TestAccHealthCheck_basic -timeout 360m -parallel 4
=== RUN   TestAccHealthCheck_basic
=== PAUSE TestAccHealthCheck_basic
=== CONT  TestAccHealthCheck_basic
--- PASS: TestAccHealthCheck_basic (152.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga        152.260s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/ga" TESTARGS="-run TestAccDatasourceHealthChecks_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ga -v -run TestAccDatasourceHealthChecks_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceHealthChecks_basic
=== PAUSE TestAccDatasourceHealthChecks_basic
=== CONT  TestAccDatasourceHealthChecks_basic
--- PASS: TestAccDatasourceHealthChecks_basic (129.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga        129.593s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
