### PR TITLE
feat(hss/event_unblock_ip): support `hss_event_unblock_ip` data source

### DIFF
--- a/docs/data-sources/hss_event_unblock_ip.md
+++ b/docs/data-sources/hss_event_unblock_ip.md
@@ -1,0 +1,77 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_event_unblock_ip"
+description: |-
+  Use this data source to get the list of HSS unblock IP within HuaweiCloud.
+---
+
+# huaweicloud_hss_event_unblock_ip
+
+Use this data source to get the list of HSS unblock IP within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_event_unblock_ip" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `last_days` - (Optional, Int) Specifies the query time range and number of days.
+
+* `host_name` - (Optional, String) Specifies the host name.
+
+* `src_ip` - (Optional, String) Specifies the IP address of the attack source.
+
+* `intercept_status` - (Optional, String) Specifies interception status
+  The valid values are as follows:
+  + **intercepted**: Indicates that it has been intercepted.
+  + **canceled**: Indicates that it has been unblocked.
+  + **cancelling**: Indicates pending unblock.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the hosts
+  belong.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `data_list` - The details of intercepted IP list.
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `host_id` - The host ID.
+
+* `host_name` - The host name.
+
+* `src_ip` - The IP address of the attack source.
+
+* `login_type` - The login type.
+  The valid values are as follows:
+  + **mysql**: Represents the MySQL service.
+  + **rdp**: Represents the RDP service.
+  + **ssh**: Represents the SSH service.
+  + **vsftp**: Represents the VSFTP service.
+
+* `intercept_num` - The number of interceptions.
+
+* `intercept_status` - The interception status.
+
+* `block_time` - The start interception time in milliseconds.
+
+* `latest_time` - The most recent interception time in milliseconds.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1016,6 +1016,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_mysql_diagnosis_instances":      taurusdb.DataSourceGaussDBMysqlDiagnosisInstances(),
 			"huaweicloud_gaussdb_mysql_audit_log_download_links": taurusdb.DataSourceGaussDBMysqlAuditLogDownloadLinks(),
 
