### PR TITLE
feat(mrs/cluster): add auto_renew for cluster and prepaid parameter for node groups

### DIFF
--- a/docs/resources/mapreduce_cluster.md
+++ b/docs/resources/mapreduce_cluster.md
@@ -444,26 +444,26 @@ The EIP must have been created and must be in the same region as the cluster.
 
 * `analysis_core_nodes` - (Optional, List, ForceNew) Specifies the informations about analysis core nodes in the
   MapReduce cluster.  
-  The [master_nodes](#v2_mapreduce_cluster_core_task_nodes) structure is documented below.  
+  The [analysis_core_nodes](#v2_mapreduce_cluster_core_nodes) structure is documented below.  
   Changing this will create a new MapReduce cluster resource.
 
 * `streaming_core_nodes` - (Optional, List, ForceNew) Specifies the informations about streaming core nodes in the
   MapReduce cluster.  
-  The [master_nodes](#v2_mapreduce_cluster_core_task_nodes) structure is documented below.  
+  The [streaming_core_nodes](#v2_mapreduce_cluster_core_nodes) structure is documented below.  
   Changing this will create a new MapReduce cluster resource.
 
 * `analysis_task_nodes` - (Optional, List, ForceNew) Specifies the informations about analysis task nodes in the
   MapReduce cluster.  
-  The [master_nodes](#v2_mapreduce_cluster_core_task_nodes) structure is documented below.  
+  The [analysis_task_nodes](#v2_mapreduce_cluster_task_nodes) structure is documented below.  
   Changing this will create a new MapReduce cluster resource.
 
 * `streaming_task_nodes` - (Optional, List, ForceNew) Specifies the informations about streaming task nodes in the
   MapReduce cluster.  
-  The [master_nodes](#v2_mapreduce_cluster_core_task_nodes) structure is documented below.  
+  The [streaming_task_nodes](#v2_mapreduce_cluster_task_nodes) structure is documented below.  
   Changing this will create a new MapReduce cluster resource.
 
 * `custom_nodes` - (Optional, List, ForceNew) Specifies the informations about custom nodes in the MapReduce cluster.  
-  The [master_nodes](#v2_mapreduce_cluster_custom_nodes) structure is documented below.  
+  The [custom_nodes](#v2_mapreduce_cluster_custom_nodes) structure is documented below.  
   Changing this will create a new MapReduce cluster resource.
 
 * `component_configs` - (Optional, List, ForceNew) Specifies the component configurations of the cluster.
@@ -497,10 +497,14 @@ The EIP must have been created and must be in the same region as the cluster.
   Changing this parameter will create a new MapReduce cluster resource.
 
 * `period` - (Optional, Int, ForceNew) Specifies the charging period of the cluster.  
-  If `period_unit` is set to **month**, the value ranges from 1 to 9.  
-  If `period_unit` is set to **year**, the value ranges from 1 to 3.  
+  If `period_unit` is set to **month**, the value ranges from `1` to `9`.  
+  If `period_unit` is set to **year**, the value ranges from `1` to `3`.  
   This parameter is mandatory if `charging_mode` is set to **prePaid**.  
   Changing this parameter will create a new MapReduce cluster resource.
+
+* `auto_renew` - (Optional, String) Specifies whether auto renew is enabled, defaults to **false**.  
+  This parameter is available if `charging_mode` is set to **prePaid**.  
+  The valid values are **true** and **false**.  
 
 <a name="v2_mapreduce_cluster_master_nodes"></a>
 The `master_nodes` block supports:
@@ -549,9 +553,103 @@ The `master_nodes` block supports:
 
   -> `DBService` is a basic component of a cluster. Components such as Hive, Hue, Oozie, Loader, and Redis, and Loader
    store their metadata in DBService, and provide the metadata backup and restoration functions by using DBService.
+  
+* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the cluster.  
+  Valid values are **prePaid** and **postPaid**, defaults to **postPaid**.  
+  Changing this parameter will create a new MapReduce cluster resource.
 
-<a name="v2_mapreduce_cluster_core_task_nodes"></a>
-The `analysis_core_nodes`, `streaming_core_nodes`, `analysis_task_nodes` and `streaming_task_nodes` blocks support:
+* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the cluster.  
+  Valid values are **month** and **year**. This parameter is mandatory if `charging_mode` is set to **prePaid**.  
+  Changing this parameter will create a new MapReduce cluster resource.
+
+* `period` - (Optional, Int, ForceNew) Specifies the charging period of the cluster.  
+  If `period_unit` is set to **month**, the value ranges from `1` to `9`.  
+  If `period_unit` is set to **year**, the value ranges from `1` to `3`.  
+  This parameter is mandatory if `charging_mode` is set to **prePaid**.  
+  Changing this parameter will create a new MapReduce cluster resource.
+
+* `auto_renew` - (Optional, String) Specifies whether auto renew is enabled, defaults to **false**.  
+  This parameter is available if `charging_mode` is set to **prePaid**.  
+  The valid values are **true** and **false**.  
+
+  -> The `period_unit` must be used together with the `period` parameter.
+  
+<a name="v2_mapreduce_cluster_core_nodes"></a>
+The `analysis_core_nodes` and `streaming_core_nodes` blocks support:
+
+* `flavor` - (Required, String, ForceNew) Specifies the instance specifications for each nodes in node group.
+  Changing this will create a new MapReduce cluster resource.
+
+* `node_number` - (Required, Int) Specifies the number of nodes for the node group.
+
+  -> The number of nodes after scaling cannot be less than the number of nodes originally created.
+
+* `root_volume_type` - (Required, String, ForceNew) Specifies the system disk flavor of the nodes. Changing this will
+  create a new MapReduce cluster resource.
+
+* `root_volume_size` - (Required, Int, ForceNew) Specifies the system disk size of the nodes. Changing this will create
+  a new MapReduce cluster resource.
+
+* `data_volume_count` - (Required, Int, ForceNew) Specifies the data disk number of the nodes. The number configuration
+  of each node are as follows:
+  + **analysis_core_nodes**: minimum is one and the maximum is subject to the configuration of the corresponding flavor.
+  + **streaming_core_nodes**: minimum is one and the maximum is subject to the configuration of the corresponding flavor.
+  + **analysis_task_nodes**: minimum is one and the maximum is subject to the configuration of the corresponding flavor.
+  + **streaming_task_nodes**: minimum is one and the maximum is subject to the configuration of the corresponding flavor.
+
+  Changing this will create a new MapReduce cluster resource.
+  
+* `data_volume_type` - (Optional, String, ForceNew) Specifies the data disk flavor of the nodes.
+  Required if `data_volume_count` is greater than zero. Changing this will create a new MapReduce cluster resource.
+   The following disk types are supported:
+  + **SATA**: common I/O disk.
+  + **SAS**: high I/O disk.
+  + **SSD**: ultra-high I/O disk.
+
+* `data_volume_size` - (Optional, Int, ForceNew) Specifies the data disk size of the nodes,in GB. The value range is 10
+  to 32768. Required if `data_volume_count` is greater than zero. Changing this will create a new MapReduce
+  cluster resource.
+
+* `assigned_roles` - (Optional, List, ForceNew) Specifies the roles deployed in a node group.This argument is mandatory
+ when the cluster type is **CUSTOM**. Each character string represents a role expression.
+
+  **Role expression definition:**
+
+   + If the role is deployed on all nodes in the node group, set this parameter to role_name, for example: `DataNode`.
+   + If the role is deployed on a specified subscript node in the node group: role_name:index1,index2..., indexN,
+ for example: `DataNode:1,2`. The subscript starts from 1.
+   + Some roles support multi-instance deployment (that is, multiple instances of the same role are deployed on a node):
+  role_name[instance_count], for example: `EsNode[9]`.
+  
+  [For details about components](https://support.huaweicloud.com/intl/en-us/productdesc-mrs/mrs_08_0005.html)
+
+  [Mapping between roles and components](https://support.huaweicloud.com/intl/en-us/api-mrs/mrs_02_0106.html)
+
+  -> `DBService` is a basic component of a cluster. Components such as Hive, Hue, Oozie, Loader, and Redis, and Loader
+   store their metadata in DBService, and provide the metadata backup and restoration functions by using DBService.
+
+  + `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the cluster.  
+  Valid values are **prePaid** and **postPaid**, defaults to **postPaid**.  
+  Changing this parameter will create a new MapReduce cluster resource.
+
+* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the cluster.  
+  Valid values are **month** and **year**. This parameter is mandatory if `charging_mode` is set to **prePaid**.  
+  Changing this parameter will create a new MapReduce cluster resource.
+
+* `period` - (Optional, Int, ForceNew) Specifies the charging period of the cluster.  
+  If `period_unit` is set to **month**, the value ranges from `1` to `9`.  
+  If `period_unit` is set to **year**, the value ranges from `1` to `3`.  
+  This parameter is mandatory if `charging_mode` is set to **prePaid**.  
+  Changing this parameter will create a new MapReduce cluster resource.
+
+* `auto_renew` - (Optional, String) Specifies whether auto renew is enabled, defaults to **false**.  
+  This parameter is available if `charging_mode` is set to **prePaid**.  
+  The valid values are **true** and **false**.  
+
+  -> The `period_unit` must be used together with the `period` parameter.
+
+<a name="v2_mapreduce_cluster_task_nodes"></a>
+The `analysis_task_nodes` and `streaming_task_nodes` blocks support:
 
 * `flavor` - (Required, String, ForceNew) Specifies the instance specifications for each nodes in node group.
   Changing this will create a new MapReduce cluster resource.
@@ -654,6 +752,26 @@ The `custom_nodes` block supports:
 
   -> `DBService` is a basic component of a cluster. Components such as Hive, Hue, Oozie, Loader, and Redis, and Loader
    store their metadata in DBService, and provide the metadata backup and restoration functions by using DBService.
+
+* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the cluster.  
+  Valid values are **prePaid** and **postPaid**, defaults to **postPaid**.  
+  Changing this parameter will create a new MapReduce cluster resource.
+
+* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the cluster.  
+  Valid values are **month** and **year**. This parameter is mandatory if `charging_mode` is set to **prePaid**.  
+  Changing this parameter will create a new MapReduce cluster resource.
+
+* `period` - (Optional, Int, ForceNew) Specifies the charging period of the cluster.  
+  If `period_unit` is set to **month**, the value ranges from `1` to `9`.  
+  If `period_unit` is set to **year**, the value ranges from `1` to `3`.  
+  This parameter is mandatory if `charging_mode` is set to **prePaid**.  
+  Changing this parameter will create a new MapReduce cluster resource.
+
+* `auto_renew` - (Optional, String) Specifies whether auto renew is enabled, defaults to **false**.  
+  This parameter is available if `charging_mode` is set to **prePaid**.  
+  The valid values are **true** and **false**.  
+
+  -> The `period_unit` must be used together with the `period` parameter.
 
 <a name="component_configurations"></a>
 The `component_configs` block supports:
@@ -786,14 +904,17 @@ This resource provides the following timeouts configuration options:
 Clusters can be imported by their `id`. For example,
 
 ```bash
-terraform import huaweicloud_mapreduce_cluster.test b11b407c-e604-4e8d-8bc4-92398320b847
+terraform import huaweicloud_mapreduce_cluster.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include:
 `manager_admin_pass`, `node_admin_pass`,`template_id`, `assigned_roles`, `external_datasources`, `component_configs`,
-`smn_notify`, `charging_mode`, `period` and `period_unit`. It is generally recommended running `terraform plan`
-after importing a cluster.
+`smn_notify`, `charging_mode`, `period`, `period_unit`, `auto_renew`, `streaming_core_nodes.0.charging_mode`,
+`streaming_core_nodes.0.period`, `streaming_core_nodes.0.period_unit`, `streaming_core_nodes.0.auto_renew`,
+`analysis_core_nodes.0.charging_mode`, `analysis_core_nodes.0.period`, `analysis_core_nodes.0.period_unit`,
+`analysis_core_nodes.0.auto_renew`, `custom_nodes.0.charging_mode`, `custom_nodes.0.period`, `custom_nodes.0.period_unit`
+and `custom_nodes.0.auto_renew`. It is generally recommended running `terraform plan` after importing a cluster.
 You can then decide if changes should be applied to the cluster, or the resource definition
 should be updated to align with the cluster. Also you can ignore changes as below.
 
@@ -804,7 +925,10 @@ resource "huaweicloud_mapreduce_cluster" "test" {
   lifecycle {
     ignore_changes = [
       manager_admin_pass, node_admin_pass, template_id, assigned_roles, external_datasources, component_configs, smn_notify,
-      charging_mode, period, period_unit,
+      charging_mode, period, period_unit, auto_renew, master_nodes.0.charging_mode, master_nodes.0.period, master_nodes.0.period_unit,
+      master_nodes.0.auto_renew, streaming_core_nodes.0.charging_mode, streaming_core_nodes.0.period, streaming_core_nodes.0.period_unit,
+      streaming_core_nodes.0.auto_renew, analysis_core_nodes.0.charging_mode, analysis_core_nodes.0.period, analysis_core_nodes.0.period_unit,
+      analysis_core_nodes.0.auto_renew, custom_nodes.0.charging_mode, custom_nodes.0.period, custom_nodes.0.period_unit, custom_nodes.0.auto_renew
     ]
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20250512020404-97ac298eb708
+	github.com/chnsz/golangsdk v0.0.0-20250522034853-eb1e624cd784
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20250512020404-97ac298eb708 h1:7SjQV567o1fb7TXZqEv253rGUo6qs4OfhqF1WgPQVK4=
-github.com/chnsz/golangsdk v0.0.0-20250512020404-97ac298eb708/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
+github.com/chnsz/golangsdk v0.0.0-20250522034853-eb1e624cd784 h1:Sxje1lzj5MeYf9QupX4p3CmDoR0kLcdPDRg2nBxlZHQ=
+github.com/chnsz/golangsdk v0.0.0-20250522034853-eb1e624cd784/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/chnsz/golangsdk/openstack/mrs/v2/clusters/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/mrs/v2/clusters/requests.go
@@ -177,6 +177,8 @@ type ChargeInfo struct {
 	//   false: indicates not to pay immediately after an order is created.
 	//   true: indicates to pay immediately after an order is created. The system will automatically deduct fees from the account balance.
 	IsAutoPay *bool `json:"is_auto_pay,omitempty"`
+	// Whether auto renew is enabled, default to false.
+	IsAutoRenew *bool `json:"is_auto_renew,omitempty"`
 }
 
 // NodeGroupOpts is a structure representing node group.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20250512020404-97ac298eb708
+# github.com/chnsz/golangsdk v0.0.0-20250522034853-eb1e624cd784
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new parameter for resource:
+ add  `auto_renew `  for cluster.
+ add `charging_mode`, `period`, `period_unit`,  `auto_renew` for **master_nodes** , **streaming_core_nodes**, **analysis_core_nodes** and **custom_nodes**.  If the node does not specify charge information, it will inherit the cluster's

**analysis_task_nodes** and **streaming_task_nodes** do not support prepaid.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o mrs -f TestAccMrsMapReduceCluster_prepaid_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccMrsMapReduceCluster_prepaid_basic -timeout 360m -parallel 10
=== RUN   TestAccMrsMapReduceCluster_prepaid_basic
=== PAUSE TestAccMrsMapReduceCluster_prepaid_basic
=== CONT  TestAccMrsMapReduceCluster_prepaid_basic
--- PASS: TestAccMrsMapReduceCluster_prepaid_basic (1089.31s)
PASS
coverage: 24.1% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       1089.392s       coverage: 24.1% of statements in ./huaweicloud/services/mrs
```
```
./scripts/coverage.sh -o mrs -f TestAccMrsMapReduceCluster_prepaid_custom
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccMrsMapReduceCluster_prepaid_custom -timeout 360m -parallel 10
=== RUN   TestAccMrsMapReduceCluster_prepaid_custom
=== PAUSE TestAccMrsMapReduceCluster_prepaid_custom
=== CONT  TestAccMrsMapReduceCluster_prepaid_custom
--- PASS: TestAccMrsMapReduceCluster_prepaid_custom (1004.07s)
PASS
coverage: 23.5% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       1004.148s       coverage: 23.5% of statements in ./huaweicloud/services/mrs
```
```
 ./scripts/coverage.sh -o mrs -f TestAccMrsMapReduceCluster_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccMrsMapReduceCluster_ -timeout 360m -parallel 10
=== RUN   TestAccMrsMapReduceCluster_basic
=== PAUSE TestAccMrsMapReduceCluster_basic
=== RUN   TestAccMrsMapReduceCluster_keypair
=== PAUSE TestAccMrsMapReduceCluster_keypair
=== RUN   TestAccMrsMapReduceCluster_analysis
=== PAUSE TestAccMrsMapReduceCluster_analysis
=== RUN   TestAccMrsMapReduceCluster_stream
=== PAUSE TestAccMrsMapReduceCluster_stream
=== RUN   TestAccMrsMapReduceCluster_hybrid
=== PAUSE TestAccMrsMapReduceCluster_hybrid
=== RUN   TestAccMrsMapReduceCluster_custom_compact
=== PAUSE TestAccMrsMapReduceCluster_custom_compact
=== RUN   TestAccMrsMapReduceCluster_custom_separate
=== PAUSE TestAccMrsMapReduceCluster_custom_separate
=== RUN   TestAccMrsMapReduceCluster_custom_fullsize
=== PAUSE TestAccMrsMapReduceCluster_custom_fullsize
=== RUN   TestAccMrsMapReduceCluster_externalDataSources
=== PAUSE TestAccMrsMapReduceCluster_externalDataSources
=== RUN   TestAccMrsMapReduceCluster_Eip_id
=== PAUSE TestAccMrsMapReduceCluster_Eip_id
=== RUN   TestAccMrsMapReduceCluster_Eip_publicIp
=== PAUSE TestAccMrsMapReduceCluster_Eip_publicIp
=== RUN   TestAccMrsMapReduceCluster_bootstrap
=== PAUSE TestAccMrsMapReduceCluster_bootstrap
=== RUN   TestAccMrsMapReduceCluster_alarm
=== PAUSE TestAccMrsMapReduceCluster_alarm
=== RUN   TestAccMrsMapReduceCluster_updateWithEpsId
=== PAUSE TestAccMrsMapReduceCluster_updateWithEpsId
=== CONT  TestAccMrsMapReduceCluster_basic
=== CONT  TestAccMrsMapReduceCluster_custom_fullsize
=== CONT  TestAccMrsMapReduceCluster_custom_separate
=== CONT  TestAccMrsMapReduceCluster_bootstrap
=== CONT  TestAccMrsMapReduceCluster_custom_compact
=== CONT  TestAccMrsMapReduceCluster_updateWithEpsId
=== CONT  TestAccMrsMapReduceCluster_Eip_publicIp
=== CONT  TestAccMrsMapReduceCluster_alarm
=== CONT  TestAccMrsMapReduceCluster_Eip_id
=== CONT  TestAccMrsMapReduceCluster_hybrid
=== CONT  TestAccMrsMapReduceCluster_updateWithEpsId
    acceptance.go:820: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccMrsMapReduceCluster_updateWithEpsId (0.04s)
=== CONT  TestAccMrsMapReduceCluster_stream
=== CONT  TestAccMrsMapReduceCluster_bootstrap
    acceptance.go:862: HW_MAPREDUCE_BOOTSTRAP_SCRIPT must be set for acceptance tests: cluster of map reduce with bootstrap
--- SKIP: TestAccMrsMapReduceCluster_bootstrap (0.11s)
=== CONT  TestAccMrsMapReduceCluster_externalDataSources
--- PASS: TestAccMrsMapReduceCluster_Eip_id (724.77s)
=== CONT  TestAccMrsMapReduceCluster_analysis
--- PASS: TestAccMrsMapReduceCluster_Eip_publicIp (756.01s)
=== CONT  TestAccMrsMapReduceCluster_keypair
--- PASS: TestAccMrsMapReduceCluster_basic (761.12s)
--- PASS: TestAccMrsMapReduceCluster_custom_fullsize (824.79s)
--- PASS: TestAccMrsMapReduceCluster_custom_compact (848.25s)
--- PASS: TestAccMrsMapReduceCluster_alarm (873.69s)
--- PASS: TestAccMrsMapReduceCluster_hybrid (1406.57s)
--- PASS: TestAccMrsMapReduceCluster_keypair (663.68s)
--- PASS: TestAccMrsMapReduceCluster_custom_separate (1868.21s)
=== CONT  TestAccMrsMapReduceCluster_stream
    testing_new.go:84: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: error deleting Subnet: timeout while waiting for state to become 'DELETED' (last state: 'ACTIVE', timeout: 10m0s)

--- FAIL: TestAccMrsMapReduceCluster_stream (2411.78s)
--- PASS: TestAccMrsMapReduceCluster_analysis (2314.77s)
=== CONT  TestAccMrsMapReduceCluster_externalDataSources
    resource_huaweicloud_mapreduce_cluster_test.go:424: Step 1/2 error: Error running apply: exit status 1

        Error: error waiting for MapReduce cluster () to become ready: unexpected state 'failed', wanted target 'running'. last error: %!s(<nil>)

          with huaweicloud_mapreduce_cluster.test,
          on terraform_plugin_test.tf line 93, in resource "huaweicloud_mapreduce_cluster" "test":
          93: resource "huaweicloud_mapreduce_cluster" "test" {

--- FAIL: TestAccMrsMapReduceCluster_externalDataSources (4105.79s)
FAIL
coverage: 42.8% of statements in ./huaweicloud/services/mrs
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       4106.127s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
