### PR TITLE
feat(ram): set endpoint as global for EU region

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2963,6 +2963,8 @@ func configureProvider(_ context.Context, d *schema.ResourceData, terraformVersi
 	if conf.Cloud == defaultEuropeCloud {
 		cdnEndpoint := fmt.Sprintf("https://cdn.%s/", conf.Cloud)
 		conf.SetServiceEndpoint("cdn", cdnEndpoint)
+		ramEndpoint := fmt.Sprintf("https://ram.%s/", conf.Cloud)
+		conf.SetServiceEndpoint("ram", ramEndpoint)
 	}
 
 	return &conf, config.CheckUpgrade(d, Version)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Set RAM service endpoint as global for EU region.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. set RAM service endpoint as global for EU region.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
