### PR TITLE
feat(dew): add a datasource to get public key.

### DIFF
--- a/docs/data-sources/kms_public_key.md
+++ b/docs/data-sources/kms_public_key.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_kms_public_key"
+description: |-
+  Use this data source to get the information of the public key which is a specified asymmetric key.
+---
+
+# huaweicloud_kms_public_key
+
+Use this data source to get the information of the public key which is a specified asymmetric key.
+
+## Example Usage
+
+```hcl
+variable "key_id" {}
+
+data "huaweicloud_kms_public_key" "test" {
+  key_id = var.key_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `key_id` - (Required, String) Specifies the ID of the key which is `36` bytes and meeting regular matching as
+  `^ [0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$`. For example,
+  **0d0466b0-e727-4d9c-b35d-f84bb474a37f**.
+
+* `sequence` - (Optional, String) Specifies the request sequence number which is a `36` byte serial number.  
+  For example, **919c82d4-8046-4722-9094-35c3c6524cff**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `public_key` - The information of the public key.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1041,6 +1041,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_key":           dew.DataSourceKmsKey(),
 			"huaweicloud_kms_keys":          dew.DataSourceKmsKeys(),
 			"huaweicloud_kms_quotas":        dew.DataSourceKMSQuotas(),
+			"huaweicloud_kms_public_key":    dew.DataSourceKmsPublicKey(),
 			"huaweicloud_kps_failed_tasks":  dew.DataSourceDewKpsFailedTasks(),
 			"huaweicloud_kps_running_tasks": dew.DataSourceDewKpsRunningTasks(),
 			"huaweicloud_kps_keypairs":      dew.DataSourceKeypairs(),

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_kms_public_key_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_kms_public_key_test.go
@@ -1,0 +1,42 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceKmsPublicKey_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_kms_public_key.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckKmsKeyID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceKmsPublicKey_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "public_key"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceKmsPublicKey_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_kms_public_key" "test" {
+  key_id = "%s"
+}
+`, acceptance.HW_KMS_KEY_ID)
+}

--- a/huaweicloud/services/dew/data_source_huaweicloud_kms_public_key.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_kms_public_key.go
@@ -1,0 +1,99 @@
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW POST /v1.0/{project_id}/kms/get-publickey
+func DataSourceKmsPublicKey() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceKmsPublicKeyRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource.`,
+			},
+			"key_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the key.`,
+			},
+			"sequence": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the request sequence number.`,
+			},
+			"public_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The information of the public key.`,
+			},
+		},
+	}
+}
+
+func buildQueryPublicKeyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	requestBody := map[string]interface{}{
+		"key_id":   d.Get("key_id"),
+		"sequence": utils.ValueIgnoreEmpty(d.Get("sequence")),
+	}
+
+	return requestBody
+}
+
+func dataSourceKmsPublicKeyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		mErr       *multierror.Error
+		getHttpUrl = "v1.0/{project_id}/kms/get-publickey"
+		product    = "kms"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildQueryPublicKeyBodyParams(d)),
+	}
+
+	getResp, err := client.Request("POST", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving KMS public key: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(d.Get("key_id").(string))
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("key_id", utils.PathSearch("key_id", getRespBody, nil)),
+		d.Set("public_key", utils.PathSearch("public_key", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new data source and names huaweicloud_kms_public_key.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccDataSourceKmsGetPublicKey_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceKmsGetPublicKey_basic
=== PAUSE TestAccDataSourceKmsGetPublicKey_basic
=== CONT  TestAccDataSourceKmsGetPublicKey_basic
--- PASS: TestAccDataSourceKmsGetPublicKey_basic (8.73s)
PASS
coverage: 3.4% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew
```
![image](https://github.com/user-attachments/assets/2a81c906-6a87-42fb-90a3-e918f7cdf347)

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
