### PR TITLE
docs(modelarts/resource_pool): add some constraints for resource

### DIFF
--- a/docs/resources/modelarts_resource_pool.md
+++ b/docs/resources/modelarts_resource_pool.md
@@ -9,6 +9,8 @@ description: ""
 
 Manages a ModelArts dedicated resource pool resource within HuaweiCloud.  
 
+~> If you want to expand hyper instance nodes, the provider version must be `1.75.5` or later.
+
 ## Example Usage
 
 ### create a basic resource pool
@@ -196,6 +198,10 @@ The following arguments are supported:
 * `resources` - (Required, List) Specifies the list of resource specifications in the resource pool.  
   Including resource flavors and the number of resources of the corresponding flavors.
   The [resources](#ModelartsResourcePool_ResourceFlavor) structure is documented below.
+
+  -> If you want to update `resources`, the order of the `resources` list must be consistent with the one used during creation.
+
+  ~> If the updated `resources` list is inconsistent with the created one, the expansion may extend to other node pools.
 
 * `scope` - (Required, List) Specifies the list of job types supported by the resource pool. It is mandatory when
   `network_id` is specified and can not be specified when `vpc_id` is specified. The options are as follows:
@@ -488,8 +494,8 @@ $ terraform import huaweicloud_modelarts_resource_pool.test <id>
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `period_unit`, `period`, `auto_renew`,
-`user_login.0.password`, `metadata`. It is generally recommended running `terraform plan` after importing a ModelArts
-resource pool.
+`user_login`, `metadata`. It is generally recommended running `terraform plan` after importing a ModelArts
+resource pool
 You can then decide if changes should be applied to the ModelArts resource pool, or the resource definition should be
 updated to align with the ModelArts resource pool. Also, you can ignore changes as below.
 
@@ -499,7 +505,7 @@ resource "huaweicloud_modelarts_resource_pool" "resource_pool" {
 
   lifecycle {
     ignore_changes = [
-      period_unit, period, auto_renew, user_login.0.password, metadata
+      period_unit, period, auto_renew, user_login, metadata
     ]
   }
 }


### PR DESCRIPTION
Add some constraints for this resource and parameters.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
