### PR TITLE
feat(cbr): new resource to batch update vault

### DIFF
--- a/docs/resources/cbr_batch_update_vault.md
+++ b/docs/resources/cbr_batch_update_vault.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbr_batch_update_vault"
+description: |-
+  Using this resource to batch update CBR vaults within HuaweiCloud.
+---
+
+# huaweicloud_cbr_batch_update_vault
+
+Using this resource to batch update CBR vaults within HuaweiCloud.
+
+-> This resource is only a one-time action resource to batch update CBR vaults. Deleting this resource will
+not change the current vault configuration, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_cbr_batch_update_vault" "test" {
+  smn_notify = true
+  threshold  = 80
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to execute the request.
+  If omitted, the provider-level region will be used. Changing this will create new resource.
+
+* `smn_notify` - (Optional, Bool, NonUpdatable) Specifies whether to enable SMN notification for the vault.
+
+* `threshold` - (Optional, Int, NonUpdatable) Specifies the threshold of the vault capacity in GB.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `updated_vaults_id` - The list of vault IDs that have been updated.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1690,6 +1690,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbr_restore":                 cbr.ResourceRestore(),
 			"huaweicloud_cbr_migrate":                 cbr.ResourceMigrate(),
 			"huaweicloud_cbr_vault_migrate_resources": cbr.ResourceVaultMigrateResources(),
+			"huaweicloud_cbr_batch_update_vault":      cbr.ResourceBatchUpdateVault(),
 
 			"huaweicloud_cbh_instance":                   cbh.ResourceCBHInstance(),
 			"huaweicloud_cbh_ha_instance":                cbh.ResourceCBHHAInstance(),

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_batch_update_vault_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_batch_update_vault_test.go
@@ -1,0 +1,31 @@
+package cbr
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceBatchUpdateVault_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testBatchUpdateVault,
+			},
+		},
+	})
+}
+
+const testBatchUpdateVault = `
+resource "huaweicloud_cbr_batch_update_vault" "test" {
+  smn_notify = true
+  threshold  = 80
+}
+`

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_batch_update_vault.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_batch_update_vault.go
@@ -1,0 +1,142 @@
+package cbr
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableBatchUpdateVaultParams = []string{
+	"smn_notify",
+	"threshold",
+}
+
+// @API CBR PUT /v3/{project_id}/vaults/batch-update
+func ResourceBatchUpdateVault() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBatchUpdateVaultCreate,
+		ReadContext:   resourceBatchUpdateVaultRead,
+		UpdateContext: resourceBatchUpdateVaultUpdate,
+		DeleteContext: resourceBatchUpdateVaultDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableBatchUpdateVaultParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+				Description: `Specifies the region in which to execute the request. 
+					If omitted, the provider-level region will be used.`,
+			},
+			"smn_notify": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Specifies whether to enable SMN notification for the vault.`,
+			},
+			"threshold": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies the threshold of the vault capacity in GB.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"updated_vaults_id": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of vault IDs that have been updated.`,
+			},
+		},
+	}
+}
+
+func buildBatchUpdateVaultBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"vault": map[string]interface{}{
+			"smn_notify": d.Get("smn_notify"),
+			"threshold":  utils.ValueIgnoreEmpty(d.Get("threshold")),
+		},
+	}
+}
+
+func resourceBatchUpdateVaultCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v3/{project_id}/vaults/batch-update"
+		region  = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("cbr", region)
+	if err != nil {
+		return diag.Errorf("error creating CBR client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildBatchUpdateVaultBodyParams(d)),
+	}
+
+	resp, err := client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error executing batch update CBR vault operation: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	updatedVaults := utils.PathSearch("updated_vaults_id", respBody, nil)
+	if err = d.Set("updated_vaults_id", updatedVaults); err != nil {
+		log.Printf("[DEBUG] error setting updated_vaults_id: %s", err)
+	}
+
+	// Generate a UUID for the resource ID
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	return nil
+}
+
+func resourceBatchUpdateVaultRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchUpdateVaultUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchUpdateVaultDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to batch update CBR vaults. 
+Deleting this resource will not change the current vault configuration, but will only remove the resource 
+information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to batch update vault.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cbr -f TestAccResourceBatchUpdateVault_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccResourceBatchUpdateVault_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceBatchUpdateVault_basic
=== PAUSE TestAccResourceBatchUpdateVault_basic
=== CONT  TestAccResourceBatchUpdateVault_basic
--- PASS: TestAccResourceBatchUpdateVault_basic (9.87s)
PASS
coverage: 5.2% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       9.935s  coverage: 5.2% of statements in ./huaweicloud/services/cbr
```
![image](https://github.com/user-attachments/assets/a88e3166-f033-4d11-a8dd-6a212d0e916a)


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
