### PR TITLE
feat(COC): add param is_sync to coc script execute resource

### DIFF
--- a/docs/resources/coc_script_execute.md
+++ b/docs/resources/coc_script_execute.md
@@ -38,37 +38,39 @@ resource "huaweicloud_coc_script_execute" "test" {
 
 The following arguments are supported:
 
-* `script_id` - (Required, String, ForceNew) Specifies the COC script ID.
-  Changing this creates a new resource.
+* `script_id` - (Required, String, NonUpdatable) Specifies the COC script ID.
 
-* `instance_id` - (Required, String, ForceNew) Specifies the ECS instance ID.
-  Changing this creates a new resource.
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ECS instance ID.
 
-* `timeout` - (Required, Int, ForceNew) Specifies the maximum time to execute the script in seconds.
-  Changing this creates a new resource.
+* `timeout` - (Required, Int, NonUpdatable) Specifies the maximum time to execute the script in seconds.
 
-* `execute_user` - (Required, String, ForceNew) Specifies the user to execute the script.
-  Changing this creates a new resource.
+* `execute_user` - (Required, String, NonUpdatable) Specifies the user to execute the script.
 
-* `parameters` - (Optional, List, ForceNew) Specifies the input parameters of the script.
-  Up to 20 script parameters can be added. Changing this creates a new resource.
+* `parameters` - (Optional, List, NonUpdatable) Specifies the input parameters of the script.
+  Up to 20 script parameters can be added.
   The [parameters](#block--parameters) structure is documented below.
+
+* `is_sync` - (Optional, Bool, NonUpdatable) Specifies whether sync data before execute the script. Defaults to **true**.
 
 <a name="block--parameters"></a>
 The `parameters` block supports:
 
-* `name` - (Required, String, ForceNew) Specifies the name of the parameter. Changing this creates a new resource.
+* `name` - (Required, String, NonUpdatable) Specifies the name of the parameter.
 
-* `value` - (Required, String, ForceNew) Specifies the value of the parameter. Changing this creates a new resource.
+* `value` - (Required, String, NonUpdatable) Specifies the value of the parameter.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
+
 * `script_name` - The script name.
+
 * `status` - The status of the script execution.
+
 * `created_at` - The start time of the script execution.
+
 * `finished_at` - The end time of the script execution.
 
 ## Timeouts
@@ -87,7 +89,7 @@ $ terraform import huaweicloud_coc_script_execute.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include `instance_id` and `parameters`.
+API response, security or some other reason. The missing attributes include `instance_id`, `parameters` and `is_sync`.
 
 It is generally recommended running `terraform plan` after importing the resource.
 You can then decide if changes should be applied to the instance, or the resource definition should be updated to
@@ -99,7 +101,7 @@ resource "huaweicloud_coc_script_execute" "test" {
 
   lifecycle {
     ignore_changes = [
-      instance_id, parameters
+      instance_id, parameters, is_sync
     ]
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add param is_sync to coc script execute resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add param is_sync to coc script execute resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/coc/ TESTARGS='-run  TestAccScriptExecute_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/coc/ -v -run  TestAccScriptExecute_ -timeout 360m -parallel 4
=== RUN   TestAccScriptExecute_basic
=== PAUSE TestAccScriptExecute_basic
=== RUN   TestAccScriptExecute_no_sync
=== PAUSE TestAccScriptExecute_no_sync
=== CONT  TestAccScriptExecute_basic
=== CONT  TestAccScriptExecute_no_sync
--- PASS: TestAccScriptExecute_no_sync (50.52s)
--- PASS: TestAccScriptExecute_basic (50.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/coc       50.961s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
