### PR TITLE
feat(dew): add a one-time resource to delete all failed tasks

### DIFF
--- a/docs/resources/kps_failed_tasks_delete.md
+++ b/docs/resources/kps_failed_tasks_delete.md
@@ -1,0 +1,33 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_kps_failed_tasks_delete"
+description: |-
+  Manages a KPS failed tasks delete resource within HuaweiCloud.
+---
+
+# huaweicloud_kps_failed_tasks_delete
+
+Manages a KPS failed tasks delete resource within HuaweiCloud.
+
+-> The current resource is a one-time resource, and destroying this resource will not recover the deleted tasks,
+but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_kps_failed_tasks_delete" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2209,6 +2209,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_kps_keypair_disassociate": dew.ResourceKpsKeypairDisassociate(),
 			"huaweicloud_kps_keypair_associate":    dew.ResourceKpsKeypairAssociate(),
+			"huaweicloud_kps_failed_tasks_delete":  dew.ResourceKpsFailedTasksDelete(),
 
 			"huaweicloud_lb_certificate":  lb.ResourceCertificateV2(),
 			"huaweicloud_lb_l7policy":     lb.ResourceL7PolicyV2(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -121,6 +121,7 @@ var (
 	HW_KPS_KEYPAIR_NAME_2   = os.Getenv("HW_KPS_KEYPAIR_NAME_2")
 	HW_KPS_KEYPAIR_KEY_1    = os.Getenv("HW_KPS_KEYPAIR_KEY_1")
 	HW_KPS_KEYPAIR_SSH_PORT = os.Getenv("HW_KPS_KEYPAIR_SSH_PORT")
+	HW_KPS_ENABLE_FLAG      = os.Getenv("HW_KPS_ENABLE_FLAG")
 
 	HW_DEST_REGION          = os.Getenv("HW_DEST_REGION")
 	HW_DEST_PROJECT_ID      = os.Getenv("HW_DEST_PROJECT_ID")
@@ -1726,6 +1727,13 @@ func TestAccPreCheckKpsKeypairKey(t *testing.T) {
 func TestAccPreCheckKpsKeyPair(t *testing.T) {
 	if HW_KPS_KEYPAIR_NAME_1 == "" || HW_KPS_KEYPAIR_NAME_2 == "" || HW_KPS_KEYPAIR_KEY_1 == "" || HW_KPS_KEYPAIR_SSH_PORT == "" {
 		t.Skip("HW_KPS_KEYPAIR_NAME_1, HW_KPS_KEYPAIR_NAME_2, HW_KPS_KEYPAIR_KEY_1, HW_KPS_KEYPAIR_SSH_PORT must be set for the acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckKpsEnable(t *testing.T) {
+	if HW_KPS_ENABLE_FLAG == "" {
+		t.Skip("HW_KPS_ENABLE_FLAG must be set for acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_failed_tasks_delete_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_failed_tasks_delete_test.go
@@ -1,0 +1,46 @@
+package dew
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccFailedTasksDelete_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare some failed KPS tasks.
+			acceptance.TestAccPreCheckKpsEnable(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFailedTasksDelete_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckOutput("is_delete_success", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccFailedTasksDelete_basic string = `
+data "huaweicloud_kps_failed_tasks" "before_delete" {}
+
+resource "huaweicloud_kps_failed_tasks_delete" "test" {
+    depends_on = [data.huaweicloud_kps_failed_tasks.before_delete]
+}
+
+data "huaweicloud_kps_failed_tasks" "after_delete" {
+    depends_on = [huaweicloud_kps_failed_tasks_delete.test]
+}
+
+output "is_delete_success" {
+    value = alltrue([length(data.huaweicloud_kps_failed_tasks.before_delete.tasks) > 0, 
+    length(data.huaweicloud_kps_failed_tasks.after_delete.tasks) == 0])
+}
+`

--- a/huaweicloud/services/dew/resource_huaweicloud_kps_failed_tasks_delete.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kps_failed_tasks_delete.go
@@ -1,0 +1,87 @@
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API DEW DELETE /v3/{project_id}/failed-tasks
+func ResourceKpsFailedTasksDelete() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKpsFailedTasksDeleteCreate,
+		ReadContext:   resourceKpsFailedTasksDeleteRead,
+		UpdateContext: resourceKpsFailedTasksDeleteUpdate,
+		DeleteContext: resourceKpsFailedTasksDeleteDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to create the resource.`,
+			},
+		},
+	}
+}
+
+func resourceKpsFailedTasksDeleteCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/failed-tasks"
+		product = "kms"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KPS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting failed tasks: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+	return nil
+}
+
+func resourceKpsFailedTasksDeleteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKpsFailedTasksDeleteUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKpsFailedTasksDeleteDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to delete all failed tasks.
+Deleting this resource will not recover the deleted tasks, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new one-time resource and names huaweicloud_kps_failed_tasks_delete.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccFailedTasksDelete_basic -timeout 360m -parallel 10
=== RUN   TestAccFailedTasksDelete_basic
=== PAUSE TestAccFailedTasksDelete_basic
=== CONT  TestAccFailedTasksDelete_basic
--- PASS: TestAccFailedTasksDelete_basic (10.38s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew
```
![image](https://github.com/user-attachments/assets/e9857135-d58d-4703-a71c-f075ccb64237)

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
