### PR TITLE
chore(fgs): do not report error if lts log is enabled

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2033,7 +2033,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_function_event":             fgs.ResourceFunctionEvent(),
 			"huaweicloud_fgs_function_topping":           fgs.ResourceFunctionTopping(),
 			"huaweicloud_fgs_function_trigger":           fgs.ResourceFunctionTrigger(),
-			"huaweicloud_fgs_lts_log_enable":             fgs.ResourceFgsLtsLogEnable(),
+			"huaweicloud_fgs_lts_log_enable":             fgs.ResourceLtsLogEnable(),
 
 			"huaweicloud_ga_accelerator":    ga.ResourceAccelerator(),
 			"huaweicloud_ga_access_log":     ga.ResourceAccessLog(),

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_lts_log_enable_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_lts_log_enable_test.go
@@ -1,0 +1,28 @@
+package fgs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccLtsLogEnable_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLtsLogEnable_basic,
+			},
+		},
+	})
+}
+
+const testAccLtsLogEnable_basic string = `
+resource "huaweicloud_fgs_lts_log_enable" "test" {}
+`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
do not report error if lts log is enabled

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. check the error and skip if its report LTS log has been enabled
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFgsLtsLogEnable_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFgsLtsLogEnable_basic -timeout 360m -parallel 10
=== RUN   TestAccFgsLtsLogEnable_basic
=== PAUSE TestAccFgsLtsLogEnable_basic
=== CONT  TestAccFgsLtsLogEnable_basic
--- PASS: TestAccFgsLtsLogEnable_basic (12.02s)
PASS
coverage: 3.1% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       12.103s coverage: 3.1% of statements in ./huaweicloud/services/fgs
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
