### PR TITLE
feat(AAD): support new resource to manage black white list

### DIFF
--- a/docs/resources/aad_black_white_list.md
+++ b/docs/resources/aad_black_white_list.md
@@ -1,0 +1,61 @@
+---
+subcategory: "Advanced Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aad_black_white_list"
+description: |-
+  Manages a black white list resource of Advanced Anti-DDos service within HuaweiCloud.
+---
+
+# huaweicloud_aad_forward_rule
+
+Manages a black white list resource of Advanced Anti-DDos service within HuaweiCloud.
+
+## Example Usage
+
+### Add whitelist
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_aad_black_white_list" "white_test" {
+  instance_id = var.instance_id
+  type        = "white"
+  ips         = ["11.1.2.114", "11.1.2.115"]
+}
+```
+
+### Add blacklist
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_aad_black_white_list" "black_test" {
+  instance_id = var.instance_id
+  type        = "black"
+  ips         = ["11.1.2.112", "11.1.2.113"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the AAD instance ID.
+
+* `type` - (Required, String, NonUpdatable) Specifies the rule type. Valid values are **black** and **white**.
+
+* `ips` - (Required, List) Specifies the IP address list.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (also `instance_id`).
+
+## Import
+
+The AAD black white list resource can be imported using the `instance_id` and `type`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_aad_black_white_list.test <instance_id>/<type>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1505,7 +1505,8 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"huaweicloud_aad_forward_rule": aad.ResourceForwardRule(),
+			"huaweicloud_aad_forward_rule":     aad.ResourceForwardRule(),
+			"huaweicloud_aad_black_white_list": aad.ResourceBlackWhiteList(),
 
 			"huaweicloud_antiddos_basic":                     antiddos.ResourceCloudNativeAntiDdos(),
 			"huaweicloud_antiddos_default_protection_policy": antiddos.ResourceDefaultProtectionPolicy(),

--- a/huaweicloud/services/aad/resource_huaweicloud_aad_black_white_list.go
+++ b/huaweicloud/services/aad/resource_huaweicloud_aad_black_white_list.go
@@ -1,0 +1,250 @@
+package aad
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var blackWhiteListNonUpdatableParams = []string{"instance_id", "type"}
+
+// @API AAD POST /v1/{project_id}/aad/external/bwlist
+// @API AAD DELETE /v1/{project_id}/aad/external/bwlist
+// @API AAD GET /v2/aad/policies/ddos/blackwhite-list
+func ResourceBlackWhiteList() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBlackWhiteListCreate,
+		ReadContext:   resourceBlackWhiteListRead,
+		UpdateContext: resourceBlackWhiteListUpdate,
+		DeleteContext: resourceBlackWhiteListDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceBlackWhiteListImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(blackWhiteListNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the AAD instance ID.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the rule type.`,
+			},
+			"ips": {
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Required:    true,
+				Description: `Specifies the IP list.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func createBlackWhiteList(client *golangsdk.ServiceClient, d *schema.ResourceData, ips []interface{}) error {
+	if len(ips) == 0 {
+		return nil
+	}
+
+	requestPath := client.Endpoint + "v1/{project_id}/aad/external/bwlist"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: map[string]interface{}{
+			"instance_id": d.Get("instance_id"),
+			"type":        d.Get("type"),
+			"ips":         ips,
+		},
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	return err
+}
+
+func resourceBlackWhiteListCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		product    = "aad"
+		instanceID = d.Get("instance_id").(string)
+		ips        = d.Get("ips").(*schema.Set).List()
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	if err := createBlackWhiteList(client, d, ips); err != nil {
+		return diag.Errorf("error creating AAD black white list: %s", err)
+	}
+
+	d.SetId(instanceID)
+
+	return resourceBlackWhiteListRead(ctx, d, meta)
+}
+
+func ReadBlackWhiteList(client *golangsdk.ServiceClient, typeParam, instanceID string) ([]interface{}, error) {
+	requestPath := client.Endpoint + "v2/aad/policies/ddos/blackwhite-list"
+	requestPath = fmt.Sprintf("%s?type=%s&instance_id=%s", requestPath, typeParam, instanceID)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	ips := utils.PathSearch("ips[].ip", respBody, make([]interface{}, 0)).([]interface{})
+	if len(ips) == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return ips, nil
+}
+
+func resourceBlackWhiteListRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		product    = "aad"
+		typeParam  = d.Get("type").(string)
+		instanceID = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	ips, err := ReadBlackWhiteList(client, typeParam, instanceID)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving AAD black white list")
+	}
+
+	return diag.FromErr(d.Set("ips", ips))
+}
+
+func deleteBlackWhiteList(client *golangsdk.ServiceClient, d *schema.ResourceData, ips []interface{}) error {
+	if len(ips) == 0 {
+		return nil
+	}
+
+	requestPath := client.Endpoint + "v1/{project_id}/aad/external/bwlist"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: map[string]interface{}{
+			"instance_id": d.Get("instance_id"),
+			"type":        d.Get("type"),
+			"ips":         ips,
+		},
+	}
+
+	_, err := client.Request("DELETE", requestPath, &requestOpt)
+	return err
+}
+
+func resourceBlackWhiteListUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	if d.HasChange("ips") {
+		oldRaws, newRaws := d.GetChange("ips")
+		deleteIpList := oldRaws.(*schema.Set).Difference(newRaws.(*schema.Set)).List()
+		addIpList := newRaws.(*schema.Set).Difference(oldRaws.(*schema.Set)).List()
+
+		if err := deleteBlackWhiteList(client, d, deleteIpList); err != nil {
+			return diag.Errorf("error deleting AAD black white list in update operation: %s", err)
+		}
+
+		if err := createBlackWhiteList(client, d, addIpList); err != nil {
+			return diag.Errorf("error creating AAD black white list in update operation: %s", err)
+		}
+	}
+
+	return resourceBlackWhiteListRead(ctx, d, meta)
+}
+
+func resourceBlackWhiteListDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+		ips     = d.Get("ips").(*schema.Set).List()
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	if err := deleteBlackWhiteList(client, d, ips); err != nil {
+		return diag.Errorf("error deleting AAD black white list: %s", err)
+	}
+
+	return nil
+}
+
+func resourceBlackWhiteListImportState(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, errors.New("invalid format specified for import ID, must be <instance_id>/<type>")
+	}
+
+	d.SetId(parts[0])
+	mErr := multierror.Append(
+		d.Set("instance_id", parts[0]),
+		d.Set("type", parts[1]),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return nil, fmt.Errorf("failed to set value to state when import AAD black white list, %s", err)
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/huaweicloud/services/acceptance/aad/resource_huaweicloud_aad_black_white_list_test.go
+++ b/huaweicloud/services/acceptance/aad/resource_huaweicloud_aad_black_white_list_test.go
@@ -1,0 +1,183 @@
+package antiddos
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/aad"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getBlackWhiteListFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		product = "aad"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating AAD client: %s", err)
+	}
+
+	return aad.ReadBlackWhiteList(client, state.Primary.Attributes["type"], state.Primary.Attributes["instance_id"])
+}
+
+func TestAccBlackWhiteList_whitelist(t *testing.T) {
+	var obj interface{}
+	resourceName := "huaweicloud_aad_black_white_list.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getBlackWhiteListFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare a valid AAD instance ID and config it to the environment variable.
+			acceptance.TestAccPreCheckAadInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBlackWhiteList_whitelist(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_AAD_INSTANCE_ID),
+					resource.TestCheckResourceAttr(resourceName, "type", "white"),
+					resource.TestCheckResourceAttr(resourceName, "ips.#", "2"),
+				),
+			},
+			{
+				Config: testAccBlackWhiteList_whitelist_update(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_AAD_INSTANCE_ID),
+					resource.TestCheckResourceAttr(resourceName, "type", "white"),
+					resource.TestCheckResourceAttr(resourceName, "ips.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ips.0", "11.1.2.116"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testBlackWhiteListImportState(resourceName),
+			},
+		},
+	})
+}
+
+func testAccBlackWhiteList_whitelist() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_aad_black_white_list" "test" {
+  instance_id = "%s"
+  type        = "white"
+  ips         = ["11.1.2.114", "11.1.2.115"]
+}
+`, acceptance.HW_AAD_INSTANCE_ID)
+}
+
+func testAccBlackWhiteList_whitelist_update() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_aad_black_white_list" "test" {
+  instance_id = "%s"
+  type        = "white"
+  ips         = ["11.1.2.116"]
+}
+`, acceptance.HW_AAD_INSTANCE_ID)
+}
+
+func TestAccBlackWhiteList_blacklist(t *testing.T) {
+	var obj interface{}
+	resourceName := "huaweicloud_aad_black_white_list.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getBlackWhiteListFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare a valid AAD instance ID and config it to the environment variable.
+			acceptance.TestAccPreCheckAadInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBlackWhiteList_blacklist(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_AAD_INSTANCE_ID),
+					resource.TestCheckResourceAttr(resourceName, "type", "black"),
+					resource.TestCheckResourceAttr(resourceName, "ips.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ips.0", "12.1.2.117"),
+				),
+			},
+			{
+				Config: testAccBlackWhiteList_blacklist_update(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_AAD_INSTANCE_ID),
+					resource.TestCheckResourceAttr(resourceName, "type", "black"),
+					resource.TestCheckResourceAttr(resourceName, "ips.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testBlackWhiteListImportState(resourceName),
+			},
+		},
+	})
+}
+
+func testAccBlackWhiteList_blacklist() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_aad_black_white_list" "test" {
+  instance_id = "%s"
+  type        = "black"
+  ips         = ["12.1.2.117"]
+}
+`, acceptance.HW_AAD_INSTANCE_ID)
+}
+
+func testAccBlackWhiteList_blacklist_update() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_aad_black_white_list" "test" {
+  instance_id = "%s"
+  type        = "black"
+  ips         = ["12.1.2.118", "12.1.2.119"]
+}
+`, acceptance.HW_AAD_INSTANCE_ID)
+}
+
+func testBlackWhiteListImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+
+		instanceID := rs.Primary.Attributes["instance_id"]
+		if instanceID == "" {
+			return "", fmt.Errorf("attribute (instance_id) of resource (%s) not found", name)
+		}
+
+		typeParam := rs.Primary.Attributes["type"]
+		if typeParam == "" {
+			return "", fmt.Errorf("attribute (type) of resource (%s) not found", name)
+		}
+
+		return fmt.Sprintf("%s/%s", instanceID, typeParam), nil
+	}
+}

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -1533,6 +1533,13 @@ func TestAccPreCheckAadForwardRule(t *testing.T) {
 }
 
 // lintignore:AT003
+func TestAccPreCheckAadInstanceID(t *testing.T) {
+	if HW_AAD_INSTANCE_ID == "" {
+		t.Skip("HW_AAD_INSTANCE_ID must be set for this acceptance test.")
+	}
+}
+
+// lintignore:AT003
 func TestAccPreCheckCCMCertificateName(t *testing.T) {
 	if HW_CCM_CERTIFICATE_NAME == "" {
 		t.Skip("HW_CCM_CERTIFICATE_NAME must be set for CCM SSL acceptance tests.")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support new resource to manage black white list.



**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/aad' TESTARGS='-run TestAccBlackWhiteList_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aad -v -run TestAccBlackWhiteList_ -timeout 360m -parallel 4
=== RUN   TestAccBlackWhiteList_whitelist
=== PAUSE TestAccBlackWhiteList_whitelist
=== RUN   TestAccBlackWhiteList_blacklist
=== PAUSE TestAccBlackWhiteList_blacklist
=== CONT  TestAccBlackWhiteList_whitelist
=== CONT  TestAccBlackWhiteList_blacklist
--- PASS: TestAccBlackWhiteList_blacklist (17.91s)
--- PASS: TestAccBlackWhiteList_whitelist (18.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aad       18.055s
```
![image](https://github.com/user-attachments/assets/38b6a326-af8f-4f49-b42b-d7e1bbef1049)

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/0134a3dc-2343-4b2e-9e88-182a72c5e999)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
