### PR TITLE
feat(cbr): add locked param to vault resource

### DIFF
--- a/docs/json/resources/cbr_vault.json
+++ b/docs/json/resources/cbr_vault.json
@@ -22,6 +22,12 @@
                 "optional": true,
                 "computed": true
               },
+              "locked": {
+                "type": "bool",
+                "description":  "Locked status of the vault.",
+                "optional": true,
+                "computed": true
+              },
               "auto_renew": {
                 "type": "string",
                 "optional": true

--- a/docs/json/resources/cbr_vault.json
+++ b/docs/json/resources/cbr_vault.json
@@ -22,12 +22,6 @@
                 "optional": true,
                 "computed": true
               },
-              "locked": {
-                "type": "bool",
-                "description":  "Locked status of the vault.",
-                "optional": true,
-                "computed": true
-              },
               "auto_renew": {
                 "type": "string",
                 "optional": true

--- a/docs/resources/cbr_vault.md
+++ b/docs/resources/cbr_vault.md
@@ -227,7 +227,7 @@ The following arguments are supported:
 
   -> You cannot configure `auto_expand` if the vault is **prePaid** mode.
 
-* `auto_expand` - (Optional, Bool) Specifies Locked status of the vault. Defaults to **false**.
+* `auto_expand` - (Optional, Bool) Specifies locked status of the vault. Defaults to **false**.
 
 * `auto_bind` - (Optional, Bool) Specifies whether automatic association is enabled. Defaults to **false**.
 

--- a/docs/resources/cbr_vault.md
+++ b/docs/resources/cbr_vault.md
@@ -92,6 +92,7 @@ resource "huaweicloud_cbr_vault" "test" {
   protection_type = "backup"
   size            = 50
   auto_expand     = true
+  locked          = false
 
   resources {
     includes = var.evs_volume_ids
@@ -225,6 +226,8 @@ The following arguments are supported:
   Defaults to **false**.
 
   -> You cannot configure `auto_expand` if the vault is **prePaid** mode.
+
+* `auto_expand` - (Optional, Bool) Specifies Locked status of the vault. Defaults to **false**.
 
 * `auto_bind` - (Optional, Bool) Specifies whether automatic association is enabled. Defaults to **false**.
 

--- a/docs/resources/cbr_vault.md
+++ b/docs/resources/cbr_vault.md
@@ -227,7 +227,8 @@ The following arguments are supported:
 
   -> You cannot configure `auto_expand` if the vault is **prePaid** mode.
 
-* `auto_expand` - (Optional, Bool) Specifies locked status of the vault. Defaults to **false**.
+* `locked` - (Optional, Bool) Specifies whether the vault is locked. A locked vault cannot be unlocked.
+  Defaults to **false**.
 
 * `auto_bind` - (Optional, Bool) Specifies whether automatic association is enabled. Defaults to **false**.
 

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_test.go
@@ -2,6 +2,7 @@ package cbr
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -1214,4 +1215,59 @@ resource "huaweicloud_cbr_vault" "test" {
   }
 }
 `, basicConfig, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func TestAccVault_locked(t *testing.T) {
+	var (
+		vault interface{}
+
+		resourceName = "huaweicloud_cbr_vault.test"
+		name         = acceptance.RandomAccResourceName()
+
+		rc = acceptance.InitResourceCheck(resourceName, &vault, getVaultResourceFunc)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVault_locked_step(name, true),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "type", "disk"),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "locked", "true"),
+				),
+			},
+			{
+				Config: testAccVault_locked_step(name, false),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "type", "disk"),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "locked", "false"),
+				),
+				ExpectError: regexp.MustCompile("cannot unlock a vault that is already locked"),
+			},
+		},
+	})
+}
+
+func testAccVault_locked_step(name string, locked bool) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cbr_vault" "test" {
+	name                  = "%[1]s"
+	type                  = "disk"
+	protection_type       = "backup"
+	size                  = 100
+    locked                = %v
+}
+`, name, locked)
 }

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_test.go
@@ -1254,7 +1254,7 @@ func TestAccVault_locked(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "size", "100"),
 					resource.TestCheckResourceAttr(resourceName, "locked", "false"),
 				),
-				ExpectError: regexp.MustCompile("cannot unlock a vault that is already locked"),
+				ExpectError: regexp.MustCompile("vault not support to modify locked attribute from true to false."),
 			},
 		},
 	})
@@ -1263,11 +1263,11 @@ func TestAccVault_locked(t *testing.T) {
 func testAccVault_locked_step(name string, locked bool) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_cbr_vault" "test" {
-	name                  = "%[1]s"
-	type                  = "disk"
-	protection_type       = "backup"
-	size                  = 100
-    locked                = %v
+  name            = "%[1]s"
+  type            = "disk"
+  protection_type = "backup"
+  size            = 100
+  locked          = %v
 }
 `, name, locked)
 }

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
@@ -902,14 +902,7 @@ func updateBasicParameters(client *golangsdk.ServiceClient, d *schema.ResourceDa
 	}
 
 	if d.HasChange("locked") {
-		newLocked := d.Get("locked").(bool)
-		oldLocked, _ := d.GetChange("locked")
-		if oldLocked.(bool) && !newLocked {
-			return errors.New("cannot unlock a vault that is already locked")
-		}
-		if !oldLocked.(bool) && newLocked {
-			requestBody["locked"] = newLocked
-		}
+		requestBody["locked"] = d.Get("locked").(bool)
 	}
 
 	if d.HasChanges("bind_rules") {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
add cbr_vault locked param


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new param locked for cbr_vault
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
scripts/coverage.sh -o cbr -f TestAccVault_locked
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccVault_locked -timeout 360m -parallel 10
=== RUN   TestAccVault_locked
=== PAUSE TestAccVault_locked
=== CONT  TestAccVault_locked
--- PASS: TestAccVault_locked (35.85s)
PASS
coverage: 15.6% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       35.922s coverage: 15.6% of statements in ./huaweicloud/services/cbr
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
