### PR TITLE
feat(apig): add new data source to query instances by tags

### DIFF
--- a/docs/data-sources/apig_instances_filter.md
+++ b/docs/data-sources/apig_instances_filter.md
@@ -1,0 +1,103 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_instances_filter"
+description: |-
+  Use this data source to query the dedicated instance list within HuaweiCloud.
+---
+
+# huaweicloud_apig_instances_filter
+
+Use this data source to query the dedicated instance list within HuaweiCloud.
+
+## Example Usage
+
+### Query all instances
+
+```hcl
+data "huaweicloud_apig_instances_filter" "test" {}
+```
+
+### Query instance list by tags
+
+```hcl
+variable "tags" {
+  type = list(object({
+    key    = string
+    values = optional(list(string), [])
+  }))
+}
+
+data "huaweicloud_apig_instances_filter" "test" {
+  dynamic "tags" {
+    for_each = var.tags
+
+    content {
+      key    = tags.value.key
+      values = tags.value.values
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `without_any_tag` - (Optional, Bool) Specifies whether to query resources without tags.  
+  Defaults to **false**.
+  + **true**: Only all resources without tags are queried.
+  + **false**: All resources are queried.
+
+* `tags` - (Optional, List) Specifies the list of the tags to be queried.  
+  The [tags](#data_instances_filter_tags) structure is documented below.
+
+* `matches` - (Optional, List) Specifies the fields to be queried.  
+  The [matches](#data_instances_filter_matches) structure is documented below.
+
+<a name="data_instances_filter_tags"></a>
+The `tags` block supports:
+
+* `key` - (Optional, String) Specifies the key of the tag.
+
+* `values` - (Optional, List) Specifies the list of values of the tag.
+
+<a name="data_instances_filter_matches"></a>
+The `matches` block supports:
+
+* `key` - (Optional, String) Specifies the key to be matched.  
+  The valid values are as follows:
+  + **resource_name**
+
+* `value` - (Optional, String) Specifies the value of the matching field. Fuzzy match is supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `instances` - All dedicated instances that match the filter parameters.
+
+  The [instances](#data_instances_filter_struct) structure is documented below.
+
+<a name="data_instances_filter_struct"></a>
+The `instances` block supports:
+
+* `resource_id` - The ID of the instance.
+
+* `resource_name` - The name of the instance.
+
+* `tags` - The tag list associated with the instance.
+
+  The [tags](#data_instances_filter_tags_struct) structure is documented below.
+
+<a name="data_instances_filter_tags_struct"></a>
+The `tags` block supports:
+
+* `key` - The key of the instance tag.
+
+* `value` - The value of the instance tag.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -504,6 +504,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_instance_features":                  apig.DataSourceInstanceFeatures(),
 			"huaweicloud_apig_instance_quotas":                    apig.DataSourceInstanceQuotas(),
 			"huaweicloud_apig_instance_supported_features":        apig.DataSourceInstanceSupportedFeatures(),
+			"huaweicloud_apig_instances_filter":                   apig.DataSourceInstancesFilter(),
 			"huaweicloud_apig_instances":                          apig.DataSourceInstances(),
 			"huaweicloud_apig_orchestration_rules":                apig.DataSourceOrchestrationRules(),
 			"huaweicloud_apig_orchestration_rule_associated_apis": apig.DataSourceOrchestrationRuleAssociatedApis(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_instances_filter_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_instances_filter_test.go
@@ -1,0 +1,181 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataSourceInstancesFilter_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		dataSource   = "data.huaweicloud_apig_instances_filter.all"
+		dcDataSource = acceptance.InitDataSourceCheck(dataSource)
+
+		byWithoutAnyTag   = "data.huaweicloud_apig_instances_filter.filter_by_without_any_tag"
+		dcByWithoutAnyTag = acceptance.InitDataSourceCheck(byWithoutAnyTag)
+
+		byTag   = "data.huaweicloud_apig_instances_filter.filter_by_tags"
+		dcByTag = acceptance.InitDataSourceCheck(byTag)
+
+		byMatchesFuzzy   = "data.huaweicloud_apig_instances_filter.filter_by_matches_fuzzy"
+		dcByMatchesFuzzy = acceptance.InitDataSourceCheck(byMatchesFuzzy)
+
+		byMatches   = "data.huaweicloud_apig_instances_filter.filter_by_matches"
+		dcByMatches = acceptance.InitDataSourceCheck(byMatches)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceInstancesFilter_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dcDataSource.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "instances.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.resource_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.resource_name"),
+					dcByWithoutAnyTag.CheckResourceExists(),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
+					dcByTag.CheckResourceExists(),
+					resource.TestCheckOutput("is_without_any_tag_filter_useful", "true"),
+					dcByMatchesFuzzy.CheckResourceExists(),
+					resource.TestCheckOutput("is_matches_fuzzy_filter_useful", "true"),
+					dcByMatches.CheckResourceExists(),
+					resource.TestCheckOutput("is_matches_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceInstancesFilter_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_apig_instance" "test" {
+  count = 2
+
+  availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  edition               = "BASIC"
+  name                  = "%[2]s${count.index}"
+  enterprise_project_id = "%[3]s"
+  tags = count.index == 0 ? {
+    owner = "terraform"
+  } : null
+}
+`, common.TestBaseNetwork(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccDataSourceInstancesFilter_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_instances_filter" "all" {
+  depends_on = [huaweicloud_apig_instance.test]
+}
+
+# Filter by without_any_tag.
+data "huaweicloud_apig_instances_filter" "filter_by_without_any_tag" {
+  without_any_tag = true
+
+  depends_on = [huaweicloud_apig_instance.test]
+}
+
+locals {
+  by_without_any_tag_filter = [
+    for tag in data.huaweicloud_apig_instances_filter.filter_by_without_any_tag.instances[*].tags : length(tag) == 0
+  ]
+}
+
+output "is_without_any_tag_filter_useful" {
+  value = length(local.by_without_any_tag_filter) > 0 && alltrue(local.by_without_any_tag_filter)
+}
+
+# Filter by tags.
+locals {
+  tag_key   = "owner"
+  tag_value = "terraform"
+}
+
+data "huaweicloud_apig_instances_filter" "filter_by_tags" {
+  tags {
+    key    = local.tag_key
+    values = [local.tag_value]
+  }
+
+  depends_on = [huaweicloud_apig_instance.test]
+}
+
+locals {
+  by_tags_result = [
+    for tag in flatten(data.huaweicloud_apig_instances_filter.filter_by_tags.instances[*].tags) :
+    true if tag.key == local.tag_key && tag.value == local.tag_value
+  ]
+}
+
+output "is_tags_filter_useful" {
+  value = length(local.by_tags_result) > 0 && alltrue(local.by_tags_result)
+}
+
+# Filter by matches.
+locals {
+  instance_name        = huaweicloud_apig_instance.test[0].name
+  instance_name_prefix = "tf_test"
+}
+
+data "huaweicloud_apig_instances_filter" "filter_by_matches_fuzzy" {
+  matches {
+    key   = "resource_name"
+    value = local.instance_name_prefix
+  }
+
+  depends_on = [huaweicloud_apig_instance.test]
+}
+
+locals {
+  by_matches_fuzzy_result = [for v in data.huaweicloud_apig_instances_filter.filter_by_matches_fuzzy.instances[*].resource_name :
+    strcontains(v, local.instance_name_prefix)
+  ]
+}
+
+output "is_matches_fuzzy_filter_useful" {
+  value = length(local.by_matches_fuzzy_result) > 0 && alltrue(local.by_matches_fuzzy_result)
+}
+
+# Filter by matches.
+data "huaweicloud_apig_instances_filter" "filter_by_matches" {
+  matches {
+    key   = "resource_name"
+    value = local.instance_name
+  }
+
+  depends_on = [huaweicloud_apig_instance.test]
+}
+
+locals {
+  by_matches_result = [for v in data.huaweicloud_apig_instances_filter.filter_by_matches.instances[*].resource_name :
+    v == local.instance_name
+  ]
+}
+
+output "is_matches_filter_useful" {
+  value = length(local.by_matches_result) > 0 && alltrue(local.by_matches_result)
+}
+`, testAccDataSourceInstancesFilter_base(name))
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_instances_filter.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_instances_filter.go
@@ -1,0 +1,229 @@
+package apig
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG POST /v2/{project_id}/apigw/resource-instances/filter
+func DataSourceInstancesFilter() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstancesFilterRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"without_any_tag": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to query resources without tags. Defaults to **false**.`,
+			},
+			"tags": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `The list of the tags to be queried.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The key of the tag.`,
+						},
+						"values": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The list of values of the tag.`,
+						},
+					},
+				},
+			},
+			"matches": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `The fields to be queried.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The key to be matched.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The value of the matching field.`,
+						},
+					},
+				},
+			},
+			"instances": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `All dedicated instances that match the filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the instance.`,
+						},
+						"resource_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the instance.`,
+						},
+						"tags": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The tag list associated with the instance.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The key of the instance tag.`,
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The value of the instance tag.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildGetInstancesBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"without_any_tag": d.Get("without_any_tag"),
+		"tags":            buildGetInstanceTagsBodyParams(d.Get("tags").([]interface{})),
+		"matches":         buildGetInstanceMatchesBodyParams(d.Get("matches").([]interface{})),
+	}
+	return bodyParams
+}
+
+func buildGetInstanceTagsBodyParams(tags []interface{}) []map[string]interface{} {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	res := make([]map[string]interface{}, len(tags))
+	for i, tag := range tags {
+		res[i] = map[string]interface{}{
+			// For interface, `key` and `values` is required, so they cannot be ignored.
+			"key":    utils.PathSearch("key", tag, nil),
+			"values": utils.PathSearch("values", tag, nil),
+		}
+	}
+	return res
+}
+
+func buildGetInstanceMatchesBodyParams(matches []interface{}) []map[string]interface{} {
+	if len(matches) == 0 {
+		return nil
+	}
+
+	res := make([]map[string]interface{}, len(matches))
+	for i, v := range matches {
+		// For interface, `key` and `value` is required, so they cannot be ignored.
+		res[i] = map[string]interface{}{
+			"key":   utils.PathSearch("key", v, nil),
+			"value": utils.PathSearch("value", v, nil),
+		}
+	}
+	return res
+}
+
+func dataSourceInstancesFilterRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/apigw/resource-instances/filter"
+	)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildGetInstancesBodyParams(d)),
+	}
+
+	// Paging is not effective, the default value of limit is 1000.
+	resp, err := client.Request("POST", listPath, &listOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving APIG instances: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("instances", flattenInstancesResp(
+			utils.PathSearch("resources", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenInstancesResp(instances []interface{}) []interface{} {
+	if len(instances) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(instances))
+	for i, v := range instances {
+		rst[i] = map[string]interface{}{
+			"resource_id":   utils.PathSearch("resource_id", v, nil),
+			"resource_name": utils.PathSearch("resource_name", v, nil),
+			"tags":          flattenResourceInstanceTagsResp(utils.PathSearch("tags", v, make([]interface{}, 0)).([]interface{})),
+		}
+	}
+	return rst
+}
+
+func flattenResourceInstanceTagsResp(tags []interface{}) []interface{} {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(tags))
+	for i, tag := range tags {
+		rst[i] = map[string]interface{}{
+			"key":   utils.PathSearch("key", tag, nil),
+			"value": utils.PathSearch("value", tag, nil),
+		}
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 Add new data source(`huaweicloud_apig_instances_filter`) to query instances.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccDataSourceInstancesFilter_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataSourceInstancesFilter_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceInstancesFilter_basic
=== PAUSE TestAccDataSourceInstancesFilter_basic
=== CONT  TestAccDataSourceInstancesFilter_basic
--- PASS: TestAccDataSourceInstancesFilter_basic (520.51s)
PASS
coverage: 4.3% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      520.764s        coverage: 4.3% of statements in ./huaweicloud/services/apig
```
![image](https://github.com/user-attachments/assets/f4c76f08-c0a9-47a8-b09b-400b2783641c)

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
