### PR TITLE
feat(encrypt): sensitive parameters supports encrypt operation

### DIFF
--- a/docs/resources/fgs_function_trigger_status.md
+++ b/docs/resources/fgs_function_trigger_status.md
@@ -67,6 +67,10 @@ The following arguments are supported:
 
 * `event_data` - (Optional, String, NonUpdatable) Specifies the trigger event data configuration, in JSON format.
 
+~> It is not recommended to reference the event_data returned by the function trigger resource.
+   <br>Instead, it is recommended to reference the same variable source.
+   <br>If not, the terraform will report this error: The provider produced inconsistent final plan.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/huaweicloud/services/dew/common.go
+++ b/huaweicloud/services/dew/common.go
@@ -1,0 +1,58 @@
+package dew
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DecryptPasswordWithDefaultKmsKey(_ context.Context, meta interface{}, d *schema.ResourceData, cipherText string) (string, error) {
+	var (
+		cfg                = meta.(*config.Config)
+		region             = cfg.GetRegion(d)
+		dataDecryptHttpUrl = "v1.0/{project_id}/kms/decrypt-data"
+		dataDecryptProduct = "kms"
+	)
+
+	client, err := cfg.NewServiceClient(dataDecryptProduct, region)
+	if err != nil {
+		return "", fmt.Errorf("error creating KMS client: %s", err)
+	}
+
+	dataDecryptPath := client.Endpoint + dataDecryptHttpUrl
+	dataDecryptPath = strings.ReplaceAll(dataDecryptPath, "{project_id}", client.ProjectID)
+
+	dataDecryptOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	bodyParams := map[string]interface{}{
+		"cipher_text": cipherText,
+	}
+
+	dataDecryptOpt.JSONBody = utils.RemoveNil(bodyParams)
+	dataDecryptResp, err := client.Request("POST", dataDecryptPath, &dataDecryptOpt)
+	if err != nil {
+		return "", fmt.Errorf("error decrypting data with KMS service: %s", err)
+	}
+
+	dataDecryptRespBody, err := utils.FlattenResponse(dataDecryptResp)
+	if err != nil {
+		return "", fmt.Errorf("error flatting response: %s", err)
+	}
+
+	plainText := utils.PathSearch("plain_text", dataDecryptRespBody, "").(string)
+	if plainText == "" {
+		return "", errors.New("unable to find the plain text from the API response")
+	}
+
+	return plainText, nil
+}

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_trigger_status_action.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_trigger_status_action.go
@@ -98,6 +98,11 @@ func resourceFunctionTriggerStatusActionCreate(ctx context.Context, d *schema.Re
 	updatePath = strings.ReplaceAll(updatePath, "{trigger_type_code}", triggerTypeCode)
 	updatePath = strings.ReplaceAll(updatePath, "{trigger_id}", triggerId)
 
+	parsedEventData, err := parseEventDataAndDecryptSentisiveParams(ctx, meta, d, utils.StringToJson(d.Get("event_data").(string)))
+	if err != nil {
+		return diag.Errorf("error parsing event data: %s", err)
+	}
+
 	opt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders: map[string]string{
@@ -105,7 +110,7 @@ func resourceFunctionTriggerStatusActionCreate(ctx context.Context, d *schema.Re
 		},
 		JSONBody: utils.RemoveNil(map[string]interface{}{
 			"trigger_status": triggerStatus,
-			"event_data":     utils.StringToJson(d.Get("event_data").(string)),
+			"event_data":     parsedEventData,
 		}),
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For function trigger, all password key/value pairs supports corresponding encrypted parameters for event data input.
The trigger action status also ditto.
For LTS register, support new encrypted password parameter for kafka instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
