### PR TITLE
feat(DEW): add a resource to manage kms alias

### DIFF
--- a/docs/resources/kms_alias.md
+++ b/docs/resources/kms_alias.md
@@ -1,0 +1,54 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_kms_alias"
+description: |-
+  Manages a KMS alias resource within HuaweiCloud
+---
+
+# huaweicloud_kms_alias
+
+Manages a KMS alias resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "key_id" {}
+variable "alias" {}
+
+resource "huaweicloud_kms_alias" "test" {
+  key_id = var.key_id
+  alias  = var.alias
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `key_id` - (Required, String, NonUpdatable) Specifies the key ID used to bind the alias.
+
+* `alias` - (Required, String, NonUpdatable) Specifies the alias of the key, it can only be prefixed with **alias/**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, the format is **key_id?alias**.
+
+* `alias_urn` - The alias resource locator.
+
+* `create_time` - The creation time of the alias.
+
+* `update_time` - The update time of the alias.
+
+## Import
+
+The KMS alias can be imported using `key_id` and `alias`, separated by a question mark (?), e.g.
+
+```bash
+$ terraform import huaweicloud_kms_alias.test <key_id>?<alias>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2121,6 +2121,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_key":                  dew.ResourceKmsKey(),
 			"huaweicloud_kps_keypair":              dew.ResourceKeypair(),
 			"huaweicloud_kms_grant":                dew.ResourceKmsGrant(),
+			"huaweicloud_kms_alias":                dew.ResourceKmsAlias(),
 			"huaweicloud_kms_dedicated_keystore":   dew.ResourceKmsDedicatedKeystore(),
 			"huaweicloud_kms_key_material":         dew.ResourceKmsKeyMaterial(),
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_alias_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_alias_test.go
@@ -1,0 +1,141 @@
+package dew
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getKmsAliasResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region          = acceptance.HW_REGION_NAME
+		getAliasHttpUrl = "v1.0/{project_id}/kms/aliases"
+		getAliasProduct = "kms"
+	)
+	getAliasClient, err := cfg.NewServiceClient(getAliasProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating KMS client: %s", err)
+	}
+
+	basePath := getAliasClient.Endpoint + getAliasHttpUrl
+	basePath = strings.ReplaceAll(basePath, "{project_id}", getAliasClient.ProjectID)
+
+	getAliasOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	allAliases := make([]interface{}, 0)
+	marker := ""
+	basePath += fmt.Sprintf("?key_id=%s&limit=50", state.Primary.Attributes["key_id"])
+	for {
+		getAliasPath := basePath
+		if marker != "" {
+			getAliasPath = basePath + fmt.Sprintf("&marker=%s", marker)
+		}
+
+		getAliasResp, err := getAliasClient.Request("GET", getAliasPath, &getAliasOpt)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving KMS alias: %s", err)
+		}
+
+		getAliasRespBody, err := utils.FlattenResponse(getAliasResp)
+		if err != nil {
+			return nil, err
+		}
+		aliases := utils.PathSearch("aliases", getAliasRespBody, make([]interface{}, 0)).([]interface{})
+		if len(aliases) == 0 {
+			break
+		}
+
+		allAliases = append(allAliases, aliases...)
+
+		marker = utils.PathSearch("page_info.next_marker", getAliasRespBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+	searchPath := fmt.Sprintf("[?alias=='%s']|[0]", state.Primary.Attributes["alias"])
+	aliasDetail := utils.PathSearch(searchPath, allAliases, nil)
+	if aliasDetail == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return aliasDetail, nil
+}
+
+func TestAccKmsAlias_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	aliasName := fmt.Sprintf("alias/%s", name)
+	rName := "huaweicloud_kms_alias.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getKmsAliasResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckKmsKeyID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKmsAlias_basic(aliasName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "key_id", acceptance.HW_KMS_KEY_ID),
+					resource.TestCheckResourceAttr(rName, "alias", aliasName),
+					resource.TestCheckResourceAttrSet(rName, "alias_urn"),
+					resource.TestCheckResourceAttrSet(rName, "update_time"),
+					resource.TestCheckResourceAttrSet(rName, "create_time"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testKmsAliasImportState(rName),
+			},
+		},
+	})
+}
+
+func testKmsAlias_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kms_alias" "test" {
+  key_id = "%s"
+  alias  = "%s"
+}
+`, acceptance.HW_KMS_KEY_ID, name)
+}
+
+func testKmsAliasImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+
+		if rs.Primary.Attributes["key_id"] == "" {
+			return "", fmt.Errorf("attribute (key_id) of Resource (%s) not found", name)
+		}
+
+		if rs.Primary.Attributes["alias"] == "" {
+			return "", fmt.Errorf("attribute (alias) of Resource (%s) not found", name)
+		}
+		return rs.Primary.Attributes["key_id"] + "?" + rs.Primary.Attributes["alias"], nil
+	}
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_kms_alias.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kms_alias.go
@@ -1,0 +1,240 @@
+package dew
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var aliasNonUpdatableParams = []string{"key_id", "alias"}
+
+// @API DEW POST /v1.0/{project_id}/kms/aliases
+// @API DEW DELETE /v1.0/{project_id}/kms/aliases
+// @API DEW GET /v1.0/{project_id}/kms/aliases
+func ResourceKmsAlias() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKmsAliasCreate,
+		ReadContext:   resourceKmsAliasRead,
+		UpdateContext: resourceKmsAliasUpdate,
+		DeleteContext: resourceKmsAliasDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceKmsAliasImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(aliasNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"key_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the key ID used to bind the alias.`,
+			},
+			"alias": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the alias of the key, it can only be prefixed with **alias/**.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"alias_urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The alias resource locator.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the alias. `,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time of the alias.`,
+			},
+		},
+	}
+}
+
+func resourceKmsAliasCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                = meta.(*config.Config)
+		region             = cfg.GetRegion(d)
+		createAliasHttpUrl = "v1.0/{project_id}/kms/aliases"
+		createAliasProduct = "kms"
+	)
+	createAliasClient, err := cfg.NewServiceClient(createAliasProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	createAliasPath := createAliasClient.Endpoint + createAliasHttpUrl
+	createAliasPath = strings.ReplaceAll(createAliasPath, "{project_id}", createAliasClient.ProjectID)
+
+	createAliasOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildCreateAliasBodyParams(d),
+	}
+	_, err = createAliasClient.Request("POST", createAliasPath, &createAliasOpt)
+	if err != nil {
+		return diag.Errorf("error creating KMS alias: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s?%s", d.Get("key_id"), d.Get("alias")))
+
+	return resourceKmsAliasRead(ctx, d, meta)
+}
+
+func buildCreateAliasBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"key_id": d.Get("key_id"),
+		"alias":  d.Get("alias"),
+	}
+	return bodyParams
+}
+
+func resourceKmsAliasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg             = meta.(*config.Config)
+		region          = cfg.GetRegion(d)
+		getAliasHttpUrl = "v1.0/{project_id}/kms/aliases"
+		getAliasProduct = "kms"
+	)
+	getAliasClient, err := cfg.NewServiceClient(getAliasProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	basePath := getAliasClient.Endpoint + getAliasHttpUrl
+	basePath = strings.ReplaceAll(basePath, "{project_id}", getAliasClient.ProjectID)
+
+	getAliasOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	allAliases := make([]interface{}, 0)
+	marker := ""
+	basePath += fmt.Sprintf("?key_id=%s&limit=50", d.Get("key_id").(string))
+	for {
+		getAliasPath := basePath
+		if marker != "" {
+			getAliasPath = basePath + fmt.Sprintf("&marker=%s", marker)
+		}
+
+		getAliasResp, err := getAliasClient.Request("GET", getAliasPath, &getAliasOpt)
+		if err != nil {
+			return diag.Errorf("error retrieve KMS alias response error: %s", err)
+		}
+
+		getAliasRespBody, err := utils.FlattenResponse(getAliasResp)
+		if err != nil {
+			return diag.Errorf("flatten KMS alias response error: %s", err)
+		}
+		aliases := utils.PathSearch("aliases", getAliasRespBody, make([]interface{}, 0)).([]interface{})
+		if len(aliases) == 0 {
+			break
+		}
+
+		allAliases = append(allAliases, aliases...)
+
+		marker = utils.PathSearch("page_info.next_marker", getAliasRespBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	searchPath := fmt.Sprintf("[?alias=='%s']|[0]", d.Get("alias").(string))
+	aliasDetail := utils.PathSearch(searchPath, allAliases, nil)
+	if aliasDetail == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("key_id", utils.PathSearch("key_id", aliasDetail, nil)),
+		d.Set("alias", utils.PathSearch("alias", aliasDetail, nil)),
+		d.Set("alias_urn", utils.PathSearch("alias_urn", aliasDetail, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", aliasDetail, nil)),
+		d.Set("update_time", utils.PathSearch("update_time", aliasDetail, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceKmsAliasUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceKmsAliasDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                = meta.(*config.Config)
+		region             = cfg.GetRegion(d)
+		deleteAliasHttpUrl = "v1.0/{project_id}/kms/aliases"
+		deleteAliasProduct = "kms"
+	)
+	deleteAliasClient, err := cfg.NewServiceClient(deleteAliasProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	deleteAliasPath := deleteAliasClient.Endpoint + deleteAliasHttpUrl
+	deleteAliasPath = strings.ReplaceAll(deleteAliasPath, "{project_id}", deleteAliasClient.ProjectID)
+
+	deleteAliasOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildDeleteAliasBodyParams(d),
+	}
+	_, err = deleteAliasClient.Request("DELETE", deleteAliasPath, &deleteAliasOpt)
+	if err != nil {
+		return diag.Errorf("error deleting KMS alias: %s", err)
+	}
+
+	return nil
+}
+
+func buildDeleteAliasBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"key_id":  d.Get("key_id"),
+		"aliases": []string{d.Get("alias").(string)},
+	}
+	return bodyParams
+}
+
+func resourceKmsAliasImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "?", 2)
+	if len(parts) != 2 {
+		return nil, errors.New("invalid format specified for import ID, must be <key_id>?<alias>")
+	}
+
+	mErr := multierror.Append(
+		d.Set("key_id", parts[0]),
+		d.Set("alias", parts[1]),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return nil, fmt.Errorf("failed to set value to state when import KMS alias：%s", err)
+	}
+
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/dew' TESTARGS='-run TestAccKmsAlias_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccKmsAlias_basic -timeout 360m -parallel 4
=== RUN   TestAccKmsAlias_basic
=== PAUSE TestAccKmsAlias_basic
=== CONT  TestAccKmsAlias_basic
--- PASS: TestAccKmsAlias_basic (49.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       49.887s
```
./scripts/coverage.sh -o dew -f TestAccKmsAlias_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccKmsAlias_basic -timeout 360m -parallel 10
=== RUN   TestAccKmsAlias_basic
=== PAUSE TestAccKmsAlias_basic
=== CONT  TestAccKmsAlias_basic
--- PASS: TestAccKmsAlias_basic (24.96s)
PASS
![image](https://github.com/user-attachments/assets/617f077e-0024-4055-a9c4-9ba6858f2175)

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
key_id not found.
![image](https://github.com/user-attachments/assets/706d40aa-8177-459c-b4ce-c3a77e25fd85)

alias not found.
![image](https://github.com/user-attachments/assets/1bebd039-81d5-4209-aecd-1297e1f90842)


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
