### PR TITLE
feat(sdrs): new resource to add nic to protected instance

### DIFF
--- a/docs/resources/sdrs_protected_instance_add_nic.md
+++ b/docs/resources/sdrs_protected_instance_add_nic.md
@@ -1,0 +1,75 @@
+---
+subcategory: "Storage Disaster Recovery Service (SDRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_sdrs_protected_instance_add_nic"
+description: |-
+  Using this resource to add a network interface card (NIC) to a protected instance in SDRS within HuaweiCloud.
+---
+
+# huaweicloud_sdrs_protected_instance_add_nic
+
+Using this resource to add a network interface card (NIC) to a protected instance in SDRS within HuaweiCloud.
+
+-> This is a one-time action resource to add a NIC to a protected instance. Deleting this resource will
+not change the current NIC configuration, but will only remove the resource information from the tfstate file.
+
+-> Using this resource may cause unexpected changes to the ECS security group used to protect the instance.
+Before using this resource, use `lifecycle` to ignore unexpected changes to the `security_group_ids` field in
+resource `huaweicloud_compute_instance`. The following restrictions apply before using this resource:
+<br/>1. Status of the protection group must be **available** or **protected**.
+<br/>2. Status of the protected instance must be **available** or **protected**.
+<br/>3. The subnet of the NIC to be added must belong to the same VPC of the protected group and protected instance.
+
+## Example Usage
+
+```hcl
+variable "protected_instance_id" {}
+variable "subnet_id" {}
+variable "ip_address" {}
+variable "security_groups" {
+  type = list(string)
+}
+
+resource "huaweicloud_sdrs_protected_instance_add_nic" "test" {
+  protected_instance_id = var.protected_instance_id
+  subnet_id             = var.subnet_id
+  ip_address            = var.ip_address
+  security_groups       = var.security_groups
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to execute the request.
+  If omitted, the provider-level region will be used. Changing this will create new resource.
+
+* `protected_instance_id` - (Required, String, NonUpdatable) Specifies the ID of the protected instance to add the NIC to.
+
+* `subnet_id` - (Required, String, NonUpdatable) Specifies the ID of the subnet to which the NIC will be attached.
+  It is network ID of the subnet, which is the same as the `neutron_network_id` value.
+
+* `security_groups` - (Optional, List, NonUpdatable) Specifies the security groups to associate with the NIC.
+  Defaults to the system default security group.
+  The [security_groups](#security_groups_struct) structure is documented below.
+
+* `ip_address` - (Optional, String, NonUpdatable) Specifies the IP address to assign to the NIC.
+  If not specified, an available IP will be automatically assigned.
+
+<a name="security_groups_struct"></a>
+The `security_groups` block supports:
+
+* `id` - (Required, String, NonUpdatable) Specifies the ID of the security group.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the resource.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2500,11 +2500,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_rms_remediation_exception":              rms.ResourceRemediationException(),
 			"huaweicloud_rms_remediation_execution":              rms.ResourceRemediationExecution(),
 
-			"huaweicloud_sdrs_drill":              sdrs.ResourceDrill(),
-			"huaweicloud_sdrs_replication_pair":   sdrs.ResourceReplicationPair(),
-			"huaweicloud_sdrs_protection_group":   sdrs.ResourceProtectionGroup(),
-			"huaweicloud_sdrs_protected_instance": sdrs.ResourceProtectedInstance(),
-			"huaweicloud_sdrs_replication_attach": sdrs.ResourceReplicationAttach(),
+			"huaweicloud_sdrs_drill":                      sdrs.ResourceDrill(),
+			"huaweicloud_sdrs_replication_pair":           sdrs.ResourceReplicationPair(),
+			"huaweicloud_sdrs_protection_group":           sdrs.ResourceProtectionGroup(),
+			"huaweicloud_sdrs_protected_instance":         sdrs.ResourceProtectedInstance(),
+			"huaweicloud_sdrs_protected_instance_add_nic": sdrs.ResourceProtectedInstanceAddNIC(),
+			"huaweicloud_sdrs_replication_attach":         sdrs.ResourceReplicationAttach(),
 
 			"huaweicloud_secmaster_incident":                    secmaster.ResourceIncident(),
 			"huaweicloud_secmaster_indicator":                   secmaster.ResourceIndicator(),

--- a/huaweicloud/services/acceptance/sdrs/resource_huaweicloud_sdrs_protected_instance_add_nic_test.go
+++ b/huaweicloud/services/acceptance/sdrs/resource_huaweicloud_sdrs_protected_instance_add_nic_test.go
@@ -1,0 +1,116 @@
+package sdrs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccProtectedInstanceAddNIC_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testProtectedInstanceAddNIC_basic(),
+			},
+		},
+	})
+}
+
+func testProtectedInstanceAddNIC_basic() string {
+	name := acceptance.RandomAccResourceName()
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_sdrs_domain" "test" {}
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_images_image" "test" {
+  name        = "CentOS 7.6 64bit"
+  most_recent = true
+}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+resource "huaweicloud_sdrs_protection_group" "test" {
+  name                     = "%[2]s"
+  source_availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  target_availability_zone = data.huaweicloud_availability_zones.test.names[1]
+  domain_id                = data.huaweicloud_sdrs_domain.test.id
+  source_vpc_id            = huaweicloud_vpc.test.id
+  description              = "test description"
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  system_disk_type   = "SSD"
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+
+  lifecycle {
+    ignore_changes = [
+      security_group_ids,
+    ]
+  }
+}
+
+resource "huaweicloud_sdrs_protected_instance" "test" {
+  name                 = "%[2]s"
+  group_id             = huaweicloud_sdrs_protection_group.test.id
+  server_id            = huaweicloud_compute_instance.test.id
+  primary_subnet_id    = huaweicloud_vpc_subnet.test.id
+  primary_ip_address   = "192.168.0.15"
+  delete_target_server = true
+  delete_target_eip    = true
+  description          = "test description"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+resource "huaweicloud_networking_secgroup" "test1" {
+  name                 = "%[2]s_test1"
+  delete_default_rules = true
+}
+
+resource "huaweicloud_networking_secgroup" "test2" {
+  name                 = "%[2]s_test2"
+  delete_default_rules = true
+}
+
+resource "huaweicloud_sdrs_protected_instance_add_nic" "test" {
+  protected_instance_id = huaweicloud_sdrs_protected_instance.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+
+  security_groups {
+    id = huaweicloud_networking_secgroup.test1.id
+  }
+
+  security_groups {
+    id = huaweicloud_networking_secgroup.test2.id
+  }
+}
+`, common.TestBaseNetwork(name), name)
+}

