### PR TITLE
feat(cbh): add new data source to get login url

### DIFF
--- a/docs/data-sources/cbh_instance_login_url.md
+++ b/docs/data-sources/cbh_instance_login_url.md
@@ -1,0 +1,38 @@
+---
+subcategory: "Cloud Bastion Host (CBH)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbh_instance_login_url"
+description: |-
+  Use this data source to get the URL for logging in to a CBH instance as IAM user within HuaweiCloud.
+---
+
+# huaweicloud_cbh_instance_login_url
+
+Use this data source to get the URL for logging in to a CBH instance as IAM user within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "server_id" {}
+
+data "huaweicloud_cbh_instance_login_url" "test" {
+  server_id = var.server_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `server_id` - (Required, String) Specifies the CBH instance ID, in UUID format.  
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID, same as `server_id`.
+
+* `login_url` - The URL for logging in to a CBH instance as IAM user.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -558,6 +558,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbh_instance_tags":      cbh.DataSourceInstanceTags(),
 			"huaweicloud_cbh_instance_ecs_quota": cbh.DataSourceInstanceEcsQuota(),
 			"huaweicloud_cbh_instance_admin_url": cbh.DataSourceInstanceAdminUrl(),
+			"huaweicloud_cbh_instance_login_url": cbh.DataSourceInstanceLoginUrl(),
 
 			"huaweicloud_cc_authorizations":                               cc.DataSourceCcAuthorizations(),
 			"huaweicloud_cc_bandwidth_packages":                           cc.DataSourceCcBandwidthPackages(),

--- a/huaweicloud/services/acceptance/cbh/data_source_huaweicloud_cbh_instance_login_url_test.go
+++ b/huaweicloud/services/acceptance/cbh/data_source_huaweicloud_cbh_instance_login_url_test.go
@@ -1,0 +1,43 @@
+package cbh
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceInstanceLoginUrl_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_cbh_instance_login_url.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare a CBH instance ID and config it to the environment variable.
+			acceptance.TestAccPreCheckCbhInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceInstanceLoginUrl_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "login_url"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceInstanceLoginUrl_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cbh_instance_login_url" "test" {
+  server_id = "%s"
+}
+`, acceptance.HW_CBH_INSTANCE_ID)
+}

--- a/huaweicloud/services/cbh/data_source_huaweicloud_cbh_instance_login_url.go
+++ b/huaweicloud/services/cbh/data_source_huaweicloud_cbh_instance_login_url.go
@@ -1,0 +1,87 @@
+package cbh
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CBH POST /v2/{project_id}/cbs/instance/login
+func DataSourceInstanceLoginUrl() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstanceLoginUrlRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource.`,
+			},
+			"server_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the CBH instance ID.`,
+			},
+			"login_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The URL for logging in to a CBH instance as IAM user.`,
+			},
+		},
+	}
+}
+
+func dataSourceInstanceLoginUrlRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		mErr       *multierror.Error
+		getHttpUrl = "v2/{project_id}/cbs/instance/login"
+		product    = "cbh"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBH client: %s", err)
+	}
+
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody: map[string]interface{}{
+			"server_id": d.Get("server_id"),
+		},
+	}
+
+	getResp, err := client.Request("POST", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CBH instance login url: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(d.Get("server_id").(string))
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("login_url", utils.PathSearch("login_url", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports new data source to get login url and names huaweicloud_cbh_instance_login_url.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbh" -v -coverprofile="./huaweicloud/services/acceptance/cbh/cbh_coverage.cov" -coverpkg="./huaweicloud/services/cbh" -run TestAccDataSourceInstanceLoginUrl_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceInstanceLoginUrl_basic
=== PAUSE TestAccDataSourceInstanceLoginUrl_basic
=== CONT  TestAccDataSourceInstanceLoginUrl_basic
--- PASS: TestAccDataSourceInstanceLoginUrl_basic (11.40s)
PASS
coverage: 2.4% of statements in ./huaweicloud/services/cbh
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh
```
![image](https://github.com/user-attachments/assets/744a3555-356f-4123-9cd9-d977c9477b2a)

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
