### PR TITLE
feat(cbr): add new resource to manage organization policies

### DIFF
--- a/docs/resources/cbr_organization_policy.md
+++ b/docs/resources/cbr_organization_policy.md
@@ -1,0 +1,149 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbr_organization_policy"
+description: |-
+  Manages a CBR organization policy resource within HuaweiCloud.
+---
+
+# huaweicloud_cbr_organization_policy
+
+Manages a CBR organization policy resource within HuaweiCloud.
+
+## Example Usage
+
+### Create a backup organization policy with retention settings
+
+```hcl
+variable "organization_policy_name" {}
+variable "policy_name" {}
+
+resource "huaweicloud_cbr_organization_policy" "test" {
+  name           = var.organization_policy_name
+  description    = "Created by terraform script"
+  operation_type = "backup"
+  policy_name    = var.policy_name
+  policy_enabled = false
+
+  policy_operation_definition {
+    day_backups          = 5
+    max_backups          = 30
+    month_backups        = 1
+    week_backups         = 2
+    year_backups         = 1
+    timezone             = "UTC+08:00"
+    full_backup_interval = 10
+  }
+
+  policy_trigger {
+    properties {
+      pattern = ["FREQ=WEEKLY;BYDAY=WE,TH,FR;BYHOUR=16;BYMINUTE=00"]
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the organization policy name.
+
+* `operation_type` - (Required, String, ForceNew) Specifies the organization policy type.  
+  The valid values are as follows:
+  + **backup**
+  + **replication**.
+
+* `policy_name` - (Required, String) Specifies the policy name.  
+  The CBR service will automatically create a corresponding policy based on this name.
+
+* `policy_enabled` - (Required, Bool) Specifies whether the policy is enabled.
+
+* `policy_operation_definition` - (Required, List) Specifies the policy operation definition for backup and replication.
+  The [policy_operation_definition](#cbr_organization_policy_operation_definition) structure is documented below.
+
+* `policy_trigger` - (Required, List) Specifies the policy execution time rule.
+  The [policy_trigger](#cbr_organization_policy_trigger) structure is documented below.
+
+* `description` - (Optional, String) Specifies the organization policy description.
+
+* `effective_scope` - (Optional, String) Specifies the effective scope of the organization policy.
+
+<a name="cbr_organization_policy_operation_definition"></a>
+The `policy_operation_definition` block supports:
+
+* `day_backups` - (Optional, Int) Specifies the maximum number of daily backups that can be retained.
+  The latest backup of each day is saved in the long term. The value ranges from **0** to **100**.
+
+* `destination_project_id` - (Optional, String) Specifies the destination project ID for replication.
+  This parameter is **mandatory** for cross-region replication.
+
+* `destination_region` - (Optional, String) Specifies the destination region for replication.
+  This parameter is **mandatory** for cross-region replication.
+
+* `enable_acceleration` - (Optional, String) Specifies whether to enable acceleration to shorten replication time for
+  cross-region replication.  
+  The valid values are as follows:
+  + **true**
+  + **false**
+
+* `max_backups` - (Optional, Int) Specifies the maximum number of backups that can be automatically created for a
+  backup object. The value can be **-1** or ranges from **0** to **99999**. If the value is set to **-1**, backups
+  will not be cleared by quantity limit.
+
+* `month_backups` - (Optional, Int) Specifies the maximum number of monthly backups that can be retained.
+  The latest backup of each month is saved in the long term. The value ranges from **0** to **100**.
+
+* `retention_duration_days` - (Optional, Int) Specifies the duration of retaining a backup, in days.
+  The maximum value is **99999**. If the value is set to **-1**, backups will not be cleared by retention duration.
+
+* `week_backups` - (Optional, Int) Specifies the maximum number of weekly backups that can be retained.
+  The latest backup of each week is saved in the long term. The value ranges from **0** to **100**.
+
+* `year_backups` - (Optional, Int) Specifies the maximum number of yearly backups that can be retained.
+  The latest backup of each year is saved in the long term. The value ranges from **0** to **100**.
+
+* `timezone` - (Optional, String) Specifies the time zone where the user is located, for example, **UTC+08:00**.
+
+* `full_backup_interval` - (Optional, Int) Defines how often a full backup is performed after incremental backups.
+  If **-1** is specified, full backup will not be performed. The value ranges from **-1** to **100**.
+
+<a name="cbr_organization_policy_trigger"></a>
+The `policy_trigger` block supports:
+
+* `properties` - (Required, List) Specifies the properties of policy trigger.
+  The [properties](#cbr_organization_policy_trigger_properties) structure is documented below.
+
+<a name="cbr_organization_policy_trigger_properties"></a>
+The `properties` block supports:
+
+* `pattern` - (Required, List) Specifies the scheduling rules for policy execution. Up to 24 rules are supported.
+  The scheduling rules follow the iCalendar RFC 2445 specification, supporting parameters like **FREQ**, **BYDAY**,
+  **BYHOUR**, **BYMINUTE**, and **INTERVAL**. For example: **FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYHOUR=14;BYMINUTE=00**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - The organization policy status.
+
+* `domain_id` - The ID of the account to which the organization policy belongs.
+
+* `domain_name` - The account to which the organization policy belongs.
+
+## Import
+
+The CBR organization policy can be imported using the `id` or `name`, e.g.
+
+```bash
+$ terraform import huaweicloud_cbr_organization_policy.test <id>
+```
+
+```bash
+$ terraform import huaweicloud_cbr_organization_policy.test <name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1657,6 +1657,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbr_backup_share_accepter": cbr.ResourceBackupShareAccepter(),
 			"huaweicloud_cbr_backup_share":          cbr.ResourceBackupShare(),
 			"huaweicloud_cbr_checkpoint":            cbr.ResourceCheckpoint(),
