### PR TITLE
feat(lts): add new one-time resource to operate log collection switch

### DIFF
--- a/docs/resources/lts_log_collection_switch.md
+++ b/docs/resources/lts_log_collection_switch.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Log Tank Service (LTS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_lts_log_collection_switch"
+description: |-
+  Use this resource to enable or disable log collection beyond free quota within HuaweiCloud.
+---
+
+# huaweicloud_lts_log_collection_switch
+
+Use this resource to enable or disable log collection beyond free quota within HuaweiCloud.
+
+-> This resource is only a one-time action resource for enabling or disabling log collection switch. Deleting this
+   resource will not clear the corresponding request record, but will only remove the resource information from the
+   tfstate file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_lts_log_collection_switch" "test" {
+  action = "enable"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `action` - (Required, String, NonUpdatable) Specifies the operation type of the log collection switch.  
+  The valid values are as follows:
+  + **enable**
+  + **disable**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2152,6 +2152,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_lts_host_access":                      lts.ResourceHostAccessConfig(),
 			"huaweicloud_lts_host_group":                       lts.ResourceHostGroup(),
 			"huaweicloud_lts_keywords_alarm_rule":              lts.ResourceKeywordsAlarmRule(),
+			"huaweicloud_lts_log_collection_switch":            lts.ResourceLogCollectionSwitch(),
 			"huaweicloud_lts_log_converge":                     lts.ResourceLogConverge(),
 			"huaweicloud_lts_log_converge_switch":              lts.ResourceLogConvergeSwitch(),
 			"huaweicloud_lts_metric_rule":                      lts.ResourceMetricRule(),

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_log_collection_switch_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_log_collection_switch_test.go
@@ -1,0 +1,39 @@
+package lts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccLogCollectionSwitch_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceLogCollectionSwitch_basic("disable"),
+			},
+			{
+				Config: resourceLogCollectionSwitch_basic("enable"),
+			},
+		},
+	})
+}
+
+func resourceLogCollectionSwitch_basic(action string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lts_log_collection_switch" "test" {
+  action           = "%[1]s"
+  enable_force_new = "true"
+}
+`, action)
+}

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_log_collection_switch.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_log_collection_switch.go
@@ -1,0 +1,104 @@
+package lts
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var logCollectionSwitchNonUpdatableParams = []string{"action"}
+
+// @API LTS POST /v2/{project_id}/collection/enable
+// @API LTS POST /v2/{project_id}/collection/disable
+func ResourceLogCollectionSwitch() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: ResourceLogCollectionSwitchCreate,
+		ReadContext:   ResourceLogCollectionSwitchRead,
+		UpdateContext: ResourceLogCollectionSwitchUpdate,
+		DeleteContext: ResourceLogCollectionSwitchDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(logCollectionSwitchNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The operation type of the log collection switch.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func ResourceLogCollectionSwitchCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/collection/{action}"
+		action  = d.Get("action").(string)
+	)
+
+	client, err := cfg.NewServiceClient("lts", region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{action}", action)
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	_, err = client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return diag.Errorf("unable to %s the log collection switch: %s", action, err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	return nil
+}
+
+func ResourceLogCollectionSwitchRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func ResourceLogCollectionSwitchUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func ResourceLogCollectionSwitchDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for enabling or disabling log collection switch. Deleting
+this resource will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new one-time resource to to enable or disable log collection beyond free quota.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new resouce.
add corresponding documentation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lts -f TestAccLogCollectionSwitch_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccLogCollectionSwitch_basic -timeout 360m -parallel 10
=== RUN   TestAccLogCollectionSwitch_basic
=== PAUSE TestAccLogCollectionSwitch_basic
=== CONT  TestAccLogCollectionSwitch_basic
--- PASS: TestAccLogCollectionSwitch_basic (29.72s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       29.819s coverage: 3.8% of statements in ./huaweicloud/services/lts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
