### PR TITLE
fix(dew): Correct the incorrect service name 'kms' to' kps'

### DIFF
--- a/docs/resources/kps_keypair_associate.md
+++ b/docs/resources/kps_keypair_associate.md
@@ -1,14 +1,14 @@
 ---
 subcategory: "Data Encryption Workshop (DEW)"
 layout: "huaweicloud"
-page_title: "HuaweiCloud: huaweicloud_kms_keypair_associate"
+page_title: "HuaweiCloud: huaweicloud_kps_keypair_associate"
 description: |-
-  Manages a KMS keypair associate resource within HuaweiCloud.
+  Manages a KPS keypair associate resource within HuaweiCloud.
 ---
 
-# huaweicloud_kms_keypair_associate
+# huaweicloud_kps_keypair_associate
 
-Manages a KMS keypair associate resource within HuaweiCloud.
+Manages a KPS keypair associate resource within HuaweiCloud.
 
 -> The current resource is a one-time resource, and destroying this resource will not change the current status.
 
@@ -33,7 +33,7 @@ variable "port" {}
 variable "type" {}
 variable "key" {}
 
-resource "huaweicloud_kms_keypair_associate" "test" {
+resource "huaweicloud_kps_keypair_associate" "test" {
   keypair_name  = var.keypair_name
 
   server {
@@ -54,7 +54,7 @@ resource "huaweicloud_kms_keypair_associate" "test" {
 variable "keypair_name" {}
 variable "server_id" {}
 
-resource "huaweicloud_kms_keypair_associate" "test" {
+resource "huaweicloud_kps_keypair_associate" "test" {
   keypair_name  = var.keypair_name
 
   server {
@@ -77,9 +77,9 @@ The following arguments are supported:
   **CoreOS**, **OpenEuler**, **FreeBSD（Other）**, **Kylin V10 64bit**, **UnionTech OS Server 20**,  
   **Euler 64bit** and **CentOS Stream 8 64bit**.
 
-  The [server](#kms_server) structure is documented below.
+  The [server](#kps_server) structure is documented below.
 
-<a name="kms_server"></a>
+<a name="kps_server"></a>
 The `server` block supports:
 
 * `id` - (Required, String, NonUpdatable) Specifies ID of the ECS which need to associate (replace or reset) the SSH keypair.

--- a/docs/resources/kps_keypair_disassociate.md
+++ b/docs/resources/kps_keypair_disassociate.md
@@ -1,14 +1,16 @@
 ---
 subcategory: "Data Encryption Workshop (DEW)"
 layout: "huaweicloud"
-page_title: "HuaweiCloud: huaweicloud_kms_keypair_disassociate"
+page_title: "HuaweiCloud: huaweicloud_kps_keypair_disassociate"
 description: |-
-  Manages a KMS keypair disassociate resource within HuaweiCloud.
+  Manages a KPS keypair disassociate resource within HuaweiCloud.
 ---
 
-# huaweicloud_kms_keypair_disassociate
+# huaweicloud_kps_keypair_disassociate
 
-Manages a KMS keypair disassociate resource within HuaweiCloud.
+Manages a KPS keypair disassociate resource within HuaweiCloud.
+
+-> The current resource is a one-time resource, and destroying this resource will not change the current status.
 
 -> Please refer to the API document link for more precautions  
 [reference](https://support.huaweicloud.com/intl/en-us/usermanual-dew/dew_01_0071.html).
@@ -23,7 +25,7 @@ variable "port" {}
 variable "type" {}
 variable "key" {}
 
-resource "huaweicloud_kms_keypair_disassociate" "test" {
+resource "huaweicloud_kps_keypair_disassociate" "test" {
   server {
     id   = var.server_id
     port = var.port
@@ -41,7 +43,7 @@ resource "huaweicloud_kms_keypair_disassociate" "test" {
 ```hcl
 variable "server_id" {}
 
-resource "huaweicloud_kms_keypair_disassociate" "test" {
+resource "huaweicloud_kps_keypair_disassociate" "test" {
   server {
     id = var.server_id
   }
@@ -56,9 +58,9 @@ The following arguments are supported:
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
 * `server` - (Required, List, NonUpdatable) Specifies the ECS information that requires disassociating keypair.
-  The [server](#kms_server) structure is documented below.
+  The [server](#kps_server) structure is documented below.
 
-<a name="kms_server"></a>
+<a name="kps_server"></a>
 The `server` block supports:
 
 * `id` - (Required, String, NonUpdatable) Specifies ID of the ECS which need to disassociate the SSH keypair.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2199,8 +2199,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_alias_associate":      dew.ResourceKmsAliasAssociate(),
 			"huaweicloud_kms_dedicated_keystore":   dew.ResourceKmsDedicatedKeystore(),
 			"huaweicloud_kms_key_material":         dew.ResourceKmsKeyMaterial(),
-			"huaweicloud_kms_keypair_disassociate": dew.ResourceKmsKeypairDisassociate(),
-			"huaweicloud_kms_keypair_associate":    dew.ResourceKmsKeypairAssociate(),
+
+			"huaweicloud_kps_keypair_disassociate": dew.ResourceKpsKeypairDisassociate(),
+			"huaweicloud_kps_keypair_associate":    dew.ResourceKpsKeypairAssociate(),
 
 			"huaweicloud_lb_certificate":  lb.ResourceCertificateV2(),
 			"huaweicloud_lb_l7policy":     lb.ResourceL7PolicyV2(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -114,8 +114,12 @@ var (
 
 	HW_DBSS_INSATNCE_ID = os.Getenv("HW_DBSS_INSATNCE_ID")
 
-	HW_DEW_ENABLE_FLAG   = os.Getenv("HW_DEW_ENABLE_FLAG")
-	HW_KPS_KEY_FILE_PATH = os.Getenv("HW_KPS_KEY_FILE_PATH")
+	HW_DEW_ENABLE_FLAG      = os.Getenv("HW_DEW_ENABLE_FLAG")
+	HW_KPS_KEY_FILE_PATH    = os.Getenv("HW_KPS_KEY_FILE_PATH")
+	HW_KPS_KEYPAIR_NAME_1   = os.Getenv("HW_KPS_KEYPAIR_NAME_1")
+	HW_KPS_KEYPAIR_NAME_2   = os.Getenv("HW_KPS_KEYPAIR_NAME_2")
+	HW_KPS_KEYPAIR_KEY_1    = os.Getenv("HW_KPS_KEYPAIR_KEY_1")
+	HW_KPS_KEYPAIR_SSH_PORT = os.Getenv("HW_KPS_KEYPAIR_SSH_PORT")
 
 	HW_DEST_REGION          = os.Getenv("HW_DEST_REGION")
 	HW_DEST_PROJECT_ID      = os.Getenv("HW_DEST_PROJECT_ID")
@@ -273,17 +277,13 @@ var (
 	HW_FGS_GPU_TYPE            = os.Getenv("HW_FGS_GPU_TYPE")
 	HW_FGS_DEPENDENCY_OBS_LINK = os.Getenv("HW_FGS_DEPENDENCY_OBS_LINK")
 
-	HW_KMS_ENVIRONMENT      = os.Getenv("HW_KMS_ENVIRONMENT")
-	HW_KMS_HSM_CLUSTER_ID   = os.Getenv("HW_KMS_HSM_CLUSTER_ID")
-	HW_KMS_KEY_ID           = os.Getenv("HW_KMS_KEY_ID")
-	HW_KMS_ALIAS            = os.Getenv("HW_KMS_ALIAS")
-	HW_KMS_IMPORT_TOKEN     = os.Getenv("HW_KMS_IMPORT_TOKEN")
-	HW_KMS_KEY_MATERIAL     = os.Getenv("HW_KMS_KEY_MATERIAL")
-	HW_KMS_KEY_PRIVATE_KEY  = os.Getenv("HW_KMS_KEY_PRIVATE_KEY")
-	HW_KMS_KEYPAIR_NAME_1   = os.Getenv("HW_KMS_KEYPAIR_NAME_1")
-	HW_KMS_KEYPAIR_NAME_2   = os.Getenv("HW_KMS_KEYPAIR_NAME_2")
-	HW_KMS_KEYPAIR_KEY_1    = os.Getenv("HW_KMS_KEYPAIR_KEY_1")
-	HW_KMS_KEYPAIR_SSH_PORT = os.Getenv("HW_KMS_KEYPAIR_SSH_PORT")
+	HW_KMS_ENVIRONMENT     = os.Getenv("HW_KMS_ENVIRONMENT")
+	HW_KMS_HSM_CLUSTER_ID  = os.Getenv("HW_KMS_HSM_CLUSTER_ID")
+	HW_KMS_KEY_ID          = os.Getenv("HW_KMS_KEY_ID")
+	HW_KMS_ALIAS           = os.Getenv("HW_KMS_ALIAS")
+	HW_KMS_IMPORT_TOKEN    = os.Getenv("HW_KMS_IMPORT_TOKEN")
+	HW_KMS_KEY_MATERIAL    = os.Getenv("HW_KMS_KEY_MATERIAL")
+	HW_KMS_KEY_PRIVATE_KEY = os.Getenv("HW_KMS_KEY_PRIVATE_KEY")
 
 	HW_MULTI_ACCOUNT_ENVIRONMENT            = os.Getenv("HW_MULTI_ACCOUNT_ENVIRONMENT")
 	HW_ORGANIZATIONS_OPEN                   = os.Getenv("HW_ORGANIZATIONS_OPEN")
@@ -1699,16 +1699,23 @@ func TestAccPreCheckKmsKeyPrivateKey(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckKmsSSHPort(t *testing.T) {
-	if HW_KMS_KEYPAIR_SSH_PORT == "" {
-		t.Skip("HW_KMS_KEYPAIR_SSH_PORT must be set for acceptance tests.")
+func TestAccPreCheckKpsSSHPort(t *testing.T) {
+	if HW_KPS_KEYPAIR_SSH_PORT == "" {
+		t.Skip("HW_KPS_KEYPAIR_SSH_PORT must be set for acceptance tests.")
 	}
 }
 
 // lintignore:AT003
-func TestAccPreCheckKmsKeyPair(t *testing.T) {
-	if HW_KMS_KEYPAIR_NAME_1 == "" || HW_KMS_KEYPAIR_NAME_2 == "" || HW_KMS_KEYPAIR_KEY_1 == "" || HW_KMS_KEYPAIR_SSH_PORT == "" {
-		t.Skip("HW_KMS_KEYPAIR_NAME_1, HW_KMS_KEYPAIR_NAME_2, HW_KMS_KEYPAIR_KEY_1, HW_KMS_KEYPAIR_SSH_PORT must be set for the acceptance tests.")
+func TestAccPreCheckKpsKeypairKey(t *testing.T) {
+	if HW_KPS_KEYPAIR_KEY_1 == "" {
+		t.Skip("HW_KPS_KEYPAIR_KEY_1 must be set for acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckKpsKeyPair(t *testing.T) {
+	if HW_KPS_KEYPAIR_NAME_1 == "" || HW_KPS_KEYPAIR_NAME_2 == "" || HW_KPS_KEYPAIR_KEY_1 == "" || HW_KPS_KEYPAIR_SSH_PORT == "" {
+		t.Skip("HW_KPS_KEYPAIR_NAME_1, HW_KPS_KEYPAIR_NAME_2, HW_KPS_KEYPAIR_KEY_1, HW_KPS_KEYPAIR_SSH_PORT must be set for the acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_keypair_associate_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_keypair_associate_test.go
@@ -14,8 +14,8 @@ func TestAccKeypairsAssociate_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			// Please prepare two valid KMS keypair and one ECS, then config it to the environment variable.
-			acceptance.TestAccPreCheckKmsKeyPair(t)
+			// Please prepare two valid KPS keypair and one ECS, then config it to the environment variable.
+			acceptance.TestAccPreCheckKpsKeyPair(t)
 			acceptance.TestAccPreCheckECSAccount(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
@@ -32,7 +32,7 @@ func TestAccKeypairsAssociate_basic(t *testing.T) {
 
 func testAccKeypairsAssociate_basic() string {
 	return fmt.Sprintf(`
-resource "huaweicloud_kms_keypair_associate" "test" {
+resource "huaweicloud_kps_keypair_associate" "test" {
   keypair_name = "%[1]s"
 
   server {
@@ -45,12 +45,12 @@ resource "huaweicloud_kms_keypair_associate" "test" {
     }
   }
 }
-`, acceptance.HW_KMS_KEYPAIR_NAME_1, acceptance.HW_ECS_ID, acceptance.HW_KMS_KEYPAIR_SSH_PORT, acceptance.HW_ECS_ROOT_PWD)
+`, acceptance.HW_KPS_KEYPAIR_NAME_1, acceptance.HW_ECS_ID, acceptance.HW_KPS_KEYPAIR_SSH_PORT, acceptance.HW_ECS_ROOT_PWD)
 }
 
 func testAccKeypairsAssociate_replace() string {
 	return fmt.Sprintf(`
-resource "huaweicloud_kms_keypair_associate" "test1" {
+resource "huaweicloud_kps_keypair_associate" "test1" {
   keypair_name = "%[1]s"
   
   server {
@@ -63,5 +63,5 @@ resource "huaweicloud_kms_keypair_associate" "test1" {
     }
   }
 }
-`, acceptance.HW_KMS_KEYPAIR_NAME_2, acceptance.HW_ECS_ID, acceptance.HW_KMS_KEYPAIR_SSH_PORT, acceptance.HW_KMS_KEYPAIR_KEY_1)
+`, acceptance.HW_KPS_KEYPAIR_NAME_2, acceptance.HW_ECS_ID, acceptance.HW_KPS_KEYPAIR_SSH_PORT, acceptance.HW_KPS_KEYPAIR_KEY_1)
 }

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_keypair_disassociate_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_keypair_disassociate_test.go
@@ -14,9 +14,9 @@ func TestAccKeypairsDisassociate_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			// Please prepare one ECS with KMS keypair, then config it to the environment variable.
-			acceptance.TestAccPreCheckKmsKeyPrivateKey(t)
-			acceptance.TestAccPreCheckKmsSSHPort(t)
+			// Please prepare one ECS with KPS keypair, then config it to the environment variable.
+			acceptance.TestAccPreCheckKpsKeypairKey(t)
+			acceptance.TestAccPreCheckKpsSSHPort(t)
 			acceptance.TestAccPreCheckECSID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
@@ -30,7 +30,7 @@ func TestAccKeypairsDisassociate_basic(t *testing.T) {
 
 func testAccKeypairsDisassociate_basic() string {
 	return fmt.Sprintf(`
-resource "huaweicloud_kms_keypair_disassociate" "test" {
+resource "huaweicloud_kps_keypair_disassociate" "test" {
   server {
     id   = "%[1]s"
     port = %[2]s
@@ -41,5 +41,5 @@ resource "huaweicloud_kms_keypair_disassociate" "test" {
     }
   }
 }
-`, acceptance.HW_ECS_ID, acceptance.HW_KMS_KEYPAIR_SSH_PORT, acceptance.HW_KMS_KEY_PRIVATE_KEY)
+`, acceptance.HW_ECS_ID, acceptance.HW_KPS_KEYPAIR_SSH_PORT, acceptance.HW_KPS_KEYPAIR_KEY_1)
 }

--- a/huaweicloud/services/dew/resource_huaweicloud_kps_keypair_disassociate.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kps_keypair_disassociate.go
@@ -17,27 +17,25 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-var keypairAssociateNonUpdatableParams = []string{
-	"keypair_name",
+var keypairDisassociateNonUpdatableParams = []string{
 	"server",
 	"server.*.id",
 	"server.*.auth",
 	"server.*.port",
-	"server.*.disable_password",
 	"server.*.auth.*.type",
 	"server.*.auth.*.key",
 }
 
-// @API DEW POST /v3/{project_id}/keypairs/associate
+// @API DEW POST /v3/{project_id}/keypairs/disassociate
 // @API DEW GET /v3/{project_id}/tasks/{task_id}
-func ResourceKmsKeypairAssociate() *schema.Resource {
+func ResourceKpsKeypairDisassociate() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceKmsKeypairAssociateCreate,
-		ReadContext:   resourceKmsKeypairAssociateRead,
-		UpdateContext: resourceKmsKeypairAssociateUpdate,
-		DeleteContext: resourceKmsKeypairAssociateDelete,
+		CreateContext: resourceKpsKeypairDisassociateCreate,
+		ReadContext:   resourceKpsKeypairDisassociateRead,
+		UpdateContext: resourceKpsKeypairDisassociateUpdate,
+		DeleteContext: resourceKpsKeypairDisassociateDelete,
 
-		CustomizeDiff: config.FlexibleForceNew(keypairAssociateNonUpdatableParams),
+		CustomizeDiff: config.FlexibleForceNew(keypairDisassociateNonUpdatableParams),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
@@ -50,16 +48,11 @@ func ResourceKmsKeypairAssociate() *schema.Resource {
 				Computed:    true,
 				Description: `Specifies the region in which to query the resource.`,
 			},
-			"keypair_name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: `Specifies the name of SSH keypair.`,
-			},
 			"server": {
 				Type:        schema.TypeList,
 				Required:    true,
 				MaxItems:    1,
-				Elem:        resourceKeypairAssociateServerSchema(),
+				Elem:        resourceServerSchema(),
 				Description: `Specifies the ECS information.`,
 			},
 			"enable_force_new": {
@@ -72,7 +65,7 @@ func ResourceKmsKeypairAssociate() *schema.Resource {
 	}
 }
 
-func resourceKeypairAssociateServerSchema() *schema.Resource {
+func resourceServerSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -84,30 +77,25 @@ func resourceKeypairAssociateServerSchema() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				MaxItems:    1,
-				Elem:        resourceKeypairAssociateServerAuthSchema(),
-				Description: `Specifies the authentication information.`,
+				Elem:        resourceServerAuthSchema(),
+				Description: `Specifies the authentication type.`,
 			},
 			"port": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: `Specifies the SSH listening port.`,
 			},
-			"disable_password": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: `Specifies whether the password is disabled.`,
-			},
 		},
 	}
 }
 
-func resourceKeypairAssociateServerAuthSchema() *schema.Resource {
+func resourceServerAuthSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"type": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: `Specifies the value of the authentication type.`,
+				Description: `Specifies the value of an enumeration type.`,
 			},
 			"key": {
 				Type:        schema.TypeString,
@@ -118,14 +106,13 @@ func resourceKeypairAssociateServerAuthSchema() *schema.Resource {
 	}
 }
 
-func buildKeypairAssociateBodyParams(d *schema.ResourceData) map[string]interface{} {
+func buildKeypairDisassociateBodyParams(d *schema.ResourceData) map[string]interface{} {
 	return map[string]interface{}{
-		"keypair_name": d.Get("keypair_name"),
-		"server":       utils.RemoveNil(buildKeypairAssociateServerBodyParams(d.Get("server").([]interface{}))),
+		"server": utils.RemoveNil(buildServerBodyParams(d.Get("server").([]interface{}))),
 	}
 }
 
-func buildKeypairAssociateServerAuthBodyParams(auths []interface{}) map[string]interface{} {
+func buildServerAuthBodyParams(auths []interface{}) map[string]interface{} {
 	if len(auths) == 0 || auths[0] == nil {
 		return nil
 	}
@@ -143,8 +130,8 @@ func buildKeypairAssociateServerAuthBodyParams(auths []interface{}) map[string]i
 	return bodyParams
 }
 
-func buildKeypairAssociateServerBodyParams(servers []interface{}) map[string]interface{} {
-	if len(servers) == 0 || servers[0] == nil {
+func buildServerBodyParams(servers []interface{}) map[string]interface{} {
+	if (len(servers) == 0) || servers[0] == nil {
 		return nil
 	}
 
@@ -152,17 +139,16 @@ func buildKeypairAssociateServerBodyParams(servers []interface{}) map[string]int
 	for _, v := range servers {
 		item := v.(map[string]interface{})
 		bodyParams = map[string]interface{}{
-			"id":               item["id"],
-			"auth":             buildKeypairAssociateServerAuthBodyParams(item["auth"].([]interface{})),
-			"port":             utils.ValueIgnoreEmpty(item["port"]),
-			"disable_password": item["disable_password"],
+			"id":   item["id"],
+			"auth": buildServerAuthBodyParams(item["auth"].([]interface{})),
+			"port": utils.ValueIgnoreEmpty(item["port"]),
 		}
 	}
 
 	return bodyParams
 }
 
-func getKeypairAssociateTask(client *golangsdk.ServiceClient, taskId string) (interface{}, error) {
+func getKeypairDisassociateTask(client *golangsdk.ServiceClient, taskId string) (interface{}, error) {
 	var (
 		httpUrl = "v3/{project_id}/tasks/{task_id}"
 		getOpt  = golangsdk.RequestOpts{
@@ -176,38 +162,38 @@ func getKeypairAssociateTask(client *golangsdk.ServiceClient, taskId string) (in
 
 	getResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return getResp, fmt.Errorf("error retrieving KMS keypair associate task: %s", err)
+		return getResp, fmt.Errorf("error retrieving KPS keypair disassociate task: %s", err)
 	}
 
 	return utils.FlattenResponse(getResp)
 }
 
-func keypairAssociateTaskStatusRefreshFunc(taskId string, client *golangsdk.ServiceClient) resource.StateRefreshFunc {
+func taskStatusRefreshFunc(taskId string, client *golangsdk.ServiceClient) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		getTaskBody, err := getKeypairAssociateTask(client, taskId)
+		getTaskBody, err := getKeypairDisassociateTask(client, taskId)
 		if err != nil {
 			return getTaskBody, "ERROR", err
 		}
 
 		taskStatus := utils.PathSearch("task_status", getTaskBody, "").(string)
-		if utils.StrSliceContains([]string{"FAILED_BIND", "FAILED_RESET", "FAILED_REPLACE"}, taskStatus) {
-			return getTaskBody, "ERROR", fmt.Errorf("unexpect status (%s)", taskStatus)
+		if taskStatus == "SUCCESS_UNBIND" {
+			return getTaskBody, "COMPLETED", nil
 		}
 
-		if utils.StrSliceContains([]string{"SUCCESS_BIND", "SUCCESS_RESET", "SUCCESS_REPLACE"}, taskStatus) {
-			return getTaskBody, "COMPLETED", nil
+		if taskStatus == "FAILED_UNBIND" {
+			return getTaskBody, "ERROR", fmt.Errorf("unexpect status (%s)", taskStatus)
 		}
 
 		return getTaskBody, "PENDING", nil
 	}
 }
 
-func waitForKeypairAssociateStatusCompleted(ctx context.Context, client *golangsdk.ServiceClient, taskId string,
+func waitForKeypairDisassociateStatusCompleted(ctx context.Context, client *golangsdk.ServiceClient, taskId string,
 	timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"PENDING"},
 		Target:       []string{"COMPLETED"},
-		Refresh:      keypairAssociateTaskStatusRefreshFunc(taskId, client),
+		Refresh:      taskStatusRefreshFunc(taskId, client),
 		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: 20 * time.Second,
@@ -218,16 +204,16 @@ func waitForKeypairAssociateStatusCompleted(ctx context.Context, client *golangs
 	return err
 }
 
-func resourceKmsKeypairAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceKpsKeypairDisassociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg     = meta.(*config.Config)
 		region  = cfg.GetRegion(d)
-		httpUrl = "v3/{project_id}/keypairs/associate"
+		httpUrl = "v3/{project_id}/keypairs/disassociate"
 		product = "kms"
 	)
 	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating KMS client: %s", err)
+		return diag.Errorf("error creating KPS client: %s", err)
 	}
 
 	requestPath := client.Endpoint + httpUrl
@@ -235,11 +221,11 @@ func resourceKmsKeypairAssociateCreate(ctx context.Context, d *schema.ResourceDa
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
-		JSONBody:         utils.RemoveNil(buildKeypairAssociateBodyParams(d)),
+		JSONBody:         utils.RemoveNil(buildKeypairDisassociateBodyParams(d)),
 	}
 	resp, err := client.Request("POST", requestPath, &requestOpt)
 	if err != nil {
-		return diag.Errorf("error associating the KMS keypair to the ECS: %s", err)
+		return diag.Errorf("error disassociating the KPS keypair from ECS: %s", err)
 	}
 
 	respBody, err := utils.FlattenResponse(resp)
@@ -249,11 +235,11 @@ func resourceKmsKeypairAssociateCreate(ctx context.Context, d *schema.ResourceDa
 
 	taskId := utils.PathSearch("task_id", respBody, "").(string)
 	if taskId == "" {
-		return diag.Errorf("unable to find KMS task ID from API response")
+		return diag.Errorf("unable to find KPS task ID from API response")
 	}
 	d.SetId(taskId)
 
-	err = waitForKeypairAssociateStatusCompleted(ctx, client, taskId, d.Timeout(schema.TimeoutCreate))
+	err = waitForKeypairDisassociateStatusCompleted(ctx, client, taskId, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("error waiting for the task (%s) completed: %s", taskId, err)
 	}
@@ -261,19 +247,19 @@ func resourceKmsKeypairAssociateCreate(ctx context.Context, d *schema.ResourceDa
 	return nil
 }
 
-func resourceKmsKeypairAssociateRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourceKpsKeypairDisassociateRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
 	return nil
 }
 
-func resourceKmsKeypairAssociateUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourceKpsKeypairDisassociateUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
 	return nil
 }
 
-func resourceKmsKeypairAssociateDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	errorMsg := `This resource is a one-time action resource using to associate a SSH keypair to a specified ECS.
-Deleting this resource will not change the current SSH key pair, but will only remove the resource information from the tfstate file.`
+func resourceKpsKeypairDisassociateDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to disassociate a SSH keypair to a specified ECS.
+Deleting this resource will not change the current SSH keypair, but will only remove the resource information from the tfstate file.`
 	return diag.Diagnostics{
 		diag.Diagnostic{
 			Severity: diag.Warning,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Correct the incorrect service name 'kms' to' kps'
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccKeypairsDisassociate_basic -timeout 360m -parallel 10
=== RUN   TestAccKeypairsDisassociate_basic
--- PASS: TestAccKeypairsDisassociate_basic (19.59s)
PASS
coverage: 5.2% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew

TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccKeypairsAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccKeypairsAssociate_basic
--- PASS: TestAccKeypairsAssociate_basic (36.09s)
PASS
coverage: 5.3% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew  
```
![image](https://github.com/user-attachments/assets/b3354a9f-d607-44a4-a119-d7aba316169c)
![image](https://github.com/user-attachments/assets/1c53d980-4958-4e97-b98c-52c6508d859f)


* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
