### PR TITLE
feat(waf): add data source to get the average bandwidth usage

### DIFF
--- a/docs/data-sources/waf_overviews_bandwidth_timeline.md
+++ b/docs/data-sources/waf_overviews_bandwidth_timeline.md
@@ -1,0 +1,80 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_overviews_bandwidth_timeline"
+description: |-
+  Use this data source to query the average bandwidth usage.
+---
+
+# huaweicloud_waf_overviews_bandwidth_timeline
+
+Use this data source to query the average bandwidth usage.
+
+## Example Usage
+
+```hcl
+variable "start_time" {}
+variable "end_time" {}
+
+data "huaweicloud_waf_overviews_bandwidth_timeline" "test" {
+  from = var.start_time
+  to   = var.end_time
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `from` - (Required, Int) Specifies the query start time.
+  The format is 13-digit timestamp in millisecond.
+
+* `to` - (Required, Int) Specifies the query end time.
+  The format is 13-digit timestamp in millisecond.
+
+* `group_by` - (Optional, String) Specifies the display dimension.
+  The value can be **DAY**, indicates data is displayed by the day.
+  If this parameter is not specified, the data is displayed by the minute.
+
+* `display_option` - (Optional, String) Specifies the number of sent or received bytes.
+  The valid values are as follows:
+  + **1**: Indicates view the peak value.
+  + **0**: Indicates view the average value.
+
+* `hosts` - (Optional, String) Specifies the ID of the domain.
+
+* `instances` - (Optional, String) Specifies the ID of the dedicated WAF instance.
+  This parameter is used to query the average bandwidth usage of domain protected by the dedicated WAF instance.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  If you want to query resources under all enterprise projects, set this parameter to **all_granted_eps**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `bandwidths` - The bandwidth statistics over the time.
+
+  The [bandwidths](#bandwidths_struct) structure is documented below.
+
+<a name="bandwidths_struct"></a>
+The `bandwidths` block supports:
+
+* `key` - The key type.
+  The options are **BANDWIDTH**, **IN_BANDWIDTH** and **OUT_BANDWIDTH**.
+
+* `timeline` - The statistics data over time for the corresponding key.
+
+  The [timeline](#bandwidths_timeline_struct) structure is documented below.
+
+<a name="bandwidths_timeline_struct"></a>
+The `timeline` block supports:
+
+* `time` - The time point.
+
+* `num` - The statistics data for the time range from the previous time point to the point specified by `time`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1436,6 +1436,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_dedicated_instances":                  waf.DataSourceWafDedicatedInstances(),
 			"huaweicloud_waf_domains":                              waf.DataSourceWafDomains(),
 			"huaweicloud_waf_instance_groups":                      waf.DataSourceWafInstanceGroups(),
+			"huaweicloud_waf_overviews_bandwidth_timeline":         waf.DataSourceWafOverviewsBandwidthTimeline(),
 			"huaweicloud_waf_overviews_classification":             waf.DataSourceWafOverviewsClassification(),
 			"huaweicloud_waf_overviews_qps_timeline":               waf.DataSourceWafOverviewsQPSTimeline(),
 			"huaweicloud_waf_overviews_statistics":                 waf.DataSourceWafOverviewsStatistics(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_overviews_bandwidth_timeline_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_overviews_bandwidth_timeline_test.go
@@ -1,0 +1,78 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceOverviewsBandwidthTimeline_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_waf_overviews_bandwidth_timeline.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		startTime      = time.Now().Add(-24*time.Hour).UnixNano() / int64(time.Millisecond)
+		endTime        = time.Now().UnixNano() / int64(time.Millisecond)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			// Before running test, please ensure have data on console.
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceOverviewsBandwidthTimeline_basic(startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "bandwidths.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "bandwidths.0.key"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "bandwidths.0.timeline.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "bandwidths.0.timeline.0.time"),
+
+					resource.TestCheckOutput("value_is_exist", "true"),
+					resource.TestCheckOutput("group_by_filter_is_useful", "true"),
+					resource.TestCheckOutput("display_option_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceOverviewsBandwidthTimeline_basic(startTime, endTime int64) string {
+	return fmt.Sprintf(`
+data "huaweicloud_waf_overviews_bandwidth_timeline" "test" {
+  from = %[1]d
+  to   = %[2]d
+}
+
+output "value_is_exist" {
+  value = length(data.huaweicloud_waf_overviews_bandwidth_timeline.test.bandwidths) > 0
+}
+
+data "huaweicloud_waf_overviews_bandwidth_timeline" "filter_group_by" {
+  from     = %[1]d
+  to       = %[2]d
+  group_by = "DAY"
+}
+
+output "group_by_filter_is_useful" {
+  value = length(data.huaweicloud_waf_overviews_bandwidth_timeline.filter_group_by.bandwidths[0].timeline) > 0
+}
+
+data "huaweicloud_waf_overviews_bandwidth_timeline" "filter_display_option" {
+  from           = %[1]d
+  to             = %[2]d
+  display_option = "1"
+}
+
+output "display_option_filter_is_useful" {
+  value = length(data.huaweicloud_waf_overviews_bandwidth_timeline.filter_display_option.bandwidths[0].timeline) > 0
+}
+`, startTime, endTime)
+}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_overviews_bandwidth_timeline.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_overviews_bandwidth_timeline.go
@@ -1,0 +1,200 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/waf/overviews/bandwidth/timeline
+func DataSourceWafOverviewsBandwidthTimeline() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceWafOverviewsBandwidthTimelineRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"from": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"to": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"group_by": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"display_option": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"hosts": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instances": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"bandwidths": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"timeline": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"time": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"num": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildOverviewsBandwidthQueryParams(cfg *config.Config, d *schema.ResourceData) string {
+	epsId := cfg.GetEnterpriseProjectID(d)
+	rst := fmt.Sprintf("?from=%v&to=%v", d.Get("from"), d.Get("to"))
+
+	if groupBy, ok := d.GetOk("group_by"); ok {
+		rst += fmt.Sprintf("&group_by=%v", groupBy)
+	}
+
+	if displayOption, ok := d.GetOk("display_option"); ok {
+		rst += fmt.Sprintf("&display_option=%v", displayOption)
+	}
+
+	if hostId, ok := d.GetOk("hosts"); ok {
+		rst += fmt.Sprintf("&hosts=%v", hostId)
+	}
+
+	if instanceId, ok := d.GetOk("instances"); ok {
+		rst += fmt.Sprintf("&instances=%v", instanceId)
+	}
+
+	if epsId != "" {
+		rst += fmt.Sprintf("&enterprise_project_id=%v", epsId)
+	}
+
+	return rst
+}
+
+func dataSourceWafOverviewsBandwidthTimelineRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/overviews/bandwidth/timeline"
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildOverviewsBandwidthQueryParams(cfg, d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	listResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving bandwidth usage statistics: %s", err)
+	}
+
+	listRespBody, err := utils.FlattenResponse(listResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	listArray, ok := listRespBody.([]interface{})
+	if !ok {
+		return diag.Errorf("convert inteface array failed")
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("bandwidths", flattenOverviewsBandwidths(listArray)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenOverviewsBandwidths(rawBandwidths []interface{}) []interface{} {
+	if len(rawBandwidths) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(rawBandwidths))
+	for _, v := range rawBandwidths {
+		rst = append(rst, map[string]interface{}{
+			"key":      utils.PathSearch("key", v, nil),
+			"timeline": flattenOverviewsBandwidthsTimeline(utils.PathSearch("timeline", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return rst
+}
+
+func flattenOverviewsBandwidthsTimeline(rawTimeline []interface{}) []interface{} {
+	if len(rawTimeline) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(rawTimeline))
+	for _, v := range rawTimeline {
+		rst = append(rst, map[string]interface{}{
+			"time": utils.PathSearch("time", v, nil),
+			"num":  utils.PathSearch("num", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add data source to get the average bandwidth usage.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ bash test.sh "./huaweicloud/services/acceptance/waf" "TestAccDataSourceOverviewsBandwidthTimeline_basic"
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -run TestAccDataSourceOverviewsBandwidthTimeline_basic -timeout 360m -parallel 4

=== RUN   TestAccDataSourceOverviewsBandwidthTimeline_basic
=== PAUSE TestAccDataSourceOverviewsBandwidthTimeline_basic
=== CONT  TestAccDataSourceOverviewsBandwidthTimeline_basic
--- PASS: TestAccDataSourceOverviewsBandwidthTimeline_basic (41.73s)
PASS
coverage: 2.6% of statements in ./huaweicloud/...
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       42.489s coverage: 2.6% of statements in ./huaweicloud/...
```
![image](https://github.com/user-attachments/assets/519c676f-4c5d-46dc-9174-0b79717f4b3f)

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
