### PR TITLE
fix(eip): fix the incorrect refresh logic

### DIFF
--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
@@ -362,6 +362,8 @@ func createPostPaidEip(ctx context.Context, cfg *config.Config, client *golangsd
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        5 * time.Second,
 		PollInterval: 10 * time.Second,
+		// Max four retries will be executed.
+		NotFoundChecks: 3,
 	}
 
 	_, err = stateConf.WaitForStateContext(ctx)
@@ -437,10 +439,10 @@ func eipStatusRefreshFunc(networkingClient *golangsdk.ServiceClient, eipId strin
 				if len(targets) < 1 {
 					return resp, "COMPLETED", nil
 				}
-				return resp, "PENDING", nil
+				// The right pending status and nil response will trigger the NotFoundCheck logic.
+				return nil, "PENDING", nil
 			}
-
-			return nil, "", err
+			return resp, "ERROR", err
 		}
 		log.Printf("[DEBUG] The details of the EIP (%s) is: %+v", eipId, resp)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The refresh logic is incorrect for the resource EIP.
If the quota of the whole bandwidth is no enough, the show API will returns a 404 error.
And we should return this 404 error, not return nil.

apply result before update codes:
![image](https://github.com/user-attachments/assets/6bf11f9f-3efe-4341-8783-ca611af86da9)

apply result after update codes:
![image](https://github.com/user-attachments/assets/3125a446-4593-4e42-afed-c821441cf630)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the incorrect refresh logic
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o eip -f TestAccVpcEip_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eip" -v -coverprofile="./huaweicloud/services/acceptance/eip/eip_coverage.cov" -coverpkg="./huaweicloud/services/eip" -run TestAccVpcEip_basic -timeout 360m -parallel 10
=== RUN   TestAccVpcEip_basic
=== PAUSE TestAccVpcEip_basic
=== CONT  TestAccVpcEip_basic
--- PASS: TestAccVpcEip_basic (43.20s)
PASS
coverage: 8.7% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       43.335s coverage: 8.7% of statements in ./huaweicloud/services/eip
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
