### PR TITLE
fix(logger): the content type match rule should be prefix

### DIFF
--- a/huaweicloud/config/logger.go
+++ b/huaweicloud/config/logger.go
@@ -146,7 +146,7 @@ func (*LogRoundTripper) dumpRequest(original io.ReadCloser, bs *bytes.Buffer) (i
 // logRequest will log the HTTP Request details.
 // If the body is JSON, it will attempt to be pretty-formatted.
 func (*LogRoundTripper) logRequest(bs *bytes.Buffer, contentType, logId string) error {
-	isJSONFormat := regexp.MustCompile(`^application/(merge-patch\+)?json$`).Match([]byte(contentType))
+	isJSONFormat := regexp.MustCompile(`^application/(merge-patch\+)?json`).Match([]byte(contentType))
 	isXMLFormat := strings.HasPrefix(bs.String(), "<") && !strings.HasPrefix(bs.String(), "<html>")
 	// Handle request contentType
 	switch {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The current match rule cannot cover this content type value: `application/json; charset=utf-8`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. the content type match rule should be prefix.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

Request Header
![image](https://github.com/user-attachments/assets/2631500a-ad05-4a8e-9266-5d6e1e6211ef)

Response Header
![image](https://github.com/user-attachments/assets/1b25627d-369e-4947-91f6-f1207348bc6a)

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
