### PR TITLE
feat(lts): add new data source to get all alarms

### DIFF
--- a/docs/data-sources/lts_alarms.md
+++ b/docs/data-sources/lts_alarms.md
@@ -1,0 +1,156 @@
+---
+subcategory: "Log Tank Service (LTS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_lts_alarms"
+description: |-
+  Use this data source to get the alarm list within HuaweiCloud.
+---
+
+# huaweicloud_lts_alarms
+
+Use this data source to get the alarm list within HuaweiCloud.
+
+## Query active alarms in the last 30 minutes
+
+```hcl
+data "huaweicloud_lts_alarms" "filter_by_time_range" {
+  type                 = "active_alert"
+  whether_custom_field = false
+  time_range           = 30
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `type` - (Required, String) Specifies the type of the alarm to be queried.  
+  The valid values are as follows:
+  + **active_alert**: Query active alarms.
+  + **history_alert**: Query historical alarms.
+
+* `whether_custom_field` - (Optional, Bool) Specifies whether to customize the query time range, defaults to **false**.
+
+* `time_range` - (Optional, String) Specifies the time range of the alarm to be queried, in minutes.  
+  This parameter is required when `whether_custom_field` set to **false**.
+
+* `search` - (Optional, String) Specifies the keyword search criteria.
+
+* `alarm_level_ids` - (Optional, List) Specifies the list of alarm levels.  
+  The valid values are as follows:
+  + **Critical**
+  + **Major**
+  + **Minor**
+  + **Info**
+
+* `start_time` - (Optional, Int) Specifies the start time of a customized time segment, in milliseconds.  
+  This parameter is required when `whether_custom_field` set to **true**.
+
+* `end_time` - (Optional, Int) Specifies the end time of a customized time segment, in milliseconds.  
+  This parameter is required when `whether_custom_field` set to **true**.
+
+* `sort` - (Optional, List) Specifies the sort criteria of the queried alarms.  
+  The [sort](#data_alarms_sort) structure is documented below.
+
+* `step` - (Optional, Int) Specifies the step of the query, in milliseconds.
+
+<a name="data_alarms_sort"></a>
+The `sort` block supports:
+
+* `order` - (Required, String) Specifies the sort mode of the alarm.  
+  The valid values are as follows:
+  + **asc**
+  + **desc**
+
+* `order_by` - (Required, List) Specifies the fields to be sorted.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `alarms` - The list of the queried alarms.  
+  The [alarms](#data_alarms) structure is documented below.
+
+<a name="data_alarms"></a>
+The `alarms` block supports:
+
+* `id` - The ID of the alarm.
+
+* `type` - The type of the alarm.
+  + **keywords**
+  + **SQL**
+
+* `timeout` - The time when the alarm is automatically cleared, in milliseconds.
+
+* `arrives_at` - The time when the alarm arrives, in milliseconds.
+
+* `ends_at` - The time when the alarm is cleared, in milliseconds.
+
+* `starts_at` - The time when the alarm is generated, in milliseconds.
+
+* `annotations` - The details of the alarm.  
+  The [annotations](#data_alarms_annotations) structure is documented below.
+
+* `metadata` - The metadata of the alarm.  
+  The [metadata](#data_alarms_metadata) structure is documented below.
+
+<a name="data_alarms_annotations"></a>
+The `annotations` block supports:
+
+* `type` - The type of the alarm rule.
+
+* `message` - The detail information of the alarm.
+
+* `log_info` - The log information of the alarm.
+
+* `current_value` - The current value of the alarm.
+
+* `old_annotations` - The raw data of the alarm detail.
+
+* `alarm_action_rule_name` - The name of the alarm action rule.
+
+* `alarm_rule_alias` - The alias of the alarm rule.
+
+* `alarm_rule_url` - The URL of the alarm rule.
+
+* `alarm_status` - The status of the alarm trigger.
+
+* `condition_expression` - The condition expression of the alarm trigger.
+
+* `condition_expression_with_value` - The condition of the alarm trigger.
+
+* `notification_frequency` - The notification frequency of the alarm.
+
+* `recovery_policy` - Whether the alarm is recovered.
+
+* `frequency` - The frequency of the alarm.
+
+<a name="data_alarms_metadata"></a>
+The `metadata` block supports:
+
+* `event_id` - The ID of the alarm rule.
+
+* `event_name` - The name of the alarm rule.
+
+* `event_type` - The mode of the alarm.
+
+* `event_severity` - The level of the alarm.
+
+* `resource_provider` - The source of the alarm.
+
+* `lts_alarm_type` - The type of the alarm rule.
+
+* `resource_id` - The ID of the resource.
+
+* `resource_type` - The type of the resource.
+
+* `log_group_name` - The original name of the log group.
+
+* `log_stream_name` - The original name of the log stream.
+
+* `event_subtype` - The type of the alarm.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1088,6 +1088,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_live_channels":             live.DataSourceLiveChannels(),
 			"huaweicloud_live_cdn_ips":              live.DataSourceLiveCdnIps(),
 
+			"huaweicloud_lts_alarms":                       lts.DataSourceAlarms(),
 			"huaweicloud_lts_aom_accesses":                 lts.DataSourceAOMAccesses(),
 			"huaweicloud_lts_cce_accesses":                 lts.DataSourceCceAccesses(),
 			"huaweicloud_lts_groups":                       lts.DataSourceLtsGroups(),

--- a/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_alarms_test.go
+++ b/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_alarms_test.go
@@ -1,0 +1,259 @@
+package lts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAlarms_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		dataSource = "data.huaweicloud_lts_alarms.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byLevel   = "data.huaweicloud_lts_alarms.filter_by_level"
+		dcByLevel = acceptance.InitDataSourceCheck(byLevel)
+
+		bySortDesc   = "data.huaweicloud_lts_alarms.filter_by_sort_desc"
+		dcBySortDesc = acceptance.InitDataSourceCheck(bySortDesc)
+
+		bySortAsc   = "data.huaweicloud_lts_alarms.filter_by_sort_asc"
+		dcBySortAsc = acceptance.InitDataSourceCheck(bySortAsc)
+
+		byTimeRange   = "data.huaweicloud_lts_alarms.filter_by_time_range"
+		dcByTimeRange = acceptance.InitDataSourceCheck(byTimeRange)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLtsAlarmActionRuleName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"null": {
+				Source:            "hashicorp/null",
+				VersionConstraint: "3.2.1",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAlarms_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "alarms.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.arrives_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.starts_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.ends_at"),
+					dcByLevel.CheckResourceExists(),
+					resource.TestCheckOutput("is_alarm_level_filter_useful", "true"),
+					dcBySortDesc.CheckResourceExists(),
+					resource.TestCheckOutput("is_sort_filter_is_useful", "true"),
+					dcBySortAsc.CheckResourceExists(),
+					dcByTimeRange.CheckResourceExists(),
+					resource.TestCheckOutput("is_arrives_at_set_and_valid", "true"),
+					resource.TestCheckOutput("is_starts_at_set_and_valid", "true"),
+					resource.TestCheckOutput("is_timeout_set_and_valid", "true"),
+					resource.TestCheckOutput("is_annotations_set_and_valid", "true"),
+					resource.TestCheckOutput("is_metadata_set_and_valid", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceAlarms_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lts_group" "test" {
+  group_name  = "%[1]s"
+  ttl_in_days = 30
+}
+
+resource "huaweicloud_lts_stream" "test" {
+  group_id    = huaweicloud_lts_group.test.id
+  stream_name = "%[1]s"
+}
+
+resource "huaweicloud_lts_keywords_alarm_rule" "test" {
+  name                   = "%[1]s"
+  alarm_level            = "INFO"
+  description            = "created by terraform"
+  alarm_action_rule_name = "%[2]s"
+  send_notifications     = true
+  notification_frequency = 0
+
+  keywords_requests {
+    keywords               = "key_words"
+    condition              = "<"
+    number                 = 1
+    log_group_id           = huaweicloud_lts_group.test.id
+    log_stream_id          = huaweicloud_lts_stream.test.id
+    search_time_range_unit = "minute"
+    search_time_range      = 5
+  }
+
+  frequency {
+    type            = "FIXED_RATE"
+    fixed_rate      = 1
+    fixed_rate_unit = "minute"
+  }
+}
+
+# Wait for the alarm to be generated.
+resource "null_resource" "test" {
+  depends_on = [huaweicloud_lts_keywords_alarm_rule.test]
+
+  provisioner "local-exec" {
+    command = "sleep 90;"
+  }
+}
+`, name, acceptance.HW_LTS_ALARM_ACTION_RULE_NAME)
+}
+
+func testDataSourceAlarms_basic(name string) string {
+	currentTime := time.Now()
+	startTime := currentTime.Add(-1 * time.Hour).UnixMilli()
+	endTime := currentTime.UnixMilli()
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_lts_alarms" "test" {
+  type                 = "active_alert"
+  whether_custom_field = true
+  start_time           = "%[2]v"
+  end_time             = "%[3]v"
+
+  depends_on = [null_resource.test]
+}
+
+# Filter by alarm level.
+data "huaweicloud_lts_alarms" "filter_by_level" {
+  type                 = "active_alert"
+  whether_custom_field = false
+  time_range           = 30
+  alarm_level_ids      = ["Info"]
+
+  depends_on = [null_resource.test]
+}
+
+locals {
+  alarm_level_filter_result = [
+    for v in flatten(data.huaweicloud_lts_alarms.filter_by_level.alarms[*].metadata[*].event_severity) : v == "Info"
+  ]
+}
+
+output "is_alarm_level_filter_useful" {
+  value = length(local.alarm_level_filter_result) > 0 && alltrue(local.alarm_level_filter_result)
+}
+
+# Filter in descending order using 'arrives_at' field as key.
+data "huaweicloud_lts_alarms" "filter_by_sort_desc" {
+  type                 = "active_alert"
+  whether_custom_field = false
+  time_range           = 30
+
+  sort {
+    order_by = ["arrives_at"]
+    order    = "desc"
+  }
+
+  depends_on = [null_resource.test]
+}
+
+# Filter in ascending order using 'arrives_at' field as key.
+data "huaweicloud_lts_alarms" "filter_by_sort_asc" {
+  type                 = "active_alert"
+  whether_custom_field = false
+  time_range           = 30
+
+  sort {
+    order_by = ["arrives_at"]
+    order    = "asc"
+  }
+
+  depends_on = [null_resource.test]
+}
+
+locals {
+  sort_desc_filter_result   = data.huaweicloud_lts_alarms.filter_by_sort_desc.alarms
+  sort_desc_last_arrives_at = data.huaweicloud_lts_alarms.filter_by_sort_desc.alarms[length(local.sort_desc_filter_result) - 1].arrives_at
+  sort_asc_first_arrives_at = data.huaweicloud_lts_alarms.filter_by_sort_asc.alarms[0].arrives_at
+}
+
+output "is_sort_filter_is_useful" {
+  value = length(local.sort_desc_filter_result) >=2 && local.sort_desc_last_arrives_at == local.sort_asc_first_arrives_at
+}
+
+# Filter by time range.
+data "huaweicloud_lts_alarms" "filter_by_time_range" {
+  type                 = "active_alert"
+  whether_custom_field = false
+  time_range           = 30
+
+  depends_on = [null_resource.test]
+}
+
+locals {
+  active_alarm = try([for v in data.huaweicloud_lts_alarms.filter_by_time_range.alarms :
+  v if v.metadata[0].event_id == huaweicloud_lts_keywords_alarm_rule.test.id][0], {})
+}
+
+output "is_arrives_at_set_and_valid" {
+  value = try(local.active_alarm.arrives_at > 0, false)
+}
+
+output "is_starts_at_set_and_valid" {
+  value = try(local.active_alarm.starts_at > 0, false)
+}
+
+output "is_timeout_set_and_valid" {
+  value = try(local.active_alarm.timeout > 0, false)
+}
+
+output "is_annotations_set_and_valid" {
+  value = try(alltrue([
+    length(local.active_alarm.annotations) > 0 &&
+    local.active_alarm.annotations[0].alarm_action_rule_name != "" &&
+    local.active_alarm.annotations[0].alarm_rule_alias != "" &&
+    local.active_alarm.annotations[0].alarm_rule_url != "" &&
+    local.active_alarm.annotations[0].alarm_status != "" &&
+    local.active_alarm.annotations[0].condition_expression != "" &&
+    local.active_alarm.annotations[0].condition_expression_with_value != "" &&
+    local.active_alarm.annotations[0].current_value != "" &&
+    local.active_alarm.annotations[0].frequency != "" &&
+    local.active_alarm.annotations[0].log_info != "" &&
+    local.active_alarm.annotations[0].message != "" &&
+    local.active_alarm.annotations[0].notification_frequency != "" &&
+    local.active_alarm.annotations[0].old_annotations != "" &&
+    local.active_alarm.annotations[0].recovery_policy != "" &&
+    local.active_alarm.annotations[0].type != ""
+  ]), false)
+}
+
+output "is_metadata_set_and_valid" {
+  value = try(alltrue([
+    length(local.active_alarm.metadata) > 0 &&
+    local.active_alarm.metadata[0].event_id != "" &&
+    local.active_alarm.metadata[0].event_name != "" &&
+    local.active_alarm.metadata[0].event_severity != "" &&
+    local.active_alarm.metadata[0].event_subtype != "" &&
+    local.active_alarm.metadata[0].event_type != "" &&
+    local.active_alarm.metadata[0].log_group_name != "" &&
+    local.active_alarm.metadata[0].log_stream_name != "" &&
+    local.active_alarm.metadata[0].lts_alarm_type != "" &&
+    local.active_alarm.metadata[0].resource_id != "" &&
+    local.active_alarm.metadata[0].resource_provider != "" &&
+    local.active_alarm.metadata[0].resource_type != ""
+  ]), false)
+}
+`, testDataSourceAlarms_base(name), startTime, endTime)
+}

--- a/huaweicloud/services/lts/data_source_huaweicloud_lts_alarms.go
+++ b/huaweicloud/services/lts/data_source_huaweicloud_lts_alarms.go
@@ -1,0 +1,446 @@
+package lts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API LTS POST /v2/{project_id}/{domain_id}/lts/alarms/sql-alarm/query
+func DataSourceAlarms() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAlarmsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the alarm to be queried.`,
+			},
+			"whether_custom_field": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to customize the query time range.`,
+			},
+			"time_range": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The time range of the alarm to be queried, in minutes.`,
+			},
+			"search": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The keyword search criteria.`,
+			},
+			"alarm_level_ids": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of alarm levels.`,
+			},
+			"start_time": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The start time of a customized time segment, in milliseconds.`,
+			},
+			"end_time": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The end time of a customized time segment, in milliseconds.`,
+			},
+			"sort": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"order_by": {
+							Type:        schema.TypeList,
+							Required:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The fields to be sorted.`,
+						},
+						"order": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The sort mode of the alarm.`,
+						},
+					},
+				},
+				Description: `The sort criteria of the queried alarms.`,
+			},
+			"step": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The step of the query, in milliseconds.`,
+			},
+			"alarms": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the queried alarms.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the alarm.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the alarm.`,
+						},
+						"timeout": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The time when the alarm is automatically cleared, in milliseconds.`,
+						},
+						"arrives_at": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The time when the alarm arrives, in milliseconds.`,
+						},
+						"ends_at": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The time when the alarm is cleared, in milliseconds.`,
+						},
+						"starts_at": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The time when the alarm is generated, in milliseconds.`,
+						},
+						"annotations": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The details of the alarm.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The type of the alarm rule.`,
+									},
+									"message": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The detail information of the alarm.`,
+									},
+									"log_info": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The log information of the alarm.`,
+									},
+									"current_value": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The current value of the alarm.`,
+									},
+									"old_annotations": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The raw data of the alarm detail.`,
+									},
+									"alarm_action_rule_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the alarm action rule.`,
+									},
+									"alarm_rule_alias": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The alias of the alarm rule.`,
+									},
+									"alarm_rule_url": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The URL of the alarm rule.`,
+									},
+									"alarm_status": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The status of the alarm trigger.`,
+									},
+									"condition_expression": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The condition expression of the alarm trigger.`,
+									},
+									"condition_expression_with_value": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The condition of the alarm trigger.`,
+									},
+									"notification_frequency": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The notification frequency of the alarm.`,
+									},
+									"recovery_policy": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: `Whether the alarm is recovered.`,
+									},
+									"frequency": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The frequency of the alarm.`,
+									},
+								},
+							},
+						},
+						"metadata": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The metadata of the alarm.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"event_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the alarm rule.`,
+									},
+									"event_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the alarm rule.`,
+									},
+									"event_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The mode of the alarm.`,
+									},
+									"event_severity": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The level of the alarm.`,
+									},
+									"resource_provider": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The source of the alarm.`,
+									},
+									"lts_alarm_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The type of the alarm rule.`,
+									},
+									"resource_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the resource.`,
+									},
+									"resource_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The type of the resource.`,
+									},
+									"log_group_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The original name of the log group.`,
+									},
+									"log_stream_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The original name of the log stream.`,
+									},
+									"event_subtype": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The type of the alarm.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func queryAlarms(client *golangsdk.ServiceClient, d *schema.ResourceData, domainId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/{domain_id}/lts/alarms/sql-alarm/query?type={alarm_type}"
+		result  = make([]interface{}, 0)
+		marker  = ""
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{domain_id}", domainId)
+	listPath = strings.ReplaceAll(listPath, "{alarm_type}", d.Get("type").(string))
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+		JSONBody:         utils.RemoveNil(buildGetAlarmsBodyParams(d)),
+	}
+
+	for {
+		listPathWithMarker := listPath
+		if marker != "" {
+			listPathWithMarker += fmt.Sprintf("&marker=%s", marker)
+		}
+
+		resp, err := client.Request("POST", listPathWithMarker, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		alarms := utils.PathSearch("events", respBody, make([]interface{}, 0)).([]interface{})
+		if len(alarms) == 0 {
+			break
+		}
+
+		result = append(result, alarms...)
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func buildGetAlarmsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"whether_custom_field": utils.ValueIgnoreEmpty(d.Get("whether_custom_field")),
+		"time_range":           utils.ValueIgnoreEmpty(d.Get("time_range")),
+		"search":               utils.ValueIgnoreEmpty(d.Get("search")),
+		"alarm_level_ids":      utils.ValueIgnoreEmpty(utils.ExpandToStringList(d.Get("alarm_level_ids").([]interface{}))),
+		"start_time":           utils.ValueIgnoreEmpty(d.Get("start_time")),
+		"end_time":             utils.ValueIgnoreEmpty(d.Get("end_time")),
+		"sort":                 buildAlarmsSort(d.Get("sort").([]interface{})),
+		"step":                 utils.ValueIgnoreEmpty(d.Get("step")),
+	}
+}
+
+func buildAlarmsSort(sort []interface{}) map[string]interface{} {
+	if len(sort) == 0 {
+		return nil
+	}
+	return map[string]interface{}{
+		"order":    utils.PathSearch("order", sort[0], nil),
+		"order_by": utils.PathSearch("order_by", sort[0], nil),
+	}
+}
+
+func dataSourceAlarmsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("lts", region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+
+	alarms, err := queryAlarms(client, d, cfg.DomainID)
+	if err != nil {
+		return diag.Errorf("error retrieving LTS alarms: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("alarms", flattenAlarms(alarms)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAlarms(alarms []interface{}) []map[string]interface{} {
+	if len(alarms) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(alarms))
+	for i, v := range alarms {
+		result[i] = map[string]interface{}{
+			"id":          utils.PathSearch("id", v, nil),
+			"type":        utils.PathSearch("type", v, nil),
+			"timeout":     utils.PathSearch("timeout", v, nil),
+			"arrives_at":  utils.PathSearch("arrives_at", v, nil),
+			"ends_at":     utils.PathSearch("ends_at", v, nil),
+			"starts_at":   utils.PathSearch("starts_at", v, nil),
+			"annotations": flattenAlarmAnnotations(utils.PathSearch("annotations", v, nil)),
+			"metadata":    flattenAlarmmetadata(utils.PathSearch("metadata", v, nil)),
+		}
+	}
+
+	return result
+}
+
+func flattenAlarmAnnotations(annotations interface{}) []interface{} {
+	if annotations == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"type":                            utils.PathSearch("type", annotations, nil),
+			"message":                         utils.PathSearch("message", annotations, nil),
+			"log_info":                        utils.PathSearch("log_info", annotations, nil),
+			"current_value":                   utils.PathSearch("current_value", annotations, nil),
+			"old_annotations":                 utils.PathSearch("old_annotations", annotations, nil),
+			"alarm_action_rule_name":          utils.PathSearch("alarm_action_rule_name", annotations, nil),
+			"alarm_rule_alias":                utils.PathSearch("alarm_rule_alias", annotations, nil),
+			"alarm_rule_url":                  utils.PathSearch("alarm_rule_url", annotations, nil),
+			"alarm_status":                    utils.PathSearch("alarm_status", annotations, nil),
+			"condition_expression":            utils.PathSearch("condition_expression", annotations, nil),
+			"condition_expression_with_value": utils.PathSearch("condition_expression_with_value", annotations, nil),
+			"notification_frequency":          utils.PathSearch("notification_frequency", annotations, nil),
+			"recovery_policy":                 utils.PathSearch("recovery_policy", annotations, nil),
+			"frequency":                       utils.PathSearch("frequency", annotations, nil),
+		},
+	}
+}
+
+func flattenAlarmmetadata(metadata interface{}) []interface{} {
+	if metadata == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"event_id":          utils.PathSearch("event_id", metadata, nil),
+			"event_name":        utils.PathSearch("event_name", metadata, nil),
+			"event_type":        utils.PathSearch("event_type", metadata, nil),
+			"event_severity":    utils.PathSearch("event_severity", metadata, nil),
+			"resource_provider": utils.PathSearch("resource_provider", metadata, nil),
+			"lts_alarm_type":    utils.PathSearch("lts_alarm_type", metadata, nil),
+			"resource_id":       utils.PathSearch("resource_id", metadata, nil),
+			"resource_type":     utils.PathSearch("resource_type", metadata, nil),
+			"log_group_name":    utils.PathSearch("log_group_name", metadata, nil),
+			"log_stream_name":   utils.PathSearch("log_stream_name", metadata, nil),
+			"event_subtype":     utils.PathSearch("event_subtype", metadata, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add new data source(huaweicloud_lts_alarms) to get all alarm list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o lts -f TestAccDataSourceAlarms_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccDataSourceAlarms_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAlarms_basic
=== PAUSE TestAccDataSourceAlarms_basic
=== CONT  TestAccDataSourceAlarms_basic
--- PASS: TestAccDataSourceAlarms_basic (125.49s)
PASS
coverage: 10.6% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       125.584s        coverage: 10.6% of statements in ./huaweicloud/services/lts
```
![image](https://github.com/user-attachments/assets/5e3ffa18-1651-4b33-8ed2-d0553665f7ef)


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
