### PR TITLE
feat(eg): add new data source to query event streams

### DIFF
--- a/docs/data-sources/eg_event_streams.md
+++ b/docs/data-sources/eg_event_streams.md
@@ -1,0 +1,118 @@
+---
+subcategory: "EventGrid (EG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_eg_event_streams"
+description: |-
+  Use this data source to query EG event streams within HuaweiCloud.
+---
+
+# huaweicloud_eg_event_streams
+
+Use this data source to query EG event streams within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_eg_event_streams" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the event sources are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `event_streams` - List of event streams.  
+  The [event_streams](#eg_event_streams_attr) structure is documented below.
+
+<a name="eg_event_streams_attr"></a>
+The `streams` block supports:
+
+* `id` - The ID of the event stream.
+
+* `name` - The name of the event stream.
+
+* `status` - The status of the event stream.
+
+* `description` - The description of the event stream.
+
+* `created_time` - The creation time of the event stream, in RFC3339 format.
+
+* `updated_time` - The latest update time of the event stream, in RFC3339 format.
+
+* `source` - The event source configuration.  
+  The [source](#eg_event_streams_source) structure is documented below.
+
+* `sink` - The event sink configuration.  
+  The [sink](#eg_event_streams_sink) structure is documented below.
+
+* `rule_config` - The configuration of event rules.  
+  The [rule_config](#eg_event_streams_rule_config) structure is documented below.
+
+* `option` - The running configuration.  
+  The [option](#eg_event_streams_run_option) structure is documented below.
+
+<a name="eg_event_streams_source"></a>
+The `source` block supports:
+
+* `name` - The name of the event source type.
+
+* `source_kafka` - The configuration of Kafka event source, in JSON format.
+
+* `source_mobile_rocketmq` - The configuration of mobile cloud RocketMQ event source, in JSON format.
+
+* `source_community_rocketmq` - The configuration of community RocketMQ event source, in JSON format.  
+
+* `source_dms_rocketmq` - The configuration of DMS RocketMQ event source, in JSON format.
+
+<a name="eg_event_streams_sink"></a>
+The `sink` block supports:
+
+* `name` - The name of the event sink type.
+
+* `sink_fg` - The configuration of function graph event sink, in JSON format.
+
+* `sink_kafka` - The configuration of Kafka event sink, in JSON format.
+
+* `sink_obs` - The configuration of OBS event sink, in JSON format.
+
+<a name="eg_event_streams_rule_config"></a>
+The `rule_config` block supports:
+
+* `transform` - The transformation rules.  
+  The [transform](#eg_event_streams_rule_config_transform) structure is documented below.
+
+* `filter` - The filter rules.
+
+<a name="eg_event_streams_rule_config_transform"></a>
+The `transform` block supports:
+
+* `type` - The type of transformation rule.
+
+* `value` - The value of transformation rule.
+
+* `template` - The template of transformation rule.
+
+<a name="eg_event_streams_run_option"></a>
+The `option` block supports:
+
+* `thread_num` - The number of concurrent threads.
+
+* `batch_window` - The batch push configuration.  
+  The [batch_window](#eg_event_streams_run_option_batch_window) structure is documented below.
+
+<a name="eg_event_streams_run_option_batch_window"></a>
+The `batch_window` block supports:
+
+* `count` - The number of batch push messages.
+
+* `time` - The number of retries.
+
+* `interval` - The batch push interval in seconds.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -882,6 +882,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_eg_custom_event_sources":  eg.DataSourceCustomEventSources(),
 			"huaweicloud_eg_event_channels":        eg.DataSourceEventChannels(),
 			"huaweicloud_eg_event_sources":         eg.DataSourceEventSources(),
+			"huaweicloud_eg_event_streams":         eg.DataSourceEventStreams(),
 
 			"huaweicloud_enterprise_project":  eps.DataSourceEnterpriseProject(),
 			"huaweicloud_enterprise_projects": eps.DataSourceEnterpriseProjects(),

--- a/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_event_streams_test.go
+++ b/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_event_streams_test.go
@@ -1,0 +1,78 @@
+package eg
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceEventStreams_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_eg_event_streams.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceEventStreamsNormalCase,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_stream_set_and_valid", "true"),
+					resource.TestCheckOutput("is_name_set_and_valid", "true"),
+					resource.TestCheckOutput("is_option_set_and_valid", "true"),
+					resource.TestCheckOutput("is_rule_config_set_and_valid", "true"),
+					resource.TestCheckOutput("is_source_set_and_valid", "true"),
+					resource.TestCheckOutput("is_sink_set_and_valid", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceEventStreamsNormalCase string = `
+data "huaweicloud_eg_event_streams" "test" {}
+
+locals {
+  stream_filter_result = data.huaweicloud_eg_event_streams.test.event_streams[0]
+}
+
+output "is_stream_set_and_valid" {
+  value = local.stream_filter_result.id != null
+}
+
+output "is_name_set_and_valid" {
+  value = local.stream_filter_result.name != null
+}
+
+output "is_option_set_and_valid" {
+  value = length(local.stream_filter_result.option) > 0
+}
+
+output "is_rule_config_set_and_valid" {
+  value = length(local.stream_filter_result.rule_config) > 0
+}
+
+output "is_source_set_and_valid" {
+  value = try(anytrue([
+    length(local.stream_filter_result.source[0].source_community_rocketmq) > 0,
+    length(local.stream_filter_result.source[0].source_dms_rocketmq) > 0,
+    length(local.stream_filter_result.source[0].source_kafka) > 0,
+    length(local.stream_filter_result.source[0].source_mobile_rocketmq) > 0,
+  ]), false)
+}
+
+output "is_sink_set_and_valid" {
+  value = try(anytrue([
+    length(local.stream_filter_result.sink[0].sink_fg) > 0,
+    length(local.stream_filter_result.sink[0].sink_kafka) > 0,
+    length(local.stream_filter_result.sink[0].sink_obs) > 0,	
+  ]), false)
+}
+`

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_event_streams.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_event_streams.go
@@ -1,0 +1,405 @@
+package eg
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EG GET /v1/{project_id}/eventstreamings
+func DataSourceEventStreams() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEventStreamsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The region in which to obtain the EG event streams resource.",
+			},
+			"event_streams": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The list of event streams.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the event stream.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the event stream.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The status of the event stream.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The description of the event stream.",
+						},
+						"source": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        dataSourceEventStreamSource(),
+							Description: "The event source configuration.",
+						},
+						"sink": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        dataSourceEventStreamSink(),
+							Description: "The event sink configuration.",
+						},
+						"rule_config": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        dataSourceEventStreamRuleConfig(),
+							Description: "The configuration of event rules.",
+						},
+						"option": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        dataSourceEventStreamOption(),
+							Description: "The running configuration.",
+						},
+						"created_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The creation time of the event stream, in RFC3339 format.",
+						},
+						"updated_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The latest update time of the event stream, in RFC3339 format.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceEventStreamSource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the event source type.",
+			},
+			"source_kafka": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The configuration of kafka event source, in JSON format.",
+			},
+			"source_mobile_rocketmq": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The configuration of mobile rocketmq event source, in JSON format.",
+			},
+			"source_community_rocketmq": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The configuration of community RocketMQ event source, in JSON format.",
+			},
+			"source_dms_rocketmq": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The configuration of DMS RocketMQ event source, in JSON format.",
+			},
+		},
+	}
+}
+
+func dataSourceEventStreamSink() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the event sink type.",
+			},
+			"sink_fg": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The configuration of function graph event sink, in JSON format.",
+			},
+			"sink_kafka": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The configuration of Kafka event sink, in JSON format.",
+			},
+			"sink_obs": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The configuration of OBS event sink, in JSON format.",
+			},
+		},
+	}
+}
+
+func dataSourceEventStreamRuleConfig() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"transform": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The transformation rules.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of transformation rule.",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The value of transformation rule.",
+						},
+						"template": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The template of transformation rule.",
+						},
+					},
+				},
+			},
+			"filter": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The filter rules.",
+			},
+		},
+	}
+}
+
+func dataSourceEventStreamOption() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"thread_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The number of concurrent threads.",
+			},
+			"batch_window": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of batch push messages.",
+						},
+						"time": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of retries.",
+						},
+						"interval": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The batch push interval in seconds.",
+						},
+					},
+				},
+				Description: "The batch push configuration.",
+			},
+		},
+	}
+}
+
+func flattenSource(source interface{}) []interface{} {
+	if source == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"name":                      utils.PathSearch("name", source, ""),
+			"source_kafka":              utils.JsonToString(utils.PathSearch("source_kafka", source, nil)),
+			"source_mobile_rocketmq":    utils.JsonToString(utils.PathSearch("source_mobile_rocketmq", source, nil)),
+			"source_community_rocketmq": utils.JsonToString(utils.PathSearch("source_community_rocketmq", source, nil)),
+			"source_dms_rocketmq":       utils.JsonToString(utils.PathSearch("source_dms_rocketmq", source, nil)),
+		},
+	}
+}
+
+func flattenSink(sink interface{}) []interface{} {
+	if sink == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"name":       utils.PathSearch("name", sink, ""),
+			"sink_fg":    utils.JsonToString(utils.PathSearch("sink_fg", sink, nil)),
+			"sink_kafka": utils.JsonToString(utils.PathSearch("sink_kafka", sink, nil)),
+			"sink_obs":   utils.JsonToString(utils.PathSearch("sink_obs", sink, nil)),
+		},
+	}
+}
+
+func flattenRuleConfig(rule interface{}) []interface{} {
+	if rule == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"filter":    utils.PathSearch("filter", rule, nil),
+			"transform": flattenTransform(utils.PathSearch("transform", rule, nil)),
+		},
+	}
+}
+
+func flattenTransform(transform interface{}) []interface{} {
+	if transform == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"type":     utils.PathSearch("type", transform, nil),
+			"value":    utils.PathSearch("value", transform, nil),
+			"template": utils.PathSearch("template", transform, nil),
+		},
+	}
+}
+
+func flattenOption(option interface{}) []interface{} {
+	if option == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"thread_num":   utils.PathSearch("thread_num", option, nil),
+			"batch_window": flattenBatchWindow(utils.PathSearch("batch_window", option, nil)),
+		},
+	}
+}
+
+func flattenBatchWindow(batchWindow interface{}) []interface{} {
+	if batchWindow == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"count":    utils.PathSearch("count", batchWindow, nil),
+			"time":     utils.PathSearch("time", batchWindow, nil),
+			"interval": utils.PathSearch("interval", batchWindow, nil),
+		},
+	}
+}
+
+func flattenEventStreams(streams []interface{}) []interface{} {
+	if len(streams) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(streams))
+	for _, item := range streams {
+		stream := item.(map[string]interface{})
+		eventStream := map[string]interface{}{
+			"id":           utils.PathSearch("id", stream, nil),
+			"name":         utils.PathSearch("name", stream, nil),
+			"status":       utils.PathSearch("status", stream, nil),
+			"description":  utils.PathSearch("description", stream, nil),
+			"source":       flattenSource(utils.PathSearch("source", stream, nil)),
+			"sink":         flattenSink(utils.PathSearch("sink", stream, nil)),
+			"rule_config":  flattenRuleConfig(utils.PathSearch("rule_config", stream, nil)),
+			"option":       flattenOption(utils.PathSearch("option", stream, nil)),
+			"created_time": utils.PathSearch("created_time", stream, nil),
+			"updated_time": utils.PathSearch("updated_time", stream, nil),
+		}
+
+		result = append(result, eventStream)
+	}
+	return result
+}
+
+func listEventStreams(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/eventstreamings"
+		offset  = 0
+		limit   = 500
+		result  = make([]interface{}, 0)
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("?limit=%d&offset=%d", limit, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		eventStreams := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, eventStreams...)
+		if len(eventStreams) < limit {
+			break
+		}
+		offset += len(eventStreams)
+	}
+
+	return result, nil
+}
+
+func dataSourceEventStreamsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("eg", region)
+	if err != nil {
+		return diag.Errorf("error creating EG client: %s", err)
+	}
+
+	eventStreams, err := listEventStreams(client)
+	if err != nil {
+		return diag.Errorf("error querying event streams: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("event_streams", flattenEventStreams(eventStreams)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add new data source to query event streams

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. implement event grid event streams data source
2. add test case for this data source
3. add doc for this data source
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eg" -v -coverprofile="./huaweicloud/services/acceptance/eg/eg_coverage.cov" -coverpkg="./huaweicloud/services/eg" -run TestAccDataSourceEventStreams_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceEventStreams_basic
=== PAUSE TestAccDataSourceEventStreams_basic
=== CONT  TestAccDataSourceEventStreams_basic
--- PASS: TestAccDataSourceEventStreams_basic (25.58s)
PASS
coverage: 7.8% of statements in ./huaweicloud/services/eg
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        25.675s coverage: 7.8% of statements in ./huaweicloud/services/eg
```

![image](https://github.com/user-attachments/assets/3cf20fe5-1dd6-46f4-a550-e965c286e49c)


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**


  - **b. During delete/disassociate/unbind operation (Delete Context)**
