### PR TITLE
feat(dew): add a new resource to delete failed task

### DIFF
--- a/docs/resources/kps_failed_task_delete.md
+++ b/docs/resources/kps_failed_task_delete.md
@@ -1,0 +1,39 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_kps_failed_task_delete"
+description: |-
+  Manages a KPS failed task delete resource within HuaweiCloud.
+---
+
+# huaweicloud_kps_failed_task_delete
+
+Manages a KPS failed task delete resource within HuaweiCloud.
+
+-> The current resource is a one-time resource, and destroying this resource will not recover the deleted task,
+but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "task_id" {}
+
+resource "huaweicloud_kps_failed_task_delete" "test" {
+  task_id = var.task_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `task_id` - (Required, String, NonUpdatable) Specifies the task ID, which identifies the failed task to be deleted.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2211,6 +2211,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kps_keypair_disassociate": dew.ResourceKpsKeypairDisassociate(),
 			"huaweicloud_kps_keypair_associate":    dew.ResourceKpsKeypairAssociate(),
 			"huaweicloud_kps_failed_tasks_delete":  dew.ResourceKpsFailedTasksDelete(),
+			"huaweicloud_kps_failed_task_delete":   dew.ResourceKpsFailedTaskDelete(),
 
 			"huaweicloud_lb_certificate":  lb.ResourceCertificateV2(),
 			"huaweicloud_lb_l7policy":     lb.ResourceL7PolicyV2(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -122,6 +122,7 @@ var (
 	HW_KPS_KEYPAIR_KEY_1    = os.Getenv("HW_KPS_KEYPAIR_KEY_1")
 	HW_KPS_KEYPAIR_SSH_PORT = os.Getenv("HW_KPS_KEYPAIR_SSH_PORT")
 	HW_KPS_ENABLE_FLAG      = os.Getenv("HW_KPS_ENABLE_FLAG")
+	HW_KPS_FAILED_TASK_ID   = os.Getenv("HW_KPS_FAILED_TASK_ID")
 
 	HW_DEST_REGION          = os.Getenv("HW_DEST_REGION")
 	HW_DEST_PROJECT_ID      = os.Getenv("HW_DEST_PROJECT_ID")
@@ -1713,6 +1714,13 @@ func TestAccPreCheckKmsKeyPrivateKey(t *testing.T) {
 func TestAccPreCheckKpsSSHPort(t *testing.T) {
 	if HW_KPS_KEYPAIR_SSH_PORT == "" {
 		t.Skip("HW_KPS_KEYPAIR_SSH_PORT must be set for acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckKpsTaskId(t *testing.T) {
+	if HW_KPS_FAILED_TASK_ID == "" {
+		t.Skip("HW_KPS_FAILED_TASK_ID must be set for acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_failed_task_delete_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_failed_task_delete_test.go
@@ -1,0 +1,46 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccKpsFailedTaskDelete_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare one failed taskId, then config it to the environment variable.
+			acceptance.TestAccPreCheckKpsTaskId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKpsFailedTaskDelete_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckOutput("is_delete_success", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKpsFailedTaskDelete_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kps_failed_task_delete" "test" {
+  task_id = "%[1]s"
+}
+
+data "huaweicloud_kps_failed_tasks" "after_delete" {
+  depends_on = [huaweicloud_kps_failed_task_delete.test]
+}
+
+output "is_delete_success" {
+  value = alltrue([for v in data.huaweicloud_kps_failed_tasks.after_delete.tasks[*].id : v != "%[1]s"])
+}
+`, acceptance.HW_KPS_FAILED_TASK_ID)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_kps_failed_task_delete.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kps_failed_task_delete.go
@@ -1,0 +1,107 @@
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var failedTaskDeleteNonUpdatableParams = []string{
+	"task_id",
+}
+
+// @API DEW DELETE /v3/{project_id}/failed-tasks/{task_id}
+func ResourceKpsFailedTaskDelete() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKpsFailedTaskDeleteCreate,
+		ReadContext:   resourceKpsFailedTaskDeleteRead,
+		UpdateContext: resourceKpsFailedTaskDeleteUpdate,
+		DeleteContext: resourceKpsFailedTaskDeleteDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(failedTaskDeleteNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to create the resource.`,
+			},
+			"task_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the task ID.`,
+			},
+			"enable_force_new": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceKpsFailedTaskDeleteCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/failed-tasks/{task_id}"
+		product = "kms"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KPS client: %s", err)
+	}
+
+	taskID := d.Get("task_id").(string)
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{task_id}", taskID)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting failed task: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+	return nil
+}
+
+func resourceKpsFailedTaskDeleteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKpsFailedTaskDeleteUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKpsFailedTaskDeleteDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to delete a specific failed task.
+Deleting this resource will not recover the deleted task, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new one-time resource and names huaweicloud_kps_failed_task_delete.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccKpsFailedTaskDelete_basic -timeout 360m -parallel 10
=== RUN   TestAccKpsFailedTaskDelete_basic
=== PAUSE TestAccKpsFailedTaskDelete_basic
=== CONT  TestAccKpsFailedTaskDelete_basic
--- PASS: TestAccKpsFailedTaskDelete_basic (12.50s)
PASS
coverage: 4.4% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew
```
![image](https://github.com/user-attachments/assets/ea92740d-76c8-4b65-9356-34708affa2fb)

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
