### PR TITLE
feat(cbr): new resource to change cbr order

### DIFF
--- a/docs/resources/cbr_change_order.md
+++ b/docs/resources/cbr_change_order.md
@@ -1,0 +1,82 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbr_change_order"
+description: |-
+  Using this resource to change the order of a CBR resource within HuaweiCloud.
+---
+
+# huaweicloud_cbr_change_order
+
+Using this resource to change the order of a CBR resource within HuaweiCloud.
+
+-> This resource is only a one-time action resource to change the order of a CBR resource. Deleting this resource will
+**not** revert the order change, it only removes the resource information from the TF state.
+
+-> The resource to change order must be in **prePaid** mode. Using this resource may cause unexpected changes to
+the `size` field of the `huaweicloud_cbr_vault` resource. At this time, you can use the `lifecycle` statement
+to ignore the change of `size`.
+
+## Example Usage
+
+```hcl
+variable "resource_id" {}
+variable "product_id" {}
+variable "resource_size" {}
+variable "resource_spec_code" {}
+
+resource "huaweicloud_cbr_change_order" "test" {
+  resource_id = var.resource_id
+
+  product_info {
+    product_id               = var.product_id
+    resource_size            = var.resource_size
+    resource_size_measure_id = 17
+    resource_spec_code       = var.resource_spec_code
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create new resource.
+
+* `resource_id` - (Required, String, NonUpdatable) Specifies the ID of the CBR resource whose order will be changed.
+  The resource must be in **prePaid** mode.
+
+* `product_info` - (Required, List, NonUpdatable) Specifies the product information.
+  The [product_info](#change_order_product_info_struct) structure is documented below.
+
+* `promotion_info` - (Optional, String, NonUpdatable) Specifies the promotion information for the order.
+
+<a name="change_order_product_info_struct"></a>
+The `product_info` block supports:
+
+* `product_id` - (Required, String, NonUpdatable) Specifies the product ID, which is obtained through the price query API.
+  The value consists of `1` to `64` characters and can contain only letters, digits, underscores (_), and hyphens (-).
+
+* `resource_size` - (Required, Int, NonUpdatable) Specifies the size of the resource. Value range: `10`-`10,485,760`.
+  The size value required must be greater than the existing size value.
+
+* `resource_size_measure_id` - (Required, Int, NonUpdatable) Specifies the measurement unit of the resource size.
+  Currently, only `17` (GB) is supported.
+
+* `resource_spec_code` - (Required, String, NonUpdatable) Specifies the spec code of the resource.
+  Valid values are: **vault.backup.server.normal**, **vault.backup.turbo.normal**, **vault.backup.database.normal**,
+  **vault.backup.volume.normal**, **vault.backup.rds.normal**, **vault.replication.server.normal**, and
+  **vault.hybrid.server.normal**.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1699,6 +1699,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbr_vault_migrate_resources":  cbr.ResourceVaultMigrateResources(),
 			"huaweicloud_cbr_batch_update_vault":       cbr.ResourceBatchUpdateVault(),
 			"huaweicloud_cbr_vault_change_charge_mode": cbr.ResourceVaultChangeChargeMode(),
+			"huaweicloud_cbr_change_order":             cbr.ResourceChangeOrder(),
 
 			"huaweicloud_cbh_instance":                   cbh.ResourceCBHInstance(),
 			"huaweicloud_cbh_ha_instance":                cbh.ResourceCBHHAInstance(),

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_change_order_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_change_order_test.go
@@ -1,0 +1,61 @@
+package cbr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Because the API capabilities are unstable, sometimes the API will report an error "The system is busy. Please try later."
+func TestAccResourceChangeOrder_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceChangeOrder_basic(),
+			},
+		},
+	})
+}
+
+func testResourceChangeOrder_basic() string {
+	name := acceptance.RandomAccResourceName()
+	return fmt.Sprintf(`
+resource "huaweicloud_cbr_vault" "test" {
+  name             = "%[1]s"
+  type             = "server"
+  consistent_level = "crash_consistent"
+  protection_type  = "backup"
+  size             = 100
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = "false"
+
+  lifecycle {
+    ignore_changes = [
+      size,
+    ]
+  }
+}
+
+resource "huaweicloud_cbr_change_order" "test" {
+  resource_id = huaweicloud_cbr_vault.test.id
+
+  product_info {
+    product_id               = "00301-34090-0--0"
+    resource_size            = 200
+    resource_size_measure_id = 17
+    resource_spec_code       = "vault.backup.server.normal"
+  }
+}
+`, name)
+}

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_change_order.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_change_order.go
@@ -1,0 +1,208 @@
+package cbr
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableChangeOrderParams = []string{
+	"resource_id",
+	"product_info",
+	"product_info.*.product_id",
+	"product_info.*.resource_size",
+	"product_info.*.resource_size_measure_id",
+	"product_info.*.resource_spec_code",
+	"promotion_info",
+	"cloud_service_console_url",
+}
+
+// @API CBR POST /v3/{project_id}/orders/change
+func ResourceChangeOrder() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceChangeOrderCreate,
+		ReadContext:   resourceChangeOrderRead,
+		UpdateContext: resourceChangeOrderUpdate,
+		DeleteContext: resourceChangeOrderDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableChangeOrderParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"resource_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the resource to change.`,
+			},
+			"product_info": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Description: `Specifies product information.`,
+				Elem:        productInfoSchema(),
+			},
+			"promotion_info": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the promotion information for the order.`,
+			},
+			// This field seems to have no usage scenario and is retained simply to align the API.
+			"cloud_service_console_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: utils.SchemaDesc("Specifies the Console URL of the cloud service.", utils.SchemaDescInput{Internal: true}),
+			},
+			// Internal field to trigger ForceNew manually when needed.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func productInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"product_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the product ID.`,
+			},
+			"resource_size": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the size of the resource.`,
+			},
+			"resource_size_measure_id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the measurement unit of the resource size.`,
+			},
+			"resource_spec_code": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the spec code of the resource.`,
+			},
+		},
+	}
+}
+
+func buildProductInfo(d *schema.ResourceData) map[string]interface{} {
+	raw := d.Get("product_info.0").(map[string]interface{})
+	return map[string]interface{}{
+		"product_id":               raw["product_id"],
+		"resource_size":            raw["resource_size"],
+		"resource_size_measure_id": raw["resource_size_measure_id"],
+		"resource_spec_code":       raw["resource_spec_code"],
+	}
+}
+
+func buildChangeOrderBodyParams(d *schema.ResourceData) map[string]interface{} {
+	body := map[string]interface{}{
+		"resource_id":               d.Get("resource_id"),
+		"product_info":              buildProductInfo(d),
+		"is_auto_pay":               true,
+		"promotion_info":            utils.ValueIgnoreEmpty(d.Get("promotion_info")),
+		"cloud_service_console_url": utils.ValueIgnoreEmpty(d.Get("cloud_service_console_url")),
+	}
+	return utils.RemoveNil(body)
+}
+
+func resourceChangeOrderCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/orders/change"
+		product = "cbr"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBR client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildChangeOrderBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error changing CBR order: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	orderId := utils.PathSearch("orderId", respBody, "").(string)
+	if orderId == "" {
+		return diag.Errorf("error changing CBR order: order ID not found in API response")
+	}
+
+	bssClient, err := cfg.BssV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating BSS v2 client: %s", err)
+	}
+
+	if err := common.WaitOrderComplete(ctx, bssClient, orderId, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("error waiting for CBR change order (%s) to complete: %s", orderId, err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	return resourceChangeOrderRead(ctx, d, meta)
+}
+
+func resourceChangeOrderRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceChangeOrderUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceChangeOrderDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to change the order of a CBR resource. Deleting this 
+resource will not change the actual order result, but will only remove the resource information from the 
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to change cbr order.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cbr -f TestAccResourceChangeOrder_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccResourceChangeOrder_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceChangeOrder_basic
=== PAUSE TestAccResourceChangeOrder_basic
=== CONT  TestAccResourceChangeOrder_basic
--- PASS: TestAccResourceChangeOrder_basic (216.56s)
PASS
coverage: 12.9% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       216.662s        coverage: 12.9% of statements in ./huaweicloud/services/cbr
```
![image](https://github.com/user-attachments/assets/8ddbe36e-e502-4696-9bfe-8738a9c98e03)


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
