### PR TITLE
fix(as): fix resources list query pagination not working

### DIFF
--- a/huaweicloud/services/as/data_source_huaweicloud_as_groups.go
+++ b/huaweicloud/services/as/data_source_huaweicloud_as_groups.go
@@ -15,6 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API AS GET /autoscaling-api/v1/{project_id}/scaling_group_tag/{id}/tags
@@ -335,7 +336,7 @@ func flattenDataSourceSecurityGroups(sgs []groups.SecurityGroup) []map[string]in
 // getDataSourceInstancesIDs using to collecting total instance IDs in AS group.
 // When the query API reports an error, only the failure log is printed and the program is not terminated.
 func getDataSourceInstancesIDs(asClient *golangsdk.ServiceClient, groupID string) []string {
-	allIns, err := getInstancesInGroup(asClient, groupID, nil)
+	allIns, err := getAllInstancesInGroup(asClient, groupID)
 	if err != nil {
 		log.Printf("[WARN] Error fetching instances in AS group (%s): %s", groupID, err)
 		return nil
@@ -343,8 +344,8 @@ func getDataSourceInstancesIDs(asClient *golangsdk.ServiceClient, groupID string
 
 	allIDs := make([]string, 0, len(allIns))
 	for _, ins := range allIns {
-		if ins.ID != "" {
-			allIDs = append(allIDs, ins.ID)
+		if instanceID := utils.PathSearch("instance_id", ins, "").(string); instanceID != "" {
+			allIDs = append(allIDs, instanceID)
 		}
 	}
 

--- a/huaweicloud/services/as/resource_huaweicloud_as_group.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_group.go
@@ -388,17 +388,6 @@ func expandGroupsTags(tagMap map[string]interface{}) []tags.ResourceTag {
 	return tagList
 }
 
-// The pagination of this query method is not effective, and other resources using this method need to be fixed.
-func getInstancesInGroup(asClient *golangsdk.ServiceClient, groupID string,
-	opts instances.ListOptsBuilder) ([]instances.Instance, error) {
-	var insList []instances.Instance
-	page, err := instances.List(asClient, groupID, opts).AllPages()
-	if err != nil {
-		return insList, fmt.Errorf("error getting instances in AS group %s: %s", groupID, err)
-	}
-	return page.(instances.InstancePage).Extract()
-}
-
 func getInstancesIDs(allInstances []interface{}) []string {
 	var allIDs = make([]string, 0, len(allInstances))
 	for _, instance := range allInstances {

--- a/huaweicloud/services/as/resource_huaweicloud_as_instance_attach.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_instance_attach.go
@@ -352,18 +352,18 @@ func waitASGroupInstanceDeleted(ctx context.Context, client *golangsdk.ServiceCl
 
 func refreshInstancesStatus(asClient *golangsdk.ServiceClient, groupID, instanceID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		allIns, err := getInstancesInGroup(asClient, groupID, nil)
+		allIns, err := getAllInstancesInGroup(asClient, groupID)
 		if err != nil {
 			return nil, "ERROR", err
 		}
 
 		for _, ins := range allIns {
-			if instanceID != "" && ins.ID != instanceID {
+			if instanceID != "" && utils.PathSearch("instance_id", ins, "").(string) != instanceID {
 				continue
 			}
 
 			// the status may be PENDING, PENDING_WAIT, REMOVING, REMOVING_WAIT, ENTERING_STANDBY
-			if strings.Contains(ins.LifeCycleStatus, "ING") {
+			if strings.Contains(utils.PathSearch("life_cycle_state", ins, "").(string), "ING") {
 				return allIns, "PENDING", nil
 			}
 		}
@@ -374,13 +374,13 @@ func refreshInstancesStatus(asClient *golangsdk.ServiceClient, groupID, instance
 
 func checkInstanceDeleted(asClient *golangsdk.ServiceClient, groupID, instanceID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		allIns, err := getInstancesInGroup(asClient, groupID, nil)
+		allIns, err := getAllInstancesInGroup(asClient, groupID)
 		if err != nil {
 			return nil, "ERROR", err
 		}
 
 		for _, ins := range allIns {
-			if ins.ID == instanceID {
+			if utils.PathSearch("instance_id", ins, "").(string) == instanceID {
 				return allIns, "REMOVING", nil
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix `as_groups` and `as_instance_attach` resources list query pagination not working

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

### `as_instance_attach` Test
```
$ make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASInstanceAttach_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASInstanceAttach_basic -timeout 360m -parallel 4
=== RUN   TestAccASInstanceAttach_basic
=== PAUSE TestAccASInstanceAttach_basic
=== CONT  TestAccASInstanceAttach_basic
--- PASS: TestAccASInstanceAttach_basic (344.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        344.851s
```

### `as_groups` Test
```
$ export HW_AS_SCALING_GROUP_ID=xxxxxxxxxxxx
$ make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccDataSourceASGroup_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccDataSourceASGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceASGroup_basic
=== PAUSE TestAccDataSourceASGroup_basic
=== CONT  TestAccDataSourceASGroup_basic
--- PASS: TestAccDataSourceASGroup_basic (18.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        18.561s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
