### PR TITLE
feat(apig): add new resource to check api group name

### DIFF
--- a/docs/resources/apig_group_name_check.md
+++ b/docs/resources/apig_group_name_check.md
@@ -1,0 +1,44 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_group_name_check"
+description: |-
+  Use this resource to check whether the API group name already exists within HuaweiCloud.
+---
+
+# huaweicloud_apig_group_name_check
+
+Use this resource to check whether the API group name already exists within HuaweiCloud.
+
+-> This resource is only a one-time resource for checking the API group name. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "group_name" {}
+
+resource "huaweicloud_apig_group_name_check" "test" {
+  instance_id = var.instance_id
+  group_name  = var.group_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the API group belongs.
+
+* `group_name` - (Required, String) Specifies the name of the API group to be checked.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1566,6 +1566,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_environment_variable":           apig.ResourceEnvironmentVariable(),
 			"huaweicloud_apig_group":                          apig.ResourceApigGroupV2(),
 			"huaweicloud_apig_group_domain_associate":         apig.ResourceGroupDomainAssociate(),
+			"huaweicloud_apig_group_name_check":               apig.ResourceGroupNameCheck(),
 			"huaweicloud_apig_instance_feature":               apig.ResourceInstanceFeature(),
 			"huaweicloud_apig_instance_routes":                apig.ResourceInstanceRoutes(),
 			"huaweicloud_apig_instance":                       apig.ResourceApigInstanceV2(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_group_name_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_group_name_test.go
@@ -1,0 +1,88 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGroupNameCheck_basic(t *testing.T) {
+	var (
+		name      = acceptance.RandomAccResourceName()
+		checkName = acceptance.RandomAccResourceName()
+	)
+
+	// Avoid CheckDestroy because this resource is a one-time resource.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			// Check APIG instance does not exist.
+			{
+				Config:      testAccGroupNameCheck_basic_step1(name),
+				ExpectError: regexp.MustCompile("The instance does not exist"),
+			},
+			// Check the API group name already exists.
+			{
+				Config:      testAccGroupNameCheck_basic_step2(name),
+				ExpectError: regexp.MustCompile("The API group name already exists"),
+			},
+			// Check the API group name does not exist.
+			{
+				Config: testAccGroupNameCheck_basic_step3(name, checkName),
+			},
+		},
+	})
+}
+
+func testAccGroupNameCheck_basic_step1(name string) string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+resource "huaweicloud_apig_group_name_check" "test" {
+  instance_id = "%[1]s"
+  group_name  = "%[2]s"
+}
+`, randomId, name)
+}
+
+func testAccGroupNameCheck_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_apig_group" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+}
+
+func testAccGroupNameCheck_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_group_name_check" "test" {
+  instance_id = "%[2]s"
+  group_name  = huaweicloud_apig_group.test.name
+
+  depends_on = [huaweicloud_apig_group.test]
+}
+`, testAccGroupNameCheck_base(name), acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+}
+
+func testAccGroupNameCheck_basic_step3(name, checkName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_group_name_check" "test" {
+  instance_id = "%[2]s"
+  group_name  = "%[3]s"
+}
+`, testAccGroupNameCheck_base(name), acceptance.HW_APIG_DEDICATED_INSTANCE_ID, checkName)
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_group_name_check.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_group_name_check.go
@@ -1,0 +1,114 @@
+package apig
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var groupNameCheckCheckNonUpdatableParams = []string{
+	"instance_id",
+	"group_name",
+}
+
+// @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/api-groups/check
+func ResourceGroupNameCheck() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGroupNameCheckCreate,
+		ReadContext:   resourceGroupNameCheckRead,
+		UpdateContext: resourceGroupNameCheckUpdate,
+		DeleteContext: resourceGroupNameCheckDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(groupNameCheckCheckNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the dedicated instance to which the API group belongs.",
+			},
+			"group_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the API group to be checked.",
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceGroupNameCheckCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/api-groups/check"
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"group_name": d.Get("group_name"),
+		},
+		OkCodes: []int{204},
+	}
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error checking API group name under APIG instance (%s): %s", instanceId, err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomId)
+
+	return nil
+}
+
+func resourceGroupNameCheckRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceGroupNameCheckUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceGroupNameCheckDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time resource for checking the API group name. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new one-time resource (`huaweicloud_apig_group_name_check`) to check whether the API group name already exists.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new one-time resource.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccGroupNameCheck_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccGroupNameCheck_basic -timeout 360m -parallel 10
=== RUN   TestAccGroupNameCheck_basic
=== PAUSE TestAccGroupNameCheck_basic
=== CONT  TestAccGroupNameCheck_basic
--- PASS: TestAccGroupNameCheck_basic (29.76s)
PASS
coverage: 2.7% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      29.857s coverage: 2.7% of statements in ./huaweicloud/services/apig
```
![image](https://github.com/user-attachments/assets/8b3a544b-fd1f-4601-bc6e-301ea6e87e46)


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
