### PR TITLE
feat(fgs): add new resource to enable LTS log

### DIFF
--- a/docs/resources/fgs_lts_log_enable.md
+++ b/docs/resources/fgs_lts_log_enable.md
@@ -1,0 +1,33 @@
+---
+subcategory: "FunctionGraph"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_fgs_lts_log_enable"
+description: |-
+  Use this resource to enable LTS logs for FunctionGraph within HuaweiCloud.
+---
+
+# huaweicloud_fgs_lts_log_enable
+
+Use this resource to enable LTS logs for FunctionGraph within HuaweiCloud.
+
+-> This resource is only a one-time action resource for enabling LTS logs for FunctionGraph. Deleting this resource will
+   not disable the LTS logs, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_fgs_lts_log_enable" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the LTS log function is to be enabled.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2017,6 +2017,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_function_event":             fgs.ResourceFunctionEvent(),
 			"huaweicloud_fgs_function_topping":           fgs.ResourceFunctionTopping(),
 			"huaweicloud_fgs_function_trigger":           fgs.ResourceFunctionTrigger(),
+			"huaweicloud_fgs_lts_log_enable":             fgs.ResourceFgsLtsLogEnable(),
 
 			"huaweicloud_ga_accelerator":    ga.ResourceAccelerator(),
 			"huaweicloud_ga_access_log":     ga.ResourceAccessLog(),

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_lts_log_enable.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_lts_log_enable.go
@@ -1,0 +1,83 @@
+package fgs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API FunctionGraph POST /v2/{project_id}/fgs/functions/enable-lts-logs
+func ResourceFgsLtsLogEnable() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceFgsLtsLogEnableCreate,
+		ReadContext:   resourceFgsLtsLogEnableRead,
+		DeleteContext: resourceFgsLtsLogEnableDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the LTS log function is to be enabled.`,
+			},
+		},
+	}
+}
+
+func resourceFgsLtsLogEnableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/fgs/functions/enable-lts-logs"
+	)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error enabling LTS logs for FunctionGraph: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	return resourceFgsLtsLogEnableRead(ctx, d, meta)
+}
+
+func resourceFgsLtsLogEnableRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceFgsLtsLogEnableDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for enabling LTS logs for FunctionGraph. Deleting this resource will
+not disable the LTS logs, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a one-time action resource to enable the LTS log for FunctionGraph
```
huaweicloud_fgs_lts_log_enable
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to enable LTS log
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

![image](https://github.com/user-attachments/assets/349b9f56-cf7c-40ac-8e30-543fce2e44a1)
![image](https://github.com/user-attachments/assets/a8b12b17-43d7-4040-a670-2eac87eb45f7)

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
