### PR TITLE
feat(cci): add datasource CCI v2 config maps

### DIFF
--- a/docs/incubating/cciv2_config_maps.md
+++ b/docs/incubating/cciv2_config_maps.md
@@ -1,0 +1,62 @@
+---
+subcategory: "Cloud Container Instance (CCI)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cciv2_config_maps"
+description: |-
+  Use this data source to get the list of CCI config maps within HuaweiCloud.
+---
+
+# huaweicloud_cciv2_config_maps
+
+Use this data source to get the list of CCI config maps within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "namespace" {}
+
+data "huaweicloud_cciv2_config_maps" "test" {
+  namespace = var.namespace
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `namespace` - (Required, String) Specifies the namespace of the CCI config maps.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `config_maps` - The config maps.
+  The [config_maps](#config_maps) structure is documented below.
+
+<a name="config_maps"></a>
+The `config_maps` block supports:
+
+* `annotations` - The annotations.
+
+* `binary_data` - The binary data.
+
+* `creation_timestamp` - The creation time.
+
+* `data` - The data.
+
+* `immutable` - The immutable.
+
+* `labels` - The labels.
+
+* `name` - The name.
+
+* `namespace` - The namespace.
+
+* `resource_version` - The resource version.
+
+* `uid` - The uid.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -568,10 +568,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_cce_cluster_configurations": cce.DataSourceClusterConfigurations(),
 			"huaweicloud_cce_addons":                 cce.DataSourceCceAddons(),
 
-			"huaweicloud_cci_namespaces":   cci.DataSourceCciNamespaces(),
-			"huaweicloud_cciv2_namespaces": cci.DataSourceV2Namespaces(),
-			"huaweicloud_cciv2_services":   cci.DataSourceV2Services(),
-			"huaweicloud_cciv2_secrets":    cci.DataSourceV2Secrets(),
+			"huaweicloud_cci_namespaces":    cci.DataSourceCciNamespaces(),
+			"huaweicloud_cciv2_namespaces":  cci.DataSourceV2Namespaces(),
+			"huaweicloud_cciv2_services":    cci.DataSourceV2Services(),
+			"huaweicloud_cciv2_secrets":     cci.DataSourceV2Secrets(),
+			"huaweicloud_cciv2_config_maps": cci.DataSourceV2ConfigMaps(),
 
 			"huaweicloud_ccm_certificates":               ccm.DataSourceCertificates(),
 			"huaweicloud_ccm_certificate_export":         ccm.DataSourceCertificateExport(),

--- a/huaweicloud/services/acceptance/cci/data_source_huaweicloud_cciv2_config_maps_test.go
+++ b/huaweicloud/services/acceptance/cci/data_source_huaweicloud_cciv2_config_maps_test.go
@@ -1,0 +1,48 @@
+package cci
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceV2ConfigMaps_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_cciv2_config_maps.test"
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceV2ConfigMaps_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "config_maps.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "config_maps.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "config_maps.0.namespace"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "config_maps.0.annotations.%"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "config_maps.0.labels.%"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "config_maps.0.creation_timestamp"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "config_maps.0.resource_version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "config_maps.0.uid"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "config_maps.0.data.%"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceV2ConfigMaps_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_cciv2_config_maps" "test" {
+  depends_on = [huaweicloud_cciv2_config_map.test]
+
+  namespace = huaweicloud_cciv2_namespace.test.name
+}
+`, testAccV2ConfigMap_basic(rName))
+}

--- a/huaweicloud/services/cci/data_source_huaweicloud_cciv2_config_maps.go
+++ b/huaweicloud/services/cci/data_source_huaweicloud_cciv2_config_maps.go
@@ -1,0 +1,150 @@
+package cci
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CCI GET /apis/cci/v2/namespaces/{namespace}/configmaps
+func DataSourceV2ConfigMaps() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV2ConfigMapsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"namespace": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"config_maps": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"namespace": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"annotations": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"labels": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"creation_timestamp": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"binary_data": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"data": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"immutable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceV2ConfigMapsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("cci", region)
+	if err != nil {
+		return diag.Errorf("error creating CCI client: %s", err)
+	}
+	listConfigMapsHttpUrl := "apis/cci/v2/namespaces/{namespace}/configmaps"
+	listConfigMapsPath := client.Endpoint + listConfigMapsHttpUrl
+	listConfigMapsPath = strings.ReplaceAll(listConfigMapsPath, "{namespace}", d.Get("namespace").(string))
+	listConfigMapsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	listConfigMapsResp, err := client.Request("GET", listConfigMapsPath, &listConfigMapsOpt)
+	if err != nil {
+		return diag.Errorf("error getting CCI configMaps list: %s", err)
+	}
+
+	listConfigMapsRespBody, err := utils.FlattenResponse(listConfigMapsResp)
+	if err != nil {
+		return diag.Errorf("error retrieving CCI configMaps: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	configMaps := utils.PathSearch("items", listConfigMapsRespBody, make([]interface{}, 0)).([]interface{})
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("config_maps", flattenConfigMaps(configMaps)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenConfigMaps(configMaps []interface{}) []interface{} {
+	if len(configMaps) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(configMaps))
+	for i, v := range configMaps {
+		rst[i] = map[string]interface{}{
+			"name":               utils.PathSearch("metadata.name", v, nil),
+			"namespace":          utils.PathSearch("metadata.namespace", v, nil),
+			"annotations":        utils.PathSearch("metadata.annotations", v, nil),
+			"labels":             utils.PathSearch("metadata.labels", v, nil),
+			"creation_timestamp": utils.PathSearch("metadata.creationTimestamp", v, nil),
+			"resource_version":   utils.PathSearch("metadata.resourceVersion", v, nil),
+			"uid":                utils.PathSearch("metadata.uid", v, nil),
+			"binary_data":        utils.PathSearch("binaryData", v, nil),
+			"data":               utils.PathSearch("data", v, nil),
+			"immutable":          utils.PathSearch("immutable", v, nil),
+		}
+	}
+	return rst
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
add datasource CCI v2 config maps

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
add datasource CCI v2 config maps
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/cci" TESTARGS="-run TestAccDataSourceV2ConfigMaps_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cci -v -run TestAccDataSourceV2ConfigMaps_basic  -timeout 360m -parallel 4
=== RUN   TestAccDataSourceV2ConfigMaps_basic
=== PAUSE TestAccDataSourceV2ConfigMaps_basic
=== CONT  TestAccDataSourceV2ConfigMaps_basic
--- PASS: TestAccDataSourceV2ConfigMaps_basic(131.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cci       131.925s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