+			"huaweicloud_hss_event_unblock_ip":               hss.DataSourceEventUnblockIp(),
 			"huaweicloud_hss_ransomware_protection_policies": hss.DataSourceRansomwareProtectionPolicies(),
 			"huaweicloud_hss_host_groups":                    hss.DataSourceHostGroups(),
 			"huaweicloud_hss_hosts":                          hss.DataSourceHosts(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_event_unblock_ip_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_event_unblock_ip_test.go
@@ -1,0 +1,151 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceEventUnblockIp_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_event_unblock_ip.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting a host ID with host protection enabled,
+			// and the host is under the default enterprise project.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceEventUnblockIp_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.host_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.host_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.src_ip"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.login_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.intercept_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.intercept_status"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.block_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.latest_time"),
+
+					resource.TestCheckOutput("is_last_days_filter_useful", "true"),
+					resource.TestCheckOutput("is_host_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_src_ip_filter_useful", "true"),
+					resource.TestCheckOutput("is_intercept_status_filter_useful", "true"),
+					resource.TestCheckOutput("is_enterprise_project_id_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceEventUnblockIp_base() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_hss_event_unblock_ip" "test" {
+  data_list {
+    host_id    = "%[1]s"
+    src_ip     = "127.0.0.5"
+    login_type = "mysql"
+  }
+
+  data_list {
+    host_id    = "%[1]s"
+    src_ip     = "127.0.0.6"
+    login_type = "mysql"
+  }
+}
+`, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
+}
+
+func testDataSourceEventUnblockIp_basic() string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_hss_event_unblock_ip" "test" {
+  depends_on = [huaweicloud_hss_event_unblock_ip.test]
+}
+
+# Filter using last_days.
+data "huaweicloud_hss_event_unblock_ip" "last_days_filter" {
+  last_days = 1
+}
+
+output "is_last_days_filter_useful" {
+  value = length(data.huaweicloud_hss_event_unblock_ip.last_days_filter.data_list) > 0
+}
+
+# Filter using host_name.
+locals {
+  host_name = data.huaweicloud_hss_event_unblock_ip.test.data_list[0].host_name
+}
+
+data "huaweicloud_hss_event_unblock_ip" "host_name_filter" {
+  host_name = local.host_name
+}
+
+output "is_host_name_filter_useful" {
+  value = length(data.huaweicloud_hss_event_unblock_ip.host_name_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_event_unblock_ip.host_name_filter.data_list[*].host_name : v == local.host_name]
+  )
+}
+
+# Filter using src_ip.
+locals {
+  src_ip = data.huaweicloud_hss_event_unblock_ip.test.data_list[0].src_ip
+}
+
+data "huaweicloud_hss_event_unblock_ip" "src_ip_filter" {
+  src_ip = local.src_ip
+}
+
+output "is_src_ip_filter_useful" {
+  value = length(data.huaweicloud_hss_event_unblock_ip.src_ip_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_event_unblock_ip.src_ip_filter.data_list[*].src_ip : v == local.src_ip]
+  )
+}
+
+# Filter using intercept_status.
+locals {
+  intercept_status = data.huaweicloud_hss_event_unblock_ip.test.data_list[0].intercept_status
+}
+
+data "huaweicloud_hss_event_unblock_ip" "intercept_status_filter" {
+  intercept_status = local.intercept_status
+}
+
+output "is_intercept_status_filter_useful" {
+  value = length(data.huaweicloud_hss_event_unblock_ip.intercept_status_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_event_unblock_ip.intercept_status_filter.data_list[*].intercept_status : v == local.intercept_status]
+  )
+}
+
+# Filter using enterprise_project_id.
+data "huaweicloud_hss_event_unblock_ip" "enterprise_project_id_filter" {
+  enterprise_project_id = "0"
+}
+
+output "is_enterprise_project_id_filter_useful" {
+  value = length(data.huaweicloud_hss_event_unblock_ip.enterprise_project_id_filter.data_list) > 0
+}
+
+# Filter using non existent enterprise_project_id.
+data "huaweicloud_hss_event_unblock_ip" "not_found" {
+  enterprise_project_id = "1"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_hss_event_unblock_ip.not_found.data_list) == 0
+}
+`, testDataSourceEventUnblockIp_base())
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_event_unblock_ip.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_event_unblock_ip.go
@@ -1,0 +1,192 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/event/blocked-ip
+func DataSourceEventUnblockIp() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEventUnblockIpRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"last_days": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"host_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"src_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"intercept_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"host_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"src_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"login_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"intercept_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"intercept_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"block_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"latest_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildEventUnblockIpQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=100"
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("last_days"); ok {
+		queryParams = fmt.Sprintf("%s&last_days=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("host_name"); ok {
+		queryParams = fmt.Sprintf("%s&host_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("src_ip"); ok {
+		queryParams = fmt.Sprintf("%s&src_ip=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("intercept_status"); ok {
+		queryParams = fmt.Sprintf("%s&intercept_status=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceEventUnblockIpRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		httpUrl = "v5/{project_id}/event/blocked-ip"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		offset  = 0
+		result  = make([]interface{}, 0)
+		mErr    *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildEventUnblockIpQueryParams(d, epsId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", getPath, offset)
+		getResp, err := client.Request("GET", currentPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS unblock IP: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataResp := utils.PathSearch("data_list", getRespBody, make([]interface{}, 0)).([]interface{})
+		if len(dataResp) == 0 {
+			break
+		}
+
+		result = append(result, dataResp...)
+		offset += len(dataResp)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr = multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data_list", flattenDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDataList(dataResp []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(dataResp))
+	for _, v := range dataResp {
+		result = append(result, map[string]interface{}{
+			"host_id":          utils.PathSearch("host_id", v, nil),
+			"host_name":        utils.PathSearch("host_name", v, nil),
+			"src_ip":           utils.PathSearch("src_ip", v, nil),
+			"login_type":       utils.PathSearch("login_type", v, nil),
+			"intercept_num":    utils.PathSearch("intercept_num", v, nil),
+			"intercept_status": utils.PathSearch("intercept_status", v, nil),
+			"block_time":       utils.PathSearch("block_time", v, nil),
+			"latest_time":      utils.PathSearch("latest_time", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_event_unblock_ip` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_event_unblock_ip` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceEventUnblockIp_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceEventUnblockIp_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceEventUnblockIp_basic
=== PAUSE TestAccDataSourceEventUnblockIp_basic
=== CONT  TestAccDataSourceEventUnblockIp_basic
--- PASS: TestAccDataSourceEventUnblockIp_basic (16.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       16.654s

```
![image](https://github.com/user-attachments/assets/eb231133-a922-4e0f-b99a-06ea59e9c5a2)


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
