### PR TITLE
feat(evs): add a data source to query volumes by tags

### DIFF
--- a/docs/data-sources/evs_volumes_by_tags.md
+++ b/docs/data-sources/evs_volumes_by_tags.md
@@ -1,0 +1,190 @@
+---
+subcategory: "Elastic Volume Service (EVS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_evs_volumes_by_tags"
+description: |-
+  Use this data source to get EVS volumes filtered by tags within HuaweiCloud.
+---
+
+# huaweicloud_evs_volumes_by_tags
+
+Use this data source to get EVS volumes filtered by tags within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_evs_volumes_by_tags" "example" {
+  action = "filter"
+
+  tags = [
+    {
+      key    = "key_string"
+      values = ["value_string"]
+    }
+  ]
+
+  matches = [
+    {
+      key   = "resource_name"
+      value = "shared01"
+    }
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `action` - (Required, String) Specifies the action name. Possible value: **filter**.
+
+* `tags` - (Required, List) Specifies the list of included tags.The key-value pairs of tags.
+  A tag list can contain a maximum of `10` keys. Tag keys in a tag list must be unique.
+  When multiple keys are specified in a tag list, only the disks having all specified keys are queried.
+  The [tags](#tags_struct) structure is documented below.
+
+* `matches` - (Optional, List) Specifies the search criteria supported by disks. Tag keys in a tag list must be unique.
+  The [matches](#matches_struct) structure is documented below.
+
+<a name="tags_struct"></a>
+The `tags` block supports:
+
+* `key` - (Required, String) Specifies the key of the resource tag.
+
+* `values` - (Required, List) Specifies the list of values corresponding to the key.
+  A tag list can contain a maximum of `10` values. Tag values in a tag list must be unique.
+  If the tag value list is empty, disks that contain any key can be queried.
+  When there are multiple values and the key requirements are met, disks that have any of the specified values are queried.
+
+<a name="matches_struct"></a>
+The `matches` block supports:
+
+* `key` - (Optional, String) Specifies the key of the resource match.
+  Supported keys: **resource_name**, **service_type**.
+
+* `value` - (Optional, String) Specifies the value of the resource match.
+  The value, which can contain a maximum of `255` characters. If **resource_name** is specified for `key`,
+  the tag value uses a fuzzy match.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `total_count` - The number of disks that meet the query criteria.
+
+* `resources` - The list of disks that meet the query criteria.
+  The [resources](#evs_volumes_resources) structure is documented below.
+
+<a name="evs_volumes_resources"></a>
+The `resources` block supports:
+
+* `resource_id` - The resource ID.
+
+* `resource_name` - The resource name.
+
+* `resource_detail` - The resource details.
+  The [resource_detail](#evs_volumes_resource_detail) structure is documented below.
+
+* `tags` - The tag list. The [tags](#evs_volumes_tags) structure is documented below.
+
+<a name="evs_volumes_tags"></a>
+The `tags` block supports:
+
+* `key` - The key of the resource tag.
+
+* `value` - The value of the resource tag.
+
+<a name="evs_volumes_resource_detail"></a>
+The `resource_detail` block supports:
+
+* `id` - The disk ID.
+
+* `links` - The disk URI. The [links](#evs_volumes_links) structure is documented below.
+
+* `name` - The disk name.
+
+* `status` - The disk status. For details, see "EVS Disk Status" in Elastic Volume Service User Guide.
+  [reference](https://support.huaweicloud.com/intl/en-us/api-evs/evs_04_0040.html)
+
+* `attachments` - The disk attachment information.
+  The [attachments](#evs_volumes_attachments) structure is documented below.
+
+* `availability_zone` - The AZ to which the disk belongs.
+
+* `snapshot_id` - The snapshot ID. This parameter has a value if the disk is created from a snapshot.
+
+* `description` - The disk description.
+
+* `created_at` - The time when the disk was created.
+
+* `os_vol_tenant_attr_tenant_id` - The ID of the tenant to which the disk belongs.
+  The tenant ID is the same as the project ID.
+
+* `volume_image_metadata` - The metadata of the disk image.
+
+* `volume_type` - The disk type. The value can be **SSD** (ultra-high I/O), **SAS** (high I/O), or **SATA** (common I/O).
+
+* `size` - The disk size, in GiB.
+
+* `bootable` - Whether the disk is bootable. **true**: The disk is bootable. **false**: The disk is not bootable.
+
+* `metadata` - The disk metadata map. Possible keys are:
+  + **__system__cmkid**: The encryption CMK ID in metadata.
+    This parameter is used together with `__system__encrypted` for encryption.
+    The length of cmkid is fixed at `36` bytes. For details about how to obtain the key ID, see Querying the Key List.
+  + **__system__encrypted**: The encryption field in metadata.
+    The value can be `0` (no encryption) or `1` (encryption). If this parameter is not specified,
+    the encryption attribute of the disk is the same as that of the data source.
+    If the disk is not created from a data source, the disk is not encrypted by default.
+  + **hw_passthrough**: If this parameter value is **true**, the disk device type is SCSI,
+    which allows ECS OSs to directly access the underlying storage media.
+    SCSI reservation commands are supported. If this parameter is set to **false**, the disk device type is **VBD**,
+    which is also the default type. VBD supports only simple SCSI read/write commands.
+    If this parameter is not specified, the disk device type is **VBD**.
+  + **orderID**: The parameter that describes the disk billing mode in metadata. If this parameter has a value,
+    the disk is billed on a yearly/monthly basis. If not, the disk is billed on a pay-per-use basis.
+
+* `updated_at` - The time when the disk was updated.
+
+* `service_type` - The service type. Supported values: **EVS**, **DSS**, **DESS**.
+
+* `multiattach` - Whether the disk is shareable.
+
+* `dedicated_storage_id` - The ID of the dedicated storage pool housing the disk.
+
+* `dedicated_storage_name` - The name of the dedicated storage pool housing the disk.
+
+* `tags` - The disk tags. This field has values if the disk has tags. Otherwise, this field is empty.
+
+* `wwn` - The unique identifier used when attaching the disk.
+
+* `enterprise_project_id` - The ID of the enterprise project that the disk has been added to.
+
+<a name="evs_volumes_attachments"></a>
+The `attachments` block supports:
+
+* `server_id` - The ID of the server to which the disk is attached.
+
+* `attachment_id` - The attachment ID.
+
+* `attached_at` - The time when the disk was attached.
+
+* `volume_id` - The disk ID.
+
+* `device` - The device name.
+
+* `id` - The ID of the attached disk.
+
+* `host_name` - The name of the physical host housing the cloud server to which the disk is attached.
+
+<a name="evs_volumes_links"></a>
+The `links` block supports:
+
+* `href` - The corresponding shortcut link.
+
+* `rel` - The shortcut link marker name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -907,6 +907,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_evsv3_volume_types":            evs.DataSourceV3VolumeTypes(),
 			"huaweicloud_evs_volume_transfers":          evs.DataSourceEvsVolumeTransfers(),
 			"huaweicloud_evs_volume_tags":               evs.DataSourceEvsVolumeTags(),
+			"huaweicloud_evs_volumes_by_tags":           evs.DataSourceEvsVolumesByTags(),
 			"huaweicloud_evsv3_volume_transfers":        evs.DataSourceEvsV3VolumeTransfers(),
 			"huaweicloud_evsv3_volume_transfer_details": evs.DataSourceEvsV3VolumeTransferDetails(),
 			"huaweicloud_evs_tags":                      evs.DataSourceEvsTags(),

--- a/huaweicloud/services/acceptance/evs/data_source_huaweicloud_evs_volumes_by_tags_test.go
+++ b/huaweicloud/services/acceptance/evs/data_source_huaweicloud_evs_volumes_by_tags_test.go
@@ -1,0 +1,140 @@
+package evs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceVolumesByTags_basic(t *testing.T) {
+	var (
+		filter_by_tags_all    = "data.huaweicloud_evs_volumes_by_tags.filter_by_tags"
+		dc_tags               = acceptance.InitDataSourceCheck(filter_by_tags_all)
+		filter_by_matches_all = "data.huaweicloud_evs_volumes_by_tags.filter_by_matches"
+		dc_matches            = acceptance.InitDataSourceCheck(filter_by_matches_all)
+		testName              = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceVolumesByTags_basic1(testName),
+				Check: resource.ComposeTestCheckFunc(
+					dc_tags.CheckResourceExists(),
+					resource.TestCheckResourceAttr(filter_by_tags_all, "resources.0.resource_name", fmt.Sprintf("%s_0", testName)),
+					resource.TestCheckResourceAttrSet(filter_by_tags_all, "resources.0.resource_id"),
+					resource.TestCheckResourceAttrSet(filter_by_tags_all, "resources.0.resource_detail.0.id"),
+					resource.TestCheckResourceAttrSet(filter_by_tags_all, "resources.0.resource_detail.0.name"),
+					resource.TestCheckResourceAttrSet(filter_by_tags_all, "resources.0.resource_detail.0.status"),
+					resource.TestCheckResourceAttrSet(filter_by_tags_all, "resources.0.resource_detail.0.size"),
+					resource.TestCheckResourceAttrSet(filter_by_tags_all, "resources.0.resource_detail.0.volume_type"),
+					resource.TestCheckResourceAttrSet(filter_by_tags_all, "resources.0.resource_detail.0.availability_zone"),
+					resource.TestCheckResourceAttrSet(filter_by_tags_all, "resources.0.resource_detail.0.created_at"),
+					resource.TestCheckResourceAttrSet(filter_by_tags_all, "resources.0.resource_detail.0.updated_at"),
+					resource.TestCheckResourceAttrSet(filter_by_tags_all, "resources.0.resource_detail.0.bootable"),
+					resource.TestCheckResourceAttrSet(filter_by_tags_all, "resources.0.resource_detail.0.multiattach"),
+					resource.TestCheckResourceAttr(filter_by_tags_all, "resources.0.tags.0.key", "foo1"),
+					resource.TestCheckResourceAttr(filter_by_tags_all, "resources.0.tags.0.value", "bar1"),
+					resource.TestCheckResourceAttr(filter_by_tags_all, "resources.0.tags.1.key", "foo0"),
+					resource.TestCheckResourceAttr(filter_by_tags_all, "resources.0.tags.1.value", "bar0"),
+				),
+			},
+			{
+				Config: testDataSourceVolumesByTags_basic2(testName),
+				Check: resource.ComposeTestCheckFunc(
+					dc_matches.CheckResourceExists(),
+					resource.TestCheckResourceAttr(filter_by_matches_all, "resources.0.resource_name", fmt.Sprintf("%s_0", testName)),
+					resource.TestCheckResourceAttrSet(filter_by_matches_all, "resources.0.resource_id"),
+					resource.TestCheckResourceAttrSet(filter_by_matches_all, "resources.0.resource_detail.0.id"),
+					resource.TestCheckResourceAttrSet(filter_by_matches_all, "resources.0.resource_detail.0.name"),
+					resource.TestCheckResourceAttrSet(filter_by_matches_all, "resources.0.resource_detail.0.status"),
+					resource.TestCheckResourceAttrSet(filter_by_matches_all, "resources.0.resource_detail.0.size"),
+					resource.TestCheckResourceAttrSet(filter_by_matches_all, "resources.0.resource_detail.0.volume_type"),
+					resource.TestCheckResourceAttrSet(filter_by_matches_all, "resources.0.resource_detail.0.availability_zone"),
+					resource.TestCheckResourceAttrSet(filter_by_matches_all, "resources.0.resource_detail.0.created_at"),
+					resource.TestCheckResourceAttrSet(filter_by_matches_all, "resources.0.resource_detail.0.updated_at"),
+					resource.TestCheckResourceAttrSet(filter_by_matches_all, "resources.0.resource_detail.0.bootable"),
+					resource.TestCheckResourceAttrSet(filter_by_matches_all, "resources.0.resource_detail.0.multiattach"),
+					resource.TestCheckResourceAttr(filter_by_matches_all, "resources.0.tags.0.key", "foo1"),
+					resource.TestCheckResourceAttr(filter_by_matches_all, "resources.0.tags.0.value", "bar1"),
+					resource.TestCheckResourceAttr(filter_by_matches_all, "resources.0.tags.1.key", "foo0"),
+					resource.TestCheckResourceAttr(filter_by_matches_all, "resources.0.tags.1.value", "bar0"),
+				),
+			},
+		},
+	},
+	)
+}
+
+func testDataSourceVolumesByTags_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  count = 2
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name              = format("%[1]s_%%d", count.index)
+  size              = 100
+  volume_type       = "GPSSD"
+  device_type       = "VBD"
+  multiattach       = false
+
+  tags = {
+    "foo0" = "bar0"
+    "foo1" = "bar1"
+  }
+}
+`, name)
+}
+
+func testDataSourceVolumesByTags_basic1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_evs_volumes_by_tags" "filter_by_tags" {
+  depends_on = [huaweicloud_evs_volume.test]
+  action     = "filter"
+
+  tags {
+    key    = "foo0"
+    values = ["bar0"]
+  }
+
+  tags {
+    key    = "foo1"
+    values = ["bar1"]
+  }
+}`, testDataSourceVolumesByTags_base(name))
+}
+
+func testDataSourceVolumesByTags_basic2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_evs_volumes_by_tags" "filter_by_matches" {
+  depends_on = [huaweicloud_evs_volume.test]
+  action     = "filter"
+
+  tags {
+    key    = "foo0"
+    values = ["bar0"]
+  }
+
+  tags {
+    key    = "foo1"
+    values = ["bar1"]
+  }
+
+  matches {
+    key    = "resource_name"
+    value  = format("%%s_0", "%[2]s")
+  }
+}`, testDataSourceVolumesByTags_base(name), name)
+}

--- a/huaweicloud/services/evs/data_source_huaweicloud_evs_volumes_by_tags.go
+++ b/huaweicloud/services/evs/data_source_huaweicloud_evs_volumes_by_tags.go
@@ -1,0 +1,457 @@
+package evs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EVS POST /v2/{project_id}/cloudvolumes/resource_instances/action
+func DataSourceEvsVolumesByTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEvsVolumesByTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"matches": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"total_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourceEvsVolumesByTagsResourceSchema(),
+			},
+		},
+	}
+}
+
+func dataSourceEvsVolumesByTagsResourceSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_detail": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourceEvsVolumesByTagsResourceDetailSchema(),
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceEvsVolumesByTagsResourceDetailSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"links": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourceEvsVolumesByTagsLinksSchema(),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attachments": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourceEvsVolumesByTagsAttachmentSchema(),
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"snapshot_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"os_vol_tenant_attr_tenant_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"volume_image_metadata": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"volume_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"bootable": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"metadata": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"multiattach": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"dedicated_storage_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dedicated_storage_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"wwn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceEvsVolumesByTagsLinksSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"href": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"rel": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceEvsVolumesByTagsAttachmentSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"server_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attachment_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attached_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"device": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"host_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildListEvsVolumesByTagsBody(d *schema.ResourceData) map[string]interface{} {
+	body := map[string]interface{}{
+		"action": d.Get("action").(string),
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		body["tags"] = expandTags(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("matches"); ok {
+		if list, ok := v.([]interface{}); ok && len(list) > 0 {
+			body["matches"] = expandMatches(list)
+		}
+	}
+	return body
+}
+
+func expandTags(rawTags []interface{}) []map[string]interface{} {
+	tags := make([]map[string]interface{}, 0, len(rawTags))
+	for _, t := range rawTags {
+		tag := t.(map[string]interface{})
+		tags = append(tags, map[string]interface{}{
+			"key":    tag["key"],
+			"values": tag["values"],
+		})
+	}
+	return tags
+}
+
+func expandMatches(rawMatches []interface{}) []map[string]interface{} {
+	matches := make([]map[string]interface{}, 0, len(rawMatches))
+	for _, m := range rawMatches {
+		match, ok := m.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		matches = append(matches, map[string]interface{}{
+			"key":   match["key"],
+			"value": match["value"],
+		})
+	}
+	return matches
+}
+
+func flattenAllEvsVolumesByTags(resp []interface{}) []map[string]interface{} {
+	results := make([]map[string]interface{}, 0, len(resp))
+	for _, resource := range resp {
+		results = append(results, map[string]interface{}{
+			"resource_id":     utils.PathSearch("resource_id", resource, nil),
+			"resource_name":   utils.PathSearch("resource_name", resource, nil),
+			"tags":            flattenEvsTags(utils.PathSearch("tags", resource, make([]interface{}, 0)).([]interface{})),
+			"resource_detail": flattenEvsResourceDetail(utils.PathSearch("resource_detail", resource, nil)),
+		})
+	}
+	return results
+}
+
+func flattenEvsTags(tags []interface{}) []map[string]interface{} {
+	rst := make([]map[string]interface{}, 0, len(tags))
+	for _, tag := range tags {
+		rst = append(rst, map[string]interface{}{
+			"key":   utils.PathSearch("key", tag, nil),
+			"value": utils.PathSearch("value", tag, nil),
+		})
+	}
+	return rst
+}
+
+func flattenEvsResourceDetail(resourceDetail interface{}) []map[string]interface{} {
+	if resourceDetail == nil {
+		return nil
+	}
+	resourceDetailLinks := utils.PathSearch("links", resourceDetail, make([]interface{}, 0)).([]interface{})
+	resourceDetailAttachments := utils.PathSearch("attachments", resourceDetail, make([]interface{}, 0)).([]interface{})
+
+	return []map[string]interface{}{
+		{
+			"id":                           utils.PathSearch("id", resourceDetail, nil),
+			"links":                        flattenEvsLinks(resourceDetailLinks),
+			"name":                         utils.PathSearch("name", resourceDetail, nil),
+			"status":                       utils.PathSearch("status", resourceDetail, nil),
+			"attachments":                  flattenEvsAttachments(resourceDetailAttachments),
+			"availability_zone":            utils.PathSearch("availability_zone", resourceDetail, nil),
+			"snapshot_id":                  utils.PathSearch("snapshot_id", resourceDetail, nil),
+			"description":                  utils.PathSearch("description", resourceDetail, nil),
+			"created_at":                   utils.PathSearch("created_at", resourceDetail, nil),
+			"os_vol_tenant_attr_tenant_id": utils.PathSearch("os-vol-tenant-attr:tenant_id", resourceDetail, nil),
+			"volume_image_metadata":        utils.PathSearch("volume_image_metadata", resourceDetail, map[string]interface{}{}),
+			"volume_type":                  utils.PathSearch("volume_type", resourceDetail, nil),
+			"size":                         utils.PathSearch("size", resourceDetail, nil),
+			"bootable":                     utils.PathSearch("bootable", resourceDetail, nil),
+			"metadata":                     utils.PathSearch("metadata", resourceDetail, map[string]interface{}{}),
+			"updated_at":                   utils.PathSearch("updated_at", resourceDetail, nil),
+			"service_type":                 utils.PathSearch("service_type", resourceDetail, nil),
+			"multiattach":                  utils.PathSearch("multiattach", resourceDetail, nil),
+			"dedicated_storage_id":         utils.PathSearch("dedicated_storage_id", resourceDetail, nil),
+			"dedicated_storage_name":       utils.PathSearch("dedicated_storage_name", resourceDetail, nil),
+			"tags":                         utils.PathSearch("tags", resourceDetail, map[string]interface{}{}),
+			"wwn":                          utils.PathSearch("wwn", resourceDetail, nil),
+			"enterprise_project_id":        utils.PathSearch("enterprise_project_id", resourceDetail, nil),
+		},
+	}
+}
+
+func flattenEvsLinks(links []interface{}) []map[string]interface{} {
+	rst := make([]map[string]interface{}, 0, len(links))
+	for _, link := range links {
+		rst = append(rst, map[string]interface{}{
+			"href": utils.PathSearch("href", link, nil),
+			"rel":  utils.PathSearch("rel", link, nil),
+		})
+	}
+	return rst
+}
+
+func flattenEvsAttachments(attachments []interface{}) []map[string]interface{} {
+	rst := make([]map[string]interface{}, 0, len(attachments))
+	for _, att := range attachments {
+		rst = append(rst, map[string]interface{}{
+			"server_id":     utils.PathSearch("server_id", att, nil),
+			"attachment_id": utils.PathSearch("attachment_id", att, nil),
+			"attached_at":   utils.PathSearch("attached_at", att, nil),
+			"volume_id":     utils.PathSearch("volume_id", att, nil),
+			"device":        utils.PathSearch("device", att, nil),
+			"id":            utils.PathSearch("id", att, nil),
+			"host_name":     utils.PathSearch("host_name", att, nil),
+		})
+	}
+	return rst
+}
+
+func dataSourceEvsVolumesByTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/cloudvolumes/resource_instances/action"
+		product = "evs"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	var allVolumes []interface{}
+	offset := 0
+	totalCount := 0
+
+	for {
+		requestBody := buildListEvsVolumesByTagsBody(d)
+		// The action only supports 'filter' by now, so other input will return null.
+		if requestBody["action"] == "filter" {
+			requestBody["offset"] = offset
+		}
+		requestOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody:         requestBody,
+		}
+		resp, err := client.Request("POST", requestPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error querying EVS volumes by tags: %s", err)
+		}
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		volumes := utils.PathSearch("resources", respBody, []interface{}{}).([]interface{})
+		totalCount = int(utils.PathSearch("total_count", respBody, float64(0)).(float64))
+		if len(volumes) == 0 {
+			break
+		}
+		allVolumes = append(allVolumes, volumes...)
+		offset += len(volumes)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_count", totalCount),
+		d.Set("resources", flattenAllEvsVolumesByTags(allVolumes)),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving data source fields of the EVS volumes by tags: %s", mErr)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a data source to query volumes by tags
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a data source to query volumes by tags
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
TF_ACC=1 go test "./huaweicloud/services/acceptance/evs" -v -coverprofile="./huaweicloud/services/acceptance/evs/evs_coverage.cov" -coverpkg="./huaweicloud/services/evs" -run TestAccDataSourceVolumesByTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceVolumesByTags_basic
=== PAUSE TestAccDataSourceVolumesByTags_basic
=== CONT  TestAccDataSourceVolumesByTags_basic
--- PASS: TestAccDataSourceVolumesByTags_basic (111.41s)
PASS
coverage: 16.2% of statements in ./huaweicloud/services/evs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       111.626s        coverage: 16.2% of statements in ./huaweicloud/services/evs
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
