### PR TITLE
feat(modelarts): supports new resource to delete resource nodes

### DIFF
--- a/docs/resources/modelartsv2_node_batch_delete.md
+++ b/docs/resources/modelartsv2_node_batch_delete.md
@@ -1,0 +1,54 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelartsv2_node_batch_delete"
+description: |-
+  Use this resource to batch delete the ModelArts nodes within HuaweiCloud.
+---
+
+# huaweicloud_modelartsv2_node_batch_delete
+
+Use this resource to batch delete the ModelArts nodes within HuaweiCloud.
+
+-> This resource is only a one-time action resource for batch delete the ModelArts nodes. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+~> This resource can only be used to delete nodes with postPaid billing.
+
+## Example Usage
+
+```hcl
+variable "resource_pool_name" {}
+variable "node_names" {
+  type = list(string)
+}
+
+resource "huaweicloud_modelartsv2_node_batch_delete" "test" {
+  resource_pool_name = var.resource_pool_name
+  node_names         = var.node_names
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the resource nodes are located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `resource_pool_name` - (Required, String, NonUpdatable) Specifies the resource pool name to which the resource nodes
+  belong.
+
+* `node_names` - (Required, List, NonUpdatable) Specifies the name list of resource nodes to be deleted.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 45 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2239,8 +2239,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_network":                modelarts.ResourceModelartsNetwork(),
 			"huaweicloud_modelarts_resource_pool":          modelarts.ResourceModelartsResourcePool(),
 			// Resource management via V2 APIs.
-			"huaweicloud_modelartsv2_service":        modelarts.ResourceV2Service(),
-			"huaweicloud_modelartsv2_service_action": modelarts.ResourceV2ServiceAction(),
+			"huaweicloud_modelartsv2_node_batch_delete": modelarts.ResourceV2NodeBatchDelete(),
+			"huaweicloud_modelartsv2_service":           modelarts.ResourceV2Service(),
+			"huaweicloud_modelartsv2_service_action":    modelarts.ResourceV2ServiceAction(),
 
 			// DataArts Studio - Management Center
 			"huaweicloud_dataarts_studio_data_connection": dataarts.ResourceDataConnection(),

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelartsv2_node_batch_delete_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelartsv2_node_batch_delete_test.go
@@ -1,0 +1,71 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceV2NodeBatchDelete_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceV2NodeBatchDelete_invalidResourcePoolName,
+				ExpectError: regexp.MustCompile(`\\"invalid-resource-pool-name\\" not found`),
+			},
+			{
+				Config:      testAccResourceV2NodeBatchDelete_invalidResourceNodeNames(),
+				ExpectError: regexp.MustCompile(`\\"invalid-node-name\\" not found`),
+			},
+			{
+				Config: testAccResourceV2NodeBatchDelete_basic_step1(),
+			},
+		},
+	})
+}
+
+const testAccResourceV2NodeBatchDelete_invalidResourcePoolName string = `
+resource "huaweicloud_modelartsv2_node_batch_delete" "test" {
+  resource_pool_name = "invalid-resource-pool-name"
+  node_names         = ["invalid-node-name"]
+}
+`
+
+func testAccResourceV2NodeBatchDelete_invalidResourceNodeNames() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_modelartsv2_node_batch_delete" "test" {
+  resource_pool_name = "%[1]s"
+  node_names         = ["invalid-node-name"]
+}
+`, acceptance.HW_MODELARTS_RESOURCE_POOL_NAME)
+}
+
+func testAccResourceV2NodeBatchDelete_basic_step1() string {
+	return fmt.Sprintf(`
+data "huaweicloud_modelartsv2_resource_pool_nodes" "test" {
+  resource_pool_name = "%[1]s"
+}
+
+resource "huaweicloud_modelartsv2_node_batch_delete" "test" {
+  resource_pool_name = "%[1]s"
+  node_names         = try(slice([for o in data.huaweicloud_modelartsv2_resource_pool_nodes.test.nodes:
+    o.metadata[0].name if lookup(jsondecode(o.metadata[0].annotations), "os.modelarts/billing.mode",
+    "0") == "0" && try(o.metadata[0].labels, "") != ""], 0, 1), [])
+
+  lifecycle {
+    # After the deletion is completed, the query result of the data source will change, so the reference to the names
+    # need to be ignored.
+    ignore_changes = [node_names]
+  }
+}
+`, acceptance.HW_MODELARTS_RESOURCE_POOL_NAME)
+}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_node_batch_delete.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_node_batch_delete.go
@@ -1,0 +1,159 @@
+package modelarts
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var v2NodeBatchDeleteNonUpdatableParams = []string{
+	"resource_pool_name",
+	"node_names",
+}
+
+// @API ModelArts POST /v2/{project_id}/pools/{pool_name}/nodes/batch-delete
+// @API ModelArts GET /v2/{project_id}/pools/{pool_name}/nodes
+func ResourceV2NodeBatchDelete() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceV2NodeBatchDeleteCreate,
+		ReadContext:   resourceV2NodeBatchDeleteRead,
+		UpdateContext: resourceV2NodeBatchDeleteUpdate,
+		DeleteContext: resourceV2NodeBatchDeleteDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(45 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(v2NodeBatchDeleteNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the resource nodes are located.`,
+			},
+			"resource_pool_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The resource pool name to which the resource nodes belong.`,
+			},
+			"node_names": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The name list of resource nodes to be deleted.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func waitForV2NodeBatchDeleteCompleted(ctx context.Context, client *golangsdk.ServiceClient, resourcePoolName string,
+	deleteNodeNames []interface{}, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			nodes, err := listV2ResourcePoolNodes(client, resourcePoolName)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			names := utils.PathSearch(`[*].metadata.name`, nodes, make([]interface{}, 0)).([]interface{})
+			if utils.IsSliceContainsAnyAnotherSliceElement(utils.ExpandToStringList(names),
+				utils.ExpandToStringList(deleteNodeNames), false, true) {
+				return names, "PENDING", nil
+			}
+			return names, "COMPLETED", nil
+		},
+		Timeout:      timeout,
+		Delay:        30 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceV2NodeBatchDeleteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		httpUrl          = "v2/{project_id}/pools/{pool_name}/nodes/batch-delete"
+		resourcePoolName = d.Get("resource_pool_name").(string)
+		deleteNodeNames  = d.Get("node_names").([]interface{})
+	)
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	batchDeletePath := client.Endpoint + httpUrl
+	batchDeletePath = strings.ReplaceAll(batchDeletePath, "{project_id}", client.ProjectID)
+	batchDeletePath = strings.ReplaceAll(batchDeletePath, "{pool_name}", resourcePoolName)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"deleteNodeNames": deleteNodeNames,
+		},
+	}
+
+	_, err = client.Request("POST", batchDeletePath, &opt)
+	if err != nil {
+		return diag.Errorf("error executing batch delete operation: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	err = waitForV2NodeBatchDeleteCompleted(ctx, client, resourcePoolName, deleteNodeNames, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceV2NodeBatchDeleteRead(ctx, d, meta)
+}
+
+func resourceV2NodeBatchDeleteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceV2NodeBatchDeleteUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceV2NodeBatchDeleteDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for batch delete the ModelArts nodes. Deleting this
+resource will not clear the corresponding request record, but will only remove the resource information from the tfstate
+file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new resource for the resource nodes management (for delete multiple resource nodes):
+ huaweicloud_modelartsv2_node_batch_delete

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new resource to delete resource nodes
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccResourceV2NodeBatchDelete_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccResourceV2NodeBatchDelete_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceV2NodeBatchDelete_basic
=== PAUSE TestAccResourceV2NodeBatchDelete_basic
=== CONT  TestAccResourceV2NodeBatchDelete_basic
--- PASS: TestAccResourceV2NodeBatchDelete_basic (122.25s)
PASS
coverage: 9.0% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 122.311s        coverage: 9.0% of statements in ./huaweicloud/services/modelarts
```

![image](https://github.com/user-attachments/assets/db4e6e50-5ba0-490b-a28e-140515bd87fb)
![84d153acbdeefb9de3a5e2e9bf0f86b](https://github.com/user-attachments/assets/6c93717e-135d-42c7-a0c2-89ede24cd8a2)
![64d2b490c36daa9519f7f38cfd30e28](https://github.com/user-attachments/assets/76b084b6-3974-49a7-9102-bd1b0bf6d4bc)

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
