### PR TITLE
feat(RDS): rds instance support change single to ha

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -172,6 +172,10 @@ The following arguments are supported:
   provider-level region will be used. Changing this creates a new rds instance resource.
 
 * `availability_zone` - (Required, List) Specifies the list of AZ name.
+  + If add standby node az to the list, then the instance will change from Single instance to Primary/Standby instance.
+    The value of `flavor` will be changed to the ha mode value, so the value of `flavor` in the script should be changed
+    to the ha mode value too.
+  + If change the standby node az, then the standby node will migrate to new az.
 
 * `name` - (Required, String) Specifies the DB instance name. The DB instance name of the same type must be unique for
   the same tenant. The value must be 4 to 64 characters in length and start with a letter. It is case-sensitive and can


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds instance support change single to ha
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds instance support change single to ha
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_single_to_ha'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_single_to_ha -timeout 360m -parallel 4
=== RUN   TestAccRdsInstance_single_to_ha
=== PAUSE TestAccRdsInstance_single_to_ha
=== CONT  TestAccRdsInstance_single_to_ha
--- PASS: TestAccRdsInstance_single_to_ha (833.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       833.855s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
