### PR TITLE
fix(fgs): three params are missing in metadata update logic after function created

### DIFF
--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -87,6 +87,8 @@ func TestAccFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withBase64Code, "functiongraph_version", "v2"),
 					resource.TestCheckResourceAttr(withBase64Code, "enable_dynamic_memory", "true"),
 					resource.TestCheckResourceAttr(withBase64Code, "is_stateful_function", "true"),
+					resource.TestCheckResourceAttr(withBase64Code, "initializer_handler", "index.handler"),
+					resource.TestCheckResourceAttr(withBase64Code, "initializer_timeout", "5"),
 					resource.TestCheckResourceAttr(withBase64Code, "network_controller.#", "1"),
 					resource.TestCheckResourceAttr(withBase64Code, "network_controller.0.trigger_access_vpcs.#", "2"),
 					resource.TestCheckResourceAttr(withBase64Code, "network_controller.0.disable_public_network", "true"),
@@ -437,6 +439,8 @@ resource "huaweicloud_fgs_function" "with_base64_code" {
   functiongraph_version = "v2"
   enable_dynamic_memory = true
   is_stateful_function  = true
+  initializer_handler   = "index.handler"
+  initializer_timeout   = 5
 
   user_data = jsonencode({
     "owner": "terraform"

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -935,6 +935,8 @@ func buildUpdateFunctionMetadataBodyParams(cfg *config.Config, d *schema.Resourc
 		"custom_image":        buildFunctionCustomImage(d.Get("custom_image").([]interface{})),
 		"gpu_memory":          utils.ValueIgnoreEmpty(d.Get("gpu_memory")),
 		"gpu_type":            utils.ValueIgnoreEmpty(d.Get("gpu_type")),
+		"initializer_handler": utils.ValueIgnoreEmpty(d.Get("initializer_handler")),
+		"initializer_timeout": utils.ValueIgnoreEmpty(d.Get("initializer_timeout")),
 		"pre_stop_handler":    utils.ValueIgnoreEmpty(d.Get("pre_stop_handler")),
 		"pre_stop_timeout":    utils.ValueIgnoreEmpty(d.Get("pre_stop_timeout")),
 		"log_config":          buildFunctionLogConfig(d),
@@ -1276,9 +1278,9 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 	funcUrnWithoutVersion := parseFunctionUrnWithoutVersion(funcUrn)
 
 	// lintignore:R019
-	if d.HasChanges("vpc_id", "func_mounts", "app_agency", "initializer_handler", "initializer_timeout", "concurrency_num",
-		"peering_cidr", "enable_auth_in_header", "enable_class_isolation", "ephemeral_storage", "heartbeat_handler",
-		"restore_hook_handler", "restore_hook_timeout", "lts_custom_tag") {
+	if d.HasChanges("vpc_id", "network_id", "func_mounts", "app_agency", "initializer_handler", "initializer_timeout",
+		"concurrency_num", "peering_cidr", "enable_auth_in_header", "enable_class_isolation", "ephemeral_storage",
+		"heartbeat_handler", "restore_hook_handler", "restore_hook_timeout", "lts_custom_tag") {
 		err = updateFunctionMetadata(client, cfg, d, funcUrnWithoutVersion)
 		if err != nil {
 			return diag.FromErr(err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There are three parameters are missing in the metadata update logic after function created.
Two parameters are missing in the request body build method.
- initializer_handler
- initializer_timeout

And one parameter is missing in the HasChanges judgement.
- network_id

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supplement three missing parameters.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFunction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_basic -timeout 360m -parallel 10
=== RUN   TestAccFunction_basic
=== PAUSE TestAccFunction_basic
=== CONT  TestAccFunction_basic
--- PASS: TestAccFunction_basic (46.17s)
PASS
coverage: 19.8% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       46.250s coverage: 19.8% of statements in ./huaweicloud/services/fgs
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
