### PR TITLE
feat(modelarts): add new resource to unsubscribe nodes

### DIFF
--- a/docs/resources/modelarts_node_batch_unsubscribe.md
+++ b/docs/resources/modelarts_node_batch_unsubscribe.md
@@ -1,0 +1,54 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelarts_node_batch_unsubscribe"
+description: |-
+  Use this resource to batch unsubscribe the ModelArts nodes within HuaweiCloud.
+---
+
+# huaweicloud_modelarts_node_batch_unsubscribe
+
+Use this resource to batch delete the ModelArts nodes within HuaweiCloud.
+
+-> This resource is only a one-time action resource for batch unsubscribe the ModelArts nodes. Deleting this resource
+   will not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+~> This resource can only be used to delete nodes with prePaid billing.
+
+## Example Usage
+
+```hcl
+variable "resource_pool_name" {}
+variable "node_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_modelarts_node_batch_unsubscribe" "test" {
+  resource_pool_name = var.resource_pool_name
+  node_ids           = var.node_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the resource nodes are located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `resource_pool_name` - (Required, String, NonUpdatable) Specifies the resource pool name to which the resource nodes
+  belong.
+
+* `node_ids` - (Required, List, NonUpdatable) Specifies the ID list of resource nodes to be unsubscribed.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 45 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2242,9 +2242,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_network":                modelarts.ResourceModelartsNetwork(),
 			"huaweicloud_modelarts_resource_pool":          modelarts.ResourceModelartsResourcePool(),
 			// Resource management via V2 APIs.
-			"huaweicloud_modelartsv2_node_batch_delete": modelarts.ResourceV2NodeBatchDelete(),
-			"huaweicloud_modelartsv2_service":           modelarts.ResourceV2Service(),
-			"huaweicloud_modelartsv2_service_action":    modelarts.ResourceV2ServiceAction(),
+			"huaweicloud_modelartsv2_node_batch_delete":      modelarts.ResourceV2NodeBatchDelete(),
+			"huaweicloud_modelartsv2_node_batch_unsubscribe": modelarts.ResourceV2NodeBatchUnsubscribe(),
+			"huaweicloud_modelartsv2_service":                modelarts.ResourceV2Service(),
+			"huaweicloud_modelartsv2_service_action":         modelarts.ResourceV2ServiceAction(),
 
 			// DataArts Studio - Management Center
 			"huaweicloud_dataarts_studio_data_connection": dataarts.ResourceDataConnection(),

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_node_batch_unsubscribe_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_node_batch_unsubscribe_test.go
@@ -1,0 +1,63 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this test, make sure that there are at least two prePaid nodes in the resource pool.
+func TestAccResourceV2NodeBatchUnsubscribe_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckModelArtsResourcePoolName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceV2NodeBatchUnsubscribe_invalidNodeId(),
+				ExpectError: regexp.MustCompile(
+					`This resource has been deleted or the subscription to this resource has not been synchronized to CBC`),
+			},
+			{
+				Config: testAccResourceV2NodeBatchUnsubscribe_basic_step1(),
+			},
+		},
+	})
+}
+
+func testAccResourceV2NodeBatchUnsubscribe_invalidNodeId() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_modelartsv2_node_batch_unsubscribe" "test" {
+  resource_pool_name = "%[1]s"
+  node_ids           = ["invalid-node-id"]
+}
+`, acceptance.HW_MODELARTS_RESOURCE_POOL_NAME)
+}
+
+func testAccResourceV2NodeBatchUnsubscribe_basic_step1() string {
+	return fmt.Sprintf(`
+data "huaweicloud_modelartsv2_resource_pool_nodes" "test" {
+  resource_pool_name = "%[1]s"
+}
+
+resource "huaweicloud_modelartsv2_node_batch_unsubscribe" "test" {
+  resource_pool_name = "%[1]s"
+  node_ids           = try(slice([for o in data.huaweicloud_modelartsv2_resource_pool_nodes.test.nodes:
+    lookup(jsondecode(o.metadata[0].labels), "os.modelarts/resource.id", "") if lookup(jsondecode(o.metadata[0].annotations),
+	"os.modelarts/billing.mode", "0") == "1" && try(o.metadata[0].labels, "") != ""], 0, 1), [])
+
+  lifecycle {
+    ignore_changes = [node_ids]
+  }
+}
+`, acceptance.HW_MODELARTS_RESOURCE_POOL_NAME)
+}

--- a/huaweicloud/services/cbc/resource_huaweicloud_cbc_resources_unsubscribe.go
+++ b/huaweicloud/services/cbc/resource_huaweicloud_cbc_resources_unsubscribe.go
@@ -71,13 +71,13 @@ func resourceResourcesUnsubscribeCreate(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("error creating BSS client: %s", err)
 	}
 
-	resourceIds := utils.ExpandToStringList(d.Get("resource_ids").([]interface{}))
-	err = unsubscribePrePaidResources(client, resourceIds)
+	resourceIds := d.Get("resource_ids").([]interface{})
+	err = UnsubscribePrePaidResources(client, resourceIds)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	err = waitForResourcesUnsubscribed(ctx, client, resourceIds, d.Timeout(schema.TimeoutCreate))
+	err = WaitForResourcesUnsubscribed(ctx, client, resourceIds, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("error waiting for all resources to be unsubscribed: %s ", err)
 	}
