### PR TITLE
feat(RDS): add rds unlock node readonly status resource

### DIFF
--- a/docs/resources/rds_unlock_node_readonly_status.md
+++ b/docs/resources/rds_unlock_node_readonly_status.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Relational Database Service (RDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rds_unlock_node_readonly_status"
+description: |-
+  Manages an RDS unlock node readonly status resource within HuaweiCloud.
+---
+
+# huaweicloud_rds_unlock_node_readonly_status
+
+Manages an RDS unlock node readonly status resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_rds_unlock_node_readonly_status" "test" {
+  instance_id              = var.instance_id
+  status_preservation_time = 0
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the RDS SQLServer instance.
+
+* `status_preservation_time` - (Required, Int, NonUpdatable) Specifies the duration (in minutes) during which the HA
+  component no longer sets the instance to read-only. Value ranges: **0** to **1440**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. The value is `instance_id`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2444,6 +2444,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_extend_log_link":                rds.ResourceRdsExtendLogLink(),
 			"huaweicloud_rds_instant_task_delete":            rds.ResourceRdsInstantTaskDelete(),
 			"huaweicloud_rds_instance_minor_version_upgrade": rds.ResourceRdsInstanceMinorVersionUpgrade(),
+			"huaweicloud_rds_unlock_node_readonly_status":    rds.ResourceUnlockNodeReadonlyStatus(),
 
 			"huaweicloud_rgc_account": rgc.ResourceAccount(),
 

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_unlock_node_readonly_status_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_unlock_node_readonly_status_test.go
@@ -1,0 +1,34 @@
+package rds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccUnlockNodeReadonlyStatus_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRdsInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUnlockNodeReadonlyStatus_basic(),
+			},
+		},
+	})
+}
+
+func testAccUnlockNodeReadonlyStatus_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rds_unlock_node_readonly_status" "test" {
+  instance_id              = "%s"
+  status_preservation_time = 100
+}`, acceptance.HW_RDS_INSTANCE_ID)
+}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_unlock_node_readonly_status.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_unlock_node_readonly_status.go
@@ -1,0 +1,123 @@
+package rds
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var unlockNodeReadonlyStatusNonUpdatableParams = []string{"instance_id", "status_preservation_time"}
+
+// @API RDS PUT /v3/{project_id}/instances/{instance_id}/unlock-node-readonly-status
+// @API RDS GET /v3/{project_id}/instances
+func ResourceUnlockNodeReadonlyStatus() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceUnlockNodeReadonlyStatusCreate,
+		ReadContext:   resourceUnlockNodeReadonlyStatusRead,
+		UpdateContext: resourceUnlockNodeReadonlyStatusUpdate,
+		DeleteContext: resourceUnlockNodeReadonlyStatusDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(unlockNodeReadonlyStatusNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"status_preservation_time": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceUnlockNodeReadonlyStatusCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/unlock-node-readonly-status"
+		product = "rds"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", d.Get("instance_id").(string))
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createOpt.JSONBody = utils.RemoveNil(buildCreateUnlockNodeReadonlyStatusBodyParams(d))
+
+	retryFunc := func() (interface{}, bool, error) {
+		_, err = client.Request("PUT", createPath, &createOpt)
+		retry, err := handleMultiOperationsError(err)
+		return nil, retry, err
+	}
+	_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     rdsInstanceStateRefreshFunc(client, d.Get("instance_id").(string)),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return diag.Errorf("error creating RDS unlock node readonly status: %s", err)
+	}
+
+	d.SetId(d.Get("instance_id").(string))
+
+	return nil
+}
+
+func buildCreateUnlockNodeReadonlyStatusBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"status_preservation_time": d.Get("status_preservation_time"),
+	}
+	return bodyParams
+}
+
+func resourceUnlockNodeReadonlyStatusRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceUnlockNodeReadonlyStatusUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceUnlockNodeReadonlyStatusDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting RDS unlock node readonly status resource is not supported. The resource is only removed " +
+		"from the state, the instance remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add rds unlock node readonly status resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add rds unlock node readonly status resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
