### PR TITLE
feat: fix(dli/elastic_resorce_pool): add new 'label' parameter and fix some issues

### DIFF
--- a/docs/resources/dli_elastic_resource_pool.md
+++ b/docs/resources/dli_elastic_resource_pool.md
@@ -15,7 +15,7 @@ Manages an elastic resource pool within HuaweiCloud.
 
 ## Example Usage
 
-### Create an elastic resource pool under the default enterprise project
+### Create a standard edition elastic resource pool under the default enterprise project
 
 ```hcl
 variable "resoure_pool_name" {}
@@ -27,6 +27,22 @@ resource "huaweicloud_dli_elastic_resource_pool" "test" {
   max_cu                = 80
   cidr                  = "192.168.128.0/18"
   enterprise_project_id = "0"
+}
+```
+
+### Create a basic elastic resource pool
+
+```hcl
+variable "resoure_pool_name" {}
+
+resource "huaweicloud_dli_elastic_resource_pool" "test" {
+  name   = var.resoure_pool_name
+  min_cu = 16
+  max_cu = 64
+
+  label = {
+    spec = "basic"
+  }
 }
 ```
 
@@ -43,10 +59,14 @@ The following arguments are supported:
   Changing this will create a new resource.
 
 * `max_cu` - (Required, Int) Specifies the maximum number of CUs for elastic resource pool scaling.
-  The valid value ranges from `64` to `32,000`, the interval is `16`.
+  The interval is `16`.
+  + For standard edition, the valid value ranges from `64` to `32,000`.
+  + For basic edition, the valid value ranges from `16` to `64`.
 
 * `min_cu` - (Required, Int) Specifies the minimum number of CUs for elastic resource pool scaling.
-  The valid value ranges from `64` to `32,000`, the interval is `16`.
+  The interval is `16`.
+  + For standard edition, the valid value ranges from `64` to `32,000`.
+  + For basic edition, the valid value ranges from `16` to `64`.
 
   ~> If the value needs to be updated, the `min_cu` value cannot be greater than the `current_cu` value.
 
@@ -61,6 +81,10 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the elastic resource pool.  
   Changing this will create a new resource.
+
+* `label` - (Optional, Map, ForceNew) Specifies the attribute fields of the elastic resource pool.  
+  Changing this will create a new resource.  
+  If not specified, the default is the standard edition. The key/value corresponding to the basic edition is `spec = "basic"`.
 
 ## Attribute Reference
 
@@ -97,4 +121,22 @@ Elastic resource pools can be imported by their `name`, e.g.
 
 ```bash
 $ terraform import huaweicloud_dli_elastic_resource_pool.test <name>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `label`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_dli_elastic_resource_pool" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      label
+    ]
+  }
+}
 ```

--- a/docs/resources/dli_elastic_resource_pool.md
+++ b/docs/resources/dli_elastic_resource_pool.md
@@ -77,7 +77,8 @@ The following arguments are supported:
   Defaults to `172.16.0.0/12`. Changing this will create a new resource.
 
 * `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the elastic resource
-  pool belongs.
+  pool belongs.  
+  This parameter is only valid for enterprise users, if omitted, default enterprise project will be used.
 
 * `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the elastic resource pool.  
   Changing this will create a new resource.
@@ -124,7 +125,7 @@ $ terraform import huaweicloud_dli_elastic_resource_pool.test <name>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: `label`.
+API response, security or some other reason. The missing attributes include: `tags` and `label`.
 It is generally recommended running `terraform plan` after importing a resource.
 You can then decide if changes should be applied to the resource, or the resource definition should be updated to
 align with the resource. Also you can ignore changes as below.
