### PR TITLE
fix(aad): fix the read method to return 404 when reading an empty value.

### DIFF
--- a/huaweicloud/services/aad/resource_huaweicloud_aad_domain.go
+++ b/huaweicloud/services/aad/resource_huaweicloud_aad_domain.go
@@ -223,7 +223,7 @@ func resourceDomainRead(_ context.Context, d *schema.ResourceData, meta interfac
 	jsonPath := fmt.Sprintf("items[?domain_id=='%s']|[0]", d.Id())
 	domain := utils.PathSearch(jsonPath, getDomainsRespBody, nil)
 	if domain == nil {
-		return common.CheckDeletedDiag(d, err, "")
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
 	}
 
 	mErr = multierror.Append(

--- a/huaweicloud/services/acceptance/aad/resource_huaweicloud_aad_domain_test.go
+++ b/huaweicloud/services/acceptance/aad/resource_huaweicloud_aad_domain_test.go
@@ -41,8 +41,8 @@ func getDomainResourceFunc(cfg *config.Config, state *terraform.ResourceState) (
 		return nil, fmt.Errorf("error flattening AAD domains response: %s", err)
 	}
 
-	ids := fmt.Sprintf("items[?domain_id=='%s']|[0]", state.Primary.ID)
-	domains := utils.PathSearch(ids, respBody, nil)
+	jsonPath := fmt.Sprintf("items[?domain_id=='%s']|[0]", state.Primary.ID)
+	domains := utils.PathSearch(jsonPath, respBody, nil)
 	if domains == nil {
 		return nil, golangsdk.ErrDefault404{}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
