### PR TITLE
feat(smn): add new resource to set topic attributes

### DIFF
--- a/docs/resources/smn_topic_attributes.md
+++ b/docs/resources/smn_topic_attributes.md
@@ -1,0 +1,76 @@
+---
+subcategory: "Simple Message Notification (SMN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_smn_topic_attributes"
+description: |-
+  Manages the SMN topic attributes within HuaweiCloud.
+---
+
+# huaweicloud_smn_topic_attributes
+
+Manages the SMN topic attributes within HuaweiCloud.
+
+-> Deleting this resource will not reset the topic attributes, but will only remove the resource information from the
+   tfstate file.
+
+## Example Usage
+
+### Attributes with access policy
+
+```hcl
+variable "smn_topic_urn" {}
+
+resource "huaweicloud_smn_topic_attributes" "access_policy" {
+  topic_urn = var.smn_topic_urn
+  name      = "access_policy"
+  value     = jsonencode({
+    "Version": "2016-09-07",
+    "Id": "__default_policy_ID",
+    "Statement": [
+      {
+        "Sid": "__org_path_pub_0",
+        "Effect": "Allow",
+        "Principal": {
+          "OrgPath": [
+            "o-xxx/r-xxx/ou-xxx"
+          ]
+        },
+        "Action": [
+          "SMN:Publish",
+          "SMN:QueryTopicDetail"
+        ],
+        "Resource": var.smn_topic_urn
+      }
+    ]
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the topic is located.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `topic_urn` - (Required, String, NonUpdatable) Specifies the topic URN. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, NonUpdatable) Specifies the topic attribute name.  
+  The valid values are as follows:
+  + **access_policy**
+
+* `value` - (Required, String) Specifies the topic attribute value, in JSON format.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (format is **{topic_urn}/{name}**).
+
+## Import
+
+The SMN topic attributes can be imported using the `topic_urn` and `name`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_smn_topic_attributes.test {topic_urn}/{name}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2455,6 +2455,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_smn_message_detection":          smn.ResourceMessageDetection(),
 			"huaweicloud_smn_message_publish":            smn.ResourceMessagePublish(),
 			"huaweicloud_smn_subscription_filter_policy": smn.ResourceSubscriptionFilterPolicy(),
+			"huaweicloud_smn_topic_attributes":           smn.ResourceTopicAttributes(),
 
 			"huaweicloud_sms_server_template": sms.ResourceServerTemplate(),
 			"huaweicloud_sms_task":            sms.ResourceMigrateTask(),

--- a/huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_topic_attributes_test.go
+++ b/huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_topic_attributes_test.go
@@ -1,0 +1,152 @@
+package smn
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/smn"
+)
+
+func getTopicAttributesFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.SmnV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SMN client: %s", err)
+	}
+
+	return smn.GetTopicAttributes(client, state.Primary.Attributes["topic_urn"],
+		state.Primary.Attributes["name"])
+}
+
+func TestAccTopicAttributes_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		rName        = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_smn_topic_attributes.test"
+
+		rc = acceptance.InitResourceCheck(resourceName, &obj, getTopicAttributesFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testTopicAttributes_basic_step1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", "access_policy"),
+					resource.TestCheckResourceAttrSet(resourceName, "value"),
+					resource.TestCheckResourceAttrSet(resourceName, "topic_urn"),
+				),
+			},
+			{
+				Config: testTopicAttributes_basic_step2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", "access_policy"),
+					resource.TestCheckResourceAttrSet(resourceName, "value"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"value",
+				},
+				ImportStateIdFunc: testTopicAttributesImportState(resourceName),
+			},
+		},
+	})
+}
+
+func testTopic_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test" {
+  name = "%s"
+}
+`, name)
+}
+
+func testTopicAttributes_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_smn_topic_attributes" "test" {
+  topic_urn = huaweicloud_smn_topic.test.topic_urn
+  name      = "access_policy"
+  value     = jsonencode({
+    "Version": "2016-09-07",
+    "Id": "__default_policy_ID",
+    "Statement": [
+      {
+        "Sid": "__org_path_pub_0",
+        "Effect": "Allow",
+        "Principal": {
+          "OrgPath": [
+            "o-xxx/r-xxx/ou-xxx"
+          ]
+        },
+        "Action": [
+          "SMN:Publish",
+          "SMN:QueryTopicDetail"
+        ],
+        "Resource": huaweicloud_smn_topic.test.topic_urn
+    }]
+  })
+}
+`, testTopic_base(name))
+}
+
+func testTopicAttributes_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_smn_topic_attributes" "test" {
+  topic_urn = huaweicloud_smn_topic.test.topic_urn
+  name      = "access_policy"
+  value     = jsonencode({
+    "Version": "2016-09-07",
+    "Id": "__default_policy_ID",
+    "Statement": [
+      {
+        "Sid": "__org_path_pub_0",
+        "Effect": "Allow",
+        "Principal": {
+          "OrgPath": [
+            "o-xxx/r-xxx/ou-yyy"
+          ]
+        },
+        "Action": [
+          "SMN:Publish",
+          "SMN:QueryTopicDetail"
+        ],
+        "Resource": huaweicloud_smn_topic.test.topic_urn
+    }]
+  })
+}
+`, testTopic_base(name))
+}
+
+func testTopicAttributesImportState(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resourceName, rs)
+		}
+		topicUrn := rs.Primary.Attributes["topic_urn"]
+		name := rs.Primary.Attributes["name"]
+		if topicUrn == "" || name == "" {
+			return "", errors.New("topic_urn or name is missing")
+		}
+		return fmt.Sprintf("%s/%s", topicUrn, name), nil
+	}
+}

