### PR TITLE
feat(sfsturbo): add datasource to get the list of SFS Turbos by tags

### DIFF
--- a/docs/data-sources/sfs_turbos_by_tags.md
+++ b/docs/data-sources/sfs_turbos_by_tags.md
@@ -1,0 +1,95 @@
+---
+subcategory: "SFS Turbo"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_sfs_turbos_by_tags"
+description: |-
+  Use this data source to get list of SFS Turbo file systems by tags.
+---
+
+# huaweicloud_sfs_turbos_by_tags
+
+Use this data source to get list of SFS Turbo file systems by tags.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_sfs_turbos_by_tags" "test" {
+  action = "filter"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `action` - (Required, String) Specifies the operation type of listing fily systems by tags.
+  The value can be **filter** or **count**.
+
+* `without_any_tag` - (Optional, Bool) Specifies the resources to be queried contain no tags.
+  If this parameter is set to **true**, all resources without specified tags are queried. In this case, the tags field
+  is ignored. If this parameter is set to **false** or not specified, it does not take effect, meaning that all
+  resources are returned or resources are filtered by `tags` or `matches`.
+
+* `tags` - (Optional, List) Specifies the tags to filter the resources. The `tags` can contain a maximum of `20` keys.
+  Each tag key can have a maximum of `20` tag values. The tag value corresponding to each tag key can be an empty array
+  but the structure cannot be missing. Each tag key must be unique, and tag values of the same tag must be unique.
+  The response returns resources containing all tags in this list. Keys in this list are in the AND relationship and
+  values in each key-value structure are in the OR relationship. If no `tags` is specified, all data is returned.
+  The [tags](#turbos_tags) structure is documented below.
+
+* `matches` - (Optional, List) Specifies the matches condition to filter the resources.
+  The [matches](#turbos_matches) structure is documented below.
+
+  -> Currently, the `matches` size is `1`.
+
+<a name="turbos_tags"></a>
+The `tags` block supports:
+
+* `key` - (Required, String) Specifies the key of the tags.
+  The `key` can contain a maximum of `128` characters and cannot be left blank.
+
+* `values` - (Required, List) Specifies the values list of the tags.
+  Each value can contain a maximum of `255` characters. An empty list for values indicates any value.
+
+<a name="turbos_matches"></a>
+The `matches` block supports:
+
+* `key` - (Required, String) Specifies the key of the matches.
+  Currently, only **resource_name** is supported.
+
+* `value` - (Required, String) Specifies the value of the matches.
+  If the `value` ends with `*`, prefix search will be performed. e.g. `sfsturbo*` indicates all resources whose names
+  start with **sfsturbo** will be returned.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `resources` - The list of the SFS Turbo file systems.
+  The [resources](#turbos_resources) structure is documented below.
+
+* `total_count` - The total count of the SFS Turbo file systems.
+
+<a name="turbos_resources"></a>
+The `resources` block supports:
+
+* `resource_id` - The ID of the SFS Turbo file systems.
+
+* `resource_name` - The name of the SFS Turbo file systems.
+
+* `resource_detail` - The detail of the SFS Turbo file systems.
+
+* `tags` - The tags list of the SFS Turbo file systems.
+  The [tags](#turbos_tags_attr) structure is documented below.
+
+<a name="turbos_tags_attr"></a>
+The `tags` block supports:
+
+* `key` - The key of the tags.
+
+* `value` - The value of the tags.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1275,6 +1275,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_sms_source_servers": sms.DataSourceServers(),
 
 			"huaweicloud_sfs_turbos":            sfsturbo.DataSourceTurbos(),
+			"huaweicloud_sfs_turbos_by_tags":    sfsturbo.DataSourceSfsTurbosByTags(),
 			"huaweicloud_sfs_turbo_data_tasks":  sfsturbo.DataSourceSfsTurboDataTasks(),
 			"huaweicloud_sfs_turbo_dir_usage":   sfsturbo.DataSourceDirusage(),
 			"huaweicloud_sfs_turbo_du_tasks":    sfsturbo.DataSourceSfsTurboDuTasks(),

--- a/huaweicloud/services/acceptance/sfsturbo/data_source_huaweicloud_sfs_turbos_by_tags_test.go
+++ b/huaweicloud/services/acceptance/sfsturbo/data_source_huaweicloud_sfs_turbos_by_tags_test.go
@@ -1,0 +1,131 @@
+package sfsturbo
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataSourceSfsTurbosByTags_basic(t *testing.T) {
+	var (
+		dataSource  = "data.huaweicloud_sfs_turbos_by_tags.test"
+		dataSource1 = "data.huaweicloud_sfs_turbos_by_tags.filter_by_count"
+		dataSource2 = "data.huaweicloud_sfs_turbos_by_tags.filter_by_tags"
+		dataSource3 = "data.huaweicloud_sfs_turbos_by_tags.filter_by_matches"
+
+		name = acceptance.RandomAccResourceName()
+		dc   = acceptance.InitDataSourceCheck(dataSource)
+		dc1  = acceptance.InitDataSourceCheck(dataSource1)
+		dc2  = acceptance.InitDataSourceCheck(dataSource2)
+		dc3  = acceptance.InitDataSourceCheck(dataSource3)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSfsTurbosByTags_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.resource_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.resource_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.tags.#"),
+
+					dc1.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource1, "total_count"),
+					resource.TestCheckOutput("results_is_not_empty", "true"),
+
+					dc2.CheckResourceExists(),
+					resource.TestCheckOutput("tags_filter_is_useful", "true"),
+
+					dc3.CheckResourceExists(),
+					resource.TestCheckOutput("matches_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSfsTurbosByTags_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  name              = "%[2]s"
+  size              = 500
+  share_proto       = "NFS"
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testDataSourceSfsTurbosByTags_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_sfs_turbos_by_tags" "test" {
+  action = "filter"
+
+  depends_on = [huaweicloud_sfs_turbo.test]
+}
+
+data "huaweicloud_sfs_turbos_by_tags" "filter_by_count" {
+  action = "count"
+
+  depends_on = [huaweicloud_sfs_turbo.test]
+}
+
+data "huaweicloud_sfs_turbos_by_tags" "filter_by_tags" {
+  action = "filter"
+
+  tags {
+    key    = "foo"
+    values = ["bar"]
+  }
+
+  depends_on = [huaweicloud_sfs_turbo.test]
+}
+
+data "huaweicloud_sfs_turbos_by_tags" "filter_by_matches" {
+  action = "filter"
+
+  matches {
+    key   = "resource_name"
+    value = huaweicloud_sfs_turbo.test.name
+  }
+
+  depends_on = [huaweicloud_sfs_turbo.test]
+}
+
+output "results_is_not_empty" {
+  value = data.huaweicloud_sfs_turbos_by_tags.filter_by_count.total_count > 0
+}
+
+output "tags_filter_is_useful" {
+  value = length(data.huaweicloud_sfs_turbos_by_tags.filter_by_tags.resources) == 1
+}
+
+output "matches_filter_is_useful" {
+  value = length(data.huaweicloud_sfs_turbos_by_tags.filter_by_matches.resources) == 1
+}
+
+`, testAccSfsTurbosByTags_base(name))
+}

--- a/huaweicloud/services/sfsturbo/data_source_huaweicloud_sfs_turbos_by_tags.go
+++ b/huaweicloud/services/sfsturbo/data_source_huaweicloud_sfs_turbos_by_tags.go
@@ -1,0 +1,271 @@
+package sfsturbo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SFSTurbo POST /v1/{project_id}/sfs-turbo/resource_instances/action
+func DataSourceSfsTurbosByTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSfsTurbosByTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"without_any_tag": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"matches": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_detail": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"total_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceSfsTurbosByTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v1/{project_id}/sfs-turbo/resource_instances/action"
+	)
+
+	client, err := cfg.NewServiceClient("sfs-turbo", region)
+	if err != nil {
+		return diag.Errorf("error creating SFS Turbo client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	reqBodyParams := utils.RemoveNil(buildSfsTurbosBodyParams(d))
+	action := d.Get("action").(string)
+	resources := make([]interface{}, 0)
+	offset := 0
+	totalCount := 0
+
+	for {
+		if action == "filter" {
+			reqBodyParams["offset"] = fmt.Sprintf("%v", offset)
+		}
+
+		listOpt.JSONBody = reqBodyParams
+		listResp, err := client.Request("POST", listPath, &listOpt)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		listRespBody, err := utils.FlattenResponse(listResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		if action == "count" {
+			totalCount = int(utils.PathSearch("total_count", listRespBody, float64(0)).(float64))
+			break
+		}
+
+		turbos := utils.PathSearch("resources", listRespBody, make([]interface{}, 0)).([]interface{})
+		if len(turbos) == 0 {
+			totalCount = len(resources)
+			break
+		}
+
+		resources = append(resources, turbos...)
+
+		offset += len(turbos)
+	}
+
+	datasourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(datasourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("resources", flattenSfsTurbosRespByTags(resources)),
+		d.Set("total_count", totalCount),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildSfsTurbosTagsBodyParams(d *schema.ResourceData) []map[string]interface{} {
+	v, ok := d.GetOk("tags")
+	if !ok {
+		return nil
+	}
+
+	bodyParams := make([]map[string]interface{}, len(v.([]interface{})))
+
+	for i, tag := range v.([]interface{}) {
+		bodyParams[i] = map[string]interface{}{
+			"key":    utils.PathSearch("key", tag, nil),
+			"values": utils.PathSearch("values", tag, nil),
+		}
+	}
+
+	return bodyParams
+}
+
+func buildSfsTurbosMatchesBodyParams(d *schema.ResourceData) []map[string]interface{} {
+	v, ok := d.GetOk("matches")
+	if !ok {
+		return nil
+	}
+
+	bodyParams := make([]map[string]interface{}, len(v.([]interface{})))
+
+	for i, match := range v.([]interface{}) {
+		bodyParams[i] = map[string]interface{}{
+			"key":   utils.PathSearch("key", match, nil),
+			"value": utils.PathSearch("value", match, nil),
+		}
+	}
+
+	return bodyParams
+}
+
+func buildSfsTurbosBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"action":  d.Get("action"),
+		"tags":    buildSfsTurbosTagsBodyParams(d),
+		"matches": buildSfsTurbosMatchesBodyParams(d),
+	}
+
+	if d.Get("without_any_tag").(bool) {
+		bodyParams["without_any_tag"] = true
+	}
+
+	return bodyParams
+}
+
+func flattenSfsTurbosRespByTags(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(resp))
+	for i, v := range resp {
+		rst[i] = map[string]interface{}{
+			"resource_id":     utils.PathSearch("resource_id", v, nil),
+			"resource_name":   utils.PathSearch("resource_name", v, nil),
+			"resource_detail": utils.PathSearch("resource_detail", v, nil),
+			"tags":            flattenResourceTags(utils.PathSearch("tags", v, make([]interface{}, 0)).([]interface{})),
+		}
+	}
+
+	return rst
+}
+
+func flattenResourceTags(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	tags := make([]interface{}, len(resp))
+	for i, v := range resp {
+		tags[i] = map[string]interface{}{
+			"key":   utils.PathSearch("key", v, nil),
+			"value": utils.PathSearch("value", v, nil),
+		}
+	}
+
+	return tags
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add datasource to get the list of SFS Turbos by tags.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/sfsturbo" TESTARGS="-run TestAccDataSourceSfsTurbosByTags_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/sfsturbo -v -run TestAccDataSourceSfsTurbosByTags_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSfsTurbosByTags_basic
=== PAUSE TestAccDataSourceSfsTurbosByTags_basic
=== CONT  TestAccDataSourceSfsTurbosByTags_basic
--- PASS: TestAccDataSourceSfsTurbosByTags_basic (345.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sfsturbo  345.288s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
