### PR TITLE
feat(cbr): new resource to sync backup

### DIFF
--- a/docs/incubating/cbr_backup_sync.md
+++ b/docs/incubating/cbr_backup_sync.md
@@ -1,0 +1,75 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbr_backup_sync"
+description: |-
+  Using this resource to synchronize VMware backups within HuaweiCloud.
+---
+
+# huaweicloud_cbr_backup_sync
+
+Using this resource to synchronize VMware backups within HuaweiCloud.
+
+-> This resource is only a one-time action resource to synchronize a VMware backup. Deleting this resource will
+not clear the corresponding backup synchronization record, but will only remove the resource information from the
+tfstate file.
+
+## Example Usage
+
+```hcl
+variable "backup_id" {}
+variable "backup_name" {}
+variable "bucket_name" {}
+variable "image_path" {}
+variable "resource_id" {}
+variable "resource_name" {}
+variable "resource_type" {}
+variable "created_at" {}
+
+resource "huaweicloud_cbr_backup_sync" "test" {
+  backup_id     = var.backup_id
+  backup_name   = var.backup_name
+  bucket_name   = var.bucket_name
+  image_path    = var.image_path
+  resource_id   = var.resource_id
+  resource_name = var.resource_name
+  resource_type = var.resource_type
+  created_at    = var.created_at
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `backup_id` - (Required, String, NonUpdatable) Specifies the ID of the backup to be synchronized.
+
+* `backup_name` - (Required, String, NonUpdatable) Specifies the name of the backup.
+
+* `bucket_name` - (Required, String, NonUpdatable) Specifies the name of the bucket where the backup is stored.
+
+* `image_path` - (Required, String, NonUpdatable) Specifies the path of the backup image in the bucket.
+
+* `resource_id` - (Required, String, NonUpdatable) Specifies the ID of the resource to be backed up.
+
+* `resource_name` - (Required, String, NonUpdatable) Specifies the name of the resource to be backed up.
+
+* `resource_type` - (Required, String, NonUpdatable) Specifies the type of the resource to be backed up.
+
+* `created_at` - (Required, Int, NonUpdatable) Specifies the timestamp when the backup was created,
+  for example `1,548,898,428`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the backup synchronization resource.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1694,6 +1694,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_cbr_backup_share_accepter":    cbr.ResourceBackupShareAccepter(),
 			"huaweicloud_cbr_backup_share":             cbr.ResourceBackupShare(),
+			"huaweicloud_cbr_backup_sync":              cbr.ResourceBackupSync(),
 			"huaweicloud_cbr_checkpoint":               cbr.ResourceCheckpoint(),
 			"huaweicloud_cbr_checkpoint_copy":          cbr.ResourceCheckpointCopy(),
 			"huaweicloud_cbr_organization_policy":      cbr.ResourceOrganizationPolicy(),

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_backup_sync_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_backup_sync_test.go
@@ -1,0 +1,40 @@
+package cbr
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Because there is a lack of scenarios for testing the API, the test case only tests one failure error.
+func TestAccResourceBackupSync_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testResourceBackupSync_basic,
+				ExpectError: regexp.MustCompile(`error creating CBR backup sync`),
+			},
+		},
+	})
+}
+
+const testResourceBackupSync_basic = `
+resource "huaweicloud_cbr_backup_sync" "test" {
+  backup_id     = "not-exist-backup-id"
+  resource_id   = "not-exist-resource-id"
+  resource_name = "not-exist-resource-name"
+  resource_type = "OS::Native::Server"
+  bucket_name   = "not-exist-bucket-name"
+  image_path    = "not-exist-image-path"
+  created_at    = 1553587260
+  backup_name   = "not-exist-backup-name"
+}
+`

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_backup_sync.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_backup_sync.go
@@ -1,0 +1,246 @@
+package cbr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableSyncParams = []string{
+	"backup_id",
+	"backup_name",
+	"bucket_name",
+	"image_path",
+	"resource_id",
+	"resource_name",
+	"resource_type",
+	"created_at",
+}
+
+// This resource uses the API for synchronizing local VMware backups.
+// Due to the lack of test scenarios, this code is not tested and is not documented externally.
+// Documentation is only stored in docs/incubating.
+
+// @API CBR POST /v3/{project_id}/backups/sync
+// @API CBR GET /v3/{project_id}/operation-logs/{operation_log_id}
+func ResourceBackupSync() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBackupSyncCreate,
+		ReadContext:   resourceBackupSyncRead,
+		UpdateContext: resourceBackupSyncUpdate,
+		DeleteContext: resourceBackupSyncDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableSyncParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level
+region will be used.`,
+			},
+			"backup_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the backup ID to be synchronized.`,
+			},
+			"backup_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the name of the backup.`,
+			},
+			"bucket_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the name of the bucket where the backup is stored.`,
+			},
+			"image_path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the path of the backup image in the bucket.`,
+			},
+			"resource_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the resource to be backed up.`,
+			},
+			"resource_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the name of the resource to be backed up.`,
+			},
+			"resource_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the type of the resource to be backed up.`,
+			},
+			"created_at": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the timestamp when the backup was created.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildSyncCreateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	syncMap := map[string]interface{}{
+		"backup_id":     d.Get("backup_id").(string),
+		"backup_name":   d.Get("backup_name").(string),
+		"bucket_name":   d.Get("bucket_name").(string),
+		"image_path":    d.Get("image_path").(string),
+		"resource_id":   d.Get("resource_id").(string),
+		"resource_name": d.Get("resource_name").(string),
+		"resource_type": d.Get("resource_type").(string),
+		"created_at":    d.Get("created_at").(int),
+	}
+
+	return map[string]interface{}{
+		"sync": []interface{}{syncMap},
+	}
+}
+
+func querySyncTask(client *golangsdk.ServiceClient, operationLogID string) (interface{}, error) {
+	requestPath := client.Endpoint + "v3/{project_id}/operation-logs/{operation_log_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{operation_log_id}", operationLogID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving CBR backup sync task: %s", err)
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func waitingForSyncTaskSuccess(ctx context.Context, client *golangsdk.ServiceClient, timeout time.Duration, operationLogID string) error {
+	unexpectedStatus := []string{"failed", "timeout"}
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			respBody, err := querySyncTask(client, operationLogID)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			status := utils.PathSearch("operation_log.status", respBody, "").(string)
+			if status == "" {
+				return nil, "ERROR", errors.New("status is not found in API response")
+			}
+
+			if status == "success" {
+				return respBody, "COMPLETED", nil
+			}
+
+			if utils.StrSliceContains(unexpectedStatus, status) {
+				return respBody, status, nil
+			}
+			return respBody, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceBackupSyncCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/backups/sync"
+		product = "cbr"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBR client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildSyncCreateBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating CBR backup sync: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	operationLogID := utils.PathSearch("sync[0].operation_log_id", respBody, "").(string)
+	if operationLogID == "" {
+		return diag.Errorf("error creating CBR backup sync: Operation Log ID is not found in API response")
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID for CBR backup sync: %s", err)
+	}
+	d.SetId(id)
+
+	if err := waitingForSyncTaskSuccess(ctx, client, d.Timeout(schema.TimeoutCreate), operationLogID); err != nil {
+		return diag.Errorf("error waiting for CBR backup sync to complete: %s", err)
+	}
+
+	return resourceBackupSyncRead(ctx, d, meta)
+}
+
+func resourceBackupSyncRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceBackupSyncUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceBackupSyncDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to synchronize a CBR backup. Deleting this 
+resource will not change the current backup synchronization result, but will only remove the resource information from the 
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to sync backup.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Due to the lack of test scenarios, this code is not tested and is not documented externally.
- Documentation is only stored in docs/incubating.
- Because there is a lack of scenarios for testing the API, the test case only tests one failure error.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cbr -f TestAccResourceBackupSync_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccResourceBackupSync_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceBackupSync_basic
=== PAUSE TestAccResourceBackupSync_basic
=== CONT  TestAccResourceBackupSync_basic
--- PASS: TestAccResourceBackupSync_basic (6.42s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       6.508s  coverage: 4.7% of statements in ./huaweicloud/services/cbr
```
![image](https://github.com/user-attachments/assets/6b11e24f-93c6-4ac2-9d25-8860c9354b51)


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
