### PR TITLE
fix(kafka): change smart connect spec code to optional

### DIFF
--- a/docs/resources/dms_kafka_smart_connect.md
+++ b/docs/resources/dms_kafka_smart_connect.md
@@ -33,7 +33,7 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `storage_spec_code` - (Required, String, ForceNew) Specifies the storage specification code of the connector.
+* `storage_spec_code` - (Optional, String, ForceNew) Specifies the storage specification code of the connector.
 
   Changing this parameter will create a new resource.
 

--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_smart_connect_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_smart_connect_test.go
@@ -24,7 +24,7 @@ func getDmsKafkaSmartConnectResourceFunc(cfg *config.Config, state *terraform.Re
 	)
 	getKafkaSmartConnectClient, err := cfg.NewServiceClient(getKafkaSmartConnectProduct, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating DMS Client: %s", err)
+		return nil, fmt.Errorf("error creating DMS client: %s", err)
 	}
 
 	instanceID := state.Primary.Attributes["instance_id"]
@@ -74,11 +74,6 @@ func TestAccDmsKafkaSmartConnect_basic(t *testing.T) {
 				Config: testDmsKafkaSmartConnect_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(resourceName, "storage_spec_code"),
-					resource.TestCheckResourceAttrSet(resourceName, "bandwidth"),
-					resource.TestCheckResourceAttrSet(resourceName, "node_count"),
-					resource.TestCheckResourceAttr(resourceName, "storage_spec_code", "dms.physical.storage.high.v2"),
-					resource.TestCheckResourceAttr(resourceName, "bandwidth", "100MB"),
 					resource.TestCheckResourceAttr(resourceName, "node_count", "2"),
 				),
 			},
@@ -98,10 +93,8 @@ func testDmsKafkaSmartConnect_basic(name string) string {
 %s
 
 resource "huaweicloud_dms_kafka_smart_connect" "test" {
-  instance_id       = huaweicloud_dms_kafka_instance.test.id
-  storage_spec_code = "dms.physical.storage.high.v2"
-  node_count        = 2
-  bandwidth         = "100MB"
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+  node_count  = 2
 }
 `, testAccKafkaInstance_newFormat(name))
 }

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_smart_connect.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_smart_connect.go
@@ -50,7 +50,7 @@ func ResourceDmsKafkaSmartConnect() *schema.Resource {
 			},
 			"storage_spec_code": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				ForceNew:    true,
 				Description: `Specifies the specification code of the smart connect.`,
 			},
@@ -147,8 +147,8 @@ func resourceDmsKafkaSmartConnectCreate(ctx context.Context, d *schema.ResourceD
 
 func buildCreateKafkaSmartConnectBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
-		"spec_code":     d.Get("storage_spec_code"),
-		"specification": d.Get("bandwidth"),
+		"spec_code":     utils.ValueIgnoreEmpty(d.Get("storage_spec_code")),
+		"specification": utils.ValueIgnoreEmpty(d.Get("bandwidth")),
 		"node_cnt":      utils.ValueIgnoreEmpty(d.Get("node_count")),
 	}
 	return bodyParams
@@ -267,7 +267,7 @@ func resourceDmsKafkaSmartConnectDelete(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("error waiting for instance (%s) to become ready: %s", instanceID, err)
 	}
 
-	return resourceDmsKafkaSmartConnectRead(ctx, d, meta)
+	return nil
 }
 
 func buildDeleteKafkaSmartConnectBodyParams(d *schema.ResourceData) map[string]interface{} {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
change smart connect spec code to optional
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/kafka" TESTARGS="-run TestAccDmsKafkaSmartConnect_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/kafka -v -run TestAccDmsKafkaSmartConnect_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaSmartConnect_basic
=== PAUSE TestAccDmsKafkaSmartConnect_basic
=== CONT  TestAccDmsKafkaSmartConnect_basic
--- PASS: TestAccDmsKafkaSmartConnect_basic (1369.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     1370.026s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
