### PR TITLE
feat(CNAD): add new resource to manage alarm notification

### DIFF
--- a/docs/resources/cnad_advanced_alarm_notification.md
+++ b/docs/resources/cnad_advanced_alarm_notification.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Cloud Native Anti-DDoS Advanced"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cnad_advanced_alarm_notification"
+description: |-
+  Manages a CNAD advanced alarm notification resource within HuaweiCloud.
+---
+
+# huaweicloud_cnad_advanced_alarm_notification
+
+Manages a CNAD advanced alarm notification resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "topic_urn" {}
+
+resource "huaweicloud_cnad_advanced_alarm_notification" "test" {
+  topic_urn = var.topic_urn
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `topic_urn` - (Required, String) Specifies the topic urn of SMN. It is required that the SMN has been subscribed successfully.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (also `topic_urn`).
+
+* `is_close_attack_source_flag` - Whether to enable the alarm content to shield the attack source information.
+
+## Import
+
+The CNAD advanced alarm notification can be imported using the `topic_urn`, e.g.
+
+```bash
+$ terraform import huaweicloud_cnad_advanced_alarm_notification.test <topic_urn>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1704,10 +1704,11 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_cloudtable_cluster": cloudtable.ResourceCloudTableCluster(),
 
-			"huaweicloud_cnad_advanced_black_white_list": cnad.ResourceBlackWhiteList(),
-			"huaweicloud_cnad_advanced_policy":           cnad.ResourceCNADAdvancedPolicy(),
-			"huaweicloud_cnad_advanced_policy_associate": cnad.ResourcePolicyAssociate(),
-			"huaweicloud_cnad_advanced_protected_object": cnad.ResourceProtectedObject(),
+			"huaweicloud_cnad_advanced_alarm_notification": cnad.ResourceAlarmNotification(),
+			"huaweicloud_cnad_advanced_black_white_list":   cnad.ResourceBlackWhiteList(),
+			"huaweicloud_cnad_advanced_policy":             cnad.ResourceCNADAdvancedPolicy(),
+			"huaweicloud_cnad_advanced_policy_associate":   cnad.ResourcePolicyAssociate(),
+			"huaweicloud_cnad_advanced_protected_object":   cnad.ResourceProtectedObject(),
 
 			"huaweicloud_compute_instance":          ecs.ResourceComputeInstance(),
 			"huaweicloud_compute_interface_attach":  ecs.ResourceComputeInterfaceAttach(),

--- a/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_alarm_notification_test.go
+++ b/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_alarm_notification_test.go
@@ -1,0 +1,104 @@
+package cnad
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cnad"
+)
+
+func getAlarmNotificationResourceFunc(cfg *config.Config, _ *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		product = "aad"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CNAD client: %s", err)
+	}
+
+	return cnad.GetAlarmNotification(client)
+}
+
+func TestAccAlarmNotification_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_cnad_advanced_alarm_notification.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAlarmNotificationResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAlarmNotification_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "topic_urn",
+						"huaweicloud_smn_topic.topic_1", "topic_urn"),
+					resource.TestCheckResourceAttrSet(rName, "is_close_attack_source_flag"),
+				),
+			},
+			{
+				Config: testAlarmNotification_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "topic_urn",
+						"huaweicloud_smn_topic.topic_2", "topic_urn"),
+					resource.TestCheckResourceAttrSet(rName, "is_close_attack_source_flag"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAlarmNotification_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "topic_1" {
+  name = "%[1]s_1"
+}
+
+resource "huaweicloud_smn_topic" "topic_2" {
+  name = "%[1]s_2"
+}
+`, name)
+}
+
+func testAlarmNotification_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cnad_advanced_alarm_notification" "test" {
+  topic_urn = huaweicloud_smn_topic.topic_1.topic_urn
+}
+`, testAlarmNotification_base(name))
+}
+
+func testAlarmNotification_basic_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cnad_advanced_alarm_notification" "test" {
+  topic_urn = huaweicloud_smn_topic.topic_2.topic_urn
+}
+`, testAlarmNotification_base(name))
+}

--- a/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_alarm_notification.go
+++ b/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_alarm_notification.go
@@ -1,0 +1,175 @@
+package cnad
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AAD POST /v1/cnad/alarm-config
+// @API AAD GET /v1/cnad/alarm-config
+// @API AAD DELETE /v1/cnad/alarm-config
+func ResourceAlarmNotification() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAlarmNotificationCreate,
+		UpdateContext: resourceAlarmNotificationUpdate,
+		ReadContext:   resourceAlarmNotificationRead,
+		DeleteContext: resourceAlarmNotificationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"topic_urn": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the topic urn of SMN.`,
+			},
+			"is_close_attack_source_flag": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to enable the alarm content to shield the attack source information.`,
+			},
+		},
+	}
+}
+
+func configAlarmNotification(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v1/cnad/alarm-config"
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: map[string]interface{}{
+			"topic_urn": d.Get("topic_urn"),
+		},
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	return err
+}
+
+func resourceAlarmNotificationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		product  = "aad"
+		topicUrn = d.Get("topic_urn").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CNAD client: %s", err)
+	}
+
+	if err := configAlarmNotification(client, d); err != nil {
+		return diag.Errorf("error creating CNAD advanced alarm notification: %s", err)
+	}
+	d.SetId(topicUrn)
+
+	return resourceAlarmNotificationRead(ctx, d, meta)
+}
+
+func GetAlarmNotification(client *golangsdk.ServiceClient) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/cnad/alarm-config"
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	// The empty topic urn indicating that the resource does not exist.
+	if utils.PathSearch("topic_urn", respBody, "").(string) == "" {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return respBody, err
+}
+
+func resourceAlarmNotificationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CNAD client: %s", err)
+	}
+
+	respBody, err := GetAlarmNotification(client)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CNAD advanced alarm notification")
+	}
+
+	mErr := multierror.Append(
+		d.Set("topic_urn", utils.PathSearch("topic_urn", respBody, nil)),
+		d.Set("is_close_attack_source_flag", utils.PathSearch("is_close_attack_source_flag", respBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceAlarmNotificationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CNAD client: %s", err)
+	}
+
+	if err := configAlarmNotification(client, d); err != nil {
+		return diag.Errorf("error updating CNAD advanced alarm notification: %s", err)
+	}
+
+	return resourceAlarmNotificationRead(ctx, d, meta)
+}
+
+func resourceAlarmNotificationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+		httpUrl = "v1/cnad/alarm-config"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CNAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting CNAD advanced alarm notification: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to manage alarm notification.
![image](https://github.com/user-attachments/assets/c6d86319-a87f-4a25-8fb7-b19de2327b3d)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cnad' TESTARGS='-run TestAccAlarmNotification_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cnad -v -run TestAccAlarmNotification_basic -timeout 360m -parallel 4
=== RUN   TestAccAlarmNotification_basic
=== PAUSE TestAccAlarmNotification_basic
=== CONT  TestAccAlarmNotification_basic
--- PASS: TestAccAlarmNotification_basic (24.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cnad      24.253s
```

* [x] Documentation updated.
* [x] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/23325d6c-3152-422e-bc3a-2fc52e0292c4)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
