### PR TITLE
fix(apig): updating other parameters error when log is enabled

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -236,6 +236,7 @@ resource "huaweicloud_fgs_function" "test" {
   code_type   = "inline"
   func_code   = base64encode(var.function_codes)
 
+  enable_lts_log  = true
   log_group_id    = var.log_group_id
   log_stream_id   = var.log_stream_id
   log_group_name  = var.log_group_name
@@ -461,12 +462,14 @@ The following arguments are supported:
 
 * `log_group_name` - (Optional, String) Specifies the LTS group name for collecting logs.
 
-* `log_stream_id` - (Optional, String) Specifies the LTS stream IID for collecting logs.
+* `log_stream_id` - (Optional, String) Specifies the LTS stream ID for collecting logs.
 
 * `log_stream_name` - (Optional, String) Specifies the LTS stream name for collecting logs.
 
--> If the `enable_lts_log` parameter is set to **true**, and the `log_group_id`, `log_group_name`, `log_stream_id` and
-   `log_stream_name` parameters are not specified, the FunctionGraph will automatically create a log group and log stream.
+-> 1. The `log_group_id`, `log_group_name`, `log_stream_id`, and `log_stream_name` are available and used together
+   only when `enable_lts_log` is set to **true**.
+   <br>2. When creating a function, if the `enable_lts_log` parameter is set to **true**, and the corresponding
+   LTS log parameters are not specified, the FunctionGraph will automatically create a log group and log stream.
 
 * `reserved_instances` - (Optional, List) Specifies the reserved instance policies of the function.  
   The [reserved_instances](#function_reserved_instances) structure is documented below.
@@ -532,6 +535,7 @@ The following arguments are supported:
   -> Only Java runtime supports the configurations of the heartbeat and restore hook.
 
 * `lts_custom_tag` - (Optional, Map) Specifies the custom tags configuration that used to filter the LTS logs.
+  This parameter is available only when `enable_lts_log` is set to **true**.
 
   -> This parameter is only supported by the `v2` version of the function.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Root cause: When `enable_lts_log` parameter is set to `true` and the corresponding log group and log stream parameters are not specified, the query interface does not return `log_group_name` and `log_stream_name`. Due to the restriction of `log_group_name` in the code, the request body parameter of the update interface (https://support.huaweicloud.com/api-functiongraph/functiongraph_06_0111.html) lacks log_config, resulting in update failure.

Solution: Use the [Get the lts log group log stream configuration of the specified function] (https://support.huaweicloud.com/api-functiongraph/functiongraph_06_0145.html) interface to obtain log-related parameters.

![image](https://github.com/user-attachments/assets/a2c45047-da8f-49e2-80fc-2ef581af2014)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o fgs -f TestAccFunction_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_ -timeout 360m -parallel 10
=== RUN   TestAccFunction_basic
=== PAUSE TestAccFunction_basic
=== RUN   TestAccFunction_withEpsId
=== PAUSE TestAccFunction_withEpsId
=== RUN   TestAccFunction_logConfig
=== PAUSE TestAccFunction_logConfig
=== RUN   TestAccFunction_strategy
=== PAUSE TestAccFunction_strategy
=== RUN   TestAccFunction_versions
=== PAUSE TestAccFunction_versions
=== RUN   TestAccFunction_network
=== PAUSE TestAccFunction_network
=== RUN   TestAccFunction_reservedInstance
=== PAUSE TestAccFunction_reservedInstance
=== RUN   TestAccFunction_gpuMemory
=== PAUSE TestAccFunction_gpuMemory
=== RUN   TestAccFunction_java
=== PAUSE TestAccFunction_java
=== CONT  TestAccFunction_basic
=== CONT  TestAccFunction_network
=== CONT  TestAccFunction_gpuMemory
=== CONT  TestAccFunction_strategy
=== CONT  TestAccFunction_logConfig
=== CONT  TestAccFunction_reservedInstance
=== CONT  TestAccFunction_versions
=== CONT  TestAccFunction_gpuMemory
    acceptance.go:933: HW_FGS_GPU_TYPE must be set for FGS acceptance tests
--- SKIP: TestAccFunction_gpuMemory (0.00s)
=== CONT  TestAccFunction_withEpsId
=== CONT  TestAccFunction_java
=== CONT  TestAccFunction_network
    resource_huaweicloud_fgs_function_test.go:1539: Step 1/4 error: Error running apply: exit status 1

        Error: failed to update the function metadata: Action forbidden: [PUT https://functiongraph.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/fgs/functions/urn:fss:cn-north-4:0970dd7a1300f5672ff2c003c60ae115:function:default:tf_test_2jkjr_with_network/config], request_id: 14589648765d3beb4c90ee12eedfe739, error message: {
         "error_code": "FSS.1048",
         "error_msg": "Exceed max vpc limit in a single project",
         "details": {
          "error_msg": "The number of bound VPCs exceeds the maximum limit allowed for a project."
         }
        }

          with huaweicloud_fgs_function.create_with_network,
          on terraform_plugin_test.tf line 66, in resource "huaweicloud_fgs_function" "create_with_network":
          66: resource "huaweicloud_fgs_function" "create_with_network" {

=== CONT  TestAccFunction_basic
    resource_huaweicloud_fgs_function_test.go:47: Step 1/7 error: Error running apply: exit status 1

        Error: failed to update the function metadata: Action forbidden: [PUT https://functiongraph.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/fgs/functions/urn:fss:cn-north-4:0970dd7a1300f5672ff2c003c60ae115:function:default:tf-test-qqdnq-custom-image/config], request_id: 5d108fc0ba3145ac13ad7b0adff31a9c, error message: {
         "error_code": "FSS.1048",
         "error_msg": "Exceed max vpc limit in a single project",
         "details": {
          "error_msg": "The number of bound VPCs exceeds the maximum limit allowed for a project."
         }
        }

          with huaweicloud_fgs_function.with_custom_image,
          on terraform_plugin_test.tf line 192, in resource "huaweicloud_fgs_function" "with_custom_image":
         192: resource "huaweicloud_fgs_function" "with_custom_image" {

--- PASS: TestAccFunction_withEpsId (57.92s)
--- FAIL: TestAccFunction_network (62.47s)
--- FAIL: TestAccFunction_basic (67.68s)
--- PASS: TestAccFunction_java (77.69s)
--- PASS: TestAccFunction_reservedInstance (83.49s)
--- PASS: TestAccFunction_logConfig (84.41s)
--- PASS: TestAccFunction_strategy (100.72s)
--- PASS: TestAccFunction_versions (115.15s)
FAIL
coverage: 31.7% of statements in ./huaweicloud/services/fgs
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       115.339s
FAIL
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
