### PR TITLE
feat(hss): add new data source to query hss policy groups

### DIFF
--- a/docs/data-sources/hss_policy_groups.md
+++ b/docs/data-sources/hss_policy_groups.md
@@ -1,0 +1,68 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_policy_groups"
+description: |-
+  Use this data source to get the list of HSS policy groups within HuaweiCloud.
+---
+
+# huaweicloud_hss_policy_groups
+
+Use this data source to get the list of HSS policy groups within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_policy_groups" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `group_id` - (Optional, String) Specifies the policy group ID.
+
+* `group_name` - (Optional, String) Specifies the policy group name.
+
+* `container_mode` - (Optional, Bool) Specifies whether to query the container edition policy.
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the resource belongs.
+  This parameter is valid only when the enterprise project function is enabled.
+  For enterprise users, if omitted, default enterprise project will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data_list` - The policy group list.
+  The [data_list](#policy_group_structure) structure is documented below.
+
+<a name="policy_group_structure"></a>
+The `data_list` block supports:
+
+* `group_id` - The policy group ID.
+
+* `group_name` - The policy group name.
+
+* `description` - The description of the policy group.
+
+* `deletable` - Whether a policy group can be deleted.
+
+* `host_num` - The number of associated servers.
+
+* `default_group` - Whether a policy group is the default policy group.
+
+* `support_os` - The supported OS. The valid value are **Linux** and **Windows**.
+
+* `support_version` - The supported versions. The valid values are as follows:
+  + **hss.version.basic**: Indicates policy group of the basic edition.
+  + **hss.version.advanced**: Indicates policy group of the professional edition.
+  + **hss.version.enterprise**: Indicates policy group of the enterprise edition.
+  + **hss.version.premium**: Indicates policy group of the premium edition.
+  + **hss.version.wtp**: Indicates policy group of the WTP edition.
+  + **hss.version.container.enterprise**: Indicates policy group of the container edition.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1008,6 +1008,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_hosts":                          hss.DataSourceHosts(),
 			"huaweicloud_hss_webtamper_hosts":                hss.DataSourceWebTamperHosts(),
 			"huaweicloud_hss_quotas":                         hss.DataSourceQuotas(),
+			"huaweicloud_hss_policy_groups":                  hss.DataSourcePolicyGroups(),
 
 			"huaweicloud_identity_permissions": iam.DataSourceIdentityPermissions(),
 			"huaweicloud_identity_role":        iam.DataSourceIdentityRole(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_policy_groups_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_policy_groups_test.go
@@ -1,0 +1,89 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourcePolicyGroups_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_policy_groups.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting a host ID with host protection enabled.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourcePolicyGroups_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.group_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.group_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.description"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.deletable"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.host_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.default_group"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.support_os"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.support_version"),
+
+					resource.TestCheckOutput("is_group_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_group_name_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourcePolicyGroups_basic string = `
+data "huaweicloud_hss_policy_groups" "test" {}
+
+# Filter using group id.
+locals {
+  group_id = data.huaweicloud_hss_policy_groups.test.data_list[0].group_id
+}
+
+data "huaweicloud_hss_policy_groups" "group_id_filter" {
+  group_id = local.group_id
+}
+
+output "is_group_id_filter_useful" {
+  value = length(data.huaweicloud_hss_policy_groups.group_id_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_policy_groups.group_id_filter.data_list[*].group_id : v == local.group_id]
+  )
+}
+
+# Filter using group name.
+locals {
+  group_name = data.huaweicloud_hss_policy_groups.test.data_list[0].group_name
+}
+
+data "huaweicloud_hss_policy_groups" "group_name_filter" {
+  group_name = local.group_name
+}
+
+output "is_group_name_filter_useful" {
+  value = length(data.huaweicloud_hss_policy_groups.group_name_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_policy_groups.group_name_filter.data_list[*].group_name : v == local.group_name]
+  )
+}
+
+# Filter using non group name.
+data "huaweicloud_hss_policy_groups" "not_found" {
+  group_name = "resource_not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_hss_policy_groups.not_found.data_list) == 0
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_policy_groups.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_policy_groups.go
@@ -1,0 +1,201 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/policy/groups
+func DataSourcePolicyGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePolicyGroupsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Specifies the region in which to query the resource.",
+			},
+			"group_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the policy group ID.",
+			},
+			"group_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the policy group name.",
+			},
+			// The filter parameter does not take effect.​
+			"container_mode": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Specifies whether to query the container edition policy.",
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the ID of the enterprise project to which the resource belongs.",
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"group_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The policy group ID.",
+						},
+						"group_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The policy group name.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The description of the policy group.",
+						},
+						"deletable": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether a policy group can be deleted.",
+						},
+						"host_num": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of associated servers.",
+						},
+						"default_group": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether a policy group is the default policy group.",
+						},
+						"support_os": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The supported OS.",
+						},
+						"support_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The supported versions.",
+						},
+					},
+				},
+				Description: "The policy group list.",
+			},
+		},
+	}
+}
+
+func dataSourcePolicyGroupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		mErr    *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient(product, cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v5/{project_id}/policy/groups"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildPolicyGroupsQueryParams(d, cfg)
+	allPolicyGroups := make([]interface{}, 0)
+	offset := 0
+
+	listPolicyGroupsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", currentPath, &listPolicyGroupsOpt)
+
+		if err != nil {
+			return diag.Errorf("error retrieving HSS policy groups: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		policyGroupsResp := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+
+		if len(policyGroupsResp) == 0 {
+			break
+		}
+		allPolicyGroups = append(allPolicyGroups, policyGroupsResp...)
+		offset += len(policyGroupsResp)
+	}
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("data_list", flattenPolicyGroups(allPolicyGroups)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildPolicyGroupsQueryParams(d *schema.ResourceData, cfg *config.Config) string {
+	epsId := cfg.GetEnterpriseProjectID(d)
+	queryParams := "?limit=10"
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("group_name"); ok {
+		queryParams = fmt.Sprintf("%s&group_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("container_mode"); ok {
+		queryParams = fmt.Sprintf("%s&container_mode=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("group_id"); ok {
+		queryParams = fmt.Sprintf("%s&group_id=%v", queryParams, v)
+	}
+	return queryParams
+}
+
+func flattenPolicyGroups(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"group_name":      utils.PathSearch("group_name", v, nil),
+			"group_id":        utils.PathSearch("group_id", v, nil),
+			"description":     utils.PathSearch("description", v, nil),
+			"deletable":       utils.PathSearch("deletable", v, nil),
+			"host_num":        utils.PathSearch("host_num", v, nil),
+			"default_group":   utils.PathSearch("default_group", v, nil),
+			"support_os":      utils.PathSearch("support_os", v, nil),
+			"support_version": utils.PathSearch("support_version", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Use this data source to get the list of HSS policy groups within HuaweiCloud.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/hss' TESTARGS='-run TestAccDataSourcePolicyGroups_basic'tance/hss' TESTARGS='-run TestAccDataSourcePolicyGroups_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourcePolicyGroups_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourcePolicyGroups_basic
=== PAUSE TestAccDataSourcePolicyGroups_basic
=== CONT  TestAccDataSourcePolicyGroups_basic
--- PASS: TestAccDataSourcePolicyGroups_basic (73.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       73.341s
```
![image](https://github.com/user-attachments/assets/841a3f4c-32be-4384-94e9-39fdcd4f2d9d)

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
