### PR TITLE
feat(cbh): add a datasource to get URL for logging in to a CBH instance as user admin.

### DIFF
--- a/docs/data-sources/cbh_instance_admin_url.md
+++ b/docs/data-sources/cbh_instance_admin_url.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Cloud Bastion Host (CBH)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbh_instance_admin_url"
+description: |-
+  Use this data source to get the URL for logging in to a CBH instance as user admin within HuaweiCloud.
+---
+
+# huaweicloud_cbh_instance_admin_url
+
+Use this data source to get the URL for logging in to a CBH instance as user admin within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "server_id" {}
+
+data "huaweicloud_cbh_instance_admin_url" "test" {
+  server_id = var.server_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `server_id` - (Required, String) Specifies the CBH instance ID, in UUID format.  
+  For details about how to obtain the value, see "Viewing CBH Instance Details" in Cloud Bastion Host User Guide.  
+  [reference](https://support.huaweicloud.com/intl/en-us/usermanual-cbh/cbh_02_0043.html).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID, same as `server_id`.
+
+* `admin_url` - The URL for logging in to a CBH instance as user admin.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -548,6 +548,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbh_instance_quota":     cbh.DataSourceInstanceQuota(),
 			"huaweicloud_cbh_instance_tags":      cbh.DataSourceInstanceTags(),
 			"huaweicloud_cbh_instance_ecs_quota": cbh.DataSourceInstanceEcsQuota(),
+			"huaweicloud_cbh_instance_admin_url": cbh.DataSourceInstanceAdminUrl(),
 
 			"huaweicloud_cc_authorizations":                               cc.DataSourceCcAuthorizations(),
 			"huaweicloud_cc_bandwidth_packages":                           cc.DataSourceCcBandwidthPackages(),

--- a/huaweicloud/services/acceptance/cbh/data_source_huaweicloud_cbh_instance_admin_url_test.go
+++ b/huaweicloud/services/acceptance/cbh/data_source_huaweicloud_cbh_instance_admin_url_test.go
@@ -1,0 +1,43 @@
+package cbh
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceInstanceAdminUrl_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_cbh_instance_admin_url.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Ensure the CBH instance ID is set before running the test
+			acceptance.TestAccPreCheckCbhInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceInstanceAdminUrl_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "admin_url"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceInstanceAdminUrl_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cbh_instance_admin_url" "test" {
+  server_id = "%s"
+}
+`, acceptance.HW_CBH_INSTANCE_ID)
+}

--- a/huaweicloud/services/cbh/data_source_huaweicloud_cbh_instance_admin_url.go
+++ b/huaweicloud/services/cbh/data_source_huaweicloud_cbh_instance_admin_url.go
@@ -1,0 +1,85 @@
+package cbh
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CBH GET /v2/{project_id}/cbs/instances/{server_id}/admin-url
+func DataSourceInstanceAdminUrl() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstanceAdminUrlRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource.`,
+			},
+			"server_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the CBH instance ID.`,
+			},
+			"admin_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The URL for logging in to a CBH instance as user admin.`,
+			},
+		},
+	}
+}
+
+func dataSourceInstanceAdminUrlRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		mErr       *multierror.Error
+		getHttpUrl = "v2/{project_id}/cbs/instances/{server_id}/admin-url"
+		product    = "cbh"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBH client: %s", err)
+	}
+
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{server_id}", d.Get("server_id").(string))
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CBH instance admin url: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(d.Get("server_id").(string))
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("admin_url", utils.PathSearch("admin_url", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
**What this PR does / why we need it**:
Supports a new data source and names huaweicloud_cbh_instance_admin_url.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbh" -v -coverprofile="./huaweicloud/services/acceptance/cbh/cbh_coverage.cov" -coverpkg="./huaweicloud/services/cbh" -run TestAccDataSourceInstanceAdminUrl_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceInstanceAdminUrl_basic
=== PAUSE TestAccDataSourceInstanceAdminUrl_basic
=== CONT  TestAccDataSourceInstanceAdminUrl_basic
--- PASS: TestAccDataSourceInstanceAdminUrl_basic (10.34s)
PASS
coverage: 2.4% of statements in ./huaweicloud/services/cbh
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh
```
![image](https://github.com/user-attachments/assets/8b91ec8b-5160-4f49-b3c8-65a0899cbe40)

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
