### PR TITLE
feat(waf): add a resource to manage web tamper rule update cache

### DIFF
--- a/docs/resources/waf_rule_web_tamper_protection_refresh.md
+++ b/docs/resources/waf_rule_web_tamper_protection_refresh.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_rule_web_tamper_protection_refresh"
+description: |-
+  Manages a resource to update the cache of the web tamper protection rule within HuaweiCloud.
+---
+
+# huaweicloud_waf_rule_web_tamper_protection_refresh
+
+Manages a resource to update the cache of the web tamper protection rule within HuaweiCloud.
+
+-> All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be used.
+
+-> The current resource is a one-time resource, and destroying this resource will not change the current status.
+
+## Example Usage
+
+```hcl
+variable "policy_id" {}
+variable "rule_id" {}
+
+resource "huaweicloud_waf_rule_web_tamper_protection_refresh" "test" {
+  policy_id = var.policy_id
+  rule_id   = var.rule_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `policy_id` - (Required, String, NonUpdatable) Specifies the ID of the policy.
+
+* `rule_id` - (Required, String, NonUpdatable) Specifies the ID of the web tamper protection rule.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID to which the web
+  tamper protection rule belongs.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2540,6 +2540,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_rule_global_protection_whitelist":    waf.ResourceRuleGlobalProtectionWhitelist(),
 			"huaweicloud_waf_rule_known_attack_source":            waf.ResourceRuleKnownAttack(),
 			"huaweicloud_waf_rule_precise_protection":             waf.ResourceRulePreciseProtection(),
+			"huaweicloud_waf_rule_web_tamper_protection_refresh":  waf.ResourceRuleWebTamperRefresh(),
 			"huaweicloud_waf_rule_web_tamper_protection":          waf.ResourceWafRuleWebTamperProtection(),
 			"huaweicloud_waf_rule_geolocation_access_control":     waf.ResourceRuleGeolocation(),
 			"huaweicloud_waf_rule_information_leakage_prevention": waf.ResourceRuleLeakagePrevention(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -96,6 +96,8 @@ var (
 	HW_WAF_CLOUD_INSTANCE_FLAG = os.Getenv("HW_WAF_CLOUD_INSTANCE_FLAG")
 	HW_WAF_INTERNATIONAL_FLAG  = os.Getenv("HW_WAF_INTERNATIONAL_FLAG")
 	HW_WAF_GROUP_FLAG          = os.Getenv("HW_WAF_GROUP_FLAG")
+	HW_WAF_POLICY_ID           = os.Getenv("HW_WAF_POLICY_ID")
+	HW_WAF_WEB_TAMPER_RULE_ID  = os.Getenv("HW_WAF_WEB_TAMPER_RULE_ID")
 
 	HW_ELB_CERT_ID         = os.Getenv("HW_ELB_CERT_ID")
 	HW_ELB_LOADBALANCER_ID = os.Getenv("HW_ELB_LOADBALANCER_ID")
@@ -999,6 +1001,20 @@ func TestAccPreCheckWafCertID(t *testing.T) {
 func TestAccPreCheckWafType(t *testing.T) {
 	if HW_WAF_TYPE == "" {
 		t.Skip("HW_WAF_TYPE must be set for this acceptance test.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckWafPolicyId(t *testing.T) {
+	if HW_WAF_POLICY_ID == "" {
+		t.Skip("HW_WAF_POLICY_ID must be set for this acceptance test.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckWafWebTamperRuleId(t *testing.T) {
+	if HW_WAF_WEB_TAMPER_RULE_ID == "" {
+		t.Skip("HW_WAF_WEB_TAMPER_RULE_ID must be set for this acceptance test.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_refresh_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_refresh_test.go
@@ -1,0 +1,39 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccWebTamperRefresh_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Before running the test case, please ensure that there is at least one WAF instance in the current region.
+			// Prepare a WAF policy and a web tamper protection rule.
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckWafPolicyId(t)
+			acceptance.TestAccPreCheckWafWebTamperRuleId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuleWebTamperRefresh_basic(),
+			},
+		},
+	})
+}
+
+func testAccRuleWebTamperRefresh_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_rule_web_tamper_protection_refresh" "test" {
+  policy_id = "%[1]s"
+  rule_id   = "%[2]s"
+}
+`, acceptance.HW_WAF_POLICY_ID, acceptance.HW_WAF_WEB_TAMPER_RULE_ID)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_web_tamper_protection_refresh.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_web_tamper_protection_refresh.go
@@ -1,0 +1,122 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF POST /v1/{project_id}/waf/policy/{policy_id}/antitamper/{rule_id}/refresh
+
+var refreshCacheNonUpdatableParams = []string{"policy_id", "rule_id", "enterprise_project_id"}
+
+func ResourceRuleWebTamperRefresh() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWebTamperRefreshCreate,
+		ReadContext:   resourceWebTamperRefreshRead,
+		UpdateContext: resourceWebTamperRefreshUpdate,
+		DeleteContext: resourceWebTamperRefreshDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(refreshCacheNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"rule_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceWebTamperRefreshCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		policyId = d.Get("policy_id").(string)
+		ruleId   = d.Get("rule_id").(string)
+		epsId    = cfg.GetEnterpriseProjectID(d)
+		httpUrl  = "v1/{project_id}/waf/policy/{policy_id}/antitamper/{rule_id}/refresh"
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{policy_id}", policyId)
+	createPath = strings.ReplaceAll(createPath, "{rule_id}", ruleId)
+	if epsId != "" {
+		createPath += fmt.Sprintf("?enterprise_project_id=%s", epsId)
+	}
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error updating cache of web tamper protection rule: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tamperId := utils.PathSearch("id", respBody, "").(string)
+	if tamperId == "" {
+		return diag.Errorf("unable to find the ID from the API response")
+	}
+
+	d.SetId(tamperId)
+
+	return nil
+}
+
+func resourceWebTamperRefreshRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a action resource.
+	return nil
+}
+
+func resourceWebTamperRefreshUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a action resource.
+	return nil
+}
+
+func resourceWebTamperRefreshDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Delete()' method because the resource is a action resource.
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a resource to manage web tamper rule update cache.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccWebTamperRefresh_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWebTamperRefresh_basic -timeout 360m -parallel 4
=== RUN   TestAccWebTamperRefresh_basic
=== PAUSE TestAccWebTamperRefresh_basic
=== CONT  TestAccWebTamperRefresh_basic
--- PASS: TestAccWebTamperRefresh_basic (31.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       32.214s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
