### PR TITLE
feat(apig): add new one tine resource to check api definition

### DIFF
--- a/docs/resources/apig_api_check.md
+++ b/docs/resources/apig_api_check.md
@@ -1,0 +1,81 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_api_check"
+description: |-
+  Use this resource to check whether the API name or path already exists within HuaweiCloud.
+---
+
+# huaweicloud_apig_api_check
+
+Use this resource to check whether the API name or path already exists within HuaweiCloud.
+
+-> This resource is only a one-time resource for checking the API definition. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+### Verify whether the API name already exists in the same group
+
+```hcl
+variable "instance_id" {}
+variable "check_name" {}
+variable "group_id" {}
+
+resource "huaweicloud_apig_api_check" "test" {
+  instance_id = var.instance_id
+  type        = "name"
+  name        = var.check_name
+  group_id    = var.group_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the API belongs.
+
+* `type` - (Required, String) Specifies the type of the API to be checked.  
+  The valid values are as follows:
+  + **name**
+  + **path**
+
+* `api_id` - (Optional, String) Specifies the ID of the API to be excluded from the check.
+
+* `name` - (Optional, String) Specifies the name of the API.  
+  This parameter is required if `type` is set to **name**.
+
+* `group_id` - (Optional, String) Specifies the ID of the group to which the API belongs.  
+  This parameter is required when verifying whether the API definition under the specified group exists.
+
+* `match_mode` - (Optional, String) Specifies the matching mode of the API.  
+  This parameter is required if `type` is set to **path**.  
+  The valid values are as follows:
+  + **SWA**: Prefix match.
+  + **NORMAL**: Exact match.
+
+* `req_method` - (Optional, String) Specifies the request method of the API.  
+  This parameter is required if `type` is set to **path**.  
+  The valid values are as follows:
+  + **GET**
+  + **POST**
+  + **PUT**
+  + **DELETE**
+  + **HEAD**
+  + **PATCH**
+  + **OPTIONS**
+  + **ANY**
+
+* `req_uri` - (Optional, String) Specifies the request path of the API.  
+  This parameter is required if `type` is set to **path**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1557,6 +1557,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_acl_policy":                     apig.ResourceAclPolicy(),
 			"huaweicloud_apig_acl_policy_associate":           apig.ResourceAclPolicyAssociate(),
 			"huaweicloud_apig_api":                            apig.ResourceApigAPIV2(),
+			"huaweicloud_apig_api_check":                      apig.ResourceApiCheck(),
 			"huaweicloud_apig_api_publishment":                apig.ResourceApigApiPublishment(),
 			"huaweicloud_apig_appcode":                        apig.ResourceAppcode(),
 			"huaweicloud_apig_application":                    apig.ResourceApigApplicationV2(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_check_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_check_test.go
@@ -1,0 +1,145 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccApiCheck_basic(t *testing.T) {
+	var (
+		name      = acceptance.RandomAccResourceName()
+		uniqeName = acceptance.RandomAccResourceName()
+	)
+
+	// Avoid CheckDestroy because this resource is a one-time resource.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccApiCheck_basic_step1(name),
+				ExpectError: regexp.MustCompile(`The instance does not exist`),
+			},
+			// Check whether the API name already exists in the same group.
+			{
+				Config:      testAccApiCheck_basic_step2(name),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("The API name already exists, api_name:%s", name)),
+			},
+			// Check whether the API path already exists in the same group.
+			{
+				Config:      testAccApiCheck_basic_step3(name),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("The API already exists, api_name:%s", name)),
+			},
+			{
+				// Check the API name does not exist in the same group.
+				Config: testAccApiCheck_basic_step4(name, uniqeName),
+			},
+			{
+				// Check the API path does not exist in the same group.
+				Config: testAccApiCheck_basic_step5(name, uniqeName),
+			},
+		},
+	})
+}
+
+func testAccApiCheck_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_apig_group" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+}
+
+resource "huaweicloud_apig_api" "test" {
+  instance_id      = "%[1]s"
+  group_id         = huaweicloud_apig_group.test.id
+  name             = "%[2]s"
+  type             = "Private"
+  request_protocol = "HTTP"
+  request_method   = "GET"
+  request_path     = "/mock/test"
+
+  mock {
+    status_code = 200
+  }
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+}
+
+func testAccApiCheck_basic_step1(name string) string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+resource "huaweicloud_apig_api_check" "test" {
+  instance_id = "%[1]s"
+  type        = "name"
+  name        = "%[2]s"
+}
+`, randomId, name)
+}
+
+func testAccApiCheck_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_api_check" "test" {
+  instance_id = "%[2]s"
+  type        = "name"
+  name        = huaweicloud_apig_api.test.name
+  group_id    = huaweicloud_apig_group.test.id
+
+  depends_on = [huaweicloud_apig_api.test]
+}
+`, testAccApiCheck_base(name), acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
+}
+
+func testAccApiCheck_basic_step3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_api_check" "test" {
+  instance_id = "%[2]s"
+  type        = "path"
+  group_id    = huaweicloud_apig_group.test.id
+  req_method  = huaweicloud_apig_api.test.request_method
+  req_uri     = huaweicloud_apig_api.test.request_path
+  match_mode  = "NORMAL"
+}
+`, testAccApiCheck_base(name), acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
+}
+
+func testAccApiCheck_basic_step4(name, uniqeName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_api_check" "check_name" {
+  instance_id = "%[2]s"
+  type        = "name"
+  name        =  "%[3]s"
+  group_id    = huaweicloud_apig_group.test.id
+}
+`, testAccApiCheck_base(name), acceptance.HW_APIG_DEDICATED_INSTANCE_ID, uniqeName)
+}
+
+func testAccApiCheck_basic_step5(name, uniqeName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_api_check" "check_path" {
+  instance_id = "%[2]s"
+  type        = "path"
+  group_id    = huaweicloud_apig_group.test.id
+  req_method  = huaweicloud_apig_api.test.request_method
+  req_uri     = "/test/%[3]s"
+  match_mode  = "NORMAL"
+}
+`, testAccApiCheck_base(name), acceptance.HW_APIG_DEDICATED_INSTANCE_ID, uniqeName)
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_api_check.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_api_check.go
@@ -1,0 +1,160 @@
+package apig
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var apiCheckNonUpdatableParams = []string{
+	"instance_id",
+	"type",
+	"api_id",
+	"name",
+	"group_id",
+	"req_method",
+	"req_uri",
+	"match_mode",
+}
+
+// @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/apis/check
+func ResourceApiCheck() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceApiCheckCreate,
+		ReadContext:   resourceApiCheckRead,
+		UpdateContext: resourceApiCheckUpdate,
+		DeleteContext: resourceApiCheckDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(apiCheckNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the dedicated instance to which the API belongs.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The type of the API to be checked.",
+			},
+			"api_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the API to be excluded from the check.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the API.",
+			},
+			"group_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the group to which the API belongs.",
+			},
+			"req_method": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The request method of the API.",
+			},
+			"req_uri": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The request path of the API.",
+			},
+			"match_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The matching mode of the API.",
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildApiCheckBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"type":       d.Get("type"),
+		"api_id":     utils.ValueIgnoreEmpty(d.Get("api_id")),
+		"name":       utils.ValueIgnoreEmpty(d.Get("name")),
+		"group_id":   utils.ValueIgnoreEmpty(d.Get("group_id")),
+		"req_method": utils.ValueIgnoreEmpty(d.Get("req_method")),
+		"req_uri":    utils.ValueIgnoreEmpty(d.Get("req_uri")),
+		"match_mode": utils.ValueIgnoreEmpty(d.Get("match_mode")),
+	}
+}
+
+func resourceApiCheckCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/apis/check"
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildApiCheckBodyParams(d)),
+		OkCodes:          []int{204},
+	}
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error checking API under APIG instance (%s): %s", instanceId, err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomId)
+
+	return nil
+}
+
+func resourceApiCheckRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceApiCheckUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceApiCheckDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time resource for checking the API definition. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new one-time resource to check whether the API name or path already exists.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource "huaweicloud_apig_api_check".
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccApiCheck_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccApiCheck_basic -timeout 360m -parallel 10
=== RUN   TestAccApiCheck_basic
=== PAUSE TestAccApiCheck_basic
=== CONT  TestAccApiCheck_basic
--- PASS: TestAccApiCheck_basic (52.58s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      52.678s coverage: 4.7% of statements in ./huaweicloud/services/apig
```
![image](https://github.com/user-attachments/assets/1c3b28e0-b3ee-4310-8cc5-6585b2583c99)

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
