### PR TITLE
feat(cbr): new resource to sync checkpoint

### DIFF
--- a/docs/incubating/cbr_checkpoint_sync.md
+++ b/docs/incubating/cbr_checkpoint_sync.md
@@ -1,0 +1,50 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbr_checkpoint_sync"
+description: |-
+  Using this resource to synchronize hybrid cloud checkpoints within HuaweiCloud.
+---
+
+# huaweicloud_cbr_checkpoint_sync
+
+Using this resource to synchronize hybrid cloud checkpoints within HuaweiCloud.
+
+-> This resource is only a one-time action resource to synchronize checkpoints from hybrid cloud vaults. Deleting this
+resource will not clear the corresponding checkpoint synchronization record, but will only remove the resource
+information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "vault_id" {}
+variable "auto_trigger" {}
+
+resource "huaweicloud_cbr_checkpoint_sync" "test" {
+  vault_id     = var.vault_id
+  auto_trigger = var.auto_trigger
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource. If omitted, the
+  provider-level region will be used.
+
+* `vault_id` - (Required, String, NonUpdatable) Specifies the ID of the hybrid cloud vault to sync checkpoints to.
+
+* `auto_trigger` - (Required, Bool, NonUpdatable) Specifies whether this checkpoint sync is automatically triggered.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the resource.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1704,6 +1704,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbr_backup_sync":              cbr.ResourceBackupSync(),
 			"huaweicloud_cbr_checkpoint":               cbr.ResourceCheckpoint(),
 			"huaweicloud_cbr_checkpoint_copy":          cbr.ResourceCheckpointCopy(),
+			"huaweicloud_cbr_checkpoint_sync":          cbr.ResourceCheckpointSync(),
 			"huaweicloud_cbr_organization_policy":      cbr.ResourceOrganizationPolicy(),
 			"huaweicloud_cbr_policy":                   cbr.ResourcePolicy(),
 			"huaweicloud_cbr_vault":                    cbr.ResourceVault(),

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_checkpoint_sync_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_checkpoint_sync_test.go
@@ -1,0 +1,34 @@
+package cbr
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Because there is a lack of scenarios for testing the API, the test case only tests one failure error.
+func TestAccResourceCheckpointSync_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testResourceCheckpointSync_basic,
+				ExpectError: regexp.MustCompile(`error creating CBR checkpoint sync`),
+			},
+		},
+	})
+}
+
+const testResourceCheckpointSync_basic = `
+resource "huaweicloud_cbr_checkpoint_sync" "test" {
+  vault_id     = "not-exist-vault-id"
+  auto_trigger = true
+}
+`

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_checkpoint_sync.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_checkpoint_sync.go
@@ -1,0 +1,149 @@
+package cbr
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableCheckpointSyncParams = []string{
+	"vault_id",
+	"auto_trigger",
+}
+
+// This resource uses the API for synchronizing hybrid cloud checkpoints.
+// Due to the lack of test scenarios, this code is not tested and is not documented externally.
+// Documentation is only stored in docs/incubating.
+
+// @API CBR POST /v3/{project_id}/checkpoints/sync
+// @API CBR GET /v3/{project_id}/operation-logs/{operation_log_id}
+func ResourceCheckpointSync() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCheckpointSyncCreate,
+		ReadContext:   resourceCheckpointSyncRead,
+		UpdateContext: resourceCheckpointSyncUpdate,
+		DeleteContext: resourceCheckpointSyncDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableCheckpointSyncParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level
+region will be used.`,
+			},
+			"vault_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the hybrid cloud vault to sync checkpoints to.`,
+			},
+			"auto_trigger": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: `Specifies whether this checkpoint sync is automatically triggered.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildCheckpointSyncCreateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"sync": map[string]interface{}{
+			"vault_id":     d.Get("vault_id"),
+			"auto_trigger": d.Get("auto_trigger"),
+		},
+	}
+}
+
+func resourceCheckpointSyncCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/checkpoints/sync"
+		product = "cbr"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBR client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildCheckpointSyncCreateBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating CBR checkpoint sync: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	operationLogID := utils.PathSearch("sync.operation_log_id", respBody, "").(string)
+	if operationLogID == "" {
+		return diag.Errorf("error creating CBR checkpoint sync: Operation Log ID is not found in API response")
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID for CBR checkpoint sync: %s", err)
+	}
+	d.SetId(id)
+
+	if err := waitingForSyncTaskSuccess(ctx, client, d.Timeout(schema.TimeoutCreate), operationLogID); err != nil {
+		return diag.Errorf("error waiting for CBR checkpoint sync to complete: %s", err)
+	}
+
+	return resourceCheckpointSyncRead(ctx, d, meta)
+}
+
+func resourceCheckpointSyncRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceCheckpointSyncUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceCheckpointSyncDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to synchronize a CBR checkpoint. Deleting this 
+resource will not change the current checkpoint synchronization result, but will only remove the resource information from the 
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to sync checkpoint.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cbr -f TestAccResourceCheckpointSync_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccResourceCheckpointSync_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceCheckpointSync_basic
=== PAUSE TestAccResourceCheckpointSync_basic
=== CONT  TestAccResourceCheckpointSync_basic
--- PASS: TestAccResourceCheckpointSync_basic (3.94s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       4.012s  coverage: 4.6% of statements in ./huaweicloud/services/cbr
```
![image](https://github.com/user-attachments/assets/01c5def1-6211-49e5-85ef-8fcf2fe862d1)


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
