### PR TITLE
feat(AAD): new resource to update domain security protection

### DIFF
--- a/docs/resources/aad_domain_security_protection.md
+++ b/docs/resources/aad_domain_security_protection.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Advanced Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aad_domain_security_protection"
+description: |-
+  Use this resource to modify Advanced Anti-DDos security protection within HuaweiCloud.
+---
+
+# huaweicloud_aad_domain_security_protection
+
+Use this resource to modify Advanced Anti-DDos security protection within HuaweiCloud.
+
+-> This resource is only a one-time action resource for updating AAD security protection. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "domain_id" {}
+variable "waf_switch" {}
+variable "cc_switch" {}
+
+resource "huaweicloud_aad_domain_security_protection" "test" {
+  domain_id  = var.domain_id
+  waf_switch = var.waf_switch
+  cc_switch  = var.cc_switch
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_id` - (Required, String, NonUpdatable) Specifies the domain ID.
+
+* `waf_switch` - (Required, Int, NonUpdatable) Specifies whether to enable basic web protection. Valid values are:
+  + `0`: On.
+  + `1`: Off.
+
+* `cc_switch` - (Required, Int, NonUpdatable) Specifies whether to enable CC protection. Valid values are:
+  + `0`: On.
+  + `1`: Off.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (also `domain_id`).

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1529,9 +1529,10 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"huaweicloud_aad_forward_rule":         aad.ResourceForwardRule(),
-			"huaweicloud_aad_black_white_list":     aad.ResourceBlackWhiteList(),
-			"huaweicloud_aad_change_specification": aad.ResourceChangeSpecification(),
+			"huaweicloud_aad_forward_rule":               aad.ResourceForwardRule(),
+			"huaweicloud_aad_black_white_list":           aad.ResourceBlackWhiteList(),
+			"huaweicloud_aad_change_specification":       aad.ResourceChangeSpecification(),
+			"huaweicloud_aad_domain_security_protection": aad.ResourceDomainSecurityProtection(),
 
 			"huaweicloud_antiddos_basic":                     antiddos.ResourceCloudNativeAntiDdos(),
 			"huaweicloud_antiddos_default_protection_policy": antiddos.ResourceDefaultProtectionPolicy(),

--- a/huaweicloud/services/aad/resource_huaweicloud_aad_domain_security_protection.go
+++ b/huaweicloud/services/aad/resource_huaweicloud_aad_domain_security_protection.go
@@ -1,0 +1,115 @@
+package aad
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableDomainSecurityProtectionParams = []string{
+	"domain_id",
+	"waf_switch",
+	"cc_switch",
+}
+
+// @API AAD POST /v1/{project_id}/aad/external/domains/switch
+func ResourceDomainSecurityProtection() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDomainSecurityProtectionCreate,
+		ReadContext:   resourceDomainSecurityProtectionRead,
+		UpdateContext: resourceDomainSecurityProtectionUpdate,
+		DeleteContext: resourceDomainSecurityProtectionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableDomainSecurityProtectionParams),
+
+		Schema: map[string]*schema.Schema{
+			"domain_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the domain ID.`,
+			},
+			"waf_switch": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies whether to enable basic web protection.`,
+			},
+			"cc_switch": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies whether to enable CC protection.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildDomainSecurityProtectionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"domain_id":  d.Get("domain_id"),
+		"waf_switch": d.Get("waf_switch"),
+		"cc_switch":  d.Get("cc_switch"),
+	}
+}
+
+func resourceDomainSecurityProtectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		httpUrl  = "v1/{project_id}/aad/external/domains/switch"
+		product  = "aad"
+		domainID = d.Get("domain_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildDomainSecurityProtectionBodyParams(d),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error updating AAD domain security protection: %s", err)
+	}
+
+	d.SetId(domainID)
+	return resourceDomainSecurityProtectionRead(ctx, d, meta)
+}
+
+func resourceDomainSecurityProtectionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDomainSecurityProtectionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDomainSecurityProtectionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to modify AAD security protection. Deleting this 
+resource will not change the current AAD security protection, but will only remove the resource information from the 
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}

--- a/huaweicloud/services/acceptance/aad/resource_huaweicloud_aad_domain_security_protection_test.go
+++ b/huaweicloud/services/acceptance/aad/resource_huaweicloud_aad_domain_security_protection_test.go
@@ -1,0 +1,37 @@
+package antiddos
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceDomainSecurityProtection_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare an AAD domain ID and set it to an environment variable.
+			acceptance.TestAccPreCheckAadDomainID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDomainSecurityProtection_basic(),
+			},
+		},
+	})
+}
+
+func testDomainSecurityProtection_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_aad_domain_security_protection" "test" {
+  domain_id  = "%s"
+  waf_switch = 0
+  cc_switch  = 0
+}
+`, acceptance.HW_AAD_DOMAIN_ID)
+}

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -234,6 +234,7 @@ var (
 	HW_AAD_IP_ADDRESS  = os.Getenv("HW_AAD_IP_ADDRESS")
 	HW_AAD_ENABLE_FLAG = os.Getenv("HW_AAD_ENABLE_FLAG")
 	HW_AAD_DOMAIN_NAME = os.Getenv("HW_AAD_DOMAIN_NAME")
+	HW_AAD_DOMAIN_ID   = os.Getenv("HW_AAD_DOMAIN_ID")
 
 	HW_WORKSPACE_AD_DOMAIN_NAMES = os.Getenv("HW_WORKSPACE_AD_DOMAIN_NAMES") // Domain name, e.g. "example.com".
 	// Please make sure all AD servers (master and standby) have the same account configuration (with same name and password).
@@ -773,6 +774,13 @@ func TestAccPrecheckAadEnable(t *testing.T) {
 func TestAccPrecheckAadDomainName(t *testing.T) {
 	if HW_AAD_DOMAIN_NAME == "" {
 		t.Skip("HW_AAD_DOMAIN_NAME must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckAadDomainID(t *testing.T) {
+	if HW_AAD_DOMAIN_ID == "" {
+		t.Skip("HW_AAD_DOMAIN_ID must be set for this acceptance test")
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to update domain security protection.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o aad -f TestAccResourceDomainSecurityProtection_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/aad" -v -coverprofile="./huaweicloud/services/acceptance/aad/aad_coverage.cov" -coverpkg="./huaweicloud/services/aad" -run TestAccResourceDomainSecurityProtection_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceDomainSecurityProtection_basic
=== PAUSE TestAccResourceDomainSecurityProtection_basic
=== CONT  TestAccResourceDomainSecurityProtection_basic
--- PASS: TestAccResourceDomainSecurityProtection_basic (10.87s)
PASS
coverage: 8.2% of statements in ./huaweicloud/services/aad
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aad       10.933s coverage: 8.2% of statements in ./huaweicloud/services/aad
```
![image](https://github.com/user-attachments/assets/a9f238c5-6bb8-4603-969b-d99b5a611ce6)



* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
