### PR TITLE
feat(hss): add new data source to query hss asset port statistics

### DIFF
--- a/docs/data-sources/hss_asset_port_statistics.md
+++ b/docs/data-sources/hss_asset_port_statistics.md
@@ -1,0 +1,72 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_asset_port_statistics"
+description: |-
+  Use this data source to get the list of HSS asset port statistics within HuaweiCloud.
+---
+
+# huaweicloud_hss_asset_port_statistics
+
+Use this data source to get the list of HSS asset port statistics within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_asset_port_statistics" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `port` - (Optional, Int) Specifies the port number.
+
+* `port_string` - (Optional, String) Specifies the port string used for fuzzy match.
+
+* `type` - (Optional, String) Specifies the port type.
+
+* `status` - (Optional, String) Specifies the port status.
+  The valid values are as follows:
+  + **danger**: Dangerous ports.
+  + **unknow**: No ports with known risks.
+
+* `sort_key` - (Optional, String) Specifies the sort key, sorting by port number is supported.
+
+* `sort_dir` - (Optional, String) Specifies the sort direction. The default value is **asc**.
+  The valid values are as follows:
+  + **asc**: Ascending order.
+  + **desc**: Descending order.
+
+* `category` - (Optional, String) Specifies the type. The default value is **host**.
+  The valid values are as follows:
+  + **host**: Host.
+  + **container**: Container.
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the resource belongs.
+  This parameter is valid only when the enterprise project function is enabled.
+  The value **all_granted_eps** indicates all enterprise projects.
+  If omitted, the default enterprise project will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data_list` - The port statistics list.
+  The [data_list](#port_statistics_structure) structure is documented below.
+
+<a name="port_statistics_structure"></a>
+The `data_list` block supports:
+
+* `port` - The port number.
+
+* `type` - The port type.
+
+* `num` - The number of ports.
+
+* `status` - The port status.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1034,6 +1034,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_event_unblock_ips":              hss.DataSourceEventUnblockIps(),
 			"huaweicloud_hss_asset_apps":                     hss.DataSourceAssetApps(),
 			"huaweicloud_hss_agent_install_script":           hss.DataSourceAgentInstallScript(),
+			"huaweicloud_hss_asset_port_statistics":          hss.DataSourceAssetPortStatistics(),
 
 			"huaweicloud_identity_permissions": iam.DataSourceIdentityPermissions(),
 			"huaweicloud_identity_role":        iam.DataSourceIdentityRole(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_asset_port_statistics_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_asset_port_statistics_test.go
@@ -1,0 +1,144 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAssetPortStatistics_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_asset_port_statistics.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting a host ID with host protection enabled.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAssetPortStatistics_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.port"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.num"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.status"),
+
+					resource.TestCheckOutput("is_port_filter_useful", "true"),
+					resource.TestCheckOutput("is_port_string_filter_useful", "true"),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					resource.TestCheckOutput("is_category_filter_useful", "true"),
+					resource.TestCheckOutput("is_sort_key_filter_useful", "true"),
+					resource.TestCheckOutput("is_sort_dir_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceAssetPortStatistics_basic string = `
+data "huaweicloud_hss_asset_port_statistics" "test" {}
+
+# Filter using port.
+locals {
+  port = data.huaweicloud_hss_asset_port_statistics.test.data_list[0].port
+}
+
+data "huaweicloud_hss_asset_port_statistics" "port_filter" {
+  port = local.port
+}
+
+output "is_port_filter_useful" {
+  value = length(data.huaweicloud_hss_asset_port_statistics.port_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_asset_port_statistics.port_filter.data_list[*].port : v == local.port]
+  )
+}
+
+# Filter using port_string.
+locals {
+  port_string = tostring(local.port)
+}
+
+data "huaweicloud_hss_asset_port_statistics" "port_string_filter" {
+  port_string = local.port_string
+}
+
+output "is_port_string_filter_useful" {
+  value = length(data.huaweicloud_hss_asset_port_statistics.port_string_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_asset_port_statistics.port_string_filter.data_list[*].port : v == local.port]
+  )
+}
+
+# Filter using type.
+locals {
+  type = data.huaweicloud_hss_asset_port_statistics.test.data_list[0].type
+}
+
+data "huaweicloud_hss_asset_port_statistics" "type_filter" {
+  type = local.type
+}
+
+output "is_type_filter_useful" {
+  value = length(data.huaweicloud_hss_asset_port_statistics.type_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_asset_port_statistics.type_filter.data_list[*].type : v == local.type]
+  )
+}
+
+# Filter using category.
+locals {
+  category = "host"
+}
+
+data "huaweicloud_hss_asset_port_statistics" "category_filter" {
+  category = local.category
+}
+
+output "is_category_filter_useful" {
+  value = length(data.huaweicloud_hss_asset_port_statistics.category_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_asset_port_statistics.category_filter.data_list[*].port : v != 0]
+  )
+}
+
+# Filter using sort_key and sort_dir.
+data "huaweicloud_hss_asset_port_statistics" "sort_desc_filter" {
+  sort_key = "port"
+  sort_dir = "desc"
+}
+
+data "huaweicloud_hss_asset_port_statistics" "sort_asc_filter" {
+  sort_key = "port"
+  sort_dir = "asc"
+}
+
+locals {
+  asc_first_port = data.huaweicloud_hss_asset_port_statistics.sort_asc_filter.data_list[0].port
+  desc_length = length(data.huaweicloud_hss_asset_port_statistics.sort_asc_filter.data_list)
+  desc_last_port = data.huaweicloud_hss_asset_port_statistics.sort_desc_filter.data_list[local.desc_length - 1].port
+}
+
+output "is_sort_key_filter_useful" {
+  value = length(data.huaweicloud_hss_asset_port_statistics.sort_desc_filter.data_list) > 0
+}
+
+output "is_sort_dir_filter_useful" {
+  value = length(data.huaweicloud_hss_asset_port_statistics.sort_desc_filter.data_list) > 0 && local.asc_first_port == local.desc_last_port
+}
+
+# Filter using non existent port.
+data "huaweicloud_hss_asset_port_statistics" "not_found" {
+  port = 99999
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_hss_asset_port_statistics.not_found.data_list) == 0
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_asset_port_statistics.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_asset_port_statistics.go
@@ -1,0 +1,206 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/asset/port/statistics
+func DataSourceAssetPortStatistics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAssetPortStatisticsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Specifies the region in which to query the resource.",
+			},
+			"port": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the port number.",
+			},
+			"port_string": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the port string.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the port type.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the port status.",
+			},
+			"sort_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the sort key.",
+			},
+			"sort_dir": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the sort direction.",
+			},
+			"category": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the type. The default value is host.",
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the ID of the enterprise project to which the resource belongs.",
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"port": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The port number.",
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The port type.",
+						},
+						"num": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of ports.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The port status.",
+						},
+					},
+				},
+				Description: "The port statistics list.",
+			},
+		},
+	}
+}
+
+func buildAssetPortStatisticsQueryParams(d *schema.ResourceData, cfg *config.Config) string {
+	epsId := cfg.GetEnterpriseProjectID(d)
+	queryParams := "?limit=100"
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("port"); ok {
+		queryParams = fmt.Sprintf("%s&port=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("port_string"); ok {
+		queryParams = fmt.Sprintf("%s&port_string=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("type"); ok {
+		queryParams = fmt.Sprintf("%s&type=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		queryParams = fmt.Sprintf("%s&status=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("sort_key"); ok {
+		queryParams = fmt.Sprintf("%s&sort_key=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("sort_dir"); ok {
+		queryParams = fmt.Sprintf("%s&sort_dir=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("category"); ok {
+		queryParams = fmt.Sprintf("%s&category=%v", queryParams, v)
+	}
+	return queryParams
+}
+
+func flattenAssetPortStatistics(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"port":   utils.PathSearch("port", v, nil),
+			"type":   utils.PathSearch("type", v, nil),
+			"num":    utils.PathSearch("num", v, nil),
+			"status": utils.PathSearch("status", v, nil),
+		})
+	}
+	return rst
+}
+
+func dataSourceAssetPortStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		mErr    *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v5/{project_id}/asset/port/statistics"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildAssetPortStatisticsQueryParams(d, cfg)
+	allPortStatistics := make([]interface{}, 0)
+	offset := 0
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", currentPath, &listOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS asset port statistics: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		portStatisticsResp := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(portStatisticsResp) == 0 {
+			break
+		}
+		allPortStatistics = append(allPortStatistics, portStatisticsResp...)
+		offset += len(portStatisticsResp)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("data_list", flattenAssetPortStatistics(allPortStatistics)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Use this data source to get the list of HSS asset port statistics within HuaweiCloud.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/hss' TESTARGS='-run TestAccDataSourceAssetPortStatistics_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceAssetPortStatistics_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAssetPortStatistics_basic
=== PAUSE TestAccDataSourceAssetPortStatistics_basic
=== CONT  TestAccDataSourceAssetPortStatistics_basic
--- PASS: TestAccDataSourceAssetPortStatistics_basic (101.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       101.728s
```
![image](https://github.com/user-attachments/assets/2b339fec-b180-4708-b386-5af6ab3c8c30)

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