@@ -135,7 +136,7 @@ resource "huaweicloud_dli_elastic_resource_pool" "test" {
 
   lifecycle {
     ignore_changes = [
-      label
+      tags, label,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_elastic_resource_pool_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_elastic_resource_pool_test.go
@@ -25,15 +25,14 @@ func getElasticResourcePoolFunc(cfg *config.Config, state *terraform.ResourceSta
 
 func TestAccElasticResourcePool_basic(t *testing.T) {
 	var (
-		obj          interface{}
-		resourceName = "huaweicloud_dli_elastic_resource_pool.test"
-		name         = acceptance.RandomAccResourceName()
-	)
+		name = acceptance.RandomAccResourceName()
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&obj,
-		getElasticResourcePoolFunc,
+		obj            interface{}
+		withStandard   = "huaweicloud_dli_elastic_resource_pool.test"
+		rcWithStandard = acceptance.InitResourceCheck(withStandard, &obj, getElasticResourcePoolFunc)
+
+		withBasic   = "huaweicloud_dli_elastic_resource_pool.basic"
+		rcWithBasic = acceptance.InitResourceCheck(withBasic, &obj, getElasticResourcePoolFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -43,21 +42,31 @@ func TestAccElasticResourcePool_basic(t *testing.T) {
 			acceptance.TestAccPreCheckDliElasticResourcePool(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcWithStandard.CheckResourceDestroy(),
+			rcWithBasic.CheckResourceDestroy(),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccElasticResourcePool_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
-					resource.TestCheckResourceAttr(resourceName, "min_cu", "80"),
-					resource.TestCheckResourceAttr(resourceName, "max_cu", "96"),
-					resource.TestCheckResourceAttr(resourceName, "cidr", "172.16.0.0/12"),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
-					resource.TestCheckResourceAttrSet(resourceName, "current_cu"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					rcWithStandard.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withStandard, "name", name),
+					resource.TestCheckResourceAttr(withStandard, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(withStandard, "min_cu", "80"),
+					resource.TestCheckResourceAttr(withStandard, "max_cu", "96"),
+					resource.TestCheckResourceAttr(withStandard, "cidr", "172.16.0.0/12"),
+					resource.TestCheckResourceAttr(withStandard, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttrSet(withStandard, "status"),
+					resource.TestCheckResourceAttrSet(withStandard, "current_cu"),
+					resource.TestCheckResourceAttrSet(withStandard, "created_at"),
+					rcWithBasic.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withBasic, "min_cu", "32"),
+					resource.TestCheckResourceAttr(withBasic, "max_cu", "48"),
+					resource.TestCheckResourceAttr(withBasic, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(withBasic, "tags.%", "1"),
+					resource.TestCheckResourceAttr(withBasic, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(withBasic, "label.spec", "basic"),
 					// The number of parameter 'actual_cu' needs to be returned after the queues are created, and will
 					// not be tested for the time being.
 				),
@@ -65,21 +74,37 @@ func TestAccElasticResourcePool_basic(t *testing.T) {
 			{
 				Config: testAccElasticResourcePool_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "description", ""),
-					resource.TestCheckResourceAttr(resourceName, "min_cu", "64"),
-					resource.TestCheckResourceAttr(resourceName, "max_cu", "112"),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
+					rcWithStandard.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withStandard, "name", name),
+					resource.TestCheckResourceAttr(withStandard, "description", ""),
+					resource.TestCheckResourceAttr(withStandard, "min_cu", "64"),
+					resource.TestCheckResourceAttr(withStandard, "max_cu", "112"),
+					resource.TestCheckResourceAttr(withStandard, "enterprise_project_id", acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
+					rcWithBasic.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withBasic, "min_cu", "16"),
+					resource.TestCheckResourceAttr(withBasic, "max_cu", "64"),
+					resource.TestCheckResourceAttr(withBasic, "description", "Updated basic resource pool by terraform script"),
+					resource.TestCheckResourceAttr(withBasic, "enterprise_project_id", acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
 					waitForDeletionCooldownComplete(),
-					waitForCUModificationComplete(resourceName),
+					waitForCUModificationComplete(withStandard),
+					waitForCUModificationComplete(withBasic),
 				),
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      withStandard,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccElasticResourcePoolImportStateFunc(resourceName),
+				ImportStateIdFunc: testAccElasticResourcePoolImportStateFunc(withStandard),
+			},
+			{
+				ResourceName:      withBasic,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccElasticResourcePoolImportStateFunc(withBasic),
+				ImportStateVerifyIgnore: []string{
+					"tags",
+					"label",
+				},
 			},
 		},
 	})
@@ -87,9 +112,9 @@ func TestAccElasticResourcePool_basic(t *testing.T) {
 
 func waitForDeletionCooldownComplete() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		// After elastic resource pool is created, it cannot be deleted within one hour.
+		// After elastic resource pool is created, it cannot be deleted within 15 minete.
 		// lintignore:R018
-		time.Sleep(time.Hour)
+		time.Sleep(15 * time.Minute)
 		return nil
 	}
 }
@@ -120,7 +145,7 @@ func waitForCUModificationComplete(resName string) resource.TestCheckFunc {
 			if status == "AVAILABLE" {
 				return nil
 			}
-			if time.Since(startTime) > time.Hour {
+			if time.Since(startTime) > 15*time.Minute {
 				break
 			}
 			// lintignore:R018
@@ -153,6 +178,21 @@ resource "huaweicloud_dli_elastic_resource_pool" "test" {
   min_cu                = 80
   enterprise_project_id = "0"
 }
+
+resource "huaweicloud_dli_elastic_resource_pool" "basic" {
+  name        = upper("%[1]s_basic")
+  description = "Created basic resource pool by terraform script"
+  min_cu      = 32
+  max_cu      = 48
+
+  tags = {
+    foo = "bar"
+  }
+ 
+  label = {
+    spec = "basic"
+  }
+}
 `, name)
 }
 
@@ -163,6 +203,22 @@ resource "huaweicloud_dli_elastic_resource_pool" "test" {
   max_cu                = 112
   min_cu                = 64
   enterprise_project_id = "%[2]s"
+}
+
+resource "huaweicloud_dli_elastic_resource_pool" "basic" {
+  name                  = upper("%[1]s_basic")
+  description           = "Updated basic resource pool by terraform script"
+  min_cu                = 16
+  max_cu                = 64
+  enterprise_project_id = "%[2]s"
+
+  tags = {
+    foo = "bar"
+  }
+
+  label = {
+    spec = "basic"
+  }
 }
 `, name, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
@@ -85,6 +85,13 @@ func ResourceElasticResourcePool() *schema.Resource {
 				Description: `The ID of the enterprise project to which the elastic resource pool belongs.`,
 			},
 			"tags": common.TagsForceNewSchema(),
+			"label": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The attribute fields of the elastic resource pool.`,
+			},
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -166,6 +173,7 @@ func buildCreateElasticResourcePoolBodyParams(cfg *config.Config, d *schema.Reso
 		"cidr_in_vpc":                utils.StringIgnoreEmpty(d.Get("cidr").(string)),
 		"enterprise_project_id":      cfg.GetEnterpriseProjectID(d),
 		"tags":                       utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{})),
+		"label":                      utils.ValueIgnoreEmpty(d.Get("label")),
 	}
 }
 

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
@@ -82,6 +82,7 @@ func ResourceElasticResourcePool() *schema.Resource {
 			"enterprise_project_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: `The ID of the enterprise project to which the elastic resource pool belongs.`,
 			},
 			"tags": common.TagsForceNewSchema(),
@@ -171,7 +172,7 @@ func buildCreateElasticResourcePoolBodyParams(cfg *config.Config, d *schema.Reso
 		"max_cu":                     d.Get("max_cu"),
 		"min_cu":                     d.Get("min_cu"),
 		"cidr_in_vpc":                utils.StringIgnoreEmpty(d.Get("cidr").(string)),
-		"enterprise_project_id":      cfg.GetEnterpriseProjectID(d),
+		"enterprise_project_id":      utils.StringIgnoreEmpty(cfg.GetEnterpriseProjectID(d)),
 		"tags":                       utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{})),
 		"label":                      utils.ValueIgnoreEmpty(d.Get("label")),
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. The resource supports `label` parameter to distinguish resource pool types.
2. Fix the issue that resource change when executing terraform plan without setting `enterprise_project_id`,  and  add `tags` to ignore_changes.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o dli -f TestAccElasticResourcePool_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dli" -v -coverprofile="./huaweicloud/services/acceptance/dli/dli_coverage.cov" -coverpkg="./huaweicloud/services/dli" -run TestAccElasticResourcePool_basic -timeout 360m -parallel 10
=== RUN   TestAccElasticResourcePool_basic
=== PAUSE TestAccElasticResourcePool_basic
=== CONT  TestAccElasticResourcePool_basic
--- PASS: TestAccElasticResourcePool_basic (1589.07s)
PASS
coverage: 5.7% of statements in ./huaweicloud/services/dli
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       1589.174s       coverage: 5.7% of statements in ./huaweicloud/services/dli
```
![image](https://github.com/user-attachments/assets/cda88c0e-0960-44b5-a84a-1f8eedfa7764)

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
