### PR TITLE
feat(ga): the endpoint supports new attributes

### DIFF
--- a/docs/data-sources/ga_endpoints.md
+++ b/docs/data-sources/ga_endpoints.md
@@ -2,7 +2,8 @@
 subcategory: "Global Accelerator (GA)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_ga_endpoints"
-description: ""
+description: |-
+  Use this data source to get the list of endpoints.
 ---
 
 # huaweicloud_ga_endpoints
@@ -79,3 +80,15 @@ The `endpoints` block supports:
 * `created_at` - The creation time of the endpoint.
 
 * `updated_at` - The latest update time of the endpoint.
+
+* `frozen_info` - The frozen details of cloud services or resources.
+  The [frozen_info](#endpoints_frozen_info) structure is documented below.
+
+<a name="endpoints_frozen_info"></a>
+The `frozen_info` block supports:
+
+* `status` - The status of a cloud service or resource.
+
+* `effect` - The status of the resource after being forzen.
+
+* `scene` - The service scenario.

--- a/docs/resources/ga_endpoint.md
+++ b/docs/resources/ga_endpoint.md
@@ -2,7 +2,8 @@
 subcategory: "Global Accelerator (GA)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_ga_endpoint"
-description: ""
+description: |-
+  Manages a GA endpoint resource within HuaweiCloud.
 ---
 
 # huaweicloud_ga_endpoint
@@ -69,6 +70,33 @@ In addition to all arguments above, the following attributes are exported:
 * `created_at` - Indicates when the endpoint was created.
 
 * `updated_at` - Indicates when the endpoint was updated.
+
+* `frozen_info` - The frozen details of cloud services or resources.
+  The [frozen_info](#endpoint_frozen_info) structure is documented below.
+
+<a name="endpoint_frozen_info"></a>
+The `frozen_info` block supports:
+
+* `status` - The status of a cloud service or resource.
+  The valid values are as follows:
+  + `0`: unfrozen/normal (The cloud service will recover after being unfrozen.)
+  + `1`: frozen (Resources and data will be retained, but the cloud service cannot be used.)
+  + `2`: deleted/terminated (Both resources and data will be cleared.)
+
+* `effect` - The status of the resource after being forzen.
+  The valid values are as follows:
+  + `1` (default): The resource is frozen and can be released.
+  + `2`: The resource is frozen and cannot be released.
+  + `3`: The resource is frozen and cannot be renewed.
+
+* `scene` - The service scenario.
+  The valid values are as follows:
+  + **ARREAR**: The cloud service is in arrears, including expiration of yearly/monthly resources and fee deduction
+    failure of pay-per-use resources.
+  + **POLICE**: The cloud service is frozen for public security.
+  + **ILLEGAL**: The cloud service is frozen due to violation of laws and regulations.
+  + **VERIFY**: The cloud service is frozen because the user fails to pass the real-name authentication.
+  + **PARTNER**: A partner freezes their customer's resources.
 
 ## Timeouts
 

--- a/huaweicloud/services/ga/data_source_huaweicloud_ga_endpoints.go
+++ b/huaweicloud/services/ga/data_source_huaweicloud_ga_endpoints.go
@@ -120,6 +120,31 @@ func endpointsSchema() *schema.Resource {
 				Computed:    true,
 				Description: "The latest update time of the endpoint.",
 			},
+			"frozen_info": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The frozen details of cloud services or resources.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"status": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The status of a cloud service or resource.`,
+						},
+						"effect": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The status of the resource after being forzen.`,
+						},
+						"scene": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The service scenario.`,
+						},
+					},
+				},
+			},
 		},
 	}
 	return &sc
@@ -196,9 +221,24 @@ func flattenListEndpointsResponseBody(resp interface{}) []interface{} {
 			"ip_address":        utils.PathSearch("ip_address", v, nil),
 			"created_at":        utils.PathSearch("created_at", v, nil),
 			"updated_at":        utils.PathSearch("updated_at", v, nil),
+			"frozen_info":       flattenEndpointsFrozenInfo(utils.PathSearch("frozen_info", v, nil)),
 		})
 	}
 	return rst
+}
+
+func flattenEndpointsFrozenInfo(resp interface{}) []map[string]interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	frozenInfo := map[string]interface{}{
+		"status": utils.PathSearch("status", resp, nil),
+		"effect": utils.PathSearch("effect", resp, nil),
+		"scene":  utils.PathSearch("scene", resp, []string{}),
+	}
+
+	return []map[string]interface{}{frozenInfo}
 }
 
 func filterListEndpointsResponseBody(all []interface{}, d *schema.ResourceData) []interface{} {

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_endpoint.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_endpoint.go
@@ -100,6 +100,31 @@ func ResourceEndpoint() *schema.Resource {
 				Computed:    true,
 				Description: `Specifies when the endpoint was updated.`,
 			},
+			"frozen_info": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The frozen details of cloud services or resources.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"status": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The status of a cloud service or resource.`,
+						},
+						"effect": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The status of the resource after being forzen.`,
+						},
+						"scene": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The service scenario.`,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -255,9 +280,24 @@ func resourceEndpointRead(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("status", utils.PathSearch("endpoint.status", respBody, nil)),
 		d.Set("updated_at", utils.PathSearch("endpoint.updated_at", respBody, nil)),
 		d.Set("weight", utils.PathSearch("endpoint.weight", respBody, nil)),
+		d.Set("frozen_info", flattenEndpointFrozenInfo(utils.PathSearch("endpoint.frozen_info", respBody, nil))),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenEndpointFrozenInfo(resp interface{}) []map[string]interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	frozenInfo := map[string]interface{}{
+		"status": utils.PathSearch("status", resp, nil),
+		"effect": utils.PathSearch("effect", resp, nil),
+		"scene":  utils.PathSearch("scene", resp, []string{}),
+	}
+
+	return []map[string]interface{}{frozenInfo}
 }
 
 func resourceEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The endpoint supports new attributes.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ga" TESTARGS="-run TestAccEndpoint_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ga -v -run TestAccEndpoint_basic -timeout 360m -parallel 4
=== RUN   TestAccEndpoint_basic
=== PAUSE TestAccEndpoint_basic
=== CONT  TestAccEndpoint_basic
--- PASS: TestAccEndpoint_basic (165.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga        166.317s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/ga" TESTARGS="-run TestAccDatasourceEndpoints_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ga -v -run TestAccDatasourceEndpoints_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceEndpoints_basic
=== PAUSE TestAccDatasourceEndpoints_basic
=== CONT  TestAccDatasourceEndpoints_basic
--- PASS: TestAccDatasourceEndpoints_basic (139.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga        139.828s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
