### PR TITLE
feat(modelarts/resource_pool): add 'creating_step' parameter

### DIFF
--- a/docs/resources/modelarts_resource_pool.md
+++ b/docs/resources/modelarts_resource_pool.md
@@ -210,13 +210,17 @@ The `resources` block supports:
 
 * `flavor_id` - (Required, String) Specifies the resource flavor ID.  
 
-* `count` - (Required, Int) Specifies the number of resources of the corresponding flavors.
+* `count` - (Required, Int) Specifies the number of resources of the corresponding flavors.  
+  This parameter must be an integer multiple of `resources.creating_step.step`.  
+  If you want to expand the nodes, you only need to increase the number of nodes to be expanded
+  based on the current parameter value.
 
 * `node_pool` - (Optional, String) Specifies the name of resource pool nodes. It can contain `1` to `50`
   characters, and should start with a letter and ending with a letter or digit, only lowercase letters, digits,
   hyphens (-) are allowed, and cannot end with a hyphen (-).
 
 * `max_count` - (Optional, Int) Specifies the max number of resources of the corresponding flavors.
+  This parameter must be an integer multiple of `resources.creating_step.step`.
 
 * `vpc_id` - (Optional, String) Specifies the VPC ID. It is mandatory when `resources.subnet_id`,
   `resources.security_group_ids` is specified, and can not be specified when `network_id` is specified.
@@ -254,6 +258,10 @@ The `resources` block supports:
 
 * `driver` - (Optional, List) Specifies the driver information.  
   The [driver](#ModelartsResourcePool_Resources_driver) structure is documented below.
+
+* `creating_step` - (Optional, List, ForceNew) Specifies the creation step configuration of the resource pool nodes.  
+  The [creating_step](#ModelartsResourcePool_Resources_creating_step) structure is documented below.  
+  Changing this parameter will create a new resource.
 
 <a name="ModelartsResourcePool_Resources_azs"></a>
 The `azs` block supports:
@@ -342,6 +350,17 @@ The `os` block supports:
 The `driver` block supports:
 
 * `version` - (Optional, String) Specifies the driver version.
+
+<a name="ModelartsResourcePool_Resources_creating_step"></a>
+The `creating_step` block supports:
+
+* `step` - (Required, Int, ForceNew) Specifies the creation step of the resource pool nodes.
+  Changing this parameter will create a new resource.
+
+* `type` - (Required, String, ForceNew) Specifies the type of the resource pool nodes.  
+  Changing this parameter will create a new resource.  
+  The valid values are as follows:
+  + **hyperinstance**
 
 <a name="ModelartsResourcePool_Clusters"></a>
 The `clusters` block supports:

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool.go
@@ -310,6 +310,30 @@ func modelartsResourcePoolResourceFlavorSchema() *schema.Resource {
 				Elem:        modelartsResourcePoolResourcesDriverSchema(),
 				Description: `The driver information.`,
 			},
+			"creating_step": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"step": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							ForceNew:    true,
+							Description: `The creation step of the resource pool nodes.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+							Description: `The type of the resource pool nodes.`,
+						},
+					},
+				},
+				Description: `The creation step configuration of the resource pool nodes.`,
+			},
 			// Internal attribute(s).
 			"volume_group_configs_origin": {
 				Type:     schema.TypeList,
@@ -882,6 +906,8 @@ func buildResourcePoolSpecResources(oldResources, newResources []interface{}) []
 			),
 			"os":     buildResourcePoolResourcesOsInfo(utils.PathSearch("os", newResource, make([]interface{}, 0)).([]interface{})),
 			"driver": buildResourcePoolResourcesDriver(utils.PathSearch("driver", newResource, make([]interface{}, 0)).([]interface{})),
+			"creatingStep": buildResourcePoolResourcesCreatingStep(
+				utils.PathSearch("creating_step", newResource, make([]interface{}, 0)).([]interface{})),
 		})
 	}
 	return result
@@ -1034,6 +1060,17 @@ func buildResourcePoolResourcesDriver(drivers []interface{}) map[string]interfac
 	driver := drivers[0]
 	return map[string]interface{}{
 		"version": utils.ValueIgnoreEmpty(utils.PathSearch("version", driver, nil)),
+	}
+}
+
+func buildResourcePoolResourcesCreatingStep(creatingSteps []interface{}) map[string]interface{} {
+	if len(creatingSteps) < 1 {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"type": utils.ValueIgnoreEmpty(utils.PathSearch("type", creatingSteps[0], nil)),
+		"step": utils.ValueIgnoreEmpty(utils.PathSearch("step", creatingSteps[0], nil)),
 	}
 }
 
@@ -1260,6 +1297,19 @@ func flattenResourcePoolResourcesDriver(driver interface{}) []map[string]interfa
 	}
 }
 
+func flattenResourcePoolResourcesCreatingStep(creatingStep interface{}) []map[string]interface{} {
+	if creatingStep == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"step": utils.PathSearch("step", creatingStep, nil),
+			"type": utils.PathSearch("type", creatingStep, nil),
+		},
+	}
+}
+
 func flattenGetResourcePoolResponseBodyResources(resp interface{}) []interface{} {
 	if resp == nil {
 		return nil
@@ -1288,8 +1338,9 @@ func flattenGetResourcePoolResponseBodyResources(resp interface{}) []interface{}
 				v, make([]interface{}, 0)).([]interface{})),
 			"volume_group_configs_origin": flattenResourcePoolResourcesVolumeGroupConfigs(utils.PathSearch("volumeGroupConfigs",
 				v, make([]interface{}, 0)).([]interface{})),
-			"os":     flattenResourcePoolResourcesOsInfo(utils.PathSearch("os", v, nil)),
-			"driver": flattenResourcePoolResourcesDriver(utils.PathSearch("driver", v, nil)),
+			"os":            flattenResourcePoolResourcesOsInfo(utils.PathSearch("os", v, nil)),
+			"driver":        flattenResourcePoolResourcesDriver(utils.PathSearch("driver", v, nil)),
+			"creating_step": flattenResourcePoolResourcesCreatingStep(utils.PathSearch("creatingStep", v, nil)),
 			// Deprecated parameter(s).
 			"post_install": utils.PathSearch("extendParams.post_install", v, nil),
 		})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The resource supports `creating_step` parameter.

Expand resource pool node from `1` to `3`.
![image](https://github.com/user-attachments/assets/d402a693-7d9c-462e-86e6-8ffd5ac96162)
Execute `terraform plan`
![image](https://github.com/user-attachments/assets/81f440dc-aae3-4bca-8bb7-a6ba7090c954)
Unsubscribe the two nodes that have been expanded
![image](https://github.com/user-attachments/assets/b17ad5ed-2e54-4c01-985a-9b33a9edf026)
Execute `terraform plan`
![image](https://github.com/user-attachments/assets/3ef52ccd-3e1f-4348-a262-68fe4ecc2e2f)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
