### PR TITLE
fix(VPC): fix vpc subnet

### DIFF
--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
@@ -397,7 +397,7 @@ func resourceVpcSubnetRead(_ context.Context, d *schema.ResourceData, meta inter
 		return diag.Errorf("error creating VpcSubnet client: %s", err)
 	}
 
-	// set dhcp extra opts ntp and addresstime
+	// set dhcp extra opts ntp, addresstime, ipv6_addresstime, domainname
 	for _, val := range n.ExtraDhcpOpts {
 		switch val.OptName {
 		case "ntp":
@@ -426,7 +426,7 @@ func resourceVpcSubnetUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if d.HasChanges("name", "description", "dhcp_enable", "primary_dns", "secondary_dns", "dns_list",
-		"ipv6_enable", "dhcp_lease_time", "ntp_server_address") {
+		"ipv6_enable", "dhcp_lease_time", "ntp_server_address", "dhcp_ipv6_lease_time", "dhcp_domain_name") {
 		var updateOpts subnets.UpdateOpts
 
 		// name is mandatory while updating subnet


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix vpc subnet
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix vpc subnet
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
 make testacc TEST=./huaweicloud/services/acceptance/vpc TESTARGS='-run TestAccVpcSubnetV1_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcSubnetV1_ -timeout 360m -parallel 4
=== RUN   TestAccVpcSubnetV1_basic
=== PAUSE TestAccVpcSubnetV1_basic
=== RUN   TestAccVpcSubnetV1_ipv6
=== PAUSE TestAccVpcSubnetV1_ipv6
=== RUN   TestAccVpcSubnetV1_dhcp
=== PAUSE TestAccVpcSubnetV1_dhcp
=== CONT  TestAccVpcSubnetV1_basic
=== CONT  TestAccVpcSubnetV1_dhcp
=== CONT  TestAccVpcSubnetV1_ipv6
--- PASS: TestAccVpcSubnetV1_dhcp (128.15s)
--- PASS: TestAccVpcSubnetV1_basic (140.34s)
--- PASS: TestAccVpcSubnetV1_ipv6 (143.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       143.668s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
