### PR TITLE
feat(dew): add a one-time resource to disassociate kms keypair

### DIFF
--- a/docs/resources/kms_keypair_disassociate.md
+++ b/docs/resources/kms_keypair_disassociate.md
@@ -1,0 +1,96 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_kms_keypair_disassociate"
+description: |-
+  Manages a KMS keypair disassociate resource within HuaweiCloud.
+---
+
+# huaweicloud_kms_keypair_disassociate
+
+Manages a KMS keypair disassociate resource within HuaweiCloud.
+
+-> Please refer to the API document link for more precautions  
+[reference](https://support.huaweicloud.com/intl/en-us/usermanual-dew/dew_01_0071.html).
+
+## Example Usage
+
+### Disassociate SSH keypair with ECS opened
+
+```hcl
+variable "server_id" {}
+variable "port" {}
+variable "type" {}
+variable "key" {}
+
+resource "huaweicloud_kms_keypair_disassociate" "test" {
+  server {
+    id   = var.server_id
+    port = var.port
+    
+    auth {
+      type = var.type
+      key  = var.key
+    }
+  }
+}
+```
+
+### Disassociate SSH keypair with ECS closed
+
+```hcl
+variable "server_id" {}
+
+resource "huaweicloud_kms_keypair_disassociate" "test" {
+  server {
+    id = var.server_id
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `server` - (Required, List, NonUpdatable) Specifies the ECS information that requires disassociating keypair.
+  The [server](#kms_server) structure is documented below.
+
+<a name="kms_server"></a>
+The `server` block supports:
+
+* `id` - (Required, String, NonUpdatable) Specifies ID of the ECS which need to disassociate the SSH keypair.
+
+* `auth` - (Optional, List, NonUpdatable) Specifies the authentication information. This parameter is required for replacement
+  and not required for reset.
+  The [auth](#server_auth) structure is documented below.
+
+* `port` - (Optional, Int, NonUpdatable) Specifies the SSH listening port. The default value is `22`.
+
+-> When the ECS is shut down, the disassociate `port` is fixed at `22` and cannot be configured.
+At the same time, `auth` can not be set. When the ECS is turned on, the disassociate `port` can be
+configured and defaults to `22`, and `auth` is required, otherwise the operation will fail.
+
+<a name="server_auth"></a>
+The `auth` block supports:
+
+* `type` - (Optional, String, NonUpdatable) Specifies the value of an authentication type.
+  The valid values are **password** and **keypair**.
+
+* `key` - (Optional, String, NonUpdatable) Specifies the value of the key depending on the `type`.
+  When the `type` is set to **password**, it represents the password.  
+  When the `type` is set to **keypair**, it represents the private key.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which is also the task ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Defaults to 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2198,6 +2198,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_alias_associate":      dew.ResourceKmsAliasAssociate(),
 			"huaweicloud_kms_dedicated_keystore":   dew.ResourceKmsDedicatedKeystore(),
 			"huaweicloud_kms_key_material":         dew.ResourceKmsKeyMaterial(),
+			"huaweicloud_kms_keypair_disassociate": dew.ResourceKmsKeypairDisassociate(),
 
 			"huaweicloud_lb_certificate":  lb.ResourceCertificateV2(),
 			"huaweicloud_lb_l7policy":     lb.ResourceL7PolicyV2(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -271,13 +271,14 @@ var (
 	HW_FGS_GPU_TYPE            = os.Getenv("HW_FGS_GPU_TYPE")
 	HW_FGS_DEPENDENCY_OBS_LINK = os.Getenv("HW_FGS_DEPENDENCY_OBS_LINK")
 
-	HW_KMS_ENVIRONMENT     = os.Getenv("HW_KMS_ENVIRONMENT")
-	HW_KMS_HSM_CLUSTER_ID  = os.Getenv("HW_KMS_HSM_CLUSTER_ID")
-	HW_KMS_KEY_ID          = os.Getenv("HW_KMS_KEY_ID")
-	HW_KMS_ALIAS           = os.Getenv("HW_KMS_ALIAS")
-	HW_KMS_IMPORT_TOKEN    = os.Getenv("HW_KMS_IMPORT_TOKEN")
-	HW_KMS_KEY_MATERIAL    = os.Getenv("HW_KMS_KEY_MATERIAL")
-	HW_KMS_KEY_PRIVATE_KEY = os.Getenv("HW_KMS_KEY_PRIVATE_KEY")
+	HW_KMS_ENVIRONMENT      = os.Getenv("HW_KMS_ENVIRONMENT")
+	HW_KMS_HSM_CLUSTER_ID   = os.Getenv("HW_KMS_HSM_CLUSTER_ID")
+	HW_KMS_KEY_ID           = os.Getenv("HW_KMS_KEY_ID")
+	HW_KMS_ALIAS            = os.Getenv("HW_KMS_ALIAS")
+	HW_KMS_IMPORT_TOKEN     = os.Getenv("HW_KMS_IMPORT_TOKEN")
+	HW_KMS_KEY_MATERIAL     = os.Getenv("HW_KMS_KEY_MATERIAL")
+	HW_KMS_KEY_PRIVATE_KEY  = os.Getenv("HW_KMS_KEY_PRIVATE_KEY")
+	HW_KMS_KEYPAIR_SSH_PORT = os.Getenv("HW_KMS_KEYPAIR_SSH_PORT")
 
 	HW_MULTI_ACCOUNT_ENVIRONMENT            = os.Getenv("HW_MULTI_ACCOUNT_ENVIRONMENT")
 	HW_ORGANIZATIONS_OPEN                   = os.Getenv("HW_ORGANIZATIONS_OPEN")
@@ -515,6 +516,7 @@ var (
 	HW_EVS_ENABLE_FLAG              = os.Getenv("HW_EVS_ENABLE_FLAG")
 
 	HW_ECS_LAUNCH_TEMPLATE_ID = os.Getenv("HW_ECS_LAUNCH_TEMPLATE_ID")
+	HW_ECS_ID                 = os.Getenv("HW_ECS_ID")
 
 	HW_IOTDA_ACCESS_ADDRESS      = os.Getenv("HW_IOTDA_ACCESS_ADDRESS")
 	HW_IOTDA_BATCHTASK_FILE_PATH = os.Getenv("HW_IOTDA_BATCHTASK_FILE_PATH")
@@ -1677,6 +1679,13 @@ func TestAccPreCheckKmsKeyPrivateKey(t *testing.T) {
 }
 
 // lintignore:AT003
+func TestAccPreCheckKmsSSHPort(t *testing.T) {
+	if HW_KMS_KEYPAIR_SSH_PORT == "" {
+		t.Skip("HW_KMS_KEYPAIR_SSH_PORT must be set for acceptance tests.")
+	}
+}
+
+// lintignore:AT003
 func TestAccPreCheckProjectID(t *testing.T) {
 	if HW_PROJECT_ID == "" {
 		t.Skip("HW_PROJECT_ID must be set for acceptance tests")
@@ -2676,6 +2685,13 @@ func TestAccPreCheckAKAndSK(t *testing.T) {
 func TestAccPreCheckECSLaunchTemplateID(t *testing.T) {
 	if HW_ECS_LAUNCH_TEMPLATE_ID == "" {
 		t.Skip("HW_ECS_LAUNCH_TEMPLATE_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckECSID(t *testing.T) {
+	if HW_ECS_ID == "" {
+		t.Skip("HW_ECS_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_keypair_disassociate_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_keypair_disassociate_test.go
@@ -1,0 +1,45 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccKeypairsDisassociate_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare one ECS with KMS keypair, then config it to the environment variable.
+			acceptance.TestAccPreCheckKmsKeyPrivateKey(t)
+			acceptance.TestAccPreCheckKmsSSHPort(t)
+			acceptance.TestAccPreCheckECSID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKeypairsDisassociate_basic(),
+			},
+		},
+	})
+}
+
+func testAccKeypairsDisassociate_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kms_keypair_disassociate" "test" {
+  server {
+    id   = "%[1]s"
+    port = %[2]s
+
+    auth {
+      type = "keypair"
+      key  = "%[3]s"
+    }
+  }
+}
+`, acceptance.HW_ECS_ID, acceptance.HW_KMS_KEYPAIR_SSH_PORT, acceptance.HW_KMS_KEY_PRIVATE_KEY)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_kms_keypair_disassociate.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kms_keypair_disassociate.go
@@ -1,0 +1,269 @@
+package dew
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var keypairDisassociateNonUpdatableParams = []string{
+	"server",
+	"server.*.id",
+	"server.*.auth",
+	"server.*.port",
+	"server.*.auth.*.type",
+	"server.*.auth.*.key",
+}
+
+// @API DEW POST /v3/{project_id}/keypairs/disassociate
+// @API DEW GET /v3/{project_id}/tasks/{task_id}
+func ResourceKmsKeypairDisassociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKmsKeypairDisassociateCreate,
+		ReadContext:   resourceKmsKeypairDisassociateRead,
+		UpdateContext: resourceKmsKeypairDisassociateUpdate,
+		DeleteContext: resourceKmsKeypairDisassociateDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(keypairDisassociateNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource.`,
+			},
+			"server": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Elem:        resourceServerSchema(),
+				Description: `Specifies the ECS information.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceServerSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies ID of the ECS.`,
+			},
+			"auth": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem:        resourceServerAuthSchema(),
+				Description: `Specifies the authentication type.`,
+			},
+			"port": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies the SSH listening port.`,
+			},
+		},
+	}
+}
+
+func resourceServerAuthSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the value of an enumeration type.`,
+			},
+			"key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the value of the key.`,
+			},
+		},
+	}
+}
+
+func buildKeypairDisassociateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"server": utils.RemoveNil(buildServerBodyParams(d.Get("server").([]interface{}))),
+	}
+}
+
+func buildServerAuthBodyParams(auths []interface{}) map[string]interface{} {
+	if len(auths) == 0 || auths[0] == nil {
+		return nil
+	}
+
+	auth, ok := auths[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	bodyParams := map[string]interface{}{
+		"type": utils.ValueIgnoreEmpty(auth["type"]),
+		"key":  utils.ValueIgnoreEmpty(auth["key"]),
+	}
+
+	return bodyParams
+}
+
+func buildServerBodyParams(servers []interface{}) map[string]interface{} {
+	if (len(servers) == 0) || servers[0] == nil {
+		return nil
+	}
+
+	bodyParams := make(map[string]interface{}, 0)
+	for _, v := range servers {
+		item := v.(map[string]interface{})
+		bodyParams = map[string]interface{}{
+			"id":   item["id"],
+			"auth": buildServerAuthBodyParams(item["auth"].([]interface{})),
+			"port": utils.ValueIgnoreEmpty(item["port"]),
+		}
+	}
+
+	return bodyParams
+}
+
+func getKeypairDisassociateTask(client *golangsdk.ServiceClient, taskId string) (interface{}, error) {
+	var (
+		httpUrl = "v3/{project_id}/tasks/{task_id}"
+		getOpt  = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		}
+	)
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{task_id}", taskId)
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return getResp, fmt.Errorf("error retrieving KMS keypair disassociate task: %s", err)
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+func taskStatusRefreshFunc(taskId string, client *golangsdk.ServiceClient) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		getTaskBody, err := getKeypairDisassociateTask(client, taskId)
+		if err != nil {
+			return getTaskBody, "ERROR", err
+		}
+
+		taskStatus := utils.PathSearch("task_status", getTaskBody, "").(string)
+		if taskStatus == "SUCCESS_UNBIND" {
+			return getTaskBody, "COMPLETED", nil
+		}
+
+		if taskStatus == "FAILED_UNBIND" {
+			return getTaskBody, "ERROR", fmt.Errorf("unexpect status (%s)", taskStatus)
+		}
+
+		return getTaskBody, "PENDING", nil
+	}
+}
+
+func waitForKeypairDisassociateStatusCompleted(ctx context.Context, client *golangsdk.ServiceClient, taskId string,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      taskStatusRefreshFunc(taskId, client),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 20 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+
+	return err
+}
+
+func resourceKmsKeypairDisassociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/keypairs/disassociate"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildKeypairDisassociateBodyParams(d)),
+	}
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error disassociating the KMS keypair from ECS: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	taskId := utils.PathSearch("task_id", respBody, "").(string)
+	if taskId == "" {
+		return diag.Errorf("unable to find KMS task ID from API response")
+	}
+	d.SetId(taskId)
+
+	err = waitForKeypairDisassociateStatusCompleted(ctx, client, taskId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for the task (%s) completed: %s", taskId, err)
+	}
+
+	return nil
+}
+
+func resourceKmsKeypairDisassociateRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKmsKeypairDisassociateUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKmsKeypairDisassociateDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to disassociate a SSH keypair to a specified ECS.
+Deleting this resource will not change the current SSH keypair, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new one-time resource and names huaweicloud_kms_keypair_disassociate.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccKeypairsDisassociate_basic -timeout 360m -parallel 10
=== RUN   TestAccKeypairsDisassociate_basic
--- PASS: TestAccKeypairsDisassociate_basic (20.03s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew
```
![image](https://github.com/user-attachments/assets/579aa04e-6b09-4e99-b516-9d6fd9e2afb3)

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
