### PR TITLE
feat(DMS): add agency_name to kafkav2 smart connect task resource

### DIFF
--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafkav2_smart_connect_task.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafkav2_smart_connect_task.go
@@ -242,6 +242,12 @@ func ResourceDmsKafkav2SmartConnectTask() *schema.Resource {
 							Sensitive:   true,
 							Description: `Specifies the secret access key used to access the OBS bucket.`,
 						},
+						"agency_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Description: "schema: Internal",
+						},
 						"consumer_strategy": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -459,6 +465,7 @@ func buildSinkTaskRequestBody(rawParams []interface{}) map[string]interface{} {
 		"consumer_strategy":     utils.ValueIgnoreEmpty(params["consumer_strategy"]),
 		"access_key":            utils.ValueIgnoreEmpty(params["access_key"]),
 		"secret_key":            utils.ValueIgnoreEmpty(params["secret_key"]),
+		"agency_name":           utils.ValueIgnoreEmpty(params["agency_name"]),
 		"obs_bucket_name":       utils.ValueIgnoreEmpty(params["obs_bucket_name"]),
 		"partition_format":      utils.ValueIgnoreEmpty(params["partition_format"]),
 		"deliver_time_interval": utils.ValueIgnoreEmpty(params["deliver_time_interval"]),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add agency_name to kafkav2 smart connect task resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add agency_name to kafkav2 smart connect task resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
