### PR TITLE
feat(AAD): support new resource to update instance specification

### DIFF
--- a/docs/resources/aad_change_specification.md
+++ b/docs/resources/aad_change_specification.md
@@ -1,0 +1,72 @@
+---
+subcategory: "Advanced Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aad_change_specification"
+description: |-
+  Use this resource to modify Advanced Anti-DDos specification within HuaweiCloud.
+---
+
+# huaweicloud_aad_change_specification
+
+Use this resource to modify Advanced Anti-DDos specification within HuaweiCloud.
+
+-> This resource is only a one-time action resource for updating AAD instance specification. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "basic_bandwidth" {}
+variable "elastic_bandwidth" {}
+variable "service_bandwidth" {}
+variable "port_num" {}
+variable "bind_domain_num" {}
+
+resource "huaweicloud_aad_change_specification" "test" {
+  instance_id = var.instance_id
+  
+  upgrade_data {
+    basic_bandwidth   = var.basic_bandwidth
+    elastic_bandwidth = var.elastic_bandwidth
+    service_bandwidth = var.service_bandwidth
+    port_num          = var.port_num
+    bind_domain_num   = var.bind_domain_num
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the AAD instance ID.
+
+* `upgrade_data` - (Required, List, NonUpdatable) Specifies the upgrade data.
+
+  The [upgrade_data](#upgrade_data_struct) structure is documented below.
+
+<a name="upgrade_data_struct"></a>
+The `upgrade_data` block supports:
+
+* `basic_bandwidth` - (Optional, String, NonUpdatable) Specifies the basic bandwidth (Gbps).
+
+* `elastic_bandwidth` - (Optional, String, NonUpdatable) Specifies the elastic bandwidth (Gbps).
+
+* `service_bandwidth` - (Optional, Int, NonUpdatable) Specifies the service bandwidth (Mbps).
+
+* `port_num` - (Optional, Int, NonUpdatable) Specifies the port number.
+
+* `bind_domain_num` - (Optional, Int, NonUpdatable) Specifies the bind domain number.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (also `instance_id`).
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Defaults to `10` minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1512,8 +1512,9 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"huaweicloud_aad_forward_rule":     aad.ResourceForwardRule(),
-			"huaweicloud_aad_black_white_list": aad.ResourceBlackWhiteList(),
+			"huaweicloud_aad_forward_rule":         aad.ResourceForwardRule(),
+			"huaweicloud_aad_black_white_list":     aad.ResourceBlackWhiteList(),
+			"huaweicloud_aad_change_specification": aad.ResourceChangeSpecification(),
 
 			"huaweicloud_antiddos_basic":                     antiddos.ResourceCloudNativeAntiDdos(),
 			"huaweicloud_antiddos_default_protection_policy": antiddos.ResourceDefaultProtectionPolicy(),

--- a/huaweicloud/services/aad/resource_huaweicloud_aad_change_specification.go
+++ b/huaweicloud/services/aad/resource_huaweicloud_aad_change_specification.go
@@ -1,0 +1,186 @@
+package aad
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableChangeSpecificationParams = []string{
+	"instance_id",
+	"upgrade_data",
+	"upgrade_data.*.basic_bandwidth",
+	"upgrade_data.*.elastic_bandwidth",
+	"upgrade_data.*.service_bandwidth",
+	"upgrade_data.*.port_num",
+	"upgrade_data.*.bind_domain_num",
+}
+
+// @API AAD PUT /v2/aad/instance
+func ResourceChangeSpecification() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceChangeSpecificationCreate,
+		ReadContext:   resourceChangeSpecificationRead,
+		UpdateContext: resourceChangeSpecificationUpdate,
+		DeleteContext: resourceChangeSpecificationDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableChangeSpecificationParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the AAD instance ID.`,
+			},
+			"upgrade_data": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Description: `Specifies the upgrade data.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"basic_bandwidth": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the basic bandwidth (Gbps).`,
+						},
+						"elastic_bandwidth": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the elastic bandwidth (Gbps).`,
+						},
+						"service_bandwidth": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: `Specifies the service bandwidth (Mbps).`,
+						},
+						"port_num": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: `Specifies the port number.`,
+						},
+						"bind_domain_num": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: `Specifies the bind domain number.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildUpgradeDataBodyParams(d *schema.ResourceData) interface{} {
+	rawArray := d.Get("upgrade_data").([]interface{})
+	if len(rawArray) == 0 {
+		// When the length of the parameter array is 0, an empty map is returned.
+		return make(map[string]interface{})
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		// When the length of the parameter array is 0, an empty map is returned.
+		return make(map[string]interface{})
+	}
+
+	rst := map[string]interface{}{
+		"basic_bandwidth":   utils.ValueIgnoreEmpty(rawMap["basic_bandwidth"]),
+		"elastic_bandwidth": utils.ValueIgnoreEmpty(rawMap["elastic_bandwidth"]),
+		"service_bandwidth": utils.ValueIgnoreEmpty(rawMap["service_bandwidth"]),
+		"port_num":          utils.ValueIgnoreEmpty(rawMap["port_num"]),
+		"bind_domain_num":   utils.ValueIgnoreEmpty(rawMap["bind_domain_num"]),
+	}
+
+	return utils.RemoveNil(rst)
+}
+
+func buildChangeSpecificationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"instance_id":  d.Get("instance_id"),
+		"upgrade_data": buildUpgradeDataBodyParams(d),
+	}
+}
+
+func resourceChangeSpecificationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v2/aad/instance"
+		product    = "aad"
+		instanceID = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildChangeSpecificationBodyParams(d),
+	}
+
+	resp, err := client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error updating AAD instance specification: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	orderID := utils.PathSearch("order_id", respBody, "").(string)
+	if orderID != "" {
+		// When the upgrade or subtraction of specifications results in a change in fees, the order ID will be returned.
+		bssClient, err := cfg.BssV2Client(cfg.GetRegion(d))
+		if err != nil {
+			return diag.Errorf("error creating BSS v2 client: %s", err)
+		}
+		if err = common.WaitOrderComplete(ctx, bssClient, orderID, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return diag.Errorf("the order is not completed while updating AAD instance (%s) specification: %s",
+				instanceID, err)
+		}
+		if _, err = common.WaitOrderAllResourceComplete(ctx, bssClient, orderID, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	d.SetId(instanceID)
+	return resourceChangeSpecificationRead(ctx, d, meta)
+}
+
+func resourceChangeSpecificationRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceChangeSpecificationUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceChangeSpecificationDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to modify AAD specification. Deleting this resource
+will not change the current AAD specification, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}

--- a/huaweicloud/services/acceptance/aad/resource_huaweicloud_aad_change_specification_test.go
+++ b/huaweicloud/services/acceptance/aad/resource_huaweicloud_aad_change_specification_test.go
@@ -1,0 +1,66 @@
+package antiddos
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccChangeSpecification_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare a valid AAD instance ID and config it to the environment variable.
+			acceptance.TestAccPreCheckAadInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testChangeSpecification_basic(),
+			},
+		},
+	})
+}
+
+func testChangeSpecification_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_aad_change_specification" "test0" {
+  instance_id = "%[1]s"
+  upgrade_data {}
+}
+
+resource "huaweicloud_aad_change_specification" "test1" {
+  depends_on = [huaweicloud_aad_change_specification.test0]
+
+  instance_id = "%[1]s"
+  upgrade_data {
+    basic_bandwidth   = "10"
+    elastic_bandwidth = "10"
+  }
+}
+
+resource "huaweicloud_aad_change_specification" "test2" {
+  depends_on = [huaweicloud_aad_change_specification.test1]
+
+  instance_id = "%[1]s"
+  upgrade_data {
+    basic_bandwidth   = "20"
+    elastic_bandwidth = "20"
+  }
+}
+
+resource "huaweicloud_aad_change_specification" "test3" {
+  depends_on = [huaweicloud_aad_change_specification.test2]
+
+  instance_id = "%[1]s"
+  upgrade_data {
+    basic_bandwidth   = "10"
+    elastic_bandwidth = "10"
+  }
+}
+`, acceptance.HW_AAD_INSTANCE_ID)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support new resource to update instance specification.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o aad -f TestAccChangeSpecification_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/aad" -v -coverprofile="./huaweicloud/services/acceptance/aad/aad_coverage.cov" -coverpkg="./huaweicloud/services/aad" -run TestAccChangeSpecification_basic -timeout 360m -parallel 10
=== RUN   TestAccChangeSpecification_basic
=== PAUSE TestAccChangeSpecification_basic
=== CONT  TestAccChangeSpecification_basic
--- PASS: TestAccChangeSpecification_basic (227.28s)
PASS
coverage: 16.1% of statements in ./huaweicloud/services/aad
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aad       227.339s        coverage: 16.1% of statements in ./huaweicloud/services/aad
```

![image](https://github.com/user-attachments/assets/f8118d1f-33bb-41c7-b86a-bfc35e05afac)


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
