### PR TITLE
feat(CNAD): add new datasource to query alarm notifications

### DIFF
--- a/docs/data-sources/cnad_advanced_alarm_notifications.md
+++ b/docs/data-sources/cnad_advanced_alarm_notifications.md
@@ -1,0 +1,27 @@
+---
+subcategory: "Cloud Native Anti-DDoS Advanced"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cnad_advanced_alarm_notifications"
+description: |-
+  Use this data source to get the list of CNAD advanced alarm notifications.
+---
+
+# huaweicloud_cnad_advanced_alarm_notifications
+
+Use this data source to get the list of CNAD advanced alarm notifications.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cnad_advanced_alarm_notifications" "test" {}
+```
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `topic_urn` - The topic urn of SMN. Empty value means no alarm notifications is configured.
+
+* `is_close_attack_source_flag` - Whether to enable the alarm content to shield the attack source information.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -631,9 +631,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_resource_tags":             cfw.DataSourceCfwResourceTags(),
 			"huaweicloud_cfw_tags":                      cfw.DataSourceCfwTags(),
 
-			"huaweicloud_cnad_advanced_instances":         cnad.DataSourceInstances(),
-			"huaweicloud_cnad_advanced_available_objects": cnad.DataSourceAvailableProtectedObjects(),
-			"huaweicloud_cnad_advanced_protected_objects": cnad.DataSourceProtectedObjects(),
+			"huaweicloud_cnad_advanced_instances":           cnad.DataSourceInstances(),
+			"huaweicloud_cnad_advanced_alarm_notifications": cnad.DataSourceAlarmNotifications(),
+			"huaweicloud_cnad_advanced_available_objects":   cnad.DataSourceAvailableProtectedObjects(),
+			"huaweicloud_cnad_advanced_protected_objects":   cnad.DataSourceProtectedObjects(),
 
 			"huaweicloud_compute_flavors":                 ecs.DataSourceEcsFlavors(),
 			"huaweicloud_compute_instance":                ecs.DataSourceComputeInstance(),

--- a/huaweicloud/services/acceptance/cnad/data_source_huaweicloud_cnad_advanced_alarm_notifications_test.go
+++ b/huaweicloud/services/acceptance/cnad/data_source_huaweicloud_cnad_advanced_alarm_notifications_test.go
@@ -1,0 +1,35 @@
+package cnad
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Field `topic_urn` has a value only after configuration. This test case does not test this field yet.
+func TestAccDatasourceAlarmNotifications_basic(t *testing.T) {
+	rName := "data.huaweicloud_cnad_advanced_alarm_notifications.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceAlarmNotifications_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "is_close_attack_source_flag"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDatasourceAlarmNotifications_basic = `
+data "huaweicloud_cnad_advanced_alarm_notifications" "test" {}
+`

--- a/huaweicloud/services/cnad/data_source_huaweicloud_cnad_advanced_alarm_notifications.go
+++ b/huaweicloud/services/cnad/data_source_huaweicloud_cnad_advanced_alarm_notifications.go
@@ -1,0 +1,77 @@
+package cnad
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AAD GET /v1/cnad/alarm-config
+func DataSourceAlarmNotifications() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAlarmNotificationsRead,
+		Schema: map[string]*schema.Schema{
+			"topic_urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The topic urn of SMN.`,
+			},
+			"is_close_attack_source_flag": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to enable the alarm content to shield the attack source information.`,
+			},
+		},
+	}
+}
+
+func dataSourceAlarmNotificationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CNAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v1/cnad/alarm-config"
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CNAD advanced alarm notifications: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("topic_urn", utils.PathSearch("topic_urn", respBody, nil)),
+		d.Set("is_close_attack_source_flag", utils.PathSearch("is_close_attack_source_flag", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new datasource to query alarm notifications.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cnad' TESTARGS='-run TestAccDatasourceAlarmNotifications_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cnad -v -run TestAccDatasourceAlarmNotifications_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceAlarmNotifications_basic
=== PAUSE TestAccDatasourceAlarmNotifications_basic
=== CONT  TestAccDatasourceAlarmNotifications_basic
--- PASS: TestAccDatasourceAlarmNotifications_basic (6.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cnad      6.911s
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
