### PR TITLE
feat(hss): add new data source to query hss asset user statistics

### DIFF
--- a/docs/data-sources/hss_asset_user_statistics.md
+++ b/docs/data-sources/hss_asset_user_statistics.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_asset_user_statistics"
+description: |-
+  Use this data source to get the list of HSS user statistics within HuaweiCloud.
+---
+
+# huaweicloud_hss_asset_user_statistics
+
+Use this data source to get the list of HSS user statistics within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_asset_user_statistics" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `user_name` - (Optional, String) Specifies the user name.
+
+* `category` - (Optional, String) Specifies the type. The default value is **host**.
+  The valid values are as follows:
+  + **host**: Host.
+  + **container**: Container.
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the resource belongs.
+  This parameter is valid only when the enterprise project function is enabled.
+  The value **all_granted_eps** indicates all enterprise projects.
+  If omitted, the default enterprise project will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data_list` - The user statistics list.
+  The [data_list](#user_statistics_structure) structure is documented below.
+
+<a name="user_statistics_structure"></a>
+The `data_list` block supports:
+
+* `user_name` - The user name.
+
+* `num` - The number of servers of the user.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1037,6 +1037,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_asset_apps":                     hss.DataSourceAssetApps(),
 			"huaweicloud_hss_agent_install_script":           hss.DataSourceAgentInstallScript(),
 			"huaweicloud_hss_asset_port_statistics":          hss.DataSourceAssetPortStatistics(),
+			"huaweicloud_hss_asset_user_statistics":          hss.DataSourceAssetUserStatistics(),
 
 			"huaweicloud_identity_permissions": iam.DataSourceIdentityPermissions(),
 			"huaweicloud_identity_role":        iam.DataSourceIdentityRole(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_asset_user_statistics_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_asset_user_statistics_test.go
@@ -1,0 +1,83 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAssetUserStatistics_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_asset_user_statistics.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting a host ID with host protection enabled.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAssetUserStatistics_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.user_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.num"),
+
+					resource.TestCheckOutput("is_user_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_category_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceAssetUserStatistics_basic string = `
+data "huaweicloud_hss_asset_user_statistics" "test" {}
+
+# Filter using user_name.
+locals {
+  user_name = data.huaweicloud_hss_asset_user_statistics.test.data_list[0].user_name
+}
+
+data "huaweicloud_hss_asset_user_statistics" "user_name_filter" {
+  user_name = local.user_name
+}
+
+output "is_user_name_filter_useful" {
+  value = length(data.huaweicloud_hss_asset_user_statistics.user_name_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_asset_user_statistics.user_name_filter.data_list[*].user_name : v == local.user_name]
+  )
+}
+
+# Filter using category.
+locals {
+  category = "host"
+}
+
+data "huaweicloud_hss_asset_user_statistics" "category_filter" {
+  category = local.category
+}
+
+output "is_category_filter_useful" {
+  value = length(data.huaweicloud_hss_asset_user_statistics.category_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_asset_user_statistics.category_filter.data_list[*].user_name : v != ""]
+  )
+}
+
+# Filter using non existent user_name.
+data "huaweicloud_hss_asset_user_statistics" "not_found" {
+  user_name = "resource_not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_hss_asset_user_statistics.not_found.data_list) == 0
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_asset_user_statistics.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_asset_user_statistics.go
@@ -1,0 +1,154 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/asset/user/statistics
+func DataSourceAssetUserStatistics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAssetUserStatisticsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Specifies the region in which to query the resource.",
+			},
+			"user_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the user name.",
+			},
+			"category": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the type. The default value is host.",
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the ID of the enterprise project to which the resource belongs.",
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"user_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The user name.",
+						},
+						"num": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of servers of the user.",
+						},
+					},
+				},
+				Description: "The user statistics list.",
+			},
+		},
+	}
+}
+
+func buildAssetUserStatisticsQueryParams(d *schema.ResourceData, cfg *config.Config) string {
+	epsId := cfg.GetEnterpriseProjectID(d)
+	queryParams := "?limit=100"
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("user_name"); ok {
+		queryParams = fmt.Sprintf("%s&user_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("category"); ok {
+		queryParams = fmt.Sprintf("%s&category=%v", queryParams, v)
+	}
+	return queryParams
+}
+
+func flattenAssetUserStatistics(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"user_name": utils.PathSearch("user_name", v, nil),
+			"num":       utils.PathSearch("num", v, nil),
+		})
+	}
+	return rst
+}
+
+func dataSourceAssetUserStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		mErr    *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v5/{project_id}/asset/user/statistics"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildAssetUserStatisticsQueryParams(d, cfg)
+	allUserStatistics := make([]interface{}, 0)
+	offset := 0
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", currentPath, &listOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS asset user statistics: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		userStatisticsResp := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(userStatisticsResp) == 0 {
+			break
+		}
+		allUserStatistics = append(allUserStatistics, userStatisticsResp...)
+		offset += len(userStatisticsResp)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("data_list", flattenAssetUserStatistics(allUserStatistics)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Use this data source to get the list of HSS user statistics within HuaweiCloud.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 make testacc TEST='./huaweicloud/services/acceptance/hss' TESTARGS='-run TestAccDataSourceAssetUserStatistics_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceAssetUserStatistics_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAssetUserStatistics_basic
=== PAUSE TestAccDataSourceAssetUserStatistics_basic
=== CONT  TestAccDataSourceAssetUserStatistics_basic
--- PASS: TestAccDataSourceAssetUserStatistics_basic (68.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       68.954s
```
![image](https://github.com/user-attachments/assets/caf2ac4e-813e-40f9-adf5-28c535cec948)


* [x] Documentation updated.
* [x Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
