### PR TITLE
feat(cbr): new datasource to query storage usages

### DIFF
--- a/docs/data-sources/cbr_storage_usages.md
+++ b/docs/data-sources/cbr_storage_usages.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbr_storage_usages"
+description: |-
+  Use this data source to query the storage usage statistics of CBR within HuaweiCloud.
+---
+
+# huaweicloud_cbr_storage_usages
+
+Use this data source to query the storage usage statistics of CBR within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cbr_storage_usages" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `resource_id` - (Optional, String) Specifies the ID of the resource to filter the storage usage.
+
+* `resource_type` - (Optional, String) Specifies the type of the resource to filter by.
+  Valid values are **OS::Nova::Server**, **OS::Cinder::Volume**, **OS::Ironic::BareMetalServer**,
+  **OS::Native::Server**, **OS::Sfs::Turbo**, **OS::Workspace::DesktopV2**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `storage_usages` - The storage usage statistics list.
+
+  The [storage_usages](#storage_usages_struct) structure is documented below.
+
+<a name="storage_usages_struct"></a>
+The `storage_usages` block supports:
+
+* `resource_id` - The ID of the resource.
+
+* `resource_name` - The name of the resource.
+
+* `resource_type` - The type of the resource.
+
+* `backup_count` - The number of backups.
+
+* `backup_size` - The size of backups in bytes.
+
+* `backup_size_multiaz` - The size of multi-AZ backups in bytes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -544,6 +544,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbr_backups":                  cbr.DataSourceBackups(),
 			"huaweicloud_cbr_vaults":                   cbr.DataSourceVaults(),
 			"huaweicloud_cbr_policies":                 cbr.DataSourcePolicies(),
+			"huaweicloud_cbr_storage_usages":           cbr.DataSourceStorageUsages(),
 			"huaweicloud_cbr_tags":                     cbr.DataSourceTags(),
 			"huaweicloud_cbr_vaults_by_tags":           cbr.DataSourceVaultsByTags(),
 			"huaweicloud_cbr_replication_capabilities": cbr.DataSourceCbrReplicationCapabilities(),

--- a/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_storage_usages_test.go
+++ b/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_storage_usages_test.go
@@ -1,0 +1,74 @@
+package cbr
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataStorageUsages_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_cbr_storage_usages.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byResourceID   = "data.huaweicloud_cbr_storage_usages.filter_by_resource_id"
+		dcByResourceID = acceptance.InitDataSourceCheck(byResourceID)
+
+		byResourceType   = "data.huaweicloud_cbr_storage_usages.filter_by_resource_type"
+		dcByResourceType = acceptance.InitDataSourceCheck(byResourceType)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataStorageUsages_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "storage_usages.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "storage_usages.0.resource_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "storage_usages.0.resource_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "storage_usages.0.resource_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "storage_usages.0.backup_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "storage_usages.0.backup_size"),
+					resource.TestCheckResourceAttrSet(dataSource, "storage_usages.0.backup_size_multiaz"),
+
+					dcByResourceID.CheckResourceExists(),
+					resource.TestCheckOutput("resource_id_filter_is_useful", "true"),
+
+					dcByResourceType.CheckResourceExists(),
+					resource.TestCheckOutput("resource_type_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataStorageUsages_basic = `
+data "huaweicloud_cbr_storage_usages" "test" {}
+
+data "huaweicloud_cbr_storage_usages" "filter_by_resource_id" {
+  resource_id = data.huaweicloud_cbr_storage_usages.test.storage_usages[0].resource_id
+}
+
+output "resource_id_filter_is_useful" {
+  value = length(data.huaweicloud_cbr_storage_usages.filter_by_resource_id.storage_usages) > 0 && alltrue(
+    [for v in data.huaweicloud_cbr_storage_usages.filter_by_resource_id.storage_usages[*] :
+  v.resource_id == data.huaweicloud_cbr_storage_usages.test.storage_usages[0].resource_id])
+}
+
+data "huaweicloud_cbr_storage_usages" "filter_by_resource_type" {
+  resource_type = data.huaweicloud_cbr_storage_usages.test.storage_usages[0].resource_type
+}
+
+output "resource_type_filter_is_useful" {
+  value = length(data.huaweicloud_cbr_storage_usages.filter_by_resource_type.storage_usages) > 0 && alltrue(
+    [for v in data.huaweicloud_cbr_storage_usages.filter_by_resource_type.storage_usages[*] :
+  v.resource_type == data.huaweicloud_cbr_storage_usages.test.storage_usages[0].resource_type])
+}
+`

--- a/huaweicloud/services/cbr/data_source_huaweicloud_cbr_storage_usages.go
+++ b/huaweicloud/services/cbr/data_source_huaweicloud_cbr_storage_usages.go
@@ -1,0 +1,179 @@
+package cbr
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CBR GET /v3/{project_id}/storage_usage
+func DataSourceStorageUsages() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceStorageUsagesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the region where the CBR storage usage is located.`,
+			},
+			"resource_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the ID of the resource to filter the storage usage.`,
+			},
+			"resource_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the type of the resource to filter the storage usage.`,
+			},
+			"storage_usages": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the resource.`,
+						},
+						"resource_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the resource.`,
+						},
+						"resource_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the resource.`,
+						},
+						"backup_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The number of backups.`,
+						},
+						"backup_size": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The size of backups in bytes.`,
+						},
+						"backup_size_multiaz": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The size of multi-AZ backups in bytes.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildStorageUsageQueryParams(d *schema.ResourceData, offset int) string {
+	res := ""
+
+	if v, ok := d.GetOk("resource_id"); ok {
+		res = fmt.Sprintf("%s&resource_id=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("resource_type"); ok {
+		res = fmt.Sprintf("%s&resource_type=%v", res, v)
+	}
+
+	if offset != 0 {
+		res = fmt.Sprintf("%s&offset=%v", res, offset)
+	}
+
+	if res != "" {
+		res = "?" + res[1:]
+	}
+
+	return res
+}
+
+func dataSourceStorageUsagesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v3/{project_id}/storage_usage"
+		product    = "cbr"
+		totalItems []interface{}
+		offset     = 0
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBR client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	for {
+		eachRequestPath := requestPath + buildStorageUsageQueryParams(d, offset)
+		resp, err := client.Request("GET", eachRequestPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving CBR storage usage: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		items := utils.PathSearch("storage_usage", respBody, make([]interface{}, 0)).([]interface{})
+		if len(items) == 0 {
+			break
+		}
+
+		totalItems = append(totalItems, items...)
+		offset += len(items)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("storage_usages", flattenStorageUsage(totalItems)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenStorageUsage(totalItems []interface{}) []interface{} {
+	if len(totalItems) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(totalItems))
+	for _, v := range totalItems {
+		result = append(result, map[string]interface{}{
+			"resource_id":         utils.PathSearch("resource_id", v, nil),
+			"resource_name":       utils.PathSearch("resource_name", v, nil),
+			"resource_type":       utils.PathSearch("resource_type", v, nil),
+			"backup_count":        utils.PathSearch("backup_count", v, nil),
+			"backup_size":         utils.PathSearch("backup_size", v, nil),
+			"backup_size_multiaz": utils.PathSearch("backup_size_multiaz", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query storage usages.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cbr -f TestAccDataStorageUsages_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccDataStorageUsages_basic -timeout 360m -parallel 10
=== RUN   TestAccDataStorageUsages_basic
=== PAUSE TestAccDataStorageUsages_basic
=== CONT  TestAccDataStorageUsages_basic
--- PASS: TestAccDataStorageUsages_basic (12.44s)
PASS
coverage: 6.4% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       12.502s coverage: 6.4% of statements in ./huaweicloud/services/cbr
```
![image](https://github.com/user-attachments/assets/492cd9a5-9032-4d83-be25-ae564f47464a)


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
