### PR TITLE
feat(lts/transfer): the resource supports new fields

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -557,6 +557,9 @@ var (
 	HW_LTS_CLUSTER_ID_ANOTHER     = os.Getenv("HW_LTS_CLUSTER_ID_ANOTHER")
 	HW_LTS_CLUSTER_NAME_ANOTHER   = os.Getenv("HW_LTS_CLUSTER_NAME_ANOTHER")
 	HW_LTS_ALARM_ACTION_RULE_NAME = os.Getenv("HW_LTS_ALARM_ACTION_RULE_NAME")
+	// When registering Kafka using the huaweicloud_lts_register_kafka_instance resource, the interface may time out.
+	// Therefore, use HW_LTS_REGISTERED_KAFKA_INSTANCE_ID instead.
+	HW_LTS_REGISTERED_KAFKA_INSTANCE_ID = os.Getenv("HW_LTS_REGISTERED_KAFKA_INSTANCE_ID")
 
 	HW_VPCEP_SERVICE_ID = os.Getenv("HW_VPCEP_SERVICE_ID")
 
@@ -2238,6 +2241,13 @@ func TestAccPreCheckLtsStructConfigCustom(t *testing.T) {
 func TestAccPreCheckLtsAlarmActionRuleName(t *testing.T) {
 	if HW_LTS_ALARM_ACTION_RULE_NAME == "" {
 		t.Skip("HW_LTS_ALARM_ACTION_RULE_NAME must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckLtsDmsTransfer(t *testing.T) {
+	if HW_LTS_REGISTERED_KAFKA_INSTANCE_ID == "" {
+		t.Skip("HW_LTS_REGISTERED_KAFKA_INSTANCE_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/lts/data_source_huaweicloud_lts_transfers.go
+++ b/huaweicloud/services/lts/data_source_huaweicloud_lts_transfers.go
@@ -348,7 +348,35 @@ func flattenTransfersElemLogTransferInfo(transferInfo interface{}) []interface{}
 			"log_storage_format":  utils.PathSearch("log_storage_format", transferInfo, nil),
 			"log_transfer_status": utils.PathSearch("log_transfer_status", transferInfo, nil),
 			"log_agency_transfer": flattenLogTransferInfoLogAgency(transferInfo),
-			"log_transfer_detail": flattenLogTransferInfoLogTransferDetail(transferInfo),
+			"log_transfer_detail": flattenDataLogTransferInfoLogTransferDetail(transferInfo),
+		},
+	}
+}
+
+func flattenDataLogTransferInfoLogTransferDetail(resp interface{}) []interface{} {
+	logTransferDetail := utils.PathSearch("log_transfer_detail", resp, nil)
+	if logTransferDetail == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"obs_period":           utils.PathSearch("obs_period", logTransferDetail, nil),
+			"obs_period_unit":      utils.PathSearch("obs_period_unit", logTransferDetail, nil),
+			"obs_bucket_name":      utils.PathSearch("obs_bucket_name", logTransferDetail, nil),
+			"obs_transfer_path":    utils.PathSearch("obs_transfer_path", logTransferDetail, nil),
+			"obs_dir_prefix_name":  utils.PathSearch("obs_dir_pre_fix_name", logTransferDetail, nil),
+			"obs_prefix_name":      utils.PathSearch("obs_prefix_name", logTransferDetail, nil),
+			"obs_eps_id":           utils.PathSearch("obs_eps_id", logTransferDetail, nil),
+			"obs_encrypted_enable": utils.PathSearch("obs_encrypted_enable", logTransferDetail, nil),
+			"obs_encrypted_id":     utils.PathSearch("obs_encrypted_id", logTransferDetail, nil),
+			"obs_time_zone":        utils.PathSearch("obs_time_zone", logTransferDetail, nil),
+			"obs_time_zone_id":     utils.PathSearch("obs_time_zone_id", logTransferDetail, nil),
+			"dis_id":               utils.PathSearch("dis_id", logTransferDetail, nil),
+			"dis_name":             utils.PathSearch("dis_name", logTransferDetail, nil),
+			"kafka_id":             utils.PathSearch("kafka_id", logTransferDetail, nil),
+			"kafka_topic":          utils.PathSearch("kafka_topic", logTransferDetail, nil),
+			"delivery_tags":        utils.PathSearch("tags", logTransferDetail, nil),
 		},
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports new fields:
+ new parameters in `log_transfer_info.log_transfer_detail` structure: `invalid_field_value`, `lts_tags`, `stream_tags`, and `struct_fields`.
+ new attribute: `created_at`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lts -f TestAccTransfer_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccTransfer_ -timeout 360m -parallel 10
=== RUN   TestAccTransfer_basic
=== PAUSE TestAccTransfer_basic
=== RUN   TestAccTransfer_dis
=== PAUSE TestAccTransfer_dis
=== RUN   TestAccTransfer_agency
=== PAUSE TestAccTransfer_agency
=== RUN   TestAccTransfer_dms
=== PAUSE TestAccTransfer_dms
=== CONT  TestAccTransfer_basic
=== CONT  TestAccTransfer_agency
=== CONT  TestAccTransfer_dms
=== CONT  TestAccTransfer_dis
--- PASS: TestAccTransfer_dis (60.76s)
--- PASS: TestAccTransfer_dms (61.27s)
--- PASS: TestAccTransfer_basic (64.02s)
--- PASS: TestAccTransfer_agency (100.48s)
PASS
coverage: 10.5% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       100.764s        coverage: 10.5% of statements in ./huaweicloud/services/lts
```
```
./scripts/coverage.sh -o lts -f TestAccDatasourceTransfers_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccDatasourceTransfers_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourceTransfers_basic
=== PAUSE TestAccDatasourceTransfers_basic
=== CONT  TestAccDatasourceTransfers_basic
--- PASS: TestAccDatasourceTransfers_basic (31.14s)
PASS
coverage: 10.8% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       31.236s coverage: 10.8% of statements in ./huaweicloud/services/lts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
