### PR TITLE
feat(modelarts): add new data source to query nodes under resource pool

### DIFF
--- a/docs/data-sources/modelartsv2_resource_pool_nodes.md
+++ b/docs/data-sources/modelartsv2_resource_pool_nodes.md
@@ -1,0 +1,135 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelartsv2_resource_pool_nodes"
+description: |-
+  Use this data source to get node list under a specified resource pool within HuaweiCloud.
+---
+
+# huaweicloud_modelartsv2_resource_pool_nodes
+
+Use this data source to get node list under a specified resource pool within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "resource_pool_name" {}
+
+data "huaweicloud_modelartsv2_resource_pool_nodes" "test" {
+  resource_pool_name = var.resource_pool_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the resource nodes are located.  
+  If omitted, the provider-level region will be used.
+
+* `resource_pool_name` - (Required, String) Specifies the resource pool name to which the resource nodes belong.  
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `nodes` - All queried resource nodes under a specified resource pool.  
+  The [nodes](#modelartsv2_resource_pool_nodes) structure is documented below.
+
+<a name="modelartsv2_resource_pool_nodes"></a>
+The `nodes` block supports:
+
+* `metadata` - The metadata information of the node.  
+  The [metadata](#modelartsv2_resource_pool_nodes_metadata) structure is documented below.
+
+* `spec` - The specification of the node.  
+  The [spec](#modelartsv2_resource_pool_nodes_spec) structure is documented below.
+
+* `status` - The status information of the node.  
+  The [status](#modelartsv2_resource_pool_nodes_status) structure is documented below.
+
+<a name="modelartsv2_resource_pool_nodes_metadata"></a>
+The `metadata` block supports:
+
+* `name` - The name of the node.
+
+* `creation_timestamp` - The creation timestamp of the node.
+
+* `labels` - The labels of the node.
+
+* `annotations` - The annotation configuration of the node.
+
+<a name="modelartsv2_resource_pool_nodes_spec"></a>
+The `spec` block supports:
+
+* `flavor` - The flavor of the node.
+
+* `extend_params` - The extend parameters of the node.
+
+* `host_network` - The network configuration of the node.  
+  The [host_network](#modelartsv2_resource_pool_nodes_spec_host_network) structure is documented below.
+
+* `os` - The OS information of the node.  
+  The [os](#modelartsv2_resource_pool_nodes_spec_os) structure is documented below.
+
+<a name="modelartsv2_resource_pool_nodes_spec_host_network"></a>
+The `host_network` block supports:
+
+* `vpc` - The VPC ID to which the node belongs.
+
+* `subnet` - The subnet ID to which the node belongs.
+
+<a name="modelartsv2_resource_pool_nodes_spec_os"></a>
+The `os` block supports:
+
+* `image_id` - The image ID of the OS.
+
+<a name="modelartsv2_resource_pool_nodes_status"></a>
+The `status` block supports:
+
+* `phase` - The current phase of the node.
+  + **Available**
+  + **Creating**
+  + **Deleting**
+  + **Abnormal**
+  + **Checking**
+
+* `az` - The availability zone where the node is located.
+
+* `driver` - The driver configuration of the node.  
+  The [driver](#modelartsv2_resource_pool_nodes_status_driver) structure is documented below.
+
+* `os` - The OS information of the kubernetes node.  
+  The [os](#modelartsv2_resource_pool_nodes_status_os) structure is documented below.
+
+* `plugins` - The plugin configuration of the node.  
+  The [plugins](#modelartsv2_resource_pool_nodes_status_plugins) structure is documented above.
+
+* `private_ip` - The private IP address of the node.
+
+* `resources` - The resource detail of the node, in JSON format.
+
+* `available_resources` - The available resource detail of the node, in JSON format.
+
+<a name="modelartsv2_resource_pool_nodes_status_driver"></a>
+The `driver` block supports:
+
+* `phase` - The current phase of the driver.
+
+* `version` - The version of the driver.
+
+<a name="modelartsv2_resource_pool_nodes_status_os"></a>
+The `os` block supports:
+
+* `name` - The OS name of the kubernetes node.
+
+<a name="modelartsv2_resource_pool_nodes_status_plugins"></a>
+The `plugins` block supports:
+
+* `name` - The name of the plugin.
+
+* `phase` - The current phase of the plugin.
+
+* `version` - The version of the plugin.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1146,8 +1146,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_services":         modelarts.DataSourceServices(),
 			"huaweicloud_modelarts_resource_flavors": modelarts.DataSourceResourceFlavors(),
 			// Resource management via V2 APIs.
-			"huaweicloud_modelartsv2_node_pool_nodes": modelarts.DataSourceV2NodePoolNodes(),
-			"huaweicloud_modelartsv2_resource_pools":  modelarts.DataSourceV2ResourcePools(),
+			"huaweicloud_modelartsv2_node_pool_nodes":     modelarts.DataSourceV2NodePoolNodes(),
+			"huaweicloud_modelartsv2_resource_pool_nodes": modelarts.DataSourceV2ResourcePoolNodes(),
+			"huaweicloud_modelartsv2_resource_pools":      modelarts.DataSourceV2ResourcePools(),
 
 			"huaweicloud_mapreduce_clusters": mrs.DataSourceMrsClusters(),
 

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelartsv2_resource_pool_nodes_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelartsv2_resource_pool_nodes_test.go
@@ -1,0 +1,104 @@
+package modelarts
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this acceptance test, please support at least one resource pool.
+func TestAccDataV2ResourcePoolNodes_basic(t *testing.T) {
+	allResourcePools := "data.huaweicloud_modelartsv2_resource_pools.test"
+	dcForAllResourcePools := acceptance.InitDataSourceCheck(allResourcePools)
+
+	allResourcePoolNodes := "data.huaweicloud_modelartsv2_resource_pool_nodes.test"
+	dcForAllResourcePoolNodes := acceptance.InitDataSourceCheck(allResourcePoolNodes)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataV2ResourcePoolNodes_invalidResourcePoolName,
+				ExpectError: regexp.MustCompile(`\\"invalid-resource-pool-name\\" not found`),
+			},
+			{
+				Config: testAccDataV2ResourcePoolNodes_basic_step1,
+				Check: resource.ComposeTestCheckFunc(
+					dcForAllResourcePools.CheckResourceExists(),
+					resource.TestMatchResourceAttr(allResourcePools, "resource_pools.#", regexp.MustCompile(`[1-9]\d*`)),
+				),
+			},
+			{
+				Config: testAccDataV2ResourcePoolNodes_basic_step2,
+				Check: resource.ComposeTestCheckFunc(
+					dcForAllResourcePoolNodes.CheckResourceExists(),
+					resource.TestMatchResourceAttr(allResourcePoolNodes, "nodes.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckOutput("is_metadata_set_and_valid", "true"),
+					resource.TestCheckOutput("is_spec_set_and_valid", "true"),
+					resource.TestCheckOutput("is_status_set_and_valid", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataV2ResourcePoolNodes_invalidResourcePoolName string = `
+data "huaweicloud_modelartsv2_resource_pool_nodes" "invalid_resource_pool_name" {
+  resource_pool_name = "invalid-resource-pool-name"
+}
+`
+
+const testAccDataV2ResourcePoolNodes_basic_step1 string = `
+data "huaweicloud_modelartsv2_resource_pools" "test" {}
+`
+
+const testAccDataV2ResourcePoolNodes_basic_step2 string = `
+data "huaweicloud_modelartsv2_resource_pools" "test" {}
+
+data "huaweicloud_modelartsv2_resource_pool_nodes" "test" {
+  resource_pool_name = try(data.huaweicloud_modelartsv2_resource_pools.test.resource_pools[0].metadata[0].name, "")
+}
+
+locals {
+  metadata = data.huaweicloud_modelartsv2_resource_pool_nodes.test.nodes[0].metadata
+  spec     = data.huaweicloud_modelartsv2_resource_pool_nodes.test.nodes[0].spec
+  status   = data.huaweicloud_modelartsv2_resource_pool_nodes.test.nodes[0].status
+}
+
+output "is_metadata_set_and_valid" {
+  value = try(length(local.metadata) > 0 && alltrue([
+    local.metadata[0].annotations != "",
+    local.metadata[0].creation_timestamp != "",
+    local.metadata[0].labels != "",
+    local.metadata[0].name != "",
+  ]))
+}
+
+output "is_spec_set_and_valid" {
+  value = try(length(local.spec) > 0 && alltrue([
+    local.spec[0].extend_params != "",
+    local.spec[0].flavor != "",
+    length(local.spec[0].host_network) > 0 && alltrue([
+      local.spec[0].host_network.0.vpc != "",
+      local.spec[0].host_network.0.subnet != "",
+    ]),
+    length(local.spec[0].os) > 0 && alltrue([
+      local.spec[0].os[0].image_id != "",
+    ]),
+  ]))
+}
+
+output "is_status_set_and_valid" {
+  value = try(length(local.status) > 0 && alltrue([
+    local.status[0].phase != "",
+    local.status[0].az != "",
+    length(local.status[0].os) > 0 && alltrue([
+      local.status[0].os.0.name != "",
+    ]),
+  ]))
+}
+`

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_resource_pool_nodes.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_resource_pool_nodes.go
@@ -1,0 +1,443 @@
+package modelarts
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ModelArts GET /v2/{project_id}/pools/{pool_name}/nodepools/{nodepool_name}/nodes
+func DataSourceV2ResourcePoolNodes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV2ResourcePoolNodesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the resource nodes are located.`,
+			},
+			"resource_pool_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The resource pool name to which the resource nodes belong.`,
+			},
+			"nodes": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataSourceV2ResourcePoolNodeSchema(),
+				Description: `All queried resource nodes under a specified resource pool.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2ResourcePoolNodeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"metadata": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataSourceV2ResourcePoolNodeMetadataSchema(),
+				Description: `The metadata information of the node.`,
+			},
+			"spec": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataSourceV2ResourcePoolNodeSpecSchema(),
+				Description: `The specification of the node.`,
+			},
+			"status": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataSourceV2ResourcePoolNodeStatusSchema(),
+				Description: `The status information of the node.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2ResourcePoolNodeMetadataSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the node.`,
+			},
+			"creation_timestamp": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation timestamp of the node.`,
+			},
+			"labels": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The labels of the node, in JSON format.`,
+			},
+			"annotations": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The annotation configuration of the node, in JSON format.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2ResourcePoolNodeSpecSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"flavor": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The flavor of the node.`,
+			},
+			"extend_params": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The extend parameters of the node.`,
+			},
+			"host_network": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataSourceV2ResourcePoolNodeSpecHostNetworkSchema(),
+				Description: `The network configuration of the node.`,
+			},
+			"os": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataSourceV2ResourcePoolNodeSpecOsSchema(),
+				Description: `The OS information of the node.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2ResourcePoolNodeSpecHostNetworkSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"vpc": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The VPC ID to which the node belongs.`,
+			},
+			"subnet": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The subnet ID to which the node belongs.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2ResourcePoolNodeSpecOsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"image_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The image ID of the OS.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2ResourcePoolNodeStatusSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"phase": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current phase of the node.`,
+			},
+			"az": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The availability zone where the node is located.`,
+			},
+			"driver": {
+				Type:        schema.TypeList,
+				Elem:        dataSourceV2ResourcePoolNodeStatusDriverSchema(),
+				Computed:    true,
+				Description: `The driver configuration of the node.`,
+			},
+			"os": {
+				Type:        schema.TypeList,
+				Elem:        dataSourceV2ResourcePoolNodeStatusOsSchema(),
+				Computed:    true,
+				Description: `The OS information of the kubernetes node.`,
+			},
+			"plugins": {
+				Type:        schema.TypeList,
+				Elem:        dataSourceV2ResourcePoolNodeStatusPluginsSchema(),
+				Computed:    true,
+				Description: `The plugin configuration of the node.`,
+			},
+			"private_ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The private IP address of the node.`,
+			},
+			"resources": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The resource detail of the node, in JSON format.`,
+			},
+			"available_resources": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The available resource detail of the node, in JSON format.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2ResourcePoolNodeStatusDriverSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"phase": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current phase of the driver.`,
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The version of the driver.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2ResourcePoolNodeStatusOsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The OS name of the kubernetes node.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2ResourcePoolNodeStatusPluginsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the plugin.`,
+			},
+			"phase": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current phase of the plugin.`,
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The version of the plugin.`,
+			},
+		},
+	}
+}
+
+func listV2ResourcePoolNodes(client *golangsdk.ServiceClient, resourcePoolName string) ([]interface{}, error) {
+	// Currently, these query parameters are not available:
+	// + continue
+	// + limit
+	// Without page parameters, the service will returns all of nodes.
+	httpUrl := "v2/{project_id}/pools/{pool_name}/nodes"
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{pool_name}", resourcePoolName)
+
+	listFlavorsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &listFlavorsOpt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenV2ResourcePoolNodeMetadata(metadata interface{}) []map[string]interface{} {
+	if metadata == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"name":               utils.PathSearch("name", metadata, nil),
+			"creation_timestamp": utils.PathSearch("creationTimestamp", metadata, nil),
+			"labels":             utils.JsonToString(utils.PathSearch("labels", metadata, nil)),
+			"annotations":        utils.JsonToString(utils.PathSearch("annotations", metadata, nil)),
+		},
+	}
+}
+
+func flattenV2ResourcePoolNodeSpecHostNetwork(os interface{}) []map[string]interface{} {
+	if os == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"vpc":    utils.PathSearch("vpc", os, nil),
+			"subnet": utils.PathSearch("subnet", os, nil),
+		},
+	}
+}
+
+func flattenV2ResourcePoolNodeSpecOs(osInfo interface{}) []map[string]interface{} {
+	if osInfo == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"image_id": utils.PathSearch("imageId", osInfo, nil),
+		},
+	}
+}
+
+func flattenV2ResourcePoolNodeSpec(spec interface{}) []map[string]interface{} {
+	if spec == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"flavor":        utils.PathSearch("flavor", spec, nil),
+			"extend_params": utils.JsonToString(utils.PathSearch("extendParams", spec, nil)),
+			"host_network":  flattenV2ResourcePoolNodeSpecHostNetwork(utils.PathSearch("hostNetwork", spec, nil)),
+			"os":            flattenV2ResourcePoolNodeSpecOs(utils.PathSearch("os", spec, nil)),
+		},
+	}
+}
+
+func flattenV2ResourcePoolNodeDriver(driver interface{}) []map[string]interface{} {
+	if driver == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"phase":   utils.PathSearch("phase", driver, nil),
+			"version": utils.PathSearch("version", driver, nil),
+		},
+	}
+}
+
+func flattenV2ResourcePoolNodeStatusOs(osInfo interface{}) []map[string]interface{} {
+	if osInfo == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"name": utils.PathSearch("name", osInfo, nil),
+		},
+	}
+}
+
+func flattenV2ResourcePoolNodePlugins(plugins []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(plugins))
+
+	for _, plugin := range plugins {
+		result = append(result, map[string]interface{}{
+			"name":    utils.PathSearch("name", plugin, nil),
+			"phase":   utils.PathSearch("phase", plugin, nil),
+			"version": utils.PathSearch("version", plugin, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenV2ResourcePoolNodeStatus(status interface{}) []map[string]interface{} {
+	if status == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"phase":               utils.PathSearch("phase", status, nil),
+			"az":                  utils.PathSearch("az", status, nil),
+			"driver":              flattenV2ResourcePoolNodeDriver(utils.PathSearch("driver", status, nil)),
+			"os":                  flattenV2ResourcePoolNodeStatusOs(utils.PathSearch("os", status, nil)),
+			"plugins":             flattenV2ResourcePoolNodePlugins(utils.PathSearch("plugins", status, make([]interface{}, 0)).([]interface{})),
+			"private_ip":          utils.PathSearch("privateIp", status, nil),
+			"resources":           utils.JsonToString(utils.PathSearch("resources", status, nil)),
+			"available_resources": utils.JsonToString(utils.PathSearch("availableResources", status, nil)),
+		},
+	}
+}
+
+func flattenV2ResourcePoolNodes(nodes []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(nodes))
+
+	for _, node := range nodes {
+		result = append(result, map[string]interface{}{
+			"metadata": flattenV2ResourcePoolNodeMetadata(utils.PathSearch("metadata", node, nil)),
+			"spec":     flattenV2ResourcePoolNodeSpec(utils.PathSearch("spec", node, nil)),
+			"status":   flattenV2ResourcePoolNodeStatus(utils.PathSearch("status", node, nil)),
+		})
+	}
+
+	return result
+}
+
+func dataSourceV2ResourcePoolNodesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		resourcePoolName = d.Get("resource_pool_name").(string)
+	)
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	nodes, err := listV2ResourcePoolNodes(client, resourcePoolName)
+	if err != nil {
+		return diag.Errorf("error querying node list for the specified resource pool (%s): %s",
+			resourcePoolName, err,
+		)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("nodes", flattenV2ResourcePoolNodes(nodes)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new data source to query resource nodes under a specified resource pool.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query nodes under resource pool.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccDataV2ResourcePoolNodes_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDataV2ResourcePoolNodes_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV2ResourcePoolNodes_basic
=== PAUSE TestAccDataV2ResourcePoolNodes_basic
=== CONT  TestAccDataV2ResourcePoolNodes_basic
--- PASS: TestAccDataV2ResourcePoolNodes_basic (10.39s)
PASS
coverage: 5.8% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 10.461s coverage: 5.8% of statements in ./huaweicloud/services/modelarts
```
![image](https://github.com/user-attachments/assets/d22470de-dbc1-46f5-9700-f81a3843e394)

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
