### PR TITLE
feat(cbr): add one time resource to replication backup

### DIFF
--- a/docs/resources/cbr_replicate_backup.md
+++ b/docs/resources/cbr_replicate_backup.md
@@ -1,0 +1,76 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbr_replicate_backup"
+description: |-
+  Manages a resource to replicate CBR backup within HuaweiCloud.
+---
+
+# huaweicloud_cbr_replicate_backup
+
+Manages a resource to replicate CBR backup within HuaweiCloud.
+
+-> The current resource is a one-time resource, and destroying this resource will not recover the replicated backup,
+but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "backup_id" {}
+variable "destination_project_id" {}
+variable "destination_region" {}
+variable "destination_vault_id" {}
+variable "name" {}
+variable "description" {}
+variable "enable_acceleration" {}
+
+resource "huaweicloud_cbr_replicate_backup" "example" {
+  backup_id = var.backup_id
+
+  replicate {
+    destination_project_id = var.destination_project_id
+    destination_region     = var.destination_region
+    destination_vault_id   = var.destination_vault_id
+    name                   = var.name
+    description            = var.description
+    enable_acceleration    = var.enable_acceleration
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `backup_id` - (Required, String, NonUpdatable) Specifies the ID of the backup to be replicated.
+
+* `replicate` - (Required, List, NonUpdatable) Specifies the replication parameter.
+  The [replicate](#replicate_struct) structure is documented below.
+
+<a name="replicate_struct"></a>
+The `replicate` block supports:
+
+* `destination_project_id` - (Required, String, NonUpdatable) Specifies the ID of the replication destination project.
+
+* `destination_region` - (Required, String, NonUpdatable) Specifies the replication destination region.
+
+* `destination_vault_id` - (Required, String, NonUpdatable) Specifies the ID of the vault in the replication
+  destination region.
+
+* `name` - (Optional, String, NonUpdatable) Specifies the replica name.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the replica description.
+
+* `enable_acceleration` - (Optional, Bool, NonUpdatable) Specifies whether to enable the acceleration function to
+  shorten the replication time for cross-region replication. If this parameter is not set, the acceleration function
+  is disabled.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1738,6 +1738,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbr_migrate":                  cbr.ResourceMigrate(),
 			"huaweicloud_cbr_vault_migrate_resources":  cbr.ResourceVaultMigrateResources(),
 			"huaweicloud_cbr_batch_update_vault":       cbr.ResourceBatchUpdateVault(),
+			"huaweicloud_cbr_replicate_backup":         cbr.ResourceReplicateBackup(),
 			"huaweicloud_cbr_vault_change_charge_mode": cbr.ResourceVaultChangeChargeMode(),
 			"huaweicloud_cbr_change_order":             cbr.ResourceChangeOrder(),
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -1116,6 +1116,13 @@ func TestAccPreCheckCBRExternalProjectID(t *testing.T) {
 }
 
 // lintignore:AT003
+func TestAccPreCheckCBRDestinationProjectID(t *testing.T) {
+	if HW_CBR_DESTINATION_PROJECT_ID == "" {
+		t.Skip("HW_CBR_DESTINATION_PROJECT_ID must be set for acceptance tests")
+	}
+}
+
+// lintignore:AT003
 func TestAccPreCheckCBRBackupID(t *testing.T) {
 	if HW_CBR_BACKUP_ID == "" {
 		t.Skip("HW_CBR_BACKUP_ID must be set for acceptance tests")

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_replicate_backup_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_replicate_backup_test.go
@@ -1,0 +1,50 @@
+package cbr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceReplicateBackup_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare backup ID using to replicate destination backup.
+			acceptance.TestAccPreCheckCBRBackupID(t)
+			// Please prepare destination project id for replicating.
+			acceptance.TestAccPreCheckCBRDestinationProjectID(t)
+			// Please prepare destination region name for replicating.
+			acceptance.TestAccPreCheckCBRRegionName(t)
+			// Please prepare destination vault id for replicating.
+			acceptance.TestAccPreCheckImsVaultId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceReplicateBackup_basic(),
+			},
+		},
+	})
+}
+
+func testResourceReplicateBackup_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cbr_replicate_backup" "test" {
+  backup_id = "%s"
+  
+  replicate {
+    destination_project_id = "%s"
+    destination_region     = "%s"
+    destination_vault_id   = "%s"
+    name                   = "test-replicate-backup"
+    description            = "test replicate backup description"
+    enable_acceleration    = false
+  }
+}
+`, acceptance.HW_CBR_BACKUP_ID, acceptance.HW_CBR_DESTINATION_PROJECT_ID, acceptance.HW_REGION_NAME_1, acceptance.HW_IMS_VAULT_ID)
+}

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_replicate_backup.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_replicate_backup.go
@@ -1,0 +1,172 @@
+package cbr
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var replicateBackupNonUpdatableParams = []string{
+	"backup_id",
+	"replicate.*.destination_project_id",
+	"replicate.*.destination_region",
+	"replicate.*.destination_vault_id",
+	"replicate.*.name",
+	"replicate.*.description",
+	"replicate.*.enable_acceleration",
+}
+
+// @API CBR POST /v3/{project_id}/backups/{backup_id}/replicate
+func ResourceReplicateBackup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceReplicateBackupCreate,
+		ReadContext:   resourceReplicateBackupRead,
+		UpdateContext: resourceReplicateBackupUpdate,
+		DeleteContext: resourceReplicateBackupDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(replicateBackupNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"backup_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"replicate": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"destination_project_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"destination_region": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"destination_vault_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"enable_acceleration": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildReplicateBackupBodyParams(d *schema.ResourceData) map[string]interface{} {
+	replicateRaw := d.Get("replicate").([]interface{})
+	if len(replicateRaw) == 0 {
+		return nil
+	}
+
+	bodyParams := map[string]interface{}{
+		"replicate": map[string]interface{}{},
+	}
+
+	replicate, ok := replicateRaw[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	bodyParams["replicate"] = map[string]interface{}{
+		"destination_project_id": replicate["destination_project_id"],
+		"destination_region":     replicate["destination_region"],
+		"destination_vault_id":   replicate["destination_vault_id"],
+		"name":                   utils.ValueIgnoreEmpty(replicate["name"]),
+		"description":            utils.ValueIgnoreEmpty(replicate["description"]),
+		"enable_acceleration":    utils.ValueIgnoreEmpty(replicate["enable_acceleration"]),
+	}
+
+	return bodyParams
+}
+
+func resourceReplicateBackupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		httpUrl  = "v3/{project_id}/backups/{backup_id}/replicate"
+		product  = "cbr"
+		backupId = d.Get("backup_id").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBR client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{backup_id}", backupId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildReplicateBackupBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error replicating CBR backup: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	return resourceReplicateBackupRead(ctx, d, meta)
+}
+
+func resourceReplicateBackupRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceReplicateBackupUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceReplicateBackupDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to replicate backup.
+Deleting this resource will not reset the replicated backup, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add one time resource to replication backup
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add one time resource to replication backup
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
![image](https://github.com/user-attachments/assets/66fa42f3-1424-423f-b377-ea26cd273f86)
![image](https://github.com/user-attachments/assets/cea793f6-56ce-4eb0-9f9c-88c92357db2a)

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
