### PR TITLE
feat(modelarts): supports new data source to query nodes under specified node pool

### DIFF
--- a/docs/data-sources/modelartsv2_node_pool_nodes.md
+++ b/docs/data-sources/modelartsv2_node_pool_nodes.md
@@ -1,0 +1,148 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelartsv2_node_pool_nodes"
+description: |-
+  Use this data source to get node list under a specified node pool within HuaweiCloud.
+---
+
+# huaweicloud_modelartsv2_node_pool_nodes
+
+Use this data source to get node list under a specified node pool within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "resource_pool_name" {}
+variable "node_pool_name" {}
+
+data "huaweicloud_modelartsv2_node_pool_nodes" "test" {
+  resource_pool_name = var.resource_pool_name
+  node_pool_name     = var.node_pool_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the resource nodes are located.  
+  If omitted, the provider-level region will be used.
+
+* `resource_pool_name` - (Required, String) Specifies the resource pool name to which the node pool belongs.  
+
+* `node_pool_name` - (Required, String) Specifies the node pool name to which the resource nodes belongs.
+
+  -> If the node pool name does not specified when the resource pool creation, the ModelArts service will auto generate
+     a name as this format: `{flavor}-default`, such as **modelarts.bm.npu.arm.8snt9b3.i6l.d.c004-default**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `nodes` - All queried resource nodes under a specified node pool.  
+  The [nodes](#v2modelarts_node_pool_nodes) structure is documented below.
+
+<a name="v2modelarts_node_pool_nodes"></a>
+The `nodes` block supports:
+
+* `metadata` - The metadata information of the node.  
+  The [metadata](#v2modelarts_node_pool_nodes_metadata) structure is documented below.
+
+* `spec` - The specification of the node.  
+  The [spec](#v2modelarts_node_pool_nodes_spec) structure is documented below.
+
+* `status` - The status information of the node.  
+  The [status](#v2modelarts_node_pool_nodes_status) structure is documented below.
+
+<a name="v2modelarts_node_pool_nodes_metadata"></a>
+The `metadata` block supports:
+
+* `name` - The name of the node.
+
+* `creation_timestamp` - The creation timestamp of the node.
+
+* `labels` - The labels of the node.
+
+* `annotations` - The annotation configuration of the node.
+
+<a name="v2modelarts_node_pool_nodes_spec"></a>
+The `spec` block supports:
+
+* `flavor` - The flavor of the node.
+
+* `extend_params` - The extend parameters of the node.
+
+* `host_network` - The network configuration of the node.  
+  The [host_network](#v2modelarts_node_pool_nodes_spec_host_network) structure is documented below.
+
+* `os` - The OS information of the node.  
+  The [os](#v2modelarts_node_pool_nodes_spec_os) structure is documented below.
+
+<a name="v2modelarts_node_pool_nodes_spec_host_network"></a>
+The `host_network` block supports:
+
+* `vpc` - The VPC ID to which the node belongs.
+
+* `subnet` - The subnet ID to which the node belongs.
+
+* `security_groups` - The security group IDs that the node used.
+
+<a name="v2modelarts_node_pool_nodes_spec_os"></a>
+The `os` block supports:
+
+* `name` - The OS name of the node.
+
+* `image_id` - The image ID of the OS.
+
+* `image_type` - The image type of the OS.
+
+<a name="v2modelarts_node_pool_nodes_status"></a>
+The `status` block supports:
+
+* `phase` - The current phase of the node.
+  + **Available**
+  + **Creating**
+  + **Deleting**
+  + **Abnormal**
+  + **Checking**
+
+* `az` - The availability zone where the node is located.
+
+* `driver` - The driver configuration of the node.  
+  The [driver](#v2modelarts_node_pool_nodes_status_driver) structure is documented below.
+
+* `os` - The OS information of the kubernetes node.  
+  The [os](#v2modelarts_node_pool_nodes_status_os) structure is documented below.
+
+* `plugins` - The plugin configuration of the node.  
+  The [plugins](#v2modelarts_node_pool_nodes_status_plugins) structure is documented above.
+
+* `private_ip` - The private IP address of the node.
+
+* `resources` - The resource detail of the node, in JSON format.
+
+* `available_resources` - The available resource detail of the node, in JSON format.
+
+<a name="v2modelarts_node_pool_nodes_status_driver"></a>
+The `driver` block supports:
+
+* `phase` - The current phase of the driver.
+
+* `version` - The version of the driver.
+
+<a name="v2modelarts_node_pool_nodes_status_os"></a>
+The `os` block supports:
+
+* `name` - The OS name of the kubernetes node.
+
+<a name="v2modelarts_node_pool_nodes_status_plugins"></a>
+The `plugins` block supports:
+
+* `name` - The name of the plugin.
+
+* `phase` - The current phase of the plugin.
+
+* `version` - The version of the plugin.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1145,7 +1145,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_services":         modelarts.DataSourceServices(),
 			"huaweicloud_modelarts_resource_flavors": modelarts.DataSourceResourceFlavors(),
 			// Resource management via V2 APIs.
-			"huaweicloud_modelartsv2_resource_pools": modelarts.DataSourceV2ResourcePools(),
+			"huaweicloud_modelartsv2_node_pool_nodes": modelarts.DataSourceV2NodePoolNodes(),
+			"huaweicloud_modelartsv2_resource_pools":  modelarts.DataSourceV2ResourcePools(),
 
 			"huaweicloud_mapreduce_clusters": mrs.DataSourceMrsClusters(),
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -390,6 +390,7 @@ var (
 	HW_MODELARTS_USER_LOGIN_PASSWORD = os.Getenv("HW_MODELARTS_USER_LOGIN_PASSWORD")
 	HW_MODELARTS_DEVSERVER_FLAVOR    = os.Getenv("HW_MODELARTS_DEVSERVER_FLAVOR")
 	HW_MODELARTS_DEVSERVER_IMAGE_ID  = os.Getenv("HW_MODELARTS_DEVSERVER_IMAGE_ID")
+	HW_MODELARTS_RESOURCE_POOL_NAME  = os.Getenv("HW_MODELARTS_RESOURCE_POOL_NAME")
 
 	// The CMDB sub-application ID of AOM service
 	HW_AOM_SUB_APPLICATION_ID                    = os.Getenv("HW_AOM_SUB_APPLICATION_ID")
@@ -2172,6 +2173,13 @@ func TestAccPreCheckModelartsUserLoginPassword(t *testing.T) {
 func TestAccPreCheckModelartsDevServer(t *testing.T) {
 	if HW_MODELARTS_DEVSERVER_FLAVOR == "" || HW_MODELARTS_DEVSERVER_IMAGE_ID == "" {
 		t.Skip("HW_MODELARTS_DEVSERVER_FLAVOR and HW_MODELARTS_DEVSERVER_IMAGE_ID must be set for ModelArts DevServer acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckModelArtsResourcePoolName(t *testing.T) {
+	if HW_MODELARTS_RESOURCE_POOL_NAME == "" {
+		t.Skip("HW_MODELARTS_RESOURCE_POOL_NAME must be set for ModelArts resource pool acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelartsv2_node_pool_nodes_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelartsv2_node_pool_nodes_test.go
@@ -1,0 +1,117 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this acceptance test, please support at least two resource nodes under the resource pool.
+func TestAccDataSourceV2NodePoolNodes_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_modelartsv2_node_pool_nodes.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckModelArtsResourcePoolName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceV2NodePoolNodes_invalidResourcePoolName,
+				ExpectError: regexp.MustCompile(`\\"invalid-resource-pool-name\\" not found`),
+			},
+			{
+				Config:      testAccDataSourceV2NodePoolNodes_invalidNodePoolName(),
+				ExpectError: regexp.MustCompile(`invalid nodepool name`),
+			},
+			{
+				Config: testAccDataSourceV2NodePoolNodes_basic_step1(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "nodes.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckOutput("is_metadata_set_and_valid", "true"),
+					resource.TestCheckOutput("is_spec_set_and_valid", "true"),
+					resource.TestCheckOutput("is_status_set_and_valid", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceV2NodePoolNodes_invalidResourcePoolName string = `
+data "huaweicloud_modelartsv2_node_pool_nodes" "test" {
+  resource_pool_name = "invalid-resource-pool-name"
+  node_pool_name     = "invalid-node-pool-name"
+}
+`
+
+func testAccDataSourceV2NodePoolNodes_invalidNodePoolName() string {
+	return fmt.Sprintf(`
+data "huaweicloud_modelartsv2_node_pool_nodes" "test" {
+  resource_pool_name = "%[1]s"
+  node_pool_name     = "invalid-node-pool-name"
+}
+`, acceptance.HW_MODELARTS_RESOURCE_POOL_NAME)
+}
+
+func testAccDataSourceV2NodePoolNodes_basic_step1() string {
+	return fmt.Sprintf(`
+data "huaweicloud_modelartsv2_resource_pools" "test" {}
+
+locals {
+  node_pool_flavor_id = try([for o in data.huaweicloud_modelartsv2_resource_pools.test.resource_pools:
+    o.resources[0].flavor_id if o.metadata[0].name == "%[1]s"][0], "")
+}
+
+data "huaweicloud_modelartsv2_node_pool_nodes" "test" {
+  resource_pool_name = "%[1]s"
+  node_pool_name     = format("%%s-default", local.node_pool_flavor_id)
+}
+
+locals {
+  metadata = data.huaweicloud_modelartsv2_node_pool_nodes.test.nodes[0].metadata
+  spec     = data.huaweicloud_modelartsv2_node_pool_nodes.test.nodes[0].spec
+  status   = data.huaweicloud_modelartsv2_node_pool_nodes.test.nodes[0].status
+}
+
+output "is_metadata_set_and_valid" {
+  value = try(length(local.metadata) > 0 && alltrue([
+    local.metadata[0].annotations != "",
+    local.metadata[0].creation_timestamp != "",
+    local.metadata[0].labels != "",
+    local.metadata[0].name != "",
+  ]))
+}
+
+output "is_spec_set_and_valid" {
+  value = try(length(local.spec) > 0 && alltrue([
+    local.spec[0].flavor != "",
+    length(local.spec[0].host_network) > 0 && alltrue([
+      local.spec[0].host_network.0.vpc != "",
+      local.spec[0].host_network.0.subnet != "",
+    ]),
+    length(local.spec[0].os) > 0 && alltrue([
+      local.spec[0].os[0].image_id != "",
+    ]),
+  ]))
+}
+
+output "is_status_set_and_valid" {
+  value = try(length(local.status) > 0 && alltrue([
+    local.status[0].phase != "",
+    local.status[0].az != "",
+    length(local.status[0].os) > 0 && alltrue([
+      local.status[0].os.0.name != "",
+    ]),
+  ]))
+}
+`, acceptance.HW_MODELARTS_RESOURCE_POOL_NAME)
+}

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_node_pool_nodes.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_node_pool_nodes.go
@@ -1,0 +1,468 @@
+package modelarts
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ModelArts GET /v2/{project_id}/pools/{pool_name}/nodepools/{nodepool_name}/nodes
+func DataSourceV2NodePoolNodes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV2NodePoolNodesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the resource nodes are located.`,
+			},
+			"resource_pool_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The resource pool name to which the node pool belongs.`,
+			},
+			"node_pool_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The node pool name to which the resource nodes belongs.`,
+			},
+			"nodes": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataSourceV2NodePoolNodeSchema(),
+				Description: `All queried resource nodes under a specified node pool.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2NodePoolNodeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"metadata": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataSourceV2NodePoolNodeMetadataSchema(),
+				Description: `The metadata information of the node.`,
+			},
+			"spec": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataSourceV2NodePoolNodeSpecSchema(),
+				Description: `The specification of the node.`,
+			},
+			"status": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataSourceV2NodePoolNodeStatusSchema(),
+				Description: `The status information of the node.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2NodePoolNodeMetadataSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the node.`,
+			},
+			"creation_timestamp": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation timestamp of the node.`,
+			},
+			"labels": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The labels of the node.`,
+			},
+			"annotations": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The annotation configuration of the node.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2NodePoolNodeSpecSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"flavor": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The flavor of the node.`,
+			},
+			"extend_params": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The extend parameters of the node.`,
+			},
+			"host_network": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataSourceV2NodePoolNodeSpecHostNetworkSchema(),
+				Description: `The network configuration of the node.`,
+			},
+			"os": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataSourceV2NodePoolNodeSpecOsSchema(),
+				Description: `The OS information of the node.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2NodePoolNodeSpecHostNetworkSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"vpc": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The VPC ID to which the node belongs.`,
+			},
+			"subnet": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The subnet ID to which the node belongs.`,
+			},
+			"security_groups": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The security group IDs that the node used.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2NodePoolNodeSpecOsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The OS name of the node.`,
+			},
+			"image_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The image ID of the OS.`,
+			},
+			"image_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The image type of the OS.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2NodePoolNodeStatusSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"phase": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current phase of the node.`,
+			},
+			"az": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The availability zone where the node is located.`,
+			},
+			"driver": {
+				Type:        schema.TypeList,
+				Elem:        dataSourceV2NodePoolNodeStatusDriverSchema(),
+				Computed:    true,
+				Description: `The driver configuration of the node.`,
+			},
+			"os": {
+				Type:        schema.TypeList,
+				Elem:        dataSourceV2NodePoolNodeStatusOsSchema(),
+				Computed:    true,
+				Description: `The OS information of the kubernetes node.`,
+			},
+			"plugins": {
+				Type:        schema.TypeList,
+				Elem:        dataSourceV2NodePoolNodeStatusPluginsSchema(),
+				Computed:    true,
+				Description: `The plugin configuration of the node.`,
+			},
+			"private_ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The private IP address of the node.`,
+			},
+			"resources": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The resource detail of the node, in JSON format.`,
+			},
+			"available_resources": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The available resource detail of the node, in JSON format.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2NodePoolNodeStatusDriverSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"phase": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current phase of the driver.`,
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The version of the driver.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2NodePoolNodeStatusOsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The OS name of the kubernetes node.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2NodePoolNodeStatusPluginsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the plugin.`,
+			},
+			"phase": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current phase of the plugin.`,
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The version of the plugin.`,
+			},
+		},
+	}
+}
+
+func listV2NodePoolNodes(client *golangsdk.ServiceClient, resourcePoolName, nodePoolName string) ([]interface{}, error) {
+	// Currently, these query parameters are not available:
+	// + continue
+	// + limit
+	// Without page parameters, the service will returns all of nodes.
+	httpUrl := "v2/{project_id}/pools/{pool_name}/nodepools/{nodepool_name}/nodes"
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{pool_name}", resourcePoolName)
+	listPath = strings.ReplaceAll(listPath, "{nodepool_name}", nodePoolName)
+
+	listFlavorsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &listFlavorsOpt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenV2NodePoolNodeMetadata(metadata interface{}) []map[string]interface{} {
+	if metadata == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"name":               utils.PathSearch("name", metadata, nil),
+			"creation_timestamp": utils.PathSearch("creationTimestamp", metadata, nil),
+			"labels":             utils.JsonToString(utils.PathSearch("labels", metadata, nil)),
+			"annotations":        utils.JsonToString(utils.PathSearch("annotations", metadata, nil)),
+		},
+	}
+}
+
+func flattenV2NodePoolNodeSpecHostNetwork(os interface{}) []map[string]interface{} {
+	if os == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"vpc":             utils.PathSearch("vpc", os, nil),
+			"subnet":          utils.PathSearch("subnet", os, nil),
+			"security_groups": utils.PathSearch("securityGroups", os, make([]interface{}, 0)).([]interface{}),
+		},
+	}
+}
+
+func flattenV2NodePoolNodeSpecOs(osInfo interface{}) []map[string]interface{} {
+	if osInfo == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"name":       utils.PathSearch("name", osInfo, nil),
+			"image_id":   utils.PathSearch("imageId", osInfo, nil),
+			"image_type": utils.PathSearch("imageType", osInfo, nil),
+		},
+	}
+}
+
+func flattenV2NodePoolNodeSpec(spec interface{}) []map[string]interface{} {
+	if spec == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"flavor":        utils.PathSearch("flavor", spec, nil),
+			"extend_params": utils.JsonToString(utils.PathSearch("extendParams", spec, nil)),
+			"host_network":  flattenV2NodePoolNodeSpecHostNetwork(utils.PathSearch("hostNetwork", spec, nil)),
+			"os":            flattenV2NodePoolNodeSpecOs(utils.PathSearch("os", spec, nil)),
+		},
+	}
+}
+
+func flattenV2NodePoolNodeDriver(driver interface{}) []map[string]interface{} {
+	if driver == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"phase":   utils.PathSearch("phase", driver, nil),
+			"version": utils.PathSearch("version", driver, nil),
+		},
+	}
+}
+
+func flattenV2NodePoolNodeStatusOs(osInfo interface{}) []map[string]interface{} {
+	if osInfo == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"name": utils.PathSearch("name", osInfo, nil),
+		},
+	}
+}
+
+func flattenV2NodePoolNodePlugins(plugins []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(plugins))
+
+	for _, plugin := range plugins {
+		result = append(result, map[string]interface{}{
+			"name":    utils.PathSearch("name", plugin, nil),
+			"phase":   utils.PathSearch("phase", plugin, nil),
+			"version": utils.PathSearch("version", plugin, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenV2NodePoolNodeStatus(status interface{}) []map[string]interface{} {
+	if status == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"phase":               utils.PathSearch("phase", status, nil),
+			"az":                  utils.PathSearch("az", status, nil),
+			"driver":              flattenV2NodePoolNodeDriver(utils.PathSearch("driver", status, nil)),
+			"os":                  flattenV2NodePoolNodeStatusOs(utils.PathSearch("os", status, nil)),
+			"plugins":             flattenV2NodePoolNodePlugins(utils.PathSearch("plugins", status, make([]interface{}, 0)).([]interface{})),
+			"private_ip":          utils.PathSearch("privateIp", status, nil),
+			"resources":           utils.JsonToString(utils.PathSearch("resources", status, nil)),
+			"available_resources": utils.JsonToString(utils.PathSearch("availableResources", status, nil)),
+		},
+	}
+}
+
+func flattenV2NodePoolNodes(nodes []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(nodes))
+
+	for _, node := range nodes {
+		result = append(result, map[string]interface{}{
+			"metadata": flattenV2NodePoolNodeMetadata(utils.PathSearch("metadata", node, nil)),
+			"spec":     flattenV2NodePoolNodeSpec(utils.PathSearch("spec", node, nil)),
+			"status":   flattenV2NodePoolNodeStatus(utils.PathSearch("status", node, nil)),
+		})
+	}
+
+	return result
+}
+
+func dataSourceV2NodePoolNodesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		resourcePoolName = d.Get("resource_pool_name").(string)
+		nodePoolName     = d.Get("node_pool_name").(string)
+	)
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	nodes, err := listV2NodePoolNodes(client, resourcePoolName, nodePoolName)
+	if err != nil {
+		return diag.Errorf("error querying node list for the specified node pool (%s) under the resource pool (%s): %s",
+			nodePoolName, resourcePoolName, err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("nodes", flattenV2NodePoolNodes(nodes)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New data source supported for the ModelArts service:
data.huaweicloud_modelarts_node_pool_nodes

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new data source to query resource nodes
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccDataSourceV2NodePoolNodes_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDataSourceV2NodePoolNodes_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceV2NodePoolNodes_basic
=== PAUSE TestAccDataSourceV2NodePoolNodes_basic
=== CONT  TestAccDataSourceV2NodePoolNodes_basic
--- PASS: TestAccDataSourceV2NodePoolNodes_basic (20.81s)
PASS
coverage: 7.8% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 20.866s coverage: 7.8% of statements in ./huaweicloud/services/modelarts
```

![image](https://github.com/user-attachments/assets/02447891-c654-48e2-8c1c-f7ac8de596e0)

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
