### PR TITLE
feat(cbc): add a new resource to unsubscribe prepaid resources

### DIFF
--- a/docs/resources/cbc_resources_unsubscribe.md
+++ b/docs/resources/cbc_resources_unsubscribe.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Cloud Business Center (CBC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbc_resources_unsubscribe"
+description: |-
+  Use this resource to unsubscribe resources within HuaweiCloud.
+---
+
+# huaweicloud_cbc_resources_unsubscribe
+
+Use this resource to unsubscribe resources within HuaweiCloud.
+
+-> This resource is only a one-time action resource for unsubscribing the specified resources. Deleting this resource
+   will not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "resource_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_cbc_resources_unsubscribe" "test" {
+  resource_ids = var.resource_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `resource_ids` - (Required, List) Specifies the IDs of the resource to be unsubscribed.
+  Supports up to `10` resource IDs.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -28,6 +28,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/bcs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/bms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cae"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbh"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cc"
@@ -1591,6 +1592,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_cae_notification_rule":        cae.ResourceNotificationRule(),
 			"huaweicloud_cae_timer_rule":               cae.ResourceTimerRule(),
 			"huaweicloud_cae_vpc_egress":               cae.ResourceVpcEgress(),
+
+			"huaweicloud_cbc_resources_unsubscribe": cbc.ResourceResourcesUnsubscribe(),
 
 			"huaweicloud_cbr_backup_share_accepter": cbr.ResourceBackupShareAccepter(),
 			"huaweicloud_cbr_backup_share":          cbr.ResourceBackupShare(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -70,6 +70,8 @@ var (
 	HW_CAE_BUILD_BASE_IMAGE   = os.Getenv("HW_CAE_BUILD_BASE_IMAGE")
 	HW_CAE_IMAGE_URL          = os.Getenv("HW_CAE_IMAGE_URL")
 
+	HW_CBC_UNSUBSCRIBE_RESOURCE_ID = os.Getenv("HW_CBC_UNSUBSCRIBE_RESOURCE_ID")
+
 	HW_MAPREDUCE_CUSTOM           = os.Getenv("HW_MAPREDUCE_CUSTOM")
 	HW_MAPREDUCE_BOOTSTRAP_SCRIPT = os.Getenv("HW_MAPREDUCE_BOOTSTRAP_SCRIPT")
 
@@ -654,6 +656,13 @@ func TestAccPreCheckCaeComponent(t *testing.T) {
 	if HW_CAE_CODE_URL == "" || HW_CAE_CODE_AUTH_NAME == "" || HW_CAE_CODE_BRANCH == "" || HW_CAE_CODE_NAMESPACE == "" ||
 		HW_CAE_ARTIFACT_NAMESPACE == "" || HW_CAE_BUILD_BASE_IMAGE == "" || HW_CAE_IMAGE_URL == "" {
 		t.Skip("Skip the CAE acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCbcResourcesUnsubscribe(t *testing.T) {
+	if HW_CBC_UNSUBSCRIBE_RESOURCE_ID == "" {
+		t.Skip("HW_CBC_UNSUBSCRIBE_RESOURCE_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cbc/resource_huaweicloud_cbc_resources_unsubscribe_test.go
+++ b/huaweicloud/services/acceptance/cbc/resource_huaweicloud_cbc_resources_unsubscribe_test.go
@@ -1,0 +1,42 @@
+package cbc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourcesUnsubscribe_basic(t *testing.T) {
+	// Avoid CheckDestroy because this resource is a one-time resource and has not destroy method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCbcResourcesUnsubscribe(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourcesUnsubscribe_basic(),
+			},
+		},
+	})
+}
+
+func testAccResourcesUnsubscribe_basic() string {
+	ramdomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+resource "huaweicloud_cbc_resources_unsubscribe" "test" {
+  resource_ids = [
+    "%[1]s",
+    "%[2]s" # Providing a non-existent resource.
+  ]
+
+  enable_force_new = true
+}
+`, acceptance.HW_CBC_UNSUBSCRIBE_RESOURCE_ID, ramdomId)
+}

--- a/huaweicloud/services/cbc/resource_huaweicloud_cbc_resources_unsubscribe.go
+++ b/huaweicloud/services/cbc/resource_huaweicloud_cbc_resources_unsubscribe.go
@@ -1,0 +1,210 @@
+package cbc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var resourcesUnsubscribeNonUpdatableParams = []string{"resource_ids"}
+
+const (
+	// '1' means unsubscribing resources.
+	// '2' means unsubscribing resources only for the renewal period.
+	unsubscribeType = 1
+	// '2' means the resource is in use.
+	resourceInUse = 2
+	// '0' means query the main resource and the subsidiary resources.
+	// '1' means query only the main resource.
+	onlyMainResource = 1
+)
+
+// @API BSS POST /v2/orders/suscriptions/resources/query
+// @API BSS POST /v2/orders/subscriptions/resources/unsubscribe
+func ResourceResourcesUnsubscribe() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceResourcesUnsubscribeCreate,
+		ReadContext:   resourceResourcesUnsubscribeRead,
+		UpdateContext: resourceResourcesUnsubscribeUpdate,
+		DeleteContext: resourceResourcesUnsubscribeDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(resourcesUnsubscribeNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"resource_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The IDs of the resource to be unsubscribed.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceResourcesUnsubscribeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("bssv2", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating BSS client: %s", err)
+	}
+
+	resourceIds := utils.ExpandToStringList(d.Get("resource_ids").([]interface{}))
+	err = unsubscribePrePaidResources(client, resourceIds)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = waitForResourcesUnsubscribed(ctx, client, resourceIds, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for all resources to be unsubscribed: %s ", err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomId)
+
+	return nil
+}
+
+func unsubscribePrePaidResources(client *golangsdk.ServiceClient, resourceIds []string) error {
+	httpUrl := "v2/orders/subscriptions/resources/unsubscribe"
+	createPath := client.Endpoint + httpUrl
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"resource_ids":     resourceIds,
+			"unsubscribe_type": unsubscribeType,
+		},
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return fmt.Errorf("error unsubscribing the resources: %s", err)
+	}
+
+	respbody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	failResources := utils.PathSearch("fail_resource_infos", respbody, make([]interface{}, 0)).([]interface{})
+	if len(failResources) > 0 {
+		failInfos := make([]string, 0)
+		for _, v := range failResources {
+			failInfos = append(failInfos, fmt.Sprintf("%s | %s;",
+				utils.PathSearch("resource_id", v, "").(string),
+				utils.PathSearch("error_msg", v, "").(string)))
+		}
+
+		log.Printf("[ERROR] error unsubscribing some resources: %s", strings.Join(failInfos, "\n"))
+	}
+
+	return nil
+}
+
+func waitForResourcesUnsubscribed(ctx context.Context, client *golangsdk.ServiceClient, resourceIds []string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshPrePaidResourcesByIds(client, resourceIds),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 20 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func refreshPrePaidResourcesByIds(client *golangsdk.ServiceClient, resourceIds []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		var (
+			httpUrl = "v2/orders/suscriptions/resources/query"
+			limit   = 100
+			offset  = 0
+			result  = make([]interface{}, 0)
+			getOpt  = golangsdk.RequestOpts{
+				KeepResponseBody: true,
+			}
+			bodyParams = map[string]interface{}{
+				"resource_ids":       resourceIds,
+				"status_list":        []int{resourceInUse},
+				"only_main_resource": onlyMainResource,
+				// The 'limit' default value is `10`.
+				"limit":  limit,
+				"offset": offset,
+			}
+		)
+
+		listPath := client.Endpoint + httpUrl
+		for {
+			bodyParams["offset"] = offset
+			getOpt.JSONBody = bodyParams
+
+			resp, err := client.Request("POST", listPath, &getOpt)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			respBody, err := utils.FlattenResponse(resp)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			resources := utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{})
+			result = append(result, resources...)
+			if len(resources) < limit {
+				break
+			}
+			offset += len(resources)
+		}
+
+		if len(result) > 0 {
+			return result, "PENDING", nil
+		}
+		return result, "COMPLETED", nil
+	}
+}
+
+func resourceResourcesUnsubscribeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceResourcesUnsubscribeUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceResourcesUnsubscribeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for unsubscribing the specified resources. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new one-time resource to subscribe prepaid resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cbc -f TestAccResourcesUnsubscribe_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbc" -v -coverprofile="./huaweicloud/services/acceptance/cbc/cbc_coverage.cov" -coverpkg="./huaweicloud/services/cbc" -run TestAccResourcesUnsubscribe_basic -timeout 360m -parallel 10
=== RUN   TestAccResourcesUnsubscribe_basic
=== PAUSE TestAccResourcesUnsubscribe_basic
=== CONT  TestAccResourcesUnsubscribe_basic
--- PASS: TestAccResourcesUnsubscribe_basic (43.83s)
PASS
coverage: 85.0% of statements in ./huaweicloud/services/cbc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbc       43.920s coverage: 85.0% of statements in ./huaweicloud/services/cbc
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
