### PR TITLE
chore(cci): fixed cci pvc markdown and add test case

### DIFF
--- a/docs/incubating/cciv2_persistent_volume_claim.md
+++ b/docs/incubating/cciv2_persistent_volume_claim.md
@@ -13,14 +13,14 @@ Manages a CCI persistent volume claim resource within HuaweiCloud.
 ## Example Usage
 
 ```hcl
-resource "kubernetes_persistent_volume_claim" "my-pvc" {
+resource "huaweicloud_persistent_volume_claim" "my-pvc" {
   name      = "my-pvc-obs"
   namespace = "default"
 
   annotations = {
-    "everest.io/obs-volume-type"                       = "STANDARD"
-    "csi.storage.k8s.io/fstype"                        = "s3fs"
-    "everest.io/enterprise-project-id"                 = "0"
+    "everest.io/obs-volume-type"       = "STANDARD"
+    "csi.storage.k8s.io/fstype"        = "s3fs"
+    "everest.io/enterprise-project-id" = "0"
   }
 
   access_modes = ["ReadWriteMany"]

--- a/huaweicloud/services/acceptance/cci/resource_huaweicloud_cciv2_persistent_volume_claim_test.go
+++ b/huaweicloud/services/acceptance/cci/resource_huaweicloud_cciv2_persistent_volume_claim_test.go
@@ -1,0 +1,88 @@
+package cci
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cci"
+)
+
+func getPersistentVolumeClaimResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.CciV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CCI client: %s", err)
+	}
+	return cci.GetV2PersistentVolumeClaimDetail(c, state.Primary.Attributes["namespace"], state.Primary.Attributes["name"])
+}
+
+func TestAccV2PersistentVolumeClaim_basic(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_cciv2_persistent_volume_claim.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getPersistentVolumeClaimResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV2PersistentVolumeClaim_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "namespace", "huaweicloud_cci_namespace.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "storage_class_name",
+						"huaweicloud_cciv2_persistent_volume.test", "name"),
+					resource.TestCheckResourceAttr(resourceName, "access_modes.0", "ReadWriteMany"),
+					resource.TestCheckResourceAttr(resourceName, "volume_mode", "Filesystem"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccV2PersistentVolumeClaim_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "huaweicloud_cciv2_persistent_volume_claim" test {
+  name               = "%[3]s"
+  namespace          = huaweicloud_cciv2_namespace.test.name
+  access_modes       = ["ReadWriteMany"]
+  storage_class_name = huaweicloud_cciv2_persistent_volume.test.name
+  volume_mode        = "Filesystem"
+
+  annotations = {
+    "everest.io/obs-volume-type"       = "STANDARD"
+    "csi.storage.k8s.io/fstype"        = "s3fs"
+    "everest.io/enterprise-project-id" = "0"
+  }
+
+  resources {
+    requests = {
+      storage = "1Gi"
+    }
+  }
+}
+`, testAccV2Namespace_basic(rName), testAccV2PersistentVolume_basic(rName), rName)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx
fixed cci pvc markdown and add test case


**Special notes for your reviewer**:

**Release note**:

```
fixed cci pvc markdown and add test case
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/cci" TESTARGS="-run TestAccV2Pod_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cci -v -run TestAccV2PersistentVolumeClaim_basic -timeout 360m -parallel 4
=== RUN   TestAccV2PersistentVolumeClaim_basic
=== PAUSE TestAccV2PersistentVolumeClaim_basic
=== CONT  TestAccV2PersistentVolumeClaim_basic
--- PASS: TestAccV2PersistentVolumeClaim_basic(134.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cci       134.567s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
