### PR TITLE
feat(cbr): new resource to restore cbr backup

### DIFF
--- a/docs/resources/cbr_restore.md
+++ b/docs/resources/cbr_restore.md
@@ -1,0 +1,119 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbr_restore"
+description: |-
+  Using this resource to restore a CBR backup within HuaweiCloud.
+---
+
+# huaweicloud_cbr_restore
+
+Using this resource to restore a CBR backup within HuaweiCloud.
+
+-> This resource is only a one-time action resource to restore a CBR backup. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+-> For backup and recovery constraints and limitations, please refer to the following documents:
+<br/>1. [Restoring from a Cloud Server Backup](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0032.html)
+<br/>2. [Restoring from a Cloud Disk Backup](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0033.html)
+<br/>3. [Restoring from a Desktop Backup](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0110.html)
+
+## Example Usage
+
+## Restoring an ECS backup
+
+```hcl
+variable "ecs_backup_id" {}
+variable "ecs_server_id" {}
+variable "evs_backup_id" {}
+variable "evs_volume_id" {}
+
+resource "huaweicloud_cbr_restore" "test" {
+  backup_id = var.ecs_backup_id
+  server_id = var.ecs_server_id
+  power_on  = true
+
+  mappings {
+    backup_id = var.evs_backup_id
+    volume_id = var.evs_volume_id
+  }
+}
+```
+
+## Restoring an EVS backup
+
+```hcl
+variable "evs_backup_id" {}
+variable "evs_volume_id" {}
+
+resource "huaweicloud_cbr_restore" "test" {
+  backup_id = var.evs_backup_id
+  volume_id = var.evs_volume_id
+}
+```
+
+## Restoring a Workspace backup
+
+```hcl
+variable "workspace_backup_id" {}
+variable "workspace_resource_id" {}
+
+resource "huaweicloud_cbr_restore" "test" {
+  backup_id   = var.workspace_backup_id
+  resource_id = var.workspace_resource_id
+  power_on    = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create new resource.
+
+* `backup_id` - (Required, String, NonUpdatable) Specifies the backup ID.
+
+* `mappings` - (Optional, List, NonUpdatable) Specifies the restored mapping relationship. This parameter is mandatory for
+  VM restoration and optional for disk restoration.
+  You can obtain the disk information through data source `huaweicloud_cbr_backup`.
+
+  The [mappings](#restore_mappings_struct) structure is documented below.
+
+* `power_on` - (Optional, Bool, NonUpdatable) Whether the server is powered on after restoration. Defaults to **false**.
+
+* `server_id` - (Optional, String, NonUpdatable) Specifies the ID of the target VM to be restored. This parameter is
+  mandatory for VM restoration.
+
+* `volume_id` - (Optional, String, NonUpdatable) Specifies the ID of the target disk to be restored. This parameter is
+  mandatory for disk restoration.
+
+* `resource_id` - (Optional, String, NonUpdatable) Specifies the ID of the resource to be restored.
+
+* `details` - (Optional, List, NonUpdatable) Specifies the restoration details.
+
+  The [details](#restore_details_struct) structure is documented below.
+
+<a name="restore_details_struct"></a>
+The `details` block supports:
+
+* `destination_path` - (Required, String, NonUpdatable) Specifies the destination path.
+
+<a name="restore_mappings_struct"></a>
+The `mappings` block supports:
+
+* `backup_id` - (Required, String, NonUpdatable) Specifies the disk backup ID.
+
+* `volume_id` - (Required, String, NonUpdatable) Specifies the ID of the disk to which data is restored.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (also `backup_id`).
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1662,6 +1662,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbr_organization_policy":   cbr.ResourceOrganizationPolicy(),
 			"huaweicloud_cbr_policy":                cbr.ResourcePolicy(),
 			"huaweicloud_cbr_vault":                 cbr.ResourceVault(),
+			"huaweicloud_cbr_restore":               cbr.ResourceRestore(),
 
 			"huaweicloud_cbh_instance":                   cbh.ResourceCBHInstance(),
 			"huaweicloud_cbh_ha_instance":                cbh.ResourceCBHHAInstance(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -56,6 +56,16 @@ var (
 	HW_IAM_V5                        = os.Getenv("HW_IAM_V5")
 	HW_RUNNER_PUBLIC_IP              = os.Getenv("HW_RUNNER_PUBLIC_IP")
 
+	// CBR environment
+	HW_CBR_ECS_BACKUP_ID         = os.Getenv("HW_CBR_ECS_BACKUP_ID")         // The ECS backup ID.
+	HW_CBR_ECS_SERVER_ID         = os.Getenv("HW_CBR_ECS_SERVER_ID")         // The ECS ID using to create backup.
+	HW_CBR_EVS_BACKUP_ID_FOR_ECS = os.Getenv("HW_CBR_EVS_BACKUP_ID_FOR_ECS") // The EVS backup ID using for ECS.
+	HW_CBR_EVS_VOLUME_ID_FOR_ECS = os.Getenv("HW_CBR_EVS_VOLUME_ID_FOR_ECS") // The EVS volume ID using for ECS.
+	HW_CBR_EVS_BACKUP_ID         = os.Getenv("HW_CBR_EVS_BACKUP_ID")         // The EVS back ID.
+	HW_CBR_EVS_VOLUME_ID         = os.Getenv("HW_CBR_EVS_VOLUME_ID")         // The EVS volume ID using to create backup.
+	HW_CBR_WORKSPACE_BACKUP_ID   = os.Getenv("HW_CBR_WORKSPACE_BACKUP_ID")   // The Workspace backup ID.
+	HW_CBR_WORKSPACE_RESOURCE_ID = os.Getenv("HW_CBR_WORKSPACE_RESOURCE_ID") // The resource ID using to create backup.
+
 	HW_VPC_BANDWIDTH_ADDON_PACKAGE_ENABLED = os.Getenv("HW_VPC_BANDWIDTH_ADDON_PACKAGE_ENABLED")
 	HW_VPC_EIP_POOL_ENABLED                = os.Getenv("HW_VPC_EIP_POOL_ENABLED")
 
@@ -3083,6 +3093,36 @@ func TestAccPreCheckVpcEipPoolEnabled(t *testing.T) {
 func TestAccPreCheckVpcEipBandwidthAddOnPackageEnabled(t *testing.T) {
 	if HW_VPC_BANDWIDTH_ADDON_PACKAGE_ENABLED == "" {
 		t.Skip("HW_VPC_BANDWIDTH_ADDON_PACKAGE_ENABLED must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckECSBackupRestore(t *testing.T) {
+	targetEnvValues := []string{
+		HW_CBR_ECS_BACKUP_ID,
+		HW_CBR_ECS_SERVER_ID,
+		HW_CBR_EVS_BACKUP_ID_FOR_ECS,
+		HW_CBR_EVS_VOLUME_ID_FOR_ECS,
+	}
+
+	for _, v := range targetEnvValues {
+		if v == "" {
+			t.Skipf("%s must be set for the acceptance test", v)
+		}
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckEVSBackupRestore(t *testing.T) {
+	if HW_CBR_EVS_BACKUP_ID == "" || HW_CBR_EVS_VOLUME_ID == "" {
+		t.Skip("HW_CBR_EVS_BACKUP_ID and HW_CBR_EVS_VOLUME_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckWorkspaceBackupRestore(t *testing.T) {
+	if HW_CBR_WORKSPACE_BACKUP_ID == "" || HW_CBR_WORKSPACE_RESOURCE_ID == "" {
+		t.Skip("HW_CBR_WORKSPACE_BACKUP_ID and HW_CBR_WORKSPACE_RESOURCE_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_restore_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_restore_test.go
@@ -1,0 +1,99 @@
+package cbr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceRestore_ECS_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare environment ID using to restore ECS backup.
+			acceptance.TestAccPreCheckECSBackupRestore(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceECSRestore_basic(),
+			},
+		},
+	})
+}
+
+func testResourceECSRestore_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cbr_restore" "test" {
+  backup_id = "%[1]s"
+  server_id = "%[2]s"
+  power_on  = true
+
+  mappings {
+    backup_id = "%[3]s"
+    volume_id = "%[4]s"
+  }
+}
+`, acceptance.HW_CBR_ECS_BACKUP_ID,
+		acceptance.HW_CBR_ECS_SERVER_ID,
+		acceptance.HW_CBR_EVS_BACKUP_ID_FOR_ECS,
+		acceptance.HW_CBR_EVS_VOLUME_ID_FOR_ECS,
+	)
+}
+
+func TestAccResourceRestore_EVS_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare environment ID using to restore EVS backup.
+			acceptance.TestAccPreCheckEVSBackupRestore(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceEVSRestore_basic(),
+			},
+		},
+	})
+}
+
+func testResourceEVSRestore_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cbr_restore" "test" {
+  backup_id = "%[1]s"
+  volume_id = "%[2]s"
+}
+`, acceptance.HW_CBR_EVS_BACKUP_ID, acceptance.HW_CBR_EVS_VOLUME_ID)
+}
+
+func TestAccResourceRestore_Workspace_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare environment ID using to restore Workspace backup.
+			acceptance.TestAccPreCheckWorkspaceBackupRestore(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceWorkspaceRestore_basic(),
+			},
+		},
+	})
+}
+
+func testResourceWorkspaceRestore_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cbr_restore" "test" {
+  backup_id   = "%[1]s"
+  resource_id = "%[2]s"
+  power_on    = true
+}
+`, acceptance.HW_CBR_WORKSPACE_BACKUP_ID, acceptance.HW_CBR_WORKSPACE_RESOURCE_ID)
+}

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_restore.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_restore.go
@@ -1,0 +1,291 @@
+package cbr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableRestoreParams = []string{
+	"backup_id",
+	"mappings",
+	"mappings.*.backup_id",
+	"mappings.*.volume_id",
+	"power_on",
+	"server_id",
+	"volume_id",
+	"resource_id",
+	"details",
+	"details.*.destination_path",
+}
+
+// @API CBR POST /v3/{project_id}/backups/{backup_id}/restore
+// @API CBR GET /v3/{project_id}/operation-logs/{operation_log_id}
+func ResourceRestore() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRestoreCreate,
+		ReadContext:   resourceRestoreRead,
+		UpdateContext: resourceRestoreUpdate,
+		DeleteContext: resourceRestoreDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableRestoreParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level
+region will be used.`,
+			},
+			"backup_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the backup ID.`,
+			},
+			"mappings": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `Specifies the restored mapping relationship.`,
+				Elem:        mappingsSchema(),
+			},
+			"power_on": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether the server is powered on after restoration.`,
+			},
+			"server_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the ID of the target VM to be restored.`,
+			},
+			"volume_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the ID of the target disk to be restored.`,
+			},
+			"resource_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the ID of the resource to be restored.`,
+			},
+			"details": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: `Specifies the restoration details.`,
+				Elem:        detailsSchema(),
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func mappingsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"backup_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the disk backup ID.`,
+			},
+			"volume_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the disk to which data is restored.`,
+			},
+		},
+	}
+}
+
+func detailsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"destination_path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the destination path.`,
+			},
+		},
+	}
+}
+
+func buildRestoreCreateMappingsBodyParams(d *schema.ResourceData) []map[string]interface{} {
+	rawArray := d.Get("mappings").([]interface{})
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rst = append(rst, map[string]interface{}{
+			"backup_id": utils.PathSearch("backup_id", v, nil),
+			"volume_id": utils.PathSearch("volume_id", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func buildRestoreCreateDetailsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	rawArray := d.Get("details").([]interface{})
+	if len(rawArray) != 1 {
+		return nil
+	}
+
+	rawMap := rawArray[0].(map[string]interface{})
+	return map[string]interface{}{
+		"destination_path": rawMap["destination_path"],
+	}
+}
+
+func buildRestoreCreateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	restoreMap := map[string]interface{}{
+		"mappings":    buildRestoreCreateMappingsBodyParams(d),
+		"power_on":    d.Get("power_on"),
+		"server_id":   utils.ValueIgnoreEmpty(d.Get("server_id")),
+		"volume_id":   utils.ValueIgnoreEmpty(d.Get("volume_id")),
+		"resource_id": utils.ValueIgnoreEmpty(d.Get("resource_id")),
+		"details":     buildRestoreCreateDetailsBodyParams(d),
+	}
+
+	return map[string]interface{}{
+		"restore": restoreMap,
+	}
+}
+
+func queryRestoreTask(client *golangsdk.ServiceClient, jobID string) (interface{}, error) {
+	requestPath := client.Endpoint + "v3/{project_id}/operation-logs/{operation_log_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{operation_log_id}", jobID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving CBR restore task: %s", err)
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func waitingForRestoreTaskSuccess(ctx context.Context, client *golangsdk.ServiceClient, timeout time.Duration,
+	jobID string) error {
+	unexpectedStatus := []string{"failed", "timeout"}
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			respBody, err := queryRestoreTask(client, jobID)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			status := utils.PathSearch("operation_log.status", respBody, "").(string)
+			if status == "" {
+				return nil, "ERROR", errors.New("status is not found in API response")
+			}
+
+			if status == "success" {
+				return respBody, "COMPLETED", nil
+			}
+
+			if utils.StrSliceContains(unexpectedStatus, status) {
+				return respBody, status, nil
+			}
+			return respBody, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceRestoreCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		httpUrl  = "v3/{project_id}/backups/{backup_id}/restore"
+		product  = "cbr"
+		backupID = d.Get("backup_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBR client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{backup_id}", backupID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildRestoreCreateBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error recovering CBR backup: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobID := utils.PathSearch("job_id", respBody, "").(string)
+	if jobID == "" {
+		return diag.Errorf("error recovering CBR backup: Job ID is not found in API response")
+	}
+
+	d.SetId(backupID)
+	if err := waitingForRestoreTaskSuccess(ctx, client, d.Timeout(schema.TimeoutCreate), jobID); err != nil {
+		return diag.Errorf("error waiting for CBR restore backup (%s) to success: %s", d.Id(), err)
+	}
+
+	return resourceRestoreRead(ctx, d, meta)
+}
+
+func resourceRestoreRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceRestoreUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceRestoreDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to restore a CBR backup. Deleting this 
+resource will not change the current restore backup result, but will only remove the resource information from the 
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to restore CBR backup.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cbr -f TestAccResourceRestore_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccResourceRestore_ -timeout 360m -parallel 10
=== RUN   TestAccResourceRestore_ECS_basic
=== PAUSE TestAccResourceRestore_ECS_basic
=== RUN   TestAccResourceRestore_EVS_basic
=== PAUSE TestAccResourceRestore_EVS_basic
=== RUN   TestAccResourceRestore_Workspace_basic
=== PAUSE TestAccResourceRestore_Workspace_basic
=== CONT  TestAccResourceRestore_ECS_basic
=== CONT  TestAccResourceRestore_Workspace_basic
=== CONT  TestAccResourceRestore_EVS_basic
--- PASS: TestAccResourceRestore_EVS_basic (49.68s)
--- PASS: TestAccResourceRestore_ECS_basic (80.14s)
--- PASS: TestAccResourceRestore_Workspace_basic (91.12s)
PASS
coverage: 6.3% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       91.220s coverage: 6.3% of statements in ./huaweicloud/services/cbr
```
![image](https://github.com/user-attachments/assets/71ff3234-e9e7-4abf-ae83-7d84616c12d8)


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