@@ -91,7 +91,7 @@ func resourceResourcesUnsubscribeCreate(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
-func unsubscribePrePaidResources(client *golangsdk.ServiceClient, resourceIds []string) error {
+func UnsubscribePrePaidResources(client *golangsdk.ServiceClient, resourceIds []interface{}) error {
 	httpUrl := "v2/orders/subscriptions/resources/unsubscribe"
 	createPath := client.Endpoint + httpUrl
 	createOpt := golangsdk.RequestOpts{
@@ -127,7 +127,8 @@ func unsubscribePrePaidResources(client *golangsdk.ServiceClient, resourceIds []
 	return nil
 }
 
-func waitForResourcesUnsubscribed(ctx context.Context, client *golangsdk.ServiceClient, resourceIds []string, timeout time.Duration) error {
+func WaitForResourcesUnsubscribed(ctx context.Context, client *golangsdk.ServiceClient, resourceIds []interface{},
+	timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"PENDING"},
 		Target:       []string{"COMPLETED"},
@@ -140,7 +141,7 @@ func waitForResourcesUnsubscribed(ctx context.Context, client *golangsdk.Service
 	return err
 }
 
-func refreshPrePaidResourcesByIds(client *golangsdk.ServiceClient, resourceIds []string) resource.StateRefreshFunc {
+func refreshPrePaidResourcesByIds(client *golangsdk.ServiceClient, resourceIds []interface{}) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		var (
 			httpUrl = "v2/orders/suscriptions/resources/query"

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_node_batch_unsubscribe.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_node_batch_unsubscribe.go
@@ -1,0 +1,156 @@
+package modelarts
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var v2NodeBatchUnsubscribeNonUpdatableParams = []string{
+	"resource_pool_name",
+	"node_ids",
+}
+
+// @API BSS POST /v2/orders/suscriptions/resources/query
+// @API BSS POST /v2/orders/subscriptions/resources/unsubscribe
+// @API ModelArts GET /v2/{project_id}/pools/{pool_name}/nodes
+func ResourceV2NodeBatchUnsubscribe() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceV2NodeBatchUnsubscribeCreate,
+		ReadContext:   resourceV2NodeBatchUnsubscribeRead,
+		UpdateContext: resourceV2NodeBatchUnsubscribeUpdate,
+		DeleteContext: resourceV2NodeBatchUnsubscribeDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(45 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(v2NodeBatchUnsubscribeNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the resource nodes are located.`,
+			},
+			"resource_pool_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The resource pool name to which the resource nodes belong.`,
+			},
+			"node_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The ID list of resource nodes to be deleted.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func waitForV2NodeBatchUnsubscribeCompleted(ctx context.Context, client *golangsdk.ServiceClient, resourcePoolName string,
+	unsubscribeNodeIds []interface{}, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			nodes, err := listV2ResourcePoolNodes(client, resourcePoolName)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			resourceIds := utils.PathSearch(`[*].metadata.labels."os.modelarts/resource.id"`, nodes,
+				make([]interface{}, 0)).([]interface{})
+			if utils.IsSliceContainsAnyAnotherSliceElement(utils.ExpandToStringList(resourceIds),
+				utils.ExpandToStringList(unsubscribeNodeIds), false, true) {
+				return resourceIds, "PENDING", nil
+			}
+			return resourceIds, "COMPLETED", nil
+		},
+		Timeout:      timeout,
+		Delay:        30 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceV2NodeBatchUnsubscribeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		resourcePoolName = d.Get("resource_pool_name").(string)
+		deleteNodeIds    = d.Get("node_ids").([]interface{})
+	)
+
+	client, err := cfg.NewServiceClient("bssv2", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating BSS client: %s", err)
+	}
+	// Delete
+	err = cbc.UnsubscribePrePaidResources(client, deleteNodeIds)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = cbc.WaitForResourcesUnsubscribed(ctx, client, deleteNodeIds, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for all resources to be unsubscribed: %s ", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	client, err = cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+	err = waitForV2NodeBatchUnsubscribeCompleted(ctx, client, resourcePoolName, deleteNodeIds,
+		d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceV2NodeBatchUnsubscribeRead(ctx, d, meta)
+}
+
+func resourceV2NodeBatchUnsubscribeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceV2NodeBatchUnsubscribeUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceV2NodeBatchUnsubscribeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for batch delete the ModelArts nodes. Deleting this
+resource will not clear the corresponding request record, but will only remove the resource information from the tfstate
+file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports new resource that used to unsubscribe resource nodes:
+ huaweicloud_modelarts_node_batch_unsubscribe

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to unsubscribe nodes
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccResourceV2NodeBatchUnsubscribe_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccResourceV2NodeBatchUnsubscribe_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceV2NodeBatchUnsubscribe_basic
=== PAUSE TestAccResourceV2NodeBatchUnsubscribe_basic
=== CONT  TestAccResourceV2NodeBatchUnsubscribe_basic
--- PASS: TestAccResourceV2NodeBatchUnsubscribe_basic (134.35s)
PASS
coverage: 6.7% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 134.421s        coverage: 6.7% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
