### PR TITLE
feat(RDS): add a data source to query wal log recovery time window

### DIFF
--- a/docs/data-sources/rds_wal_log_recovery_time_window.md
+++ b/docs/data-sources/rds_wal_log_recovery_time_window.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Relational Database Service (RDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rds_wal_log_recovery_time_window"
+description: |-
+  Use this data source to query the WAL log recovery time window of a specified RDS read-replica instance.
+---
+
+# huaweicloud_rds_wal_log_recovery_time_window
+
+Use this data source to query the WAL log recovery time window of a specified RDS read-replica instance.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_rds_wal_log_recovery_time_window" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the RDS instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `recovery_min_time` - Indicates the start of the WAL log recovery window (exclusive), formatted as a timestamp string.
+
+* `recovery_max_time` - Indicates the end of the WAL log recovery window (inclusive), formatted as a timestamp string.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1273,6 +1273,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_lts_configs":                      rds.DataSourceRdsLtsConfigs(),
 			"huaweicloud_rds_instance_configurations":          rds.DataSourceRdsInstanceConfigurations(),
 			"huaweicloud_rds_wal_log_replay_delay_status":      rds.DataSourceRdsWalLogReplayDelayStatus(),
+			"huaweicloud_rds_wal_log_recovery_time_window":     rds.DataSourceRdsWalLogRecoveryTimeWindow(),
 
 			"huaweicloud_rms_policy_definitions":                       rms.DataSourcePolicyDefinitions(),
 			"huaweicloud_rms_assignment_package_templates":             rms.DataSourceTemplates(),

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_wal_log_recovery_time_window_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_wal_log_recovery_time_window_test.go
@@ -1,0 +1,82 @@
+package rds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRdsWalLogRecoveryTimeWindow_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_rds_wal_log_recovery_time_window.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceRdsWalLogRecoveryTimeWindow_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "recovery_min_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "recovery_max_time"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceRdsWalLogRecoveryTimeWindow_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "huaweicloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = "rds.pg.n1.medium.2"
+  vpc_id            = data.huaweicloud_vpc.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  charging_mode     = "postPaid"
+  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
+  db {
+    type     = "PostgreSQL"
+    version  = "12"
+    password = "Trerraform125@"
+  }
+  volume {
+    type = "CLOUDSSD"
+    size = 40
+  }
+}
+resource "huaweicloud_rds_read_replica_instance" "test" {
+  name                = "%[2]s-read-replica"
+  flavor              = "rds.pg.n1.medium.2.rr"
+  primary_instance_id = huaweicloud_rds_instance.test.id
+  availability_zone   = data.huaweicloud_availability_zones.test.names[0]
+  security_group_id   = data.huaweicloud_networking_secgroup.test.id
+  db {
+    port = "5432"
+  }
+  volume {
+    type              = "CLOUDSSD"
+    size              = 40
+    limit_size        = 200
+    trigger_threshold = 10
+  }
+}
+`, testAccRdsInstance_base(), name)
+}
+
+func testDataSourceRdsWalLogRecoveryTimeWindow_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+data "huaweicloud_rds_wal_log_recovery_time_window" "test" {
+  instance_id = huaweicloud_rds_read_replica_instance.test.id
+}
+`, testDataSourceRdsWalLogRecoveryTimeWindow_base(name))
+}

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_wal_log_recovery_time_window.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_wal_log_recovery_time_window.go
@@ -1,0 +1,90 @@
+package rds
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RDS GET /v3/{project_id}/instances/{instance_id}/recovery-time
+func DataSourceRdsWalLogRecoveryTimeWindow() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRdsWalLogRecoveryTimeWindowRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"recovery_min_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"recovery_max_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceRdsWalLogRecoveryTimeWindowRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	client, err := cfg.NewServiceClient("rds", region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	httpUrl := "v3/{project_id}/instances/{instance_id}/recovery-time"
+	getUrl := client.Endpoint + httpUrl
+	getUrl = strings.ReplaceAll(getUrl, "{project_id}", client.ProjectID)
+	getUrl = strings.ReplaceAll(getUrl, "{instance_id}", d.Get("instance_id").(string))
+
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"Accept":       "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getUrl, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving RDS WAL log recovery time window: %s", err)
+	}
+
+	body, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("recovery_min_time", utils.PathSearch("recovery_min_time", body, nil)),
+		d.Set("recovery_max_time", utils.PathSearch("recovery_max_time", body, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a data source to query wal log recovery time window
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a data source to query wal log recovery time window
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test /mnt/d/projects/go_projects/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds -v -run=TestAccDataSourceRdsWalLogRecoveryTimeWindow_basic -timeout 360m -parallel 4     
=== RUN   TestAccDataSourceRdsWalLogRecoveryTimeWindow_basic
=== PAUSE TestAccDataSourceRdsWalLogRecoveryTimeWindow_basic
=== CONT  TestAccDataSourceRdsWalLogRecoveryTimeWindow_basic
--- PASS: TestAccDataSourceRdsWalLogRecoveryTimeWindow_basic (897.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       897.770s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
