### PR TITLE
feat(cbr): new resource to migrate vault resources

### DIFF
--- a/docs/resources/cbr_vault_migrate_resources.md
+++ b/docs/resources/cbr_vault_migrate_resources.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Cloud Backup and Recovery"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbr_vault_migrate_resources"
+description: |-
+  Use this resource to migrate resources between CBR vaults within HuaweiCloud.
+---
+
+# huaweicloud_cbr_vault_migrate_resources
+
+Use this resource to migrate resources between CBR vaults within HuaweiCloud.
+
+-> This resource is only a one-time action resource to migrate resources between CBR vaults. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "source_vault_id" {}
+variable "destination_vault_id" {}
+variable "resource_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_cbr_vault_migrate_resources" "test" {
+  vault_id             = var.source_vault_id
+  destination_vault_id = var.destination_vault_id
+  resource_ids         = var.resource_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource. If omitted, the provider-level
+  region will be used. Changing this will create a new resource.
+
+* `vault_id` - (Required, String, NonUpdatable) Specifies the source vault ID from which resources will be migrated.
+
+* `destination_vault_id` - (Required, String, NonUpdatable) Specifies the destination vault ID where resources
+  will be migrated to.
+
+* `resource_ids` - (Required, List, NonUpdatable) Specifies the IDs of the resources to be migrated.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the source vault (also `vault_id`).
+
+* `migrated_resources` - The list of resources that have been successfully migrated.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1676,14 +1676,15 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_cbc_resources_unsubscribe": cbc.ResourceResourcesUnsubscribe(),
 
-			"huaweicloud_cbr_backup_share_accepter": cbr.ResourceBackupShareAccepter(),
-			"huaweicloud_cbr_backup_share":          cbr.ResourceBackupShare(),
-			"huaweicloud_cbr_checkpoint":            cbr.ResourceCheckpoint(),
-			"huaweicloud_cbr_organization_policy":   cbr.ResourceOrganizationPolicy(),
-			"huaweicloud_cbr_policy":                cbr.ResourcePolicy(),
-			"huaweicloud_cbr_vault":                 cbr.ResourceVault(),
-			"huaweicloud_cbr_restore":               cbr.ResourceRestore(),
-			"huaweicloud_cbr_migrate":               cbr.ResourceMigrate(),
+			"huaweicloud_cbr_backup_share_accepter":   cbr.ResourceBackupShareAccepter(),
+			"huaweicloud_cbr_backup_share":            cbr.ResourceBackupShare(),
+			"huaweicloud_cbr_checkpoint":              cbr.ResourceCheckpoint(),
+			"huaweicloud_cbr_organization_policy":     cbr.ResourceOrganizationPolicy(),
+			"huaweicloud_cbr_policy":                  cbr.ResourcePolicy(),
+			"huaweicloud_cbr_vault":                   cbr.ResourceVault(),
+			"huaweicloud_cbr_restore":                 cbr.ResourceRestore(),
+			"huaweicloud_cbr_migrate":                 cbr.ResourceMigrate(),
+			"huaweicloud_cbr_vault_migrate_resources": cbr.ResourceVaultMigrateResources(),
 
 			"huaweicloud_cbh_instance":                   cbh.ResourceCBHInstance(),
 			"huaweicloud_cbh_ha_instance":                cbh.ResourceCBHHAInstance(),

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_migrate_resources_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_migrate_resources_test.go
@@ -1,0 +1,77 @@
+package cbr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceVaultMigrateResources_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceVaultMigrateResources_basic(),
+			},
+		},
+	})
+}
+
+func testResourceVaultMigrateResources_base() string {
+	name := acceptance.RandomAccResourceName()
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name              = "%[1]s"
+  size              = 50
+  description       = "test description"
+  volume_type       = "GPSSD"
+  multiattach       = false
+  charging_mode     = "postPaid"
+}
+
+resource "huaweicloud_cbr_vault" "test1" {
+  name            = "%[1]s_1"
+  type            = "disk"
+  protection_type = "backup"
+  size            = 100
+
+  resources {
+    includes = [huaweicloud_evs_volume.test.id]
+  }
+
+  lifecycle {
+    ignore_changes = [
+      resources,
+    ]
+  }
+}
+
+resource "huaweicloud_cbr_vault" "test2" {
+  name            = "%[1]s_2"
+  type            = "disk"
+  protection_type = "backup"
+  size            = 100
+}
+`, name)
+}
+
+func testResourceVaultMigrateResources_basic() string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cbr_vault_migrate_resources" "test" {
+  vault_id             = huaweicloud_cbr_vault.test1.id
+  destination_vault_id = huaweicloud_cbr_vault.test2.id
+  resource_ids         = [huaweicloud_evs_volume.test.id]
+}`, testResourceVaultMigrateResources_base())
+}

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault_migrate_resources.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault_migrate_resources.go
@@ -1,0 +1,147 @@
+package cbr
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableMigrationParams = []string{
+	"vault_id",
+	"destination_vault_id",
+	"resource_ids",
+}
+
+// @API CBR POST /v3/{project_id}/vaults/{vault_id}/migrateresources
+func ResourceVaultMigrateResources() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVaultMigrateResourcesCreate,
+		ReadContext:   resourceVaultMigrateResourcesRead,
+		UpdateContext: resourceVaultMigrateResourcesUpdate,
+		DeleteContext: resourceVaultMigrateResourcesDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableMigrationParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level
+region will be used.`,
+			},
+			"vault_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the source vault ID from which resources will be migrated.`,
+			},
+			"destination_vault_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the destination vault ID where resources will be migrated to.`,
+			},
+			"resource_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: `Specifies the IDs of the resources to be migrated.`,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"migrated_resources": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Specifies the list of resources that have been successfully migrated.`,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func buildVaultMigrateResourcesBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"destination_vault_id": d.Get("destination_vault_id"),
+		"resource_ids":         d.Get("resource_ids"),
+	}
+}
+
+func resourceVaultMigrateResourcesCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/vaults/{vault_id}/migrateresources"
+		product = "cbr"
+		vaultID = d.Get("vault_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBR client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{vault_id}", vaultID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildVaultMigrateResourcesBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error migrating CBR resources between vaults: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("migrated_resources", utils.PathSearch("migrated_resources", respBody, nil)); err != nil {
+		log.Printf("[ERROR] error setting migrated_resources: %s", err)
+	}
+
+	d.SetId(vaultID)
+
+	return nil
+}
+
+func resourceVaultMigrateResourcesRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceVaultMigrateResourcesUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceVaultMigrateResourcesDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to migrate CBR resources between vaults. Deleting this 
+resource will not change the current migration result, but will only remove the resource information from the 
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to migrate vault resources.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cbr -f TestAccResourceVaultMigrateResources_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccResourceVaultMigrateResources_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceVaultMigrateResources_basic
=== PAUSE TestAccResourceVaultMigrateResources_basic
=== CONT  TestAccResourceVaultMigrateResources_basic
--- PASS: TestAccResourceVaultMigrateResources_basic (56.28s)
PASS
coverage: 12.8% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       56.348s coverage: 12.8% of statements in ./huaweicloud/services/cbr
```
![image](https://github.com/user-attachments/assets/7fc68905-e359-4d7a-b6e2-0f7f591d88f4)


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
