### PR TITLE
feat(aad): add a data source to get block statistics

### DIFF
--- a/docs/data-sources/aad_block_statistics.md
+++ b/docs/data-sources/aad_block_statistics.md
@@ -1,0 +1,41 @@
+---
+subcategory: "Advanced Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aad_block_statistics"
+description: |-
+  Use this data source to get information about the AAD block statistics within HuaweiCloud.
+---
+
+# huaweicloud_aad_block_statistics
+
+Use this data source to get information about the AAD block statistics within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "domain_id" {}
+
+data "huaweicloud_aad_block_statistics" "test" {
+  domain_id = var.domain_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_id` - (Required, String) Specified the account ID of IAM user.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - The data source ID.
+
+* `total_unblocking_times` - The total unblocking times.
+
+* `manual_unblocking_times` - The manual unblocking times.
+
+* `automatic_unblocking_times` - The automatic unblocking times.
+
+* `current_blocked_ip_numbers` - The current blocked IP number.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -456,6 +456,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aad_unblock_quota_statistics": aad.DataSourceUnblockQuotaStatistics(),
 			"huaweicloud_aad_black_white_lists":        aad.DataSourceAadBlackWhiteLists(),
 			"huaweicloud_aad_web_protection_policies":  aad.DataSourceAadWebProtectionPolicies(),
+			"huaweicloud_aad_block_statistics":        aad.DataSourceBlockStatistics(),
 
 			"huaweicloud_antiddos_config_ranges":                antiddos.DataSourceConfigRanges(),
 			"huaweicloud_antiddos_weekly_protection_statistics": antiddos.DataSourceWeeklyProtectionStatistics(),

--- a/huaweicloud/services/aad/data_source_huaweicloud_aad_block_statistics.go
+++ b/huaweicloud/services/aad/data_source_huaweicloud_aad_block_statistics.go
@@ -1,0 +1,100 @@
+package aad
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AAD GET /v1/unblockservice/{domain_id}/block-statistics
+func DataSourceBlockStatistics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBlockStatisticsRead,
+
+		Schema: map[string]*schema.Schema{
+			"domain_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specified the account ID of IAM user.",
+			},
+			"total_unblocking_times": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The total unblocking times.",
+			},
+			"manual_unblocking_times": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The manual unblocking times.",
+			},
+			"automatic_unblocking_times": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The automatic unblocking times.",
+			},
+			"current_blocked_ip_numbers": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The current blocked IP number.",
+			},
+		},
+	}
+}
+
+func dataSourceBlockStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		mErr   *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient("aad", region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	httpUrl := "v1/unblockservice/{domain_id}/block-statistics"
+	httpUrl = strings.ReplaceAll(httpUrl, "{domain_id}", d.Get("domain_id").(string))
+	listPath := client.Endpoint + httpUrl
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return diag.Errorf("error retrieving AAD block statistics: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("total_unblocking_times", utils.PathSearch("total_unblocking_times", respBody, nil)),
+		d.Set("manual_unblocking_times", utils.PathSearch("manual_unblocking_times", respBody, nil)),
+		d.Set("current_blocked_ip_numbers", utils.PathSearch("current_blocked_ip_numbers", respBody, nil)),
+		d.Set("automatic_unblocking_times", utils.PathSearch("automatic_unblocking_times", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_block_statistics_test.go
+++ b/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_block_statistics_test.go
@@ -1,0 +1,46 @@
+package antiddos
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBlockStatisticsDataSource_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_aad_block_statistics.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare domain_id before running this test cases.
+			acceptance.TestAccPrecheckDomainId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testBlockStatistics_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total_unblocking_times"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "manual_unblocking_times"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "automatic_unblocking_times"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "current_blocked_ip_numbers"),
+				),
+			},
+		},
+	})
+}
+
+func testBlockStatistics_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_aad_block_statistics" "test" {
+  domain_id = "%[1]s"
+}
+`, acceptance.HW_DOMAIN_ID)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Use this data source to get information about the AAD block statistics within HuaweiCloud.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/aad' TESTARGS='-run TestAccBlockStatisticsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aad -v -run TestAccBlockStatisticsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccBlockStatisticsDataSource_basic
=== PAUSE TestAccBlockStatisticsDataSource_basic
=== CONT  TestAccBlockStatisticsDataSource_basic
--- PASS: TestAccBlockStatisticsDataSource_basic (18.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aad       18.233s
```
![image](https://github.com/user-attachments/assets/52071ecd-94cf-4186-a6a2-843cc585f895)

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
