### PR TITLE
feat(modelarts): add 'creating_step' attribute for v2 resource pools

### DIFF
--- a/docs/data-sources/modelartsv2_resource_pools.md
+++ b/docs/data-sources/modelartsv2_resource_pools.md
@@ -130,6 +130,9 @@ The `resources` block supports:
 * `volume_group_configs` - The extend configurations of the volume groups.  
   The [volume_group_configs](#modelarts_resource_pool_resource_volume_group_configs) structure is documented below.
 
+* `creating_step` - The creation step configuration of the resource pool nodes.  
+  The [creating_step](#data_modelarts_resource_pool_resource_creating_step) structure is documented below.
+
 <a name="modelarts_resource_pool_resource_azs"></a>
 The `azs` block supports:
 
@@ -175,6 +178,13 @@ The `volume_group_configs` block supports:
   The [lvm_config](#modelarts_resource_pool_group_config_lvm_config) structure is documented below.
 
 * `types` - The list of storage types of the volume group.
+
+<a name="data_modelarts_resource_pool_resource_creating_step"></a>
+The `creating_step` block supports:
+
+* `step` - The creation step of the resource pool nodes.
+
+* `type` - The type of the resource pool nodes.
 
 <a name="modelarts_resource_pool_group_config_lvm_config"></a>
 The `lvm_config` block supports:

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_resource_pools.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_resource_pools.go
@@ -244,6 +244,25 @@ func dataV2ResourcePoolResourceSchema() *schema.Resource {
 				Elem:        dataV2ResourcePoolResourceVolumeGroupConfigsSchema(),
 				Description: `The extend configurations of the volume groups.`,
 			},
+			"creating_step": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"step": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The creation step of the resource pool nodes.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the resource pool nodes.`,
+						},
+					},
+				},
+				Description: `The creation step configuration of the resource pool nodes.`,
+			},
 		},
 	}
 }
@@ -521,6 +540,7 @@ func flattenV2ResourcePoolResources(resources []interface{}) []map[string]interf
 				resource, make([]interface{}, 0)).([]interface{})),
 			"volume_group_configs": flattenResourcePoolResourcesVolumeGroupConfigs(utils.PathSearch("volumeGroupConfigs",
 				resource, make([]interface{}, 0)).([]interface{})),
+			"creating_step": flattenResourcePoolResourcesCreatingStep(utils.PathSearch("creatingStep", resource, nil)),
 		})
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add `resources.creating_step`  attribute for `huaweicloud_modelartsv2_resource_pools`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
