### PR TITLE
feat(sfsturbo): the data task resource supports new API

### DIFF
--- a/docs/resources/sfs_turbo_data_task.md
+++ b/docs/resources/sfs_turbo_data_task.md
@@ -10,8 +10,7 @@ description: |-
 
 Manages a data import or export task resource under the SFS Turbo within HuaweiCloud.
 
--> Destroying resources does not change the current state. Please pay attention to the results of task execution
-  through `status`.
+-> Please pay attention to the results of task execution through `status`.
 
 -> This resource is only available for the following SFS Turbo file system types:
   **20MB/s/TiB**, **40MB/s/TiB**, **125MB/s/TiB**,**250MB/s/TiB**, **500MB/s/TiB**, **1,000MB/s/TiB**, **HPC缓存型**.
@@ -94,6 +93,8 @@ In addition to all arguments above, the following attributes are exported:
 This resource provides the following timeouts configuration options:
 
 * `create` - Default is 5 minutes.
+
+* `delete` - Default is 5 minutes.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/sfsturbo/resource_huaweicloud_sfs_turbo_data_task_test.go
+++ b/huaweicloud/services/acceptance/sfsturbo/resource_huaweicloud_sfs_turbo_data_task_test.go
@@ -58,7 +58,7 @@ func TestAccDataTask_basic(t *testing.T) {
 			acceptance.TestAccPreCheckOBSEndpoint(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      nil,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataTask_basic(name, randInt),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The data task resource supports new API.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/sfsturbo" TESTARGS="-run TestAccDataTask_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/sfsturbo -v -run TestAccDataTask_basic -timeout 360m -parallel 4
=== RUN   TestAccDataTask_basic
=== PAUSE TestAccDataTask_basic
=== CONT  TestAccDataTask_basic
--- PASS: TestAccDataTask_basic (630.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sfsturbo  630.940s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/6d10566f-838c-4669-9257-fb861944d0cc)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/2a885743-0777-4245-8b9f-d954b26dc5c1)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
