### PR TITLE
feat(RDS): add a data source to query wal log replay delay status

### DIFF
--- a/docs/data-sources/rds_wal_log_replay_delay_status.md
+++ b/docs/data-sources/rds_wal_log_replay_delay_status.md
@@ -1,0 +1,50 @@
+---
+subcategory: "Relational Database Service (RDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rds_wal_log_replay_delay_status"
+description: |-
+  Use this data source to query the WAL log replay delay status of a specified RDS instance.
+---
+
+# huaweicloud_rds_wal_log_replay_delay_status
+
+Use this data source to query the WAL log replay delay status of a specified RDS instance.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_rds_wal_log_replay_delay_status" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the RDS instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `cur_delay_time_mills` - Indicates the current WAL log replay delay time in milliseconds.
+
+* `delay_time_value_range` - Indicates the valid range for the WAL log delay time.
+
+* `real_delay_time_mills` - Indicates the actual replay delay time of the WAL log in milliseconds.
+
+* `cur_log_replay_paused` - Indicates whether WAL log replay is currently paused. Value can be as follow:
+  + **true**: Indicates that the WAL log replay is paused.
+  + **false**: Indicates that the WAL log replay is actively running.
+
+* `latest_receive_log` - Indicates the latest WAL log that has been received by the RDS instance.
+
+* `latest_replay_log` - Indicates the latest WAL log that has been replayed by the RDS instance.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1272,6 +1272,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_dr_relationships":                 rds.DataSourceRdsDrRelationships(),
 			"huaweicloud_rds_lts_configs":                      rds.DataSourceRdsLtsConfigs(),
 			"huaweicloud_rds_instance_configurations":          rds.DataSourceRdsInstanceConfigurations(),
+			"huaweicloud_rds_wal_log_replay_delay_status":      rds.DataSourceRdsWalLogReplayDelayStatus(),
 
 			"huaweicloud_rms_policy_definitions":                       rms.DataSourcePolicyDefinitions(),
 			"huaweicloud_rms_assignment_package_templates":             rms.DataSourceTemplates(),

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_wal_log_replay_delay_status_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_wal_log_replay_delay_status_test.go
@@ -1,0 +1,89 @@
+package rds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRdsWalLogReplayDelayStatus_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_rds_wal_log_replay_delay_status.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceRdsWalLogReplayDelayStatus_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "cur_delay_time_mills"),
+					resource.TestCheckResourceAttrSet(dataSource, "delay_time_value_range"),
+					resource.TestCheckResourceAttrSet(dataSource, "real_delay_time_mills"),
+					resource.TestCheckResourceAttrSet(dataSource, "cur_log_replay_paused"),
+					resource.TestCheckResourceAttrSet(dataSource, "latest_receive_log"),
+					resource.TestCheckResourceAttrSet(dataSource, "latest_replay_log"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceRdsWalLogReplayDelayStatus_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "huaweicloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = "rds.pg.n1.medium.2"
+  vpc_id            = data.huaweicloud_vpc.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  charging_mode     = "postPaid"
+  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
+  db {
+    type     = "PostgreSQL"
+    version  = "12"
+    password = "Trerraform125@"
+  }
+  volume {
+    type = "CLOUDSSD"
+    size = 40
+  }
+}
+
+resource "huaweicloud_rds_read_replica_instance" "test" {
+  name                = "%[2]s-read-replica"
+  flavor              = "rds.pg.n1.medium.2.rr"
+  primary_instance_id = huaweicloud_rds_instance.test.id
+  availability_zone   = data.huaweicloud_availability_zones.test.names[0]
+  security_group_id   = data.huaweicloud_networking_secgroup.test.id
+
+  db {
+    port = "5432"
+  }
+
+  volume {
+    type              = "CLOUDSSD"
+    size              = 40
+    limit_size        = 200
+    trigger_threshold = 10
+  }
+}
+`, testAccRdsInstance_base(), name)
+}
+
+func testDataSourceRdsWalLogReplayDelayStatus_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+data "huaweicloud_rds_wal_log_replay_delay_status" "test" {
+  instance_id = huaweicloud_rds_read_replica_instance.test.id
+}
+`, testDataSourceRdsWalLogReplayDelayStatus_base(name))
+}

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_wal_log_replay_delay_status.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_wal_log_replay_delay_status.go
@@ -1,0 +1,110 @@
+package rds
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RDS GET /v3/{project_id}/instances/{instance_id}/replay-delay/show
+func DataSourceRdsWalLogReplayDelayStatus() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRdsWalLogReplayDelayStatusRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cur_delay_time_mills": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"delay_time_value_range": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"real_delay_time_mills": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"cur_log_replay_paused": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"latest_receive_log": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"latest_replay_log": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceRdsWalLogReplayDelayStatusRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	client, err := cfg.NewServiceClient("rds", region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	url := "v3/{project_id}/instances/{instance_id}/replay-delay/show"
+	getUrl := client.Endpoint + url
+	getUrl = strings.ReplaceAll(getUrl, "{project_id}", client.ProjectID)
+	getUrl = strings.ReplaceAll(getUrl, "{instance_id}", d.Get("instance_id").(string))
+
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"Accept":       "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getUrl, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving RDS WAL log replay delay status: %s", err)
+	}
+
+	body, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("cur_delay_time_mills", utils.PathSearch("cur_delay_time_mills", body, nil)),
+		d.Set("delay_time_value_range", utils.PathSearch("delay_time_value_range", body, nil)),
+		d.Set("real_delay_time_mills", utils.PathSearch("real_delay_time_mills", body, nil)),
+		d.Set("cur_log_replay_paused", utils.PathSearch("cur_log_replay_paused", body, nil)),
+		d.Set("latest_receive_log", utils.PathSearch("latest_receive_log", body, nil)),
+		d.Set("latest_replay_log", utils.PathSearch("latest_replay_log", body, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a data source to query wal log replay delay status
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a data source to query wal log replay delay status
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test /mnt/d/projects/go_projects/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds -v -run=TestAccDataSourceRdsWalLogReplayDelayStatus_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRdsWalLogReplayDelayStatus_basic
=== PAUSE TestAccDataSourceRdsWalLogReplayDelayStatus_basic
=== CONT  TestAccDataSourceRdsWalLogReplayDelayStatus_basic
--- PASS: TestAccDataSourceRdsWalLogReplayDelayStatus_basic (841.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       841.943s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
