### PR TITLE
feat(fgs): make some changes for the parameter network_controller

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -685,7 +685,7 @@ The `metric_configs` block supports:
 <a name="function_network_controller"></a>
 The `network_controller` block supports:
 
-* `trigger_access_vpcs` - (Required, List) Specifies the configuration of the VPCs that can trigger the function.  
+* `trigger_access_vpcs` - (Optional, List) Specifies the configuration of the VPCs that can trigger the function.  
   The [trigger_access_vpcs](#function_network_controller_trigger_access_vpcs) structure is documented below.
 
 * `disable_public_network` - (Optional, Bool) Specifies whether to disable the public network access.
@@ -693,7 +693,9 @@ The `network_controller` block supports:
 <a name="function_network_controller_trigger_access_vpcs"></a>
 The `trigger_access_vpcs` block supports:
 
-* `vpc_id` - (Required, String) Specifies the ID of the VPC that can trigger the function.
+* `vpc_id` - (Optional, String) Specifies the ID of the VPC that can trigger the function.
+
+* `vpc_name` - (Optional, String) Specifies the name of the VPC that can trigger the function.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -520,12 +520,20 @@ func ResourceFgsFunction() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"trigger_access_vpcs": {
 							Type:     schema.TypeSet,
-							Required: true,
+							Optional: true,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"vpc_id": {
 										Type:        schema.TypeString,
-										Required:    true,
+										Optional:    true,
+										Computed:    true,
+										Description: `The ID of the VPC that can trigger the function.`,
+									},
+									"vpc_name": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Computed:    true,
 										Description: `The ID of the VPC that can trigger the function.`,
 									},
 								},
@@ -775,21 +783,22 @@ func buildFunctionLogConfig(d *schema.ResourceData) map[string]interface{} {
 }
 
 func buildNetworkControllerTriggerAccessVpcs(triggerAccessVpcs []interface{}) []map[string]interface{} {
-	if len(triggerAccessVpcs) < 1 {
+	if len(triggerAccessVpcs) < 1 || triggerAccessVpcs[0] == nil {
 		return nil
 	}
 
 	result := make([]map[string]interface{}, 0, len(triggerAccessVpcs))
 	for _, triggerAccessVpc := range triggerAccessVpcs {
 		result = append(result, map[string]interface{}{
-			"vpc_id": utils.PathSearch("vpc_id", triggerAccessVpc, nil),
+			"vpc_id":   utils.PathSearch("vpc_id", triggerAccessVpc, nil),
+			"vpc_name": utils.PathSearch("vpc_name", triggerAccessVpc, nil),
 		})
 	}
 	return result
 }
 
 func buildFunctionNetworkController(networkControlers []interface{}) map[string]interface{} {
-	if len(networkControlers) < 1 {
+	if len(networkControlers) < 1 || networkControlers[0] == nil {
 		return nil
 	}
 
@@ -1498,7 +1507,8 @@ func flattenNetworkControllerTriggerAccessVpcs(triggerAccessVpcs []interface{}) 
 	result := make([]map[string]interface{}, 0, len(triggerAccessVpcs))
 	for _, triggerAccessVpc := range triggerAccessVpcs {
 		result = append(result, map[string]interface{}{
-			"vpc_id": utils.PathSearch("vpc_id", triggerAccessVpc, nil),
+			"vpc_id":   utils.PathSearch("vpc_id", triggerAccessVpc, nil),
+			"vpc_name": utils.PathSearch("vpc_name", triggerAccessVpc, nil),
 		})
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. The behavior of the parameter 'network_controller' has been changed: from Required to Optional.
2. Supports a new paremter 'trigger_access_vpcs.vpc_name' to the parameter 'network_controller'.
![image](https://github.com/user-attachments/assets/50b88cd6-4299-497d-9b8f-748971e4eb38)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. adjust the design of the parameter network_controller.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
NONE
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