+			"huaweicloud_cbr_organization_policy":   cbr.ResourceOrganizationPolicy(),
 			"huaweicloud_cbr_policy":                cbr.ResourcePolicy(),
 			"huaweicloud_cbr_vault":                 cbr.ResourceVault(),
 

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_organization_policy_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_organization_policy_test.go
@@ -1,0 +1,185 @@
+package cbr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
+)
+
+func getOrganizationPolicyResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	client, err := conf.NewServiceClient("cbr", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CBR client: %s", err)
+	}
+
+	return cbr.GetOrganizationPolicyById(client, state.Primary.ID)
+}
+
+func TestAccOrganizationPolicy_basic(t *testing.T) {
+	var (
+		organizationPolicy interface{}
+		name               = acceptance.RandomAccResourceName()
+		updateName         = acceptance.RandomAccResourceName()
+		resourceName       = "huaweicloud_cbr_organization_policy.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&organizationPolicy,
+		getOrganizationPolicyResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrganizationPolicy_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(resourceName, "operation_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "policy_name", fmt.Sprintf("%s_policy", name)),
+					resource.TestCheckResourceAttr(resourceName, "policy_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "policy_operation_definition.0.day_backups", "5"),
+					resource.TestCheckResourceAttr(resourceName, "policy_operation_definition.0.max_backups", "30"),
+					resource.TestCheckResourceAttr(resourceName, "policy_operation_definition.0.month_backups", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_operation_definition.0.week_backups", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policy_operation_definition.0.year_backups", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_operation_definition.0.timezone", "UTC+08:00"),
+					resource.TestCheckResourceAttr(resourceName, "policy_operation_definition.0.full_backup_interval", "10"),
+					resource.TestCheckResourceAttr(resourceName, "policy_trigger.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_trigger.0.properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_trigger.0.properties.0.pattern.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_trigger.0.properties.0.pattern.0",
+						"FREQ=WEEKLY;BYDAY=WE,TH,FR;BYHOUR=16;BYMINUTE=00"),
+					resource.TestCheckResourceAttrSet(resourceName, "effective_scope"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_name"),
+				),
+			},
+			{
+				Config: testAccOrganizationPolicy_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by terraform script"),
+					resource.TestCheckResourceAttr(resourceName, "operation_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "policy_name", fmt.Sprintf("%s_policy", updateName)),
+					resource.TestCheckResourceAttr(resourceName, "policy_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "policy_operation_definition.0.day_backups", "10"),
+					resource.TestCheckResourceAttr(resourceName, "policy_operation_definition.0.max_backups", "40"),
+					resource.TestCheckResourceAttr(resourceName, "policy_operation_definition.0.month_backups", "3"),
+					resource.TestCheckResourceAttr(resourceName, "policy_operation_definition.0.week_backups", "5"),
+					resource.TestCheckResourceAttr(resourceName, "policy_operation_definition.0.year_backups", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policy_operation_definition.0.timezone", "UTC+09:00"),
+					resource.TestCheckResourceAttr(resourceName, "policy_operation_definition.0.full_backup_interval", "15"),
+					resource.TestCheckResourceAttr(resourceName, "policy_trigger.0.properties.0.pattern.0",
+						"FREQ=WEEKLY;BYDAY=SA,SU;BYHOUR=08;BYMINUTE=00"),
+					resource.TestCheckResourceAttr(resourceName, "policy_trigger.0.properties.0.pattern.1",
+						"FREQ=WEEKLY;BYDAY=WE,TH,FR,SA,TU,MO,SU;BYHOUR=14;BYMINUTE=00"),
+					resource.TestCheckResourceAttrSet(resourceName, "effective_scope"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccOrganizationPolicyImportState(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccOrganizationPolicy_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cbr_organization_policy" "test" {
+  name           = "%[1]s"
+  description    = "Created by terraform script"
+  operation_type = "backup"
+  policy_name    = "%[1]s_policy"
+  policy_enabled = false
+
+  policy_operation_definition {
+    day_backups          = 5
+    max_backups          = 30
+    month_backups        = 1
+    week_backups         = 2
+    year_backups         = 1
+    timezone             = "UTC+08:00"
+    full_backup_interval = 10
+  }
+
+  policy_trigger {
+    properties {
+      pattern = ["FREQ=WEEKLY;BYDAY=WE,TH,FR;BYHOUR=16;BYMINUTE=00"]
+    }
+  }
+}
+`, name)
+}
+
+func testAccOrganizationPolicy_basic_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cbr_organization_policy" "test" {
+  name           = "%[1]s"
+  description    = "Updated by terraform script"
+  operation_type = "backup"
+  policy_name    = "%[1]s_policy"
+  policy_enabled = true
+
+  policy_operation_definition {
+    day_backups          = 10
+    max_backups          = 40
+    month_backups        = 3
+    week_backups         = 5
+    year_backups         = 2
+    timezone             = "UTC+09:00"
+    full_backup_interval = 15
+  }
+
+  policy_trigger {
+    properties {
+      pattern = [
+        "FREQ=WEEKLY;BYDAY=SA,SU;BYHOUR=08;BYMINUTE=00",
+        "FREQ=WEEKLY;BYDAY=WE,TH,FR,SA,TU,MO,SU;BYHOUR=14;BYMINUTE=00",
+      ]
+    }
+  }
+}
+`, name, name, name)
+}
+
+// testAccOrganizationPolicyImportState returns a function for importing a CBR organization policy by name
+func testAccOrganizationPolicyImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.Attributes["name"] == "" {
+			return "", fmt.Errorf("attribute (name) of resource (%s) not found: %s", name, rs)
+		}
+		return rs.Primary.Attributes["name"], nil
+	}
+}

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_organization_policy.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_organization_policy.go
@@ -1,0 +1,590 @@
+package cbr
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var organizationPolicyNonUpdatableParams = []string{
+	"operation_type",
+}
+
+var organizationPolicyNotFoundCodes = []string{
+	"CBR.404",
+}
+
+// @API CBR POST /v3/{project_id}/organization-policies
+// @API CBR GET /v3/{project_id}/organization-policies/{organization_policy_id}
+// @API CBR PUT /v3/{project_id}/organization-policies/{organization_policy_id}
+// @API CBR DELETE /v3/{project_id}/organization-policies/{organization_policy_id}
+// @API CBR GET /v3/{project_id}/organization-policies
+func ResourceOrganizationPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceOrganizationPolicyCreate,
+		ReadContext:   resourceOrganizationPolicyRead,
+		UpdateContext: resourceOrganizationPolicyUpdate,
+		DeleteContext: resourceOrganizationPolicyDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(organizationPolicyNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceOrganizationPolicyImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the organization policy is located.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The organization policy name.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The organization policy description.`,
+			},
+			"operation_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The organization policy type.`,
+			},
+			"policy_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The policy name.`,
+			},
+			"policy_enabled": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: `Whether the organization policy is enabled.`,
+			},
+			"policy_operation_definition": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"day_backups": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: `Maximum number of daily backups that can be retained.`,
+						},
+						"destination_project_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: `The destination project ID for replication.`,
+						},
+						"destination_region": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: `The destination region for replication.`,
+						},
+						"enable_acceleration": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"true", "false",
+							}, false),
+							Description: `Whether to enable acceleration to shorten replication time for cross-region replication.`,
+						},
+						"max_backups": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: `Maximum number of backups that can be automatically created for a backup object.`,
+						},
+						"month_backups": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: `Maximum number of monthly backups that can be retained.`,
+						},
+						"retention_duration_days": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: `Duration of retaining a backup, in days.`,
+						},
+						"week_backups": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: `Maximum number of weekly backups that can be retained.`,
+						},
+						"year_backups": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: `Maximum number of yearly backups that can be retained.`,
+						},
+						"timezone": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: `The time zone where the user is located.`,
+						},
+						"full_backup_interval": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: `Defines how often a full backup is performed after incremental backups.`,
+						},
+					},
+				},
+				Description: `The policy operation definition for backup and replication.`,
+			},
+			"policy_trigger": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"properties": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"pattern": {
+										Type:        schema.TypeList,
+										Required:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: `The scheduling rules for policy execution.`,
+									},
+								},
+							},
+							Description: `The properties of policy trigger.`,
+						},
+					},
+				},
+				Description: `The policy execution time rule.`,
+			},
+			"effective_scope": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The effective scope of the organization policy.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The organization policy status.`,
+			},
+			"domain_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the account to which the organization policy belongs.`,
+			},
+			"domain_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The account to which the organizational policy belongs.`,
+			},
+			// Internal parameter
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildOrganizationPolicyCreateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		// Required parameters
+		"name":                        d.Get("name"),
+		"operation_type":              d.Get("operation_type"),
+		"policy_name":                 d.Get("policy_name"),
+		"policy_enabled":              d.Get("policy_enabled"),
+		"policy_operation_definition": buildPolicyOperationDefinition(d.Get("policy_operation_definition").([]interface{})),
+		"policy_trigger":              buildPolicyTrigger(d.Get("policy_trigger").([]interface{})),
+		// Optional parameters
+		"description":     utils.ValueIgnoreEmpty(d.Get("description")),
+		"effective_scope": utils.ValueIgnoreEmpty(d.Get("effective_scope")),
+	}
+}
+
+func parsePolicyAccelerationEnabled(enabled string) interface{} {
+	if enabled == "" {
+		return nil
+	}
+	if enabled == "true" {
+		return true
+	}
+	return false
+}
+
+func buildPolicyOperationDefinition(policyOpDefRaw []interface{}) map[string]interface{} {
+	if len(policyOpDefRaw) < 1 {
+		return nil
+	}
+
+	policyOpDef := policyOpDefRaw[0].(map[string]interface{})
+	return map[string]interface{}{
+		"day_backups":            utils.ValueIgnoreEmpty(utils.PathSearch("day_backups", policyOpDef, nil)),
+		"destination_project_id": utils.ValueIgnoreEmpty(utils.PathSearch("destination_project_id", policyOpDef, nil)),
+		"destination_region":     utils.ValueIgnoreEmpty(utils.PathSearch("destination_region", policyOpDef, nil)),
+		"enable_acceleration": utils.ValueIgnoreEmpty(parsePolicyAccelerationEnabled(utils.PathSearch("enable_acceleration",
+			policyOpDef, "").(string))),
+		"max_backups":             utils.ValueIgnoreEmpty(utils.PathSearch("max_backups", policyOpDef, nil)),
+		"month_backups":           utils.ValueIgnoreEmpty(utils.PathSearch("month_backups", policyOpDef, nil)),
+		"retention_duration_days": utils.ValueIgnoreEmpty(utils.PathSearch("retention_duration_days", policyOpDef, nil)),
+		"week_backups":            utils.ValueIgnoreEmpty(utils.PathSearch("week_backups", policyOpDef, nil)),
+		"year_backups":            utils.ValueIgnoreEmpty(utils.PathSearch("year_backups", policyOpDef, nil)),
+		"timezone":                utils.ValueIgnoreEmpty(utils.PathSearch("timezone", policyOpDef, nil)),
+		"full_backup_interval":    utils.ValueIgnoreEmpty(utils.PathSearch("full_backup_interval", policyOpDef, nil)),
+	}
+}
+
+func buildPolicyTrigger(policyTriggerRaw []interface{}) map[string]interface{} {
+	if len(policyTriggerRaw) < 1 {
+		return nil
+	}
+
+	policyTrigger := policyTriggerRaw[0].(map[string]interface{})
+
+	return map[string]interface{}{
+		"properties": buildPolicyTriggerProperties(utils.PathSearch("properties", policyTrigger,
+			make([]interface{}, 0)).([]interface{})),
+	}
+}
+
+func buildPolicyTriggerProperties(policyTriggerPropertiesRaw []interface{}) map[string]interface{} {
+	if len(policyTriggerPropertiesRaw) < 1 {
+		return nil
+	}
+
+	policyTriggerProperties := policyTriggerPropertiesRaw[0].(map[string]interface{})
+
+	return map[string]interface{}{
+		"pattern": utils.PathSearch("pattern", policyTriggerProperties, make([]interface{}, 0)).([]interface{}),
+	}
+}
+
+func resourceOrganizationPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/organization-policies"
+	)
+	client, err := cfg.NewServiceClient("cbr", region)
+	if err != nil {
+		return diag.Errorf("error creating CBR client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(map[string]interface{}{
+			"policy": buildOrganizationPolicyCreateBodyParams(d),
+		}),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating organization policy: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	policyId := utils.PathSearch("policy.id", respBody, "").(string)
+	if policyId == "" {
+		return diag.Errorf("failed to find the organization policy ID from the API response")
+	}
+	d.SetId(policyId)
+
+	return resourceOrganizationPolicyRead(ctx, d, meta)
+}
+
+func GetOrganizationPolicyById(client *golangsdk.ServiceClient, policyId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/organization-policies/{organization_policy_id}"
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{organization_policy_id}", policyId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func flattenPolicyOperationDefinition(policyOpDefRaw interface{}) []map[string]interface{} {
+	if policyOpDefRaw == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"day_backups":             utils.PathSearch("day_backups", policyOpDefRaw, nil),
+			"destination_project_id":  utils.PathSearch("destination_project_id", policyOpDefRaw, nil),
+			"destination_region":      utils.PathSearch("destination_region", policyOpDefRaw, nil),
+			"enable_acceleration":     utils.PathSearch("enable_acceleration", policyOpDefRaw, nil),
+			"max_backups":             utils.PathSearch("max_backups", policyOpDefRaw, nil),
+			"month_backups":           utils.PathSearch("month_backups", policyOpDefRaw, nil),
+			"retention_duration_days": utils.PathSearch("retention_duration_days", policyOpDefRaw, nil),
+			"week_backups":            utils.PathSearch("week_backups", policyOpDefRaw, nil),
+			"year_backups":            utils.PathSearch("year_backups", policyOpDefRaw, nil),
+			"timezone":                utils.PathSearch("timezone", policyOpDefRaw, nil),
+			"full_backup_interval":    utils.PathSearch("full_backup_interval", policyOpDefRaw, nil),
+		},
+	}
+}
+
+func flattenPolicyTrigger(policyTriggerRaw interface{}) []map[string]interface{} {
+	if policyTriggerRaw == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"properties": flattenPolicyTriggerProperties(utils.PathSearch("properties", policyTriggerRaw, nil)),
+		},
+	}
+}
+
+func flattenPolicyTriggerProperties(policyTriggerPropertiesRaw interface{}) []map[string]interface{} {
+	if policyTriggerPropertiesRaw == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"pattern": utils.PathSearch("pattern", policyTriggerPropertiesRaw, make([]interface{}, 0)).([]interface{}),
+		},
+	}
+}
+
+func resourceOrganizationPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		policyId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("cbr", region)
+	if err != nil {
+		return diag.Errorf("error creating CBR client: %s", err)
+	}
+
+	respBody, err := GetOrganizationPolicyById(client, policyId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error getting organization policy (%s)", policyId))
+	}
+
+	policy := utils.PathSearch("policy", respBody, nil)
+	if policy == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error: organization policy not found")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", policy, nil)),
+		d.Set("description", utils.PathSearch("description", policy, nil)),
+		d.Set("operation_type", utils.PathSearch("operation_type", policy, nil)),
+		d.Set("policy_name", utils.PathSearch("policy_name", policy, nil)),
+		d.Set("policy_enabled", utils.PathSearch("policy_enabled", policy, nil)),
+		d.Set("status", utils.PathSearch("status", policy, nil)),
+		d.Set("domain_id", utils.PathSearch("domain_id", policy, nil)),
+		d.Set("domain_name", utils.PathSearch("domain_name", policy, nil)),
+		d.Set("policy_operation_definition", flattenPolicyOperationDefinition(utils.PathSearch("policy_operation_definition",
+			policy, nil))),
+		d.Set("policy_trigger", flattenPolicyTrigger(utils.PathSearch("policy_trigger", policy, nil))),
+		d.Set("effective_scope", utils.PathSearch("effective_scope", policy, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildOrganizationPolicyUpdateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":                        d.Get("name"),
+		"description":                 utils.ValueIgnoreEmpty(d.Get("description")),
+		"policy_name":                 d.Get("policy_name"),
+		"policy_enabled":              d.Get("policy_enabled"),
+		"policy_operation_definition": buildPolicyOperationDefinition(d.Get("policy_operation_definition").([]interface{})),
+		"policy_trigger":              buildPolicyTrigger(d.Get("policy_trigger").([]interface{})),
+		"effective_scope":             utils.ValueIgnoreEmpty(d.Get("effective_scope")),
+	}
+}
+
+func resourceOrganizationPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		httpUrl  = "v3/{project_id}/organization-policies/{organization_policy_id}"
+		policyId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("cbr", region)
+	if err != nil {
+		return diag.Errorf("error creating CBR client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{organization_policy_id}", policyId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(map[string]interface{}{
+			"policy": buildOrganizationPolicyUpdateBodyParams(d),
+		}),
+	}
+
+	_, err = client.Request("PUT", updatePath, &opt)
+	if err != nil {
+		return diag.Errorf("error updating organization policy (%s): %s", policyId, err)
+	}
+
+	return resourceOrganizationPolicyRead(ctx, d, meta)
+}
+
+func resourceOrganizationPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		httpUrl  = "v3/{project_id}/organization-policies/{organization_policy_id}"
+		policyId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("cbr", region)
+	if err != nil {
+		return diag.Errorf("error creating CBR client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{organization_policy_id}", policyId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &opt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting organization policy (%s)", policyId))
+	}
+	return nil
+}
+
+func QueryOrganizationPolicies(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	httpUrl := "v3/{project_id}/organization-policies"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, fmt.Errorf("error querying organization policies: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("policies", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func getOrganizationPolicyByName(client *golangsdk.ServiceClient, name string) (interface{}, error) {
+	policies, err := QueryOrganizationPolicies(client)
+	if err != nil {
+		return nil, err
+	}
+
+	policy := utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0]", name), policies, nil)
+	if policy == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v3/{project_id}/organization-policies",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the organization policy (%s) does not exist", name)),
+			},
+		}
+	}
+	return policy, nil
+}
+
+func resourceOrganizationPolicyImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		importId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("cbr", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CBR client: %s", err)
+	}
+
+	// If the import ID is a UUID, use it directly
+	if utils.IsUUID(importId) {
+		return []*schema.ResourceData{d}, nil
+	}
+
+	// If not a UUID, treat as name and find the corresponding ID
+	policy, err := getOrganizationPolicyByName(client, importId)
+	if err != nil {
+		return nil, fmt.Errorf("error getting organization policy by name (%s): %s", importId, err)
+	}
+
+	policyId := utils.PathSearch("id", policy, "").(string)
+	if policyId == "" {
+		return nil, fmt.Errorf("unable to find the organization policy ID by name (%s)", importId)
+	}
+
+	d.SetId(policyId)
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports new resource to manage organization policies:
`huaweicloud_cbr_organization_policy`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to manage organization policies.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cbr -f TestAccOrganizationPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccOrganizationPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccOrganizationPolicy_basic
=== PAUSE TestAccOrganizationPolicy_basic
=== CONT  TestAccOrganizationPolicy_basic
--- PASS: TestAccOrganizationPolicy_basic (86.61s)
PASS
coverage: 10.5% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       86.690s coverage: 10.5% of statements in ./huaweicloud/services/cbr
```
![1748923449268](https://github.com/user-attachments/assets/9b08b8b8-3dd1-4fea-a00a-a10ba4beb066)

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![6b61173335f96a648e221563de87d16](https://github.com/user-attachments/assets/9adf4318-3727-4024-b5a3-b1f87f3472ec)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![7e887ec1e5cbdcf11ae7212cf3eb28f](https://github.com/user-attachments/assets/2399413b-614b-466c-b566-afa8640d1760)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
