### PR TITLE
feat(evs): suuport `evsv3_volume_types` data source

### DIFF
--- a/docs/data-sources/evsv3_volume_types.md
+++ b/docs/data-sources/evsv3_volume_types.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Elastic Volume Service (EVS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_evsv3_volume_types"
+description: |-
+  Use this data source to query the list of EVS v3 volume types within HuaweiCloud.
+---
+
+# huaweicloud_evsv3_volume_types
+
+Use this data source to query the list of EVS v3 volume types within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_evsv3_volume_types" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `volume_types` - The list of volume types.  
+  The [volume_types](#volume_types_struct) structure is documented below.
+
+<a name="volume_types_struct"></a>
+The `volume_types` block supports:
+
+* `id` - The volume type ID.
+
+* `name` - The volume type name.
+
+* `extra_specs` - The volume type flavor.  
+  The [extra_specs](#extra_specs_struct) structure is documented below.
+
+* `description` - The volume type description.
+
+<a name="extra_specs_struct"></a>
+The `extra_specs` block supports:
+
+* `availability_zones` - The list of availability zones where the volume type is supported.
+  Multiple availability zones separated by commas (,).
+  If this filed is empty, the volume type is supported all availability zones.
+
+* `sold_out_availability_zones` - The list of availability zones where the volume type has been sold out.
+  Multiple availability zones separated by commas (,).

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -893,6 +893,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_evsv3_snapshots":        evs.DataSourceV3Snapshots(),
 			"huaweicloud_evs_availability_zones": evs.DataSourceEvsAvailabilityZones(),
 			"huaweicloud_evs_volume_types":       evs.DataSourceEvsVolumeTypes(),
+			"huaweicloud_evsv3_volume_types":     evs.DataSourceV3VolumeTypes(),
 			"huaweicloud_evs_volume_transfers":   evs.DataSourceEvsVolumeTransfers(),
 			"huaweicloud_evsv3_volume_transfers": evs.DataSourceEvsV3VolumeTransfers(),
 			"huaweicloud_evs_tags":               evs.DataSourceEvsTags(),

--- a/huaweicloud/services/acceptance/evs/data_source_huaweicloud_evsv3_volume_types_test.go
+++ b/huaweicloud/services/acceptance/evs/data_source_huaweicloud_evsv3_volume_types_test.go
@@ -1,0 +1,40 @@
+package evs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceV3VolumeTypes_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_evsv3_volume_types.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceV3VolumeTypes_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "volume_types.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "volume_types.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "volume_types.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "volume_types.0.extra_specs.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "volume_types.0.extra_specs.0.availability_zones"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceV3VolumeTypes_basic = `
+data "huaweicloud_evsv3_volume_types" "test" {}
+`

--- a/huaweicloud/services/evs/data_source_huaweicloud_evsv3_volume_types.go
+++ b/huaweicloud/services/evs/data_source_huaweicloud_evsv3_volume_types.go
@@ -1,0 +1,148 @@
+package evs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EVS GET /v3/{project_id}/types
+func DataSourceV3VolumeTypes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV3VolumeTypesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"volume_types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"extra_specs": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									// This field in the API is `RESKEY:availability zones`,
+									// the naming of fields in the schema cannot have ":",
+									// so we did a mapping.
+									"availability_zones": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									// This field in the API is `os-vendor-extended:sold_out_availability_zones`,
+									// the naming of fields in the schema cannot have ":",
+									// so we did a mapping.
+									"sold_out_availability_zones": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceV3VolumeTypesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		mErr       *multierror.Error
+		product    = "evs"
+		getHttpUrl = "v3/{project_id}/types"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving EVS v3 volume types: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	volumeTypesResp := utils.PathSearch("volume_types", getRespBody, make([]interface{}, 0)).([]interface{})
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("volume_types", flattenV3VolumeTypes(volumeTypesResp)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenV3VolumeTypes(volumeTypesResp []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(volumeTypesResp))
+	for _, v := range volumeTypesResp {
+		rst = append(rst, map[string]interface{}{
+			"id":          utils.PathSearch("id", v, nil),
+			"name":        utils.PathSearch("name", v, nil),
+			"extra_specs": flattenExtraSpecs(utils.PathSearch("extra_specs", v, nil)),
+			"description": utils.PathSearch("description", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenExtraSpecs(extraSpecsResp interface{}) []map[string]interface{} {
+	if extraSpecsResp == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"availability_zones":          utils.PathSearch(`"RESKEY:availability_zones"`, extraSpecsResp, nil),
+			"sold_out_availability_zones": utils.PathSearch(`"os-vendor-extended:sold_out_availability_zones"`, extraSpecsResp, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

suuport `evsv3_volume_types` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

suuport `evsv3_volume_types` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/evs" TESTARGS="-run TestAccDataSourceV3VolumeTypes_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccDataSourceV3VolumeTypes_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceV3VolumeTypes_basic
=== PAUSE TestAccDataSourceV3VolumeTypes_basic
=== CONT  TestAccDataSourceV3VolumeTypes_basic
--- PASS: TestAccDataSourceV3VolumeTypes_basic (12.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       12.252s

```
![image](https://github.com/user-attachments/assets/9a70dbb8-4666-49f8-bd76-fa3eeb6ab56f)


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