--- a/huaweicloud/services/sdrs/resource_huaweicloud_sdrs_protected_instance_add_nic.go
+++ b/huaweicloud/services/sdrs/resource_huaweicloud_sdrs_protected_instance_add_nic.go
@@ -1,0 +1,235 @@
+package sdrs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SDRS POST /v1/{project_id}/protected-instances/{protected_instance_id}/nic
+// @API SDRS GET /v1/{project_id}/jobs/{job_id}
+func ResourceProtectedInstanceAddNIC() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceProtectedInstanceAddNICCreate,
+		ReadContext:   resourceProtectedInstanceAddNICRead,
+		UpdateContext: resourceProtectedInstanceAddNICUpdate,
+		DeleteContext: resourceProtectedInstanceAddNICDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"protected_instance_id",
+			"subnet_id",
+			"security_groups",
+			"security_groups.*.id",
+			"ip_address",
+		}),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"protected_instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the protected instance to add the NIC to.`,
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the subnet to which the NIC will be attached.`,
+			},
+			"security_groups": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `Specifies the security groups to associate with the NIC.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `Specifies the ID of the security group.`,
+						},
+					},
+				},
+			},
+			"ip_address": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the IP address to assign to the NIC. If not specified, an available IP will be automatically assigned.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildSecurityGroups(d *schema.ResourceData) []map[string]interface{} {
+	securityGroups := d.Get("security_groups").([]interface{})
+	sgList := make([]map[string]interface{}, 0, len(securityGroups))
+	for _, sg := range securityGroups {
+		sgMap, ok := sg.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		sgList = append(sgList, map[string]interface{}{
+			"id": sgMap["id"],
+		})
+	}
+
+	return sgList
+}
+
+func buildAddNICBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"subnet_id":       d.Get("subnet_id"),
+		"security_groups": buildSecurityGroups(d),
+		"ip_address":      utils.ValueIgnoreEmpty(d.Get("ip_address")),
+	}
+}
+
+func resourceProtectedInstanceAddNICCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/protected-instances/{protected_instance_id}/nic"
+		product = "sdrs"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating SDRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{protected_instance_id}", d.Get("protected_instance_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildAddNICBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error adding NIC to SDRS protected instance: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobID := utils.PathSearch("job_id", respBody, "").(string)
+	if jobID == "" {
+		return diag.Errorf("error adding NIC to SDRS protected instance: job ID not found in API response")
+	}
+
+	if err := waitingForAddNICSuccess(ctx, client, d.Timeout(schema.TimeoutCreate), jobID); err != nil {
+		return diag.Errorf("error waiting for SDRS NIC addition to complete: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	return resourceProtectedInstanceAddNICRead(ctx, d, meta)
+}
+
+func resourceProtectedInstanceAddNICRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceProtectedInstanceAddNICUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceProtectedInstanceAddNICDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to add a NIC to a protected instance. Deleting this 
+resource will not change the current NIC configuration, but will only remove the resource information from the 
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}
+
+func queryJobStatus(client *golangsdk.ServiceClient, jobID string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/jobs/{job_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", jobID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving SDRS job status: %s", err)
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func waitingForAddNICSuccess(ctx context.Context, client *golangsdk.ServiceClient, timeout time.Duration, jobID string) error {
+	unexpectedStatus := []string{"FAIL"}
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			respBody, err := queryJobStatus(client, jobID)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			status := utils.PathSearch("status", respBody, "").(string)
+			if status == "" {
+				return nil, "ERROR", errors.New("status is not found in API response")
+			}
+
+			if status == "SUCCESS" {
+				return respBody, "COMPLETED", nil
+			}
+
+			if utils.StrSliceContains(unexpectedStatus, status) {
+				return respBody, status, fmt.Errorf("job failed with status: %s", status)
+			}
+
+			return respBody, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to add nic to protected instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o sdrs -f TestAccProtectedInstanceAddNIC_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/sdrs" -v -coverprofile="./huaweicloud/services/acceptance/sdrs/sdrs_coverage.cov" -coverpkg="./huaweicloud/services/sdrs" -run TestAccProtectedInstanceAddNIC_basic -timeout 360m -parallel 10
=== RUN   TestAccProtectedInstanceAddNIC_basic
=== PAUSE TestAccProtectedInstanceAddNIC_basic
=== CONT  TestAccProtectedInstanceAddNIC_basic
--- PASS: TestAccProtectedInstanceAddNIC_basic (304.45s)
PASS
coverage: 27.1% of statements in ./huaweicloud/services/sdrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sdrs      304.522s        coverage: 27.1% of statements in ./huaweicloud/services/sdrs
```
![image](https://github.com/user-attachments/assets/d3a6869a-4d76-40c3-b634-6471dc93bee2)


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