--- a/huaweicloud/services/smn/resource_huaweicloud_smn_topic_attributes.go
+++ b/huaweicloud/services/smn/resource_huaweicloud_smn_topic_attributes.go
@@ -1,0 +1,201 @@
+package smn
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var topicAttributesNonUpdatableParams = []string{
+	"topic_urn",
+	"name",
+}
+
+// @API SMN PUT /v2/{project_id}/notifications/topics/{topic_urn}/attributes/{name}
+// @API SMN GET /v2/{project_id}/notifications/topics/{topic_urn}/attributes
+func ResourceTopicAttributes() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTopicAttributesCreate,
+		ReadContext:   resourceTopicAttributesRead,
+		UpdateContext: resourceTopicAttributesUpdate,
+		DeleteContext: resourceTopicAttributesDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(topicAttributesNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceTopicAttributesImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the topic is located.`,
+			},
+			"topic_urn": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The topic URN.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The topic attribute name.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The topic attribute value, in JSON format.`,
+			},
+		},
+	}
+}
+
+func updateTopicAttribute(client *golangsdk.ServiceClient, topicUrn, name, value string) error {
+	httpUrl := "v2/{project_id}/notifications/topics/{topic_urn}/attributes/{name}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{topic_urn}", topicUrn)
+	updatePath = strings.ReplaceAll(updatePath, "{name}", name)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"value": value,
+		},
+	}
+
+	_, err := client.Request("PUT", updatePath, &opt)
+	return err
+}
+
+func resourceTopicAttributesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.SmnV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating SMN client: %s", err)
+	}
+
+	topicUrn := d.Get("topic_urn").(string)
+	name := d.Get("name").(string)
+	value := d.Get("value").(string)
+
+	if err := updateTopicAttribute(client, topicUrn, name, value); err != nil {
+		return diag.Errorf("error setting attributes (names %s) for topic %s: %s", name, topicUrn, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", topicUrn, name))
+
+	return resourceTopicAttributesRead(ctx, d, meta)
+}
+
+func GetTopicAttributes(client *golangsdk.ServiceClient, topicUrn, name string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/notifications/topics/{topic_urn}/attributes?name={name}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{topic_urn}", topicUrn)
+	getPath = strings.ReplaceAll(getPath, "{name}", name)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch(fmt.Sprintf("attributes.%s", name), respBody, nil), nil
+}
+
+func resourceTopicAttributesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.SmnV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating SMN client: %s", err)
+	}
+
+	topicUrn := d.Get("topic_urn").(string)
+	name := d.Get("name").(string)
+
+	attributes, err := GetTopicAttributes(client, topicUrn, name)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving SMN topic attributes")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("value", attributes),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceTopicAttributesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.SmnV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating SMN client: %s", err)
+	}
+
+	topicUrn := d.Get("topic_urn").(string)
+	name := d.Get("name").(string)
+	value := d.Get("value").(string)
+
+	if err := updateTopicAttribute(client, topicUrn, name, value); err != nil {
+		return diag.Errorf("error updating attributes (names %s) for topic %s: %s", name, topicUrn, err)
+	}
+
+	return resourceTopicAttributesRead(ctx, d, meta)
+}
+
+func resourceTopicAttributesDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `Deleting this resource will not reset the topic attributes, but will only remove the resource
+information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}
+
+func resourceTopicAttributesImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<topic_urn>/<name>', but got '%s'", d.Id())
+	}
+
+	topicUrn := parts[0]
+	name := parts[1]
+
+	mErr := multierror.Append(nil,
+		d.Set("topic_urn", topicUrn),
+		d.Set("name", name),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports new resource to set/update the topic attributes
Currently, only access_policy is supported.
<img width="1045" alt="截屏2025-06-02 16 50 46" src="https://github.com/user-attachments/assets/1eac2d6d-43d3-42f0-bafd-198f20349376" />
<img width="843" alt="截屏2025-06-02 16 51 27" src="https://github.com/user-attachments/assets/0c4c2d85-b61f-4b27-a055-945606e22a8a" />

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new resource to set/update the topic attributes.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
TF_ACC=1 go test "./huaweicloud/services/acceptance/smn" -v -coverprofile="./huaweicloud/services/acceptance/smn/smn_coverage.cov" -coverpkg="./huaweicloud/services/acceptance/smn" -run TestAccTopicAttributes_basic -timeout 360m -parallel 10
=== RUN   TestAccTopicAttributes_basic
=== PAUSE TestAccTopicAttributes_basic
=== CONT  TestAccTopicAttributes_basic
--- PASS: TestAccTopicAttributes_basic (32.42s)
PASS
coverage: [no statements]
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/smn       36.724s    coverage: [no statements]
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
   <img width="874" alt="截屏2025-06-02 17 13 05" src="https://github.com/user-attachments/assets/60d330b1-6509-4aff-a421-a5c64164c431" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
