### PR TITLE
feat(apig): add new data source to query associated apis under orchestration rule

### DIFF
--- a/docs/data-sources/apig_orchestration_rule_associated_apis.md
+++ b/docs/data-sources/apig_orchestration_rule_associated_apis.md
@@ -1,0 +1,82 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_orchestration_rule_associated_apis"
+description: |-
+  Use this data source to get the list of associated APIs under specified orchestration rule within HuaweiCloud.
+---
+
+# huaweicloud_apig_orchestration_rule_associated_apis
+
+Use this data source to get the list of associated APIs under specified orchestration rule within HuaweiCloud.
+
+## Example Usage
+
+### Query all associated APIs under a specified orchestration rule
+
+```hcl
+variable "instance_id" {}
+variable "orchestration_rule_id" {}
+
+data "huaweicloud_apig_orchestration_rule_associated_apis" "test" {
+  instance_id = var.instance_id
+  rule_id     = var.orchestration_rule_id
+}
+```
+
+### Query a specified associated API information under a specified orchestration rule
+
+```hcl
+variable "instance_id" {}
+variable "orchestration_rule_id" {}
+variable "associated_api_id" {}
+
+data "huaweicloud_apig_orchestration_rule_associated_apis" "test" {
+  instance_id = var.instance_id
+  rule_id     = var.orchestration_rule_id
+  api_id      = var.associated_api_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the orchestration rule is located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the orchestration rule belongs.
+
+* `rule_id` - (Required, String) Specifies the ID of the orchestration rule to be queried.
+
+* `api_id` - (Optional, String) Specifies the associated API ID under the orchestration rule.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `apis` - All API list that match the filter parameters under a specified orchestration rule.  
+  The [apis](#orchestration_rule_associated_apis) structure is documented below.
+
+<a name="orchestration_rule_associated_apis"></a>
+The `apis` block supports:
+
+* `api_id` - The ID of the associated API.
+
+* `api_name` - The name of the associated API.
+
+* `req_method` - The request method of the associated API.
+
+* `req_uri` - The request URI of the associated API.
+
+* `auth_type` - The auth type of the associated API.
+
+* `match_mode` - The match mode of the associated API.
+
+* `group_id` - The group ID to which the associated API belongs.
+
+* `group_name` - The group name to which the associated API belongs.
+
+* `attached_time` - The attached time of the associated API.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -499,6 +499,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_instance_supported_features":        apig.DataSourceInstanceSupportedFeatures(),
 			"huaweicloud_apig_instances":                          apig.DataSourceInstances(),
 			"huaweicloud_apig_orchestration_rules":                apig.DataSourceOrchestrationRules(),
+			"huaweicloud_apig_orchestration_rule_associated_apis": apig.DataSourceOrchestrationRuleAssociatedApis(),
 			"huaweicloud_apig_signatures":                         apig.DataSourceSignatures(),
 			"huaweicloud_apig_throttling_policies":                apig.DataSourceThrottlingPolicies(),
 

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_orchestration_rule_associated_apis_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_orchestration_rule_associated_apis_test.go
@@ -1,0 +1,197 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceOrchestrationRuleAssociatedApis_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_apig_orchestration_rule_associated_apis.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byApiId   = "data.huaweicloud_apig_orchestration_rule_associated_apis.filter_by_api_id"
+		dcByApiId = acceptance.InitDataSourceCheck(byApiId)
+
+		byNotFoundApiId   = "data.huaweicloud_apig_orchestration_rule_associated_apis.filter_by_not_found_api_id"
+		dcByNotFoundApiId = acceptance.InitDataSourceCheck(byNotFoundApiId)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceOrchestrationRuleAssociatedApis_basic_step1(),
+				ExpectError: regexp.MustCompile(`The instance does not exist`),
+			},
+			{
+				Config:      testAccDataSourceOrchestrationRuleAssociatedApis_basic_step2(),
+				ExpectError: regexp.MustCompile(`The orchestrations does not exist`),
+			},
+			{
+				Config: testAccDataSourceOrchestrationRuleAssociatedApis_basic_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "apis.#", regexp.MustCompile(`[1-9]\d*`)),
+					// Filter by API ID.
+					dcByApiId.CheckResourceExists(),
+					resource.TestCheckOutput("is_api_id_filter_useful", "true"),
+					dcByNotFoundApiId.CheckResourceExists(),
+					resource.TestCheckOutput("is_not_found_api_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceOrchestrationRuleAssociatedApis_basic_step1() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_apig_orchestration_rule_associated_apis" "incorrect_instance_id" {
+  instance_id = "%[1]s"
+  rule_id     = "%[1]s"
+}
+`, randUUID)
+}
+
+func testAccDataSourceOrchestrationRuleAssociatedApis_basic_step2() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_apig_orchestration_rule_associated_apis" "incorrect_orchestration_rule_id" {
+  instance_id = "%[1]s"
+  rule_id     = "%[2]s"
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, randUUID)
+}
+
+func testAccDataSourceOrchestrationRuleAssociatedApis_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_apig_group" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+}
+
+resource "huaweicloud_apig_orchestration_rule" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+  strategy    = "hash"
+
+  mapped_param = jsonencode({
+    "mapped_param_name": "standard-param",
+    "mapped_param_type": "string",
+    "mapped_param_location": "header"
+  })
+}
+
+resource "huaweicloud_apig_api" "test" {
+  count = 2
+
+  instance_id             = "%[1]s"
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = format("%[2]s_%%d", count.index)
+  type                    = "Private"
+  request_protocol        = "HTTP"
+  request_method          = "GET"
+  request_path            = format("/orchestration/test/%%d", count.index)
+  security_authentication = "NONE"
+
+  request_params {
+    name     = "X-Service-Name"
+    type     = "STRING"
+    location = "HEADER"
+    maximum  = 30
+    minimum  = 5
+
+    orchestrations = [
+      huaweicloud_apig_orchestration_rule.test.id,
+    ]
+  }
+
+  backend_params {
+    type              = "REQUEST"
+    name              = "ServiceName"
+    location          = "HEADER"
+    value             = "X-Service-Name"
+    system_param_type = "backend"
+  }
+
+  mock {
+    status_code   = 201
+    response      = "{'message':'hello world'}"
+  }
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+}
+
+func testAccDataSourceOrchestrationRuleAssociatedApis_basic_step3(name string) string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_orchestration_rule_associated_apis" "all" {
+  depends_on = [
+    huaweicloud_apig_api.test,
+  ]
+
+  instance_id = "%[2]s"
+  rule_id     = huaweicloud_apig_orchestration_rule.test.id
+}
+
+# Filter by ID
+locals {
+  api_id = huaweicloud_apig_api.test[0].id
+}
+
+data "huaweicloud_apig_orchestration_rule_associated_apis" "filter_by_api_id" {
+  # Need to be executed after all resources are created (excluding implicit dependencies).
+  depends_on = [
+    huaweicloud_apig_api.test,
+  ]
+
+  instance_id = "%[2]s"
+  rule_id     = huaweicloud_apig_orchestration_rule.test.id
+  api_id      = local.api_id
+}
+
+locals {
+  api_id_filter_result = [
+    for v in data.huaweicloud_apig_orchestration_rule_associated_apis.filter_by_api_id.apis[*].api_id : v == local.api_id
+  ]
+}
+
+output "is_api_id_filter_useful" {
+  value = length(local.api_id_filter_result) > 0 && alltrue(local.api_id_filter_result)
+}
+
+# Filter by not found ID
+data "huaweicloud_apig_orchestration_rule_associated_apis" "filter_by_not_found_api_id" {
+  # Need to be executed after all resources are created (excluding implicit dependencies).
+  depends_on = [
+    huaweicloud_apig_api.test,
+  ]
+
+  instance_id = "%[2]s"
+  rule_id     = huaweicloud_apig_orchestration_rule.test.id
+  api_id      = "%[3]s"
+}
+
+output "is_not_found_api_id_filter_useful" {
+  value = length(data.huaweicloud_apig_orchestration_rule_associated_apis.filter_by_not_found_api_id.apis) == 0
+}
+`, testAccDataSourceOrchestrationRuleAssociatedApis_base(name), acceptance.HW_APIG_DEDICATED_INSTANCE_ID, randUUID)
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_orchestration_rule_associated_apis.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_orchestration_rule_associated_apis.go
@@ -1,0 +1,208 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/orchestrations/{orchestration_id}/attached-apis
+func DataSourceOrchestrationRuleAssociatedApis() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceOrchestrationRuleAssociatedApisRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the orchestration rule is located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the orchestration rule belongs.`,
+			},
+			"rule_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the orchestration rule to be queried.`,
+			},
+			"api_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The associated API ID under the orchestration rule.`,
+			},
+			"apis": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"api_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the associated API.`,
+						},
+						"api_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the associated API.`,
+						},
+						"req_method": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The request method of the associated API.`,
+						},
+						"req_uri": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The request URI of the associated API.`,
+						},
+						"auth_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The auth type of the associated API.`,
+						},
+						"match_mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The match mode of the associated API.`,
+						},
+						"group_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The group ID to which the associated API belongs.`,
+						},
+						"group_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The group name to which the associated API belongs.`,
+						},
+						"attached_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The attached time of the associated API.`,
+						},
+					},
+				},
+				Description: `All API list that match the filter parameters under a specified orchestration rule.`,
+			},
+		},
+	}
+}
+
+func buildOrchestrationRuleAssociatedApisQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if apiId, ok := d.GetOk("api_id"); ok {
+		res = fmt.Sprintf("%s&api_id=%v", res, apiId)
+	}
+	return res
+}
+
+func listOrchestrationRuleAssociatedApis(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/orchestrations/{orchestration_id}/attached-apis?limit={limit}"
+		instanceId = d.Get("instance_id").(string)
+		ruleId     = d.Get("rule_id").(string)
+		limit      = 500
+		offset     = 0
+		result     = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{orchestration_id}", ruleId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildOrchestrationRuleAssociatedApisQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error query API list under a specified orchestration rule (%s): %s", ruleId, err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		assoiciatedApis := utils.PathSearch("apis", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, assoiciatedApis...)
+		pageSize := int(utils.PathSearch("size", respBody, float64(0)).(float64))
+		if pageSize < limit {
+			break
+		}
+		offset += pageSize
+	}
+
+	return result, nil
+}
+
+func flattenOrchestrationRuleAssoiciatedApis(assoiciatedApis []interface{}) []interface{} {
+	if len(assoiciatedApis) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(assoiciatedApis))
+	for _, assoiciatedApi := range assoiciatedApis {
+		result = append(result, map[string]interface{}{
+			"api_id":        utils.PathSearch("api_id", assoiciatedApi, nil),
+			"api_name":      utils.PathSearch("api_name", assoiciatedApi, nil),
+			"req_method":    utils.PathSearch("req_method", assoiciatedApi, nil),
+			"req_uri":       utils.PathSearch("req_uri", assoiciatedApi, nil),
+			"auth_type":     utils.PathSearch("auth_type", assoiciatedApi, nil),
+			"match_mode":    utils.PathSearch("match_mode", assoiciatedApi, nil),
+			"group_id":      utils.PathSearch("group_id", assoiciatedApi, nil),
+			"group_name":    utils.PathSearch("group_name", assoiciatedApi, nil),
+			"attached_time": utils.PathSearch("attached_time", assoiciatedApi, nil),
+		})
+	}
+	return result
+}
+
+func dataSourceOrchestrationRuleAssociatedApisRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	assoiciatedApis, err := listOrchestrationRuleAssociatedApis(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("apis", flattenOrchestrationRuleAssoiciatedApis(assoiciatedApis)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new data source and names `huaweicloud_apig_orchestration_rule_associated_apis`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query associated apis under orchestration rule
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccDataSourceOrchestrationRuleAssociatedApis_basic -n 10
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataSourceOrchestrationRuleAssociatedApis_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceOrchestrationRuleAssociatedApis_basic
=== PAUSE TestAccDataSourceOrchestrationRuleAssociatedApis_basic
=== CONT  TestAccDataSourceOrchestrationRuleAssociatedApis_basic
--- PASS: TestAccDataSourceOrchestrationRuleAssociatedApis_basic (22.19s)
PASS
coverage: 7.3% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      22.323s coverage: 7.3% of statements in ./huaweicloud/services/apig
```

![捕获](https://github.com/user-attachments/assets/a579d918-7486-45df-9399-23480a26063a)

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.
