### PR TITLE
feat(smn): add new parameter for subscription extension

### DIFF
--- a/docs/resources/smn_subscription.md
+++ b/docs/resources/smn_subscription.md
@@ -30,6 +30,19 @@ resource "huaweicloud_smn_subscription" "subscription_2" {
   protocol  = "sms"
   remark    = "O&M"
 }
+
+resource "huaweicloud_smn_subscription" "subscription_3" {
+  topic_urn = huaweicloud_smn_topic.topic_1.id
+  endpoint  = "https://example.com/notification"
+  protocol  = "https"
+  remark    = "API webhook"
+  
+  extension {
+    header = {
+      "X-Custom-Test" = "test"
+    }
+  }
+}
 ```
 
 ## Argument Reference
@@ -88,6 +101,23 @@ The `extension` block supports:
   to **feishu** or **dingding**, this field or `keyword` must be specified. The key configurations must be
   the same as those on the Lark or DingTalk client. For example, if only key is configured on the Lark client,
   enter the key field obtained from the Lark client. If only keyword is configured on the Lark client, skip this field.
+  Changing this parameter will create a new resource.
+
+* `header` - (Optional, Map, ForceNew) Specifies the HTTP/HTTPS headers to be added to the requests when the
+  message is delivered via HTTP/HTTPS. This field is used when `protocol` is set to **http** or **https**.
+  The following requirements apply to the header keys and values:
+  + Header keys must:
+    - Contain only letters, numbers, and hyphens (`[A-Za-z0-9-]`)
+    - Not end with a hyphen
+    - Not contain consecutive hyphens
+    - Start with "x-" (e.g., "x-abc-cba", "x-abc")
+    - Not start with "x-smn"
+    - Be case-insensitive (e.g., "X-Custom" and "x-custom" are considered the same)
+    - Not be duplicated
+  + Maximum of 10 key-value pairs allowed
+  + Total length of all keys and values combined must not exceed 1024 characters
+  + Values must only contain ASCII characters (no Chinese or other Unicode characters, spaces are allowed)
+
   Changing this parameter will create a new resource.
 
 ## Attribute Reference

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20250529023604-407526f9efac
+	github.com/chnsz/golangsdk v0.0.0-20250603120404-660228dbb088
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20250529023604-407526f9efac h1:x+NrnhVCl1742NgN9xuNPzGiRlBmHkiqP4CHcFma7WQ=
-github.com/chnsz/golangsdk v0.0.0-20250529023604-407526f9efac/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
+github.com/chnsz/golangsdk v0.0.0-20250603120404-660228dbb088 h1:L+kPdUxKt/+hkolzkBv9SD7Y7YkmR3i5NLeChGR6CUc=
+github.com/chnsz/golangsdk v0.0.0-20250603120404-660228dbb088/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_subscription_test.go
+++ b/huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_subscription_test.go
@@ -89,6 +89,9 @@ func TestAccSMNV2Subscription_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName1, "endpoint", "mailtest@gmail.com"),
 					resource.TestCheckResourceAttr(resourceName2, "endpoint", "13600000000"),
 					resource.TestCheckResourceAttr(resourceName3, "endpoint", "https://test.com"),
+					resource.TestCheckResourceAttr(resourceName3, "extension.#", "1"),
+					resource.TestCheckResourceAttr(resourceName3, "extension.0.header.%", "1"),
+					resource.TestCheckResourceAttr(resourceName3, "extension.0.header.X-Custom-Header", "test"),
 					resource.TestCheckResourceAttrPair(
 						resourceName4, "endpoint", "huaweicloud_fgs_function.test", "urn"),
 				),
@@ -172,6 +175,12 @@ resource "huaweicloud_smn_subscription" "subscription_3" {
   endpoint  = "https://test.com"
   protocol  = "https"
   remark    = "O&M"
+
+  extension {
+    header = {
+      "X-Custom-Header" = "test"
+    }
+  }
 }
 
 resource "huaweicloud_smn_subscription" "subscription_4" {

--- a/huaweicloud/services/smn/resource_huaweicloud_smn_subscription.go
+++ b/huaweicloud/services/smn/resource_huaweicloud_smn_subscription.go
@@ -84,6 +84,12 @@ func ResourceSubscription() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
+						"header": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 					},
 				},
 			},
@@ -162,6 +168,7 @@ func buildExtensionOpts(extensionRaw []interface{}) *subscriptions.ExtensionSpec
 		ClientSecret: extension["client_secret"].(string),
 		Keyword:      extension["keyword"].(string),
 		SignSecret:   extension["sign_secret"].(string),
+		Header:       extension["header"].(map[string]interface{}),
 	}
 
 	return &res

--- a/vendor/github.com/chnsz/golangsdk/openstack/smn/v2/subscriptions/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/smn/v2/subscriptions/requests.go
@@ -32,6 +32,21 @@ type ExtensionSpec struct {
 	ClientSecret string `json:"client_secret,omitempty"`
 	Keyword      string `json:"keyword,omitempty"`
 	SignSecret   string `json:"sign_secret,omitempty"`
+	// The HTTP/HTTPS headers to be added to the requests when the message is delivered via HTTP/HTTPS.
+	// This field is used when `protocol` is set to **http** or **https**.
+	// The following requirements apply to the header keys and values:
+	// + Header keys must:
+	//   - Contain only letters, numbers, and hyphens (`[A-Za-z0-9-]`)
+	//   - Not end with a hyphen
+	//   - Not contain consecutive hyphens
+	//   - Start with "x-" (e.g., "x-abc-cba", "x-abc")
+	//   - Not start with "x-smn"
+	//   - Be case-insensitive (e.g., "X-Custom" and "x-custom" are considered the same)
+	//   - Not be duplicated
+	// + Maximum of 10 key-value pairs allowed
+	// + Total length of all keys and values combined must not exceed 1024 characters
+	// + Values must only contain ASCII characters (no Chinese or other Unicode characters, spaces are allowed)
+	Header map[string]interface{} `json:"header,omitempty"`
 }
 
 func (ops CreateOps) ToSubscriptionCreateMap() (map[string]interface{}, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20250529023604-407526f9efac
+# github.com/chnsz/golangsdk v0.0.0-20250603120404-660228dbb088
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add new parameter 'header' for subscription extension (this parameter has no setting logic).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new parameter for subscription extension.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o smn -f TestAccSMNV2Subscription_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/smn" -v -coverprofile="./huaweicloud/services/acceptance/smn/smn_coverage.cov" -coverpkg="./huaweicloud/services/smn" -run TestAccSMNV2Subscription_basic -timeout 360m -parallel 10
=== RUN   TestAccSMNV2Subscription_basic
=== PAUSE TestAccSMNV2Subscription_basic
=== CONT  TestAccSMNV2Subscription_basic
--- PASS: TestAccSMNV2Subscription_basic (29.41s)
PASS
coverage: 16.2% of statements in ./huaweicloud/services/smn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/smn       29.500s coverage: 16.2% of statements in ./huaweicloud/services/smn
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
