### PR TITLE
feat(apig): add a new data source to query apis associated with orchestration rule

### DIFF
--- a/docs/data-sources/apig_orchestration_rule_associated_apis.md
+++ b/docs/data-sources/apig_orchestration_rule_associated_apis.md
@@ -1,0 +1,85 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_orchestration_rule_associated_apis"
+description: |-
+  Use this data source to get API list associated with the specified orchestration rule within HuaweiCloud.
+---
+
+# huaweicloud_apig_orchestration_rule_associated_apis
+
+Use this data source to get API list associated with the specified orchestration rule within HuaweiCloud.
+
+## Example Usage
+
+### Querying all APIs associated with the specified orchestration rule
+
+```hcl
+variable "instance_id" {}
+variable "orchestration_rule_id" {}
+
+data "huaweicloud_apig_orchestration_rule_associated_apis" "test" {
+  instance_id = var.instance_id
+  rule_id     = var.orchestration_rule_id
+}
+```
+
+### Querying API associated with the orchestration rule using specified API ID
+
+```hcl
+variable "instance_id" {}
+variable "orchestration_rule_id" {}
+variable "api_id" {}
+
+data "huaweicloud_apig_orchestration_rule_associated_apis" "test" {
+  instance_id = var.instance_id
+  rule_id     = var.orchestration_rule_id
+  api_id      = var.api_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the orchestration rule belongs.
+
+* `rule_id` - (Required, String) Specifies the ID of the orchestration rule.
+
+* `api_id` - (Optional, String) Specifies the ID of the API associated with the orchestration rule.
+
+* `api_name` - (Optional, String) Specifies the name of the API associated with the orchestration rule,
+  fuzzy matching is supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `apis` - All associated APIs that match the filter parameters.  
+  The [apis](#orchestration_rule_associated_apis) structure is documented below.
+
+<a name="orchestration_rule_associated_apis"></a>
+The `apis` block supports:
+
+* `api_id` - The ID of the API.
+
+* `api_name` - The name of the API.
+
+* `req_uri` - The request address of the API.
+
+* `req_method` - The request method of the API.
+
+* `auth_type` - The security authentication mode of the API request.
+
+* `match_mode` - The matching mode of the API.
+
+* `group_id` - The ID of the API group to which the API belongs.
+
+* `group_name` - The name of the API group to which the API belongs.
+
+* `attached_time` - The time when the orchestration rule is associated with the API, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -496,6 +496,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_instance_supported_features":        apig.DataSourceInstanceSupportedFeatures(),
 			"huaweicloud_apig_instances":                          apig.DataSourceInstances(),
 			"huaweicloud_apig_orchestration_rules":                apig.DataSourceOrchestrationRules(),
+			"huaweicloud_apig_orchestration_rule_associated_apis": apig.DataSourceOrchestrationRuleAssociatedApis(),
 			"huaweicloud_apig_signatures":                         apig.DataSourceSignatures(),
 			"huaweicloud_apig_throttling_policies":                apig.DataSourceThrottlingPolicies(),
 

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_orchestration_rule_associated_apis_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_orchestration_rule_associated_apis_test.go
@@ -1,0 +1,215 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceOrchestrationRuleAssociatedApis_basic(t *testing.T) {
+	var (
+		rName       = acceptance.RandomAccResourceName()
+		randomId, _ = uuid.GenerateUUID()
+
+		all = "data.huaweicloud_apig_orchestration_rule_associated_apis.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byApiId   = "data.huaweicloud_apig_orchestration_rule_associated_apis.filter_by_api_id"
+		dcByApiId = acceptance.InitDataSourceCheck(byApiId)
+
+		byNotFoundApiId   = "data.huaweicloud_apig_orchestration_rule_associated_apis.filter_by_not_found_api_id"
+		dcByNotFoundApiId = acceptance.InitDataSourceCheck(byNotFoundApiId)
+
+		byApiName   = "data.huaweicloud_apig_orchestration_rule_associated_apis.filter_by_api_name"
+		dcByApiName = acceptance.InitDataSourceCheck(byApiName)
+
+		apiNameNotFound   = "data.huaweicloud_apig_orchestration_rule_associated_apis.filter_by_not_found_api_name"
+		dcApiNameNotFound = acceptance.InitDataSourceCheck(apiNameNotFound)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceOrchestrationRuleAssociatedApis_basic_step1(randomId),
+				ExpectError: regexp.MustCompile(`The instance does not exist`),
+			},
+			{
+				Config:      testAccDataSourceOrchestrationRuleAssociatedApis_basic_step2(randomId),
+				ExpectError: regexp.MustCompile(`The orchestrations does not exist`),
+			},
+			{
+				Config: testAccDataSourceOrchestrationRuleAssociatedApis_basic_step3(rName, randomId),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "apis.#", regexp.MustCompile(`[1-9]\d*`)),
+					dcByApiId.CheckResourceExists(),
+					resource.TestCheckOutput("is_api_id_filter_useful", "true"),
+					dcByNotFoundApiId.CheckResourceExists(),
+					resource.TestCheckOutput("is_not_found_api_id_filter_useful", "true"),
+					dcByApiName.CheckResourceExists(),
+					resource.TestCheckOutput("is_api_name_filter_useful", "true"),
+					dcApiNameNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_not_found_api_name_filter_useful", "true"),
+					// Check attributes.
+					resource.TestCheckResourceAttrSet(byApiId, "apis.0.api_id"),
+					resource.TestCheckResourceAttrSet(byApiId, "apis.0.api_name"),
+					resource.TestCheckResourceAttrSet(byApiId, "apis.0.req_uri"),
+					resource.TestCheckResourceAttrSet(byApiId, "apis.0.req_method"),
+					resource.TestCheckResourceAttrSet(byApiId, "apis.0.auth_type"),
+					resource.TestCheckResourceAttrSet(byApiId, "apis.0.match_mode"),
+					resource.TestCheckResourceAttrPair(byApiId, "apis.0.group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttrPair(byApiId, "apis.0.group_name", "huaweicloud_apig_group.test", "name"),
+					resource.TestMatchResourceAttr(byApiId, "apis.0.attached_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceOrchestrationRuleAssociatedApis_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_apig_group" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+}
+
+resource "huaweicloud_apig_orchestration_rule" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+  strategy    = "hash"
+
+  mapped_param = jsonencode({
+    "mapped_param_name" : "standard-param",
+    "mapped_param_type" : "string",
+    "mapped_param_location" : "header"
+  })
+}
+
+resource "huaweicloud_apig_api" "test" {
+  count = 2
+
+  instance_id      = "%[1]s"
+  group_id         = huaweicloud_apig_group.test.id
+  type             = "Private"
+  name             = "%[2]s${count.index}"
+  request_protocol = "HTTP"
+  request_method   = "GET"
+  request_path     = "/test${count.index}/users"
+
+  request_params {
+    name           = "X-Service-Name"
+    type           = "STRING"
+    location       = "HEADER"
+    orchestrations = [huaweicloud_apig_orchestration_rule.test.id]
+  }
+
+  mock {
+    status_code = 200
+  }
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+}
+
+func testAccDataSourceOrchestrationRuleAssociatedApis_basic_step1(randomId string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_apig_orchestration_rule_associated_apis" "incorrect_instance_id" {
+  instance_id = "%[1]s"
+  rule_id     = "%[1]s"
+}
+`, randomId)
+}
+
+func testAccDataSourceOrchestrationRuleAssociatedApis_basic_step2(randomId string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_apig_orchestration_rule_associated_apis" "incorrect_orchestration_rule_id" {
+  instance_id = "%[1]s"
+  rule_id     = "%[2]s"
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, randomId)
+}
+
+func testAccDataSourceOrchestrationRuleAssociatedApis_basic_step3(name, randomId string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_orchestration_rule_associated_apis" "test" {
+  instance_id = "%[2]s"
+  rule_id     = huaweicloud_apig_orchestration_rule.test.id
+
+  depends_on = [huaweicloud_apig_api.test]
+}
+
+locals {
+  api_id   = huaweicloud_apig_api.test[0].id
+  api_name = huaweicloud_apig_api.test[0].name
+}
+
+data "huaweicloud_apig_orchestration_rule_associated_apis" "filter_by_api_id" {
+  instance_id = "%[2]s"
+  rule_id     = huaweicloud_apig_orchestration_rule.test.id
+  api_id      = local.api_id
+}
+
+locals {
+  api_id_filter_result = [for v in data.huaweicloud_apig_orchestration_rule_associated_apis.filter_by_api_id.apis[*].api_id : v == local.api_id]
+}
+
+output "is_api_id_filter_useful" {
+  value = length(local.api_id_filter_result) > 0 && alltrue(local.api_id_filter_result)
+}
+
+# Filter by not found API ID.
+data "huaweicloud_apig_orchestration_rule_associated_apis" "filter_by_not_found_api_id" {
+  instance_id = "%[2]s"
+  rule_id     = huaweicloud_apig_orchestration_rule.test.id
+  api_id      = "%[3]s"
+
+  depends_on = [huaweicloud_apig_api.test]
+}
+
+output "is_not_found_api_id_filter_useful" {
+  value = length(data.huaweicloud_apig_orchestration_rule_associated_apis.filter_by_not_found_api_id.apis) == 0
+}
+
+# Filter by API name.
+data "huaweicloud_apig_orchestration_rule_associated_apis" "filter_by_api_name" {
+  instance_id = "%[2]s"
+  rule_id     = huaweicloud_apig_orchestration_rule.test.id
+  api_name    = local.api_name
+
+  depends_on = [huaweicloud_apig_api.test]
+}
+
+locals {
+  api_name_filter_result = [for v in data.huaweicloud_apig_orchestration_rule_associated_apis.filter_by_api_name.apis[*].api_name :
+  strcontains(v, local.api_name)]
+}
+
+output "is_api_name_filter_useful" {
+  value = length(local.api_name_filter_result) > 0 && alltrue(local.api_name_filter_result)
+}
+
+# Filter by non-existent API name.
+data "huaweicloud_apig_orchestration_rule_associated_apis" "filter_by_not_found_api_name" {
+  instance_id = "%[2]s"
+  rule_id     = huaweicloud_apig_orchestration_rule.test.id
+  api_name    = "not_found_name"
+
+  depends_on = [huaweicloud_apig_api.test]
+}
+
+output "is_not_found_api_name_filter_useful" {
+  value = length(data.huaweicloud_apig_orchestration_rule_associated_apis.filter_by_not_found_api_name.apis) == 0
+}
+`, testAccDataSourceOrchestrationRuleAssociatedApis_base(name), acceptance.HW_APIG_DEDICATED_INSTANCE_ID, randomId)
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_orchestration_rule_associated_apis.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_orchestration_rule_associated_apis.go
@@ -1,0 +1,213 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/orchestrations/{orchestration_id}/attached-apis
+func DataSourceOrchestrationRuleAssociatedApis() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceOrchestrationRuleAssociatedApisRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the orchestration rule belongs.`,
+			},
+			"rule_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the orchestration rule.",
+			},
+			"api_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the API associated with the orchestration rule.",
+			},
+			"api_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the API associated with the orchestration rule, fuzzy matching is supported.",
+			},
+			"apis": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"api_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the API.`,
+						},
+						"api_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the API.`,
+						},
+						"req_uri": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The request address of the API.`,
+						},
+						"req_method": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The request method of the API.`,
+						},
+						"auth_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The security authentication mode of the API request.`,
+						},
+						"match_mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The matching mode of the API.`,
+						},
+						"group_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the API group to which the API belongs.`,
+						},
+						"group_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the API group to which the API belongs.`,
+						},
+						"attached_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time when the orchestration rule is associated with the API, in RFC3339 format.`,
+						},
+					},
+				},
+				Description: `All associated APIs that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildOrchestrationRuleAssociatedApisQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if apiId, ok := d.GetOk("api_id"); ok {
+		res = fmt.Sprintf("%s&api_id=%v", res, apiId)
+	}
+
+	if apiName, ok := d.GetOk("api_name"); ok {
+		res = fmt.Sprintf("%s&api_name=%v", res, apiName)
+	}
+	return res
+}
+
+func listOrchestrationRuleAssociatedApis(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl             = "v2/{project_id}/apigw/instances/{instance_id}/orchestrations/{orchestration_id}/attached-apis"
+		instanceId          = d.Get("instance_id").(string)
+		orchestrationRuleId = d.Get("rule_id").(string)
+		limit               = 500
+		offset              = 0
+		result              = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + fmt.Sprintf("%s?limit=%d", httpUrl, limit)
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{orchestration_id}", orchestrationRuleId)
+	listPath += buildOrchestrationRuleAssociatedApisQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error query the APIs associated with the orchestration rule (%s) under specified dedicated instance (%s): %s",
+				orchestrationRuleId, instanceId, err)
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		rules := utils.PathSearch("apis", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, rules...)
+		if len(rules) < limit {
+			break
+		}
+		offset += len(rules)
+	}
+	return result, nil
+}
+
+func dataSourceOrchestrationRuleAssociatedApisRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	rules, err := listOrchestrationRuleAssociatedApis(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("apis", flattenOrchestrationRuleAssociatedApis(rules)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenOrchestrationRuleAssociatedApis(apis []interface{}) []interface{} {
+	if len(apis) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(apis))
+	for _, rule := range apis {
+		result = append(result, map[string]interface{}{
+			"api_id":     utils.PathSearch("api_id", rule, nil),
+			"api_name":   utils.PathSearch("api_name", rule, nil),
+			"req_uri":    utils.PathSearch("req_uri", rule, nil),
+			"req_method": utils.PathSearch("req_method", rule, nil),
+			"auth_type":  utils.PathSearch("auth_type", rule, nil),
+			"match_mode": utils.PathSearch("match_mode", rule, nil),
+			"group_id":   utils.PathSearch("group_id", rule, nil),
+			"group_name": utils.PathSearch("group_name", rule, nil),
+			"attached_time": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(
+				utils.PathSearch("attached_time", rule, "").(string))/1000, false),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source to query apis associated with orchestration rule.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccDataSourceOrchestrationRuleAssociatedApis_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataSourceOrchestrationRuleAssociatedApis_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceOrchestrationRuleAssociatedApis_basic
=== PAUSE TestAccDataSourceOrchestrationRuleAssociatedApis_basic
=== CONT  TestAccDataSourceOrchestrationRuleAssociatedApis_basic
--- PASS: TestAccDataSourceOrchestrationRuleAssociatedApis_basic (20.65s)
PASS
coverage: 6.7% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      20.738s coverage: 6.7% of statements in ./huaweicloud/services/apig
```

![image](https://github.com/user-attachments/assets/afa8974b-b159-4b98-bb95-b0bb6e385997)


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
