### PR TITLE
feat(cci): add data source CCI storage classes

### DIFF
--- a/docs/incubating/cciv2_storage_classes.md
+++ b/docs/incubating/cciv2_storage_classes.md
@@ -1,0 +1,76 @@
+---
+subcategory: "Cloud Container Instance (CCI)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cciv2_storage_classes"
+description: |-
+  Use this data source to get the list of CCI storage classes within HuaweiCloud.
+---
+
+# huaweicloud_cciv2_storage_classes
+
+Use this data source to get the list of CCI storage classes within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cciv2_storage_classes" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `storage_classes` - The storage classes.
+  The [storage_classes](#storage_classes) structure is documented below.
+
+<a name="storage_classes"></a>
+The `storage_classes` block supports:
+
+* `name` - The name.
+
+* `allow_volume_expansion` - The allow volume expansion.
+
+* `allowed_topologies` - The allowed topologies.
+  The [allowed_topologies](#storage_classes_allowed_topologies) structure is documented below.
+
+* `annotations` - The annotations.
+
+* `creation_timestamp` - The creation timestamp.
+
+* `labels` - The labels.
+
+* `mount_options` - The mount options.
+
+* `parameters` - The parameters.
+
+* `provisioner` - The provisioner.
+
+* `reclaim_policy` - The reclaim policy.
+
+* `resource_version` - The resource version.
+
+* `uid` - The uid.
+
+* `volume_binding_mode` - The volume binding mode.
+
+<a name="storage_classes_allowed_topologies"></a>
+The `allowed_topologies` block supports:
+
+* `match_label_expressions` - The match label expressions.
+  The [match_label_expressions](#storage_classes_allowed_topologies_match_label_expressions) structure is documented below.
+
+<a name="storage_classes_allowed_topologies_match_label_expressions"></a>
+The `match_label_expressions` block supports:
+
+* `key` - The key.
+
+* `values` - The values.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -598,6 +598,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cciv2_pods":                     cci.DataSourceV2Pods(),
 			"huaweicloud_cciv2_persistent_volumes":       cci.DataSourceV2PersistentVolumes(),
 			"huaweicloud_cciv2_persistent_volume_claims": cci.DataSourceV2PersistentVolumeClaims(),
+			"huaweicloud_cciv2_storage_classes":          cci.DataSourceV2StorageClasses(),
 
 			"huaweicloud_ccm_certificates":               ccm.DataSourceCertificates(),
 			"huaweicloud_ccm_certificate_export":         ccm.DataSourceCertificateExport(),

--- a/huaweicloud/services/acceptance/cci/data_source_huaweicloud_cciv2_storage_classes_test.go
+++ b/huaweicloud/services/acceptance/cci/data_source_huaweicloud_cciv2_storage_classes_test.go
@@ -1,0 +1,36 @@
+package cci
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceV2StorageClasses_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_cciv2_storage_classes.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceV2StorageClasses_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "storage_classes.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "storage_classes.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "storage_classes.0.creation_timestamp"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "storage_classes.0.parameters.%"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "storage_classes.0.provisioner"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "storage_classes.0.resource_version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "storage_classes.0.uid"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "storage_classes.0.reclaim_policy"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "storage_classes.0.volume_binding_mode"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceV2StorageClasses_basic = `data "huaweicloud_cciv2_storage_classes" "test" {}`

--- a/huaweicloud/services/cci/data_source_huaweicloud_cciv2_storage_classes.go
+++ b/huaweicloud/services/cci/data_source_huaweicloud_cciv2_storage_classes.go
@@ -1,0 +1,211 @@
+package cci
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CCI GET /apis/cci/v2/storageclasses
+func DataSourceV2StorageClasses() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV2StorageClassesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"storage_classes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"allow_volume_expansion": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"allowed_topologies": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"match_label_expressions": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"key": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"values": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"annotations": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"labels": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_timestamp": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mount_options": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"parameters": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"provisioner": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"reclaim_policy": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"volume_binding_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceV2StorageClassesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("cci", region)
+	if err != nil {
+		return diag.Errorf("error creating CCI client: %s", err)
+	}
+	listStorageClassesHttpUrl := "apis/cci/v2/storageclasses"
+	listStorageClassesPath := client.Endpoint + listStorageClassesHttpUrl
+	listStorageClassesOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	listStorageClassesResp, err := client.Request("GET", listStorageClassesPath, &listStorageClassesOpt)
+	if err != nil {
+		return diag.Errorf("error getting CCI storage classes: %s", err)
+	}
+
+	listStorageClassesRespBody, err := utils.FlattenResponse(listStorageClassesResp)
+	if err != nil {
+		return diag.Errorf("error retrieving CCI storage classes: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	storageClasses := utils.PathSearch("items", listStorageClassesRespBody, make([]interface{}, 0)).([]interface{})
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("storage_classes", flattenStorageClasses(storageClasses)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenStorageClasses(storageClasses []interface{}) []interface{} {
+	if len(storageClasses) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(storageClasses))
+	for i, v := range storageClasses {
+		allowedTopologies := utils.PathSearch("allowedTopologies", v, make([]interface{}, 0)).([]interface{})
+		rst[i] = map[string]interface{}{
+			"name":                   utils.PathSearch("metadata.name", v, nil),
+			"annotations":            utils.PathSearch("metadata.annotations", v, nil),
+			"labels":                 utils.PathSearch("metadata.labels", v, nil),
+			"creation_timestamp":     utils.PathSearch("metadata.creationTimestamp", v, nil),
+			"resource_version":       utils.PathSearch("metadata.resourceVersion", v, nil),
+			"uid":                    utils.PathSearch("metadata.uid", v, nil),
+			"allow_volume_expansion": utils.PathSearch("allowVolumeExpansion", v, nil),
+			"mount_options":          utils.PathSearch("mountOptions", v, nil),
+			"parameters":             utils.PathSearch("parameters", v, nil),
+			"provisioner":            utils.PathSearch("provisioner", v, nil),
+			"reclaim_policy":         utils.PathSearch("reclaimPolicy", v, nil),
+			"volume_binding_mode":    utils.PathSearch("volumeBindingMode", v, nil),
+			"allowed_topologies":     flattenAllowedTopologies(allowedTopologies),
+		}
+	}
+	return rst
+}
+
+func flattenAllowedTopologies(allowedTopologies []interface{}) []interface{} {
+	if len(allowedTopologies) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(allowedTopologies))
+	for i, v := range allowedTopologies {
+		matchLabelExpressions := utils.PathSearch("matchLabelExpressions", v, make([]interface{}, 0)).([]interface{})
+		rst[i] = map[string]interface{}{
+			"match_label_expressions": flattenMatchLabelExpressions(matchLabelExpressions),
+		}
+	}
+	return rst
+}
+
+func flattenMatchLabelExpressions(matchLabelExpressions []interface{}) []interface{} {
+	if len(matchLabelExpressions) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(matchLabelExpressions))
+	for i, v := range matchLabelExpressions {
+		rst[i] = map[string]interface{}{
+			"key":    utils.PathSearch("key", v, nil),
+			"values": utils.PathSearch("values", v, nil),
+		}
+	}
+	return rst
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
add data source CCI storage classes

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
add data source CCI storage classes
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/cci" TESTARGS="-run TestAccDataSourceV2StorageClasses_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cci -v -run TestAccDataSourceV2StorageClasses_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceV2StorageClasses_basic
=== PAUSE TestAccDataSourceV2StorageClasses_basic
=== CONT  TestAccDataSourceV2StorageClasses_basic
--- PASS: TestAccDataSourceV2StorageClasses_basic(32.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cci       35.600s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
