### PR TITLE
feat(cce): add cce cluster upgrade step (precheck, snapshot, postcheck)

### DIFF
--- a/docs/resources/cce_cluster_upgrade.md
+++ b/docs/resources/cce_cluster_upgrade.md
@@ -134,6 +134,8 @@ The following arguments are supported:
   The value is the priority of the node pool. **0** indicating the lowest priority.
   A larger value indicates a higher priority.
 
+* `is_snapshot` - (Optional, Bool, NonUpdatable) Specifies whether the cluster is snapshotted.
+
 <a name="addons"></a>
 The `addons` block supports:
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add cce cluster upgrade step (precheck, snapshot, postcheck)
![image](https://github.com/user-attachments/assets/cc2cc4b6-9eb9-454a-a962-6e4a26f06cba)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```
add cce cluster upgrade step (precheck, snapshot, postcheck)
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/cce" TESTARGS="-run TestAccClusterUpgrade_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cci -v -run TestAccClusterUpgrade_basic -timeout 360m -parallel 4
=== RUN   TestAccClusterUpgrade_basic
=== PAUSE TestAccClusterUpgrade_basic
=== CONT  TestAccClusterUpgrade_basic
--- PASS: TestAccClusterUpgrade_basic(1411.043s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1411.572s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
