### PR TITLE
feat(IAM): support filter by display mode for permissions datasource

### DIFF
--- a/docs/data-sources/identity_permissions.md
+++ b/docs/data-sources/identity_permissions.md
@@ -46,6 +46,14 @@ data "huaweicloud_identity_permissions" "custom" {
 }
 ```
 
+### All Project Level System Defined Permissions
+
+```hcl
+data "huaweicloud_identity_permissions" "project_all" {
+  scope_type = "project"
+}
+```
+
 ## Argument Reference
 
 * `type` - (Optional, String) Specifies the type of the permission. The default value is **system**, and valid values are
@@ -55,6 +63,18 @@ data "huaweicloud_identity_permissions" "custom" {
   + **system-policy**: The system-defined policies.
   + **system-role**: The system-defined roles.
   + **custom**: The custom policies.
+
+* `scope_type` - (Optional, String) Specifies the mode of the permission. Valid values are
+  as follows:
+  + **domain**: All permissions of the AA and AX levels.
+  + **project**: All permissions of the AA and XA levels
+  + **all**: Permissions of the AA, AX, and XA permissions.
+
+  Note:
+  + **AX**: Account level.
+  + **XA**: Project level.
+  + **AA**: Both the account level and project level.
+  + **XX**: Neither the account level nor project level.
 
 * `catalog` - (Optional, String) Specifies the service catalog of the permission.
 

--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_permissions_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_permissions_test.go
@@ -28,6 +28,7 @@ func TestAccIdentityPermissionsDataSource_basic(t *testing.T) {
 					resource.TestCheckOutput("catalog_filter_is_useful", "true"),
 					resource.TestCheckOutput("type_filter_is_useful", "true"),
 					resource.TestCheckOutput("custom_filter_is_useful", "true"),
+					resource.TestCheckOutput("scope_type_filter_is_useful", "true"),
 				),
 			},
 		},
@@ -56,6 +57,11 @@ data "huaweicloud_identity_permissions" "custom" {
   type = "custom"
 }
 
+data "huaweicloud_identity_permissions" "by_scope_type" {
+  scope_type = "project"
+  name = "CCE FullAccess"
+}
+
 output "name_filter_is_useful" {
   value = alltrue([for v in data.huaweicloud_identity_permissions.by_name.permissions[*].name : v == "KMS Administrator"])
 }
@@ -70,6 +76,10 @@ output "type_filter_is_useful" {
 
 output "custom_filter_is_useful" {
   value = alltrue([for v in data.huaweicloud_identity_permissions.custom.permissions[*].catalog : v == "CUSTOMED"])
+}
+
+output "scope_type_filter_is_useful" {
+  value = alltrue([length(data.huaweicloud_identity_permissions.by_scope_type.permissions) == 1])
 }
 `
 }

--- a/huaweicloud/services/iam/data_source_huaweicloud_identity_permissions.go
+++ b/huaweicloud/services/iam/data_source_huaweicloud_identity_permissions.go
@@ -29,6 +29,10 @@ func DataSourceIdentityPermissions() *schema.Resource {
 				Default:      "system",
 				ValidateFunc: validation.StringInSlice([]string{"system", "system-role", "system-policy", "custom"}, false),
 			},
+			"scope_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"catalog": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -90,6 +94,7 @@ func dataSourceIdentityPermissionsRead(_ context.Context, d *schema.ResourceData
 	listOpts := roles.ListOpts{
 		DisplayName: d.Get("name").(string),
 		Catalog:     d.Get("catalog").(string),
+		Type:        d.Get("scope_type").(string),
 	}
 
 	roleType := d.Get("type").(string)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support filter by display mode for permissions datasource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
support filter by display mode for permissions datasource

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/iam' TESTARGS='-run TestAccIdentityPermissionsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityPermissionsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityPermissionsDataSource_basic
=== PAUSE TestAccIdentityPermissionsDataSource_basic
=== CONT  TestAccIdentityPermissionsDataSource_basic
--- PASS: TestAccIdentityPermissionsDataSource_basic (314.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       314.325s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
