### PR TITLE
feat(dew): add new resource to manage delete secret task

### DIFF
--- a/docs/resources/csms_scheduled_delete_secret_task.md
+++ b/docs/resources/csms_scheduled_delete_secret_task.md
@@ -1,0 +1,62 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_csms_scheduled_delete_secret_task"
+description: |
+  Manages a scheduled delete secret task resource within HuaweiCloud
+---
+
+# huaweicloud_csms_scheduled_delete_secret_task
+
+Manages a scheduled delete secret task resource within HuaweiCloud.
+
+-> The current resource is a one-time resource, and destroying this resource will not recover the deleted secret task,
+but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+### Create a scheduled delete task
+
+```hcl
+variable "secret_name" {}
+
+resource "huaweicloud_csms_scheduled_delete_secret_task" "test" {
+  secret_name = var.secret_name
+  action      = "create"
+}
+```
+
+### Cancel a scheduled delete task
+
+```hcl
+variable "secret_name" {}
+
+resource "huaweicloud_csms_scheduled_delete_secret_task" "test" {
+  secret_name = var.secret_name
+  action      = "cancel"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the CSMS scheduled delete secret task.
+  If omitted, the provider-level region will be used.
+  Changing this setting will create a new resource.
+
+* `secret_name` - (Required, String, NonUpdatable) Specifies the secret name.
+
+* `action` - (Required, String) Specifies the action name. The valid values are as follows:  
+  + **create**: Create a scheduled delete task.
+  + **cancel**: Cancel a scheduled delete task.
+
+* `recovery_window_in_days` - (Optional, Int, NonUpdatable) Specifies the recovery window in days.
+  When `action` is set to **create**, this feild will take effect.
+  The valid value ranges form `7` to `30`. The default value is `30`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1851,9 +1851,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_cse_microservice_instance":             cse.ResourceMicroserviceInstance(),
 			"huaweicloud_cse_nacos_namespace":                   cse.ResourceNacosNamespace(),
 
-			"huaweicloud_csms_event":                dew.ResourceCsmsEvent(),
-			"huaweicloud_csms_secret":               dew.ResourceSecret(),
-			"huaweicloud_csms_secret_version_state": dew.ResourceSecretVersionState(),
+			"huaweicloud_csms_event":                        dew.ResourceCsmsEvent(),
+			"huaweicloud_csms_secret":                       dew.ResourceSecret(),
+			"huaweicloud_csms_secret_version_state":         dew.ResourceSecretVersionState(),
+			"huaweicloud_csms_scheduled_delete_secret_task": dew.ResourceCsmsScheduledDeleteSecretTask(),
 
 			"huaweicloud_css_cluster":                     css.ResourceCssCluster(),
 			"huaweicloud_css_cluster_restart":             css.ResourceCssClusterRestart(),

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_csms_scheduled_delete_secret_task_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_csms_scheduled_delete_secret_task_test.go
@@ -1,0 +1,45 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccCsmsScheduledDeleteSecretTask_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCsmsScheduledDeleteSecretTask_basic(name),
+			},
+		},
+	})
+}
+
+func testAccCsmsScheduledDeleteSecretTask_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_csms_secret" "test" {
+  name        = "%s"
+  secret_text = "this is a password"
+}
+
+resource "huaweicloud_csms_scheduled_delete_secret_task" "test1" {
+  secret_name = huaweicloud_csms_secret.test.name
+  action      = "create"
+}
+
+resource "huaweicloud_csms_scheduled_delete_secret_task" "test2" {
+  secret_name = huaweicloud_csms_secret.test.name
+  action      = "cancel"
+
+  depends_on = [huaweicloud_csms_scheduled_delete_secret_task.test1]
+}
+`, name)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_csms_scheduled_delete_secret_task.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_csms_scheduled_delete_secret_task.go
@@ -1,0 +1,143 @@
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var scheduledDeleteSecretTaskNonUpdatableParams = []string{
+	"secret_name",
+	"action",
+	"recovery_window_in_days",
+}
+
+// @API DEW POST /v1/{project_id}/secrets/{secret_name}/scheduled-deleted-tasks/create
+// @API DEW POST /v1/{project_id}/secrets/{secret_name}/scheduled-deleted-tasks/cancel
+func ResourceCsmsScheduledDeleteSecretTask() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCsmsScheduledDeleteSecretTaskCreate,
+		ReadContext:   resourceCsmsScheduledDeleteSecretTaskRead,
+		UpdateContext: resourceCsmsScheduledDeleteSecretTaskUpdate,
+		DeleteContext: resourceCsmsScheduledDeleteSecretTaskDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(scheduledDeleteSecretTaskNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to create the resource.`,
+			},
+			"secret_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the secret name.`,
+			},
+			"action": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"create", "cancel"}, false),
+				Description:  `Specifies the secret name.`,
+			},
+			"recovery_window_in_days": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     30,
+				Description: `Specifies the recovery window in days.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildReqsuestOpts(action string, recoveryDays int) golangsdk.RequestOpts {
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	if action == "create" {
+		requestOpt.JSONBody = map[string]interface{}{
+			"recovery_window_in_days": recoveryDays,
+		}
+	}
+
+	return requestOpt
+}
+
+func resourceCsmsScheduledDeleteSecretTaskCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		product    = "kms"
+		httpUrl    = "v1/{project_id}/secrets/{secret_name}/scheduled-deleted-tasks/{action}"
+		requestOpt golangsdk.RequestOpts
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CSMS client: %s", err)
+	}
+
+	secretName := d.Get("secret_name").(string)
+	action := d.Get("action").(string)
+	recoveryDays := d.Get("recovery_window_in_days").(int)
+
+	requestOpt = buildReqsuestOpts(action, recoveryDays)
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{secret_name}", secretName)
+	requestPath = strings.ReplaceAll(requestPath, "{action}", action)
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error managing (%s) CSMS scheduled delete secret task: %s", action, err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	return nil
+}
+
+func resourceCsmsScheduledDeleteSecretTaskRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceCsmsScheduledDeleteSecretTaskUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceCsmsScheduledDeleteSecretTaskDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to manage scheduled delete secret task.
+Deleting this resource will not recover the scheduled delete task, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports new resource to manage delete secret task and names huaweicloud_csms_scheduled_delete_secret_task.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccCsmsScheduledDeleteSecretTask_basic -timeout 360m -parallel 10
=== RUN   TestAccCsmsScheduledDeleteSecretTask_basic
=== PAUSE TestAccCsmsScheduledDeleteSecretTask_basic
=== CONT  TestAccCsmsScheduledDeleteSecretTask_basic
--- PASS: TestAccCsmsScheduledDeleteSecretTask_basic (11.44s)
PASS
coverage: 7.0% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew
```
![image](https://github.com/user-attachments/assets/b5871278-3574-45c4-b719-715c18bb89fd)

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
