### PR TITLE
feat(modelarts): resource pool query result supplement the name attribute

### DIFF
--- a/docs/data-sources/modelartsv2_resource_pools.md
+++ b/docs/data-sources/modelartsv2_resource_pools.md
@@ -84,6 +84,8 @@ The `resource_pools` block supports:
 <a name="modelarts_resource_pool_metadata"></a>
 The `metadata` block supports:
 
+* `name` - The name of the resource pool.
+
 * `annotations` - The annotations of the resource pool.
 
 * `labels` - The labels of the resource pool.

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_resource_pools.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_resource_pools.go
@@ -135,6 +135,11 @@ func DataSourceV2ResourcePools() *schema.Resource {
 func dataV2ResourcePoolMetadataSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the resource pool.`,
+			},
 			"annotations": {
 				Type:        schema.TypeMap,
 				Computed:    true,
@@ -449,6 +454,7 @@ func flattenV2ResourcePoolMetadata(metadata interface{}) []map[string]interface{
 
 	return []map[string]interface{}{
 		{
+			"name":        utils.PathSearch("name", metadata, nil),
 			"annotations": utils.PathSearch("annotations", metadata, make(map[string]interface{})),
 			"labels":      utils.PathSearch("labels", metadata, make(map[string]interface{})),
 			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("creationTimestamp",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Resource pool query result supplement the name attribute.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supplement the name attribute to the element structure of the resource_pools list
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccDataSourceV2ResourcePools_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDataSourceV2ResourcePools_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceV2ResourcePools_basic
=== PAUSE TestAccDataSourceV2ResourcePools_basic
=== CONT  TestAccDataSourceV2ResourcePools_basic
--- PASS: TestAccDataSourceV2ResourcePools_basic (10.57s)
PASS
coverage: 6.3% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 10.627s  coverage: 6.3% of statements in ./huaweicloud/services/modelarts
```

![image](https://github.com/user-attachments/assets/b2db093f-d243-4834-abb6-6f08c0730d28)

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
