### PR TITLE
fix(ECS): fix compute interface attach check deleted

### DIFF
--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_interface_attach.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_interface_attach.go
@@ -296,7 +296,9 @@ func resourceComputeInterfaceAttachRead(_ context.Context, d *schema.ResourceDat
 	}
 	listNicsResp, err := computeClient.Request("GET", listNicsPath, &listNicsOpt)
 	if err != nil {
-		return diag.Errorf("error getting NIC list: %s", err)
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error.code", "Ecs.0307"),
+			"error retrieving NIC list")
 	}
 	listNicsRespBody, err := utils.FlattenResponse(listNicsResp)
 	if err != nil {
@@ -315,7 +317,7 @@ func resourceComputeInterfaceAttachRead(_ context.Context, d *schema.ResourceDat
 	}
 	port, err := readVPCPort(vpcClient, id)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("error retrieving VPC port: %s", err)
 	}
 
 	mErr := multierror.Append(nil,
@@ -345,7 +347,7 @@ func readVPCPort(vpcClient *golangsdk.ServiceClient, portID string) (interface{}
 
 	getPortResp, err := vpcClient.Request("GET", getPortPath, &getPortOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving VPC port: %s", err)
+		return nil, err
 	}
 	return utils.FlattenResponse(getPortResp)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix compute interface attach check deleted
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix compute interface attach check deleted
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
