### PR TITLE
feat(ecs): add a resource to attach a port to ECS an instance

### DIFF
--- a/huaweicloud/helper/httphelper/http_helper.go
+++ b/huaweicloud/helper/httphelper/http_helper.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"reflect"
 	"strconv"
@@ -34,6 +35,7 @@ type HttpHelper struct {
 
 	responseBody []byte
 	result       golangsdk.Result
+	Response     *http.Response
 }
 
 func New(client *golangsdk.ServiceClient) *HttpHelper {
@@ -211,8 +213,8 @@ func (c *HttpHelper) Send() (*gjson.Result, error) {
 	c.appendQueryParams()
 	c.requestOpts.JSONBody = c.body
 
-	_, err := c.client.Request(c.method, c.url, c.requestOpts)
-
+	response, err := c.client.Request(c.method, c.url, c.requestOpts)
+	c.Response = response
 	return nil, err
 }
 
@@ -304,23 +306,24 @@ func (c *HttpHelper) requestWithPage() {
 
 func (c *HttpHelper) requestNoPage() {
 	var err error
-
+	var response *http.Response
 	switch c.method {
 	case "HEAD":
-		_, err = c.client.Head(c.url, c.requestOpts)
+		response, err = c.client.Head(c.url, c.requestOpts)
 	case "GET":
-		_, err = c.client.Get(c.url, &c.result.Body, c.requestOpts)
+		response, err = c.client.Get(c.url, &c.result.Body, c.requestOpts)
 	case "POST":
-		_, err = c.client.Post(c.url, c.body, &c.result.Body, c.requestOpts)
+		response, err = c.client.Post(c.url, c.body, &c.result.Body, c.requestOpts)
 	case "PUT":
-		_, err = c.client.Put(c.url, c.body, &c.result.Body, c.requestOpts)
+		response, err = c.client.Put(c.url, c.body, &c.result.Body, c.requestOpts)
 	case "PATCH":
-		_, err = c.client.Patch(c.url, c.body, &c.result.Body, c.requestOpts)
+		response, err = c.client.Patch(c.url, c.body, &c.result.Body, c.requestOpts)
 	case "DELETE":
-		_, err = c.client.DeleteWithBodyResp(c.url, c.body, &c.result.Body, c.requestOpts)
+		response, err = c.client.DeleteWithBodyResp(c.url, c.body, &c.result.Body, c.requestOpts)
 	}
 
 	c.result.Err = err
+	c.Response = response
 	c.parseRspBody()
 }
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1867,6 +1867,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_compute_eip_associate":     ecs.ResourceComputeEIPAssociate(),
 			"huaweicloud_compute_volume_attach":     ecs.ResourceComputeVolumeAttach(),
 			"huaweicloud_compute_auto_launch_group": ecs.ResourceComputeAutoLaunchGroup(),
+			"huaweicloud_compute_port_attach":       ecs.ResourceComputePortAttach(),
 
 			"huaweicloud_coc_script":                 coc.ResourceScript(),
 			"huaweicloud_coc_script_execute":         coc.ResourceScriptExecute(),

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_port_attach_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_port_attach_test.go
@@ -1,0 +1,157 @@
+package ecs
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getPortAttachResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("ecs", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating compute client: %s", err)
+	}
+
+	url := client.Endpoint + "v2.1/{project_id}/servers/{server_id}/os-interface/{port_id}"
+	url = strings.ReplaceAll(url, "{project_id}", client.ProjectID)
+	url = strings.ReplaceAll(url, "{server_id}", state.Primary.Attributes["instance_id"])
+	url = strings.ReplaceAll(url, "{port_id}", state.Primary.Attributes["port_id"])
+	reqOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	response, err := client.Request("GET", url, &reqOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving ECS Port: %s", err)
+	}
+	body, err := utils.FlattenResponse(response)
+	if err != nil {
+		return nil, fmt.Errorf("error prasing ECS Port: %s", err)
+	}
+
+	port := utils.PathSearch("interfaceAttachment.port_id", body, nil)
+	if port == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return port, nil
+}
+
+func TestAccComputePortAttach_basic(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_compute_port_attach.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getPortAttachResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputePortAttachBase(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "port_state", "ACTIVE"),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "huaweicloud_compute_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "port_id", "huaweicloud_vpc_network_interface.port", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccComputePortAttachImport(resourceName),
+			},
+		},
+	})
+}
+
+func testAccComputePortAttachImport(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+
+		if rs.Primary.Attributes["instance_id"] == "" || rs.Primary.Attributes["port_id"] == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<port_id>', but got '%s/%s'",
+				rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["port_id"])
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["port_id"]), nil
+	}
+}
+
+func testAccComputePortAttachBase(rName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id     = huaweicloud_vpc.test.id
+  name       = "%[1]s"
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 0)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 0), 1)
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name = "%[1]s"
+}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+data "huaweicloud_images_images" "test" {
+  flavor_id = data.huaweicloud_compute_flavors.test.ids[0]
+
+  os         = "Ubuntu"
+  visibility = "public"
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[1]s"
+  image_id           = data.huaweicloud_images_images.test.images[0].id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  system_disk_type   = "SSD"
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+}
+
+resource "huaweicloud_vpc_network_interface" "port" {
+  name               = "%[1]s_port"
+  subnet_id          = huaweicloud_vpc_subnet.test.id
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+}
+
+resource "huaweicloud_compute_port_attach" "test" {
+  instance_id = huaweicloud_compute_instance.test.id
+  port_id     = huaweicloud_vpc_network_interface.port.id
+}
+
+`, rName)
+}

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_port_attach.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_port_attach.go
@@ -1,0 +1,366 @@
+package ecs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/tidwall/gjson"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/httphelper"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/schemas"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ECS POST /v2.1/{project_id}/servers/{server_id}/os-interface
+// @API ECS GET /v2.1/{project_id}/servers/{server_id}/os-interface
+// @API ECS PUT /v1/{project_id}/cloudservers/{server_id}/os-interface/{port_id}
+// @API ECS DELETE /v2.1/{project_id}/servers/{server_id}/os-interface/{port_id}
+// @API IAM POST /v3/auth/tokens
+func ResourceComputePortAttach() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceComputePortAttachCreate,
+		ReadContext:   resourceComputePortAttachRead,
+		DeleteContext: resourceComputePortAttachDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceComputeInstancePortAttachImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"port_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				AtLeastOneOf: []string{"port_id", "net_id"},
+			},
+			"net_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				AtLeastOneOf: []string{"port_id", "net_id"},
+			},
+			"api_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "v2.1",
+			},
+			"assume_role": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Description: "This is a beta feature and requires application.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"agency_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"domain_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"domain_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"port_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+type ComputePortAttachWrapper struct {
+	*schemas.ResourceDataWrapper
+	Config     *config.Config
+	ApiVersion string
+}
+
+func newComputePortAttachWrapper(d *schema.ResourceData, meta interface{}) *ComputePortAttachWrapper {
+	return &ComputePortAttachWrapper{
+		ResourceDataWrapper: schemas.NewSchemaWrapper(d),
+		Config:              meta.(*config.Config),
+		ApiVersion:          d.Get("api_version").(string),
+	}
+}
+
+func resourceComputePortAttachCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	wrapper := newComputePortAttachWrapper(d, meta)
+	rst, err := wrapper.AttachPort()
+	instanceId := d.Get("instance_id").(string)
+	if err != nil {
+		log.Printf("[ERROR] failed to attach port to instance[%s], error: %s", instanceId, err)
+		return diag.Errorf("failed to attach port: %s", err)
+	}
+
+	portID := rst.Get("interfaceAttachment").Get("port_id").String()
+	d.SetId(fmt.Sprintf("%s/%s", instanceId, portID))
+	return resourceComputePortAttachRead(ctx, d, meta)
+}
+
+func resourceComputePortAttachRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	wrapper := newComputePortAttachWrapper(d, meta)
+
+	instanceId := d.Get("instance_id").(string)
+	portId := d.Get("port_id").(string)
+	rst, err := wrapper.GetPort(instanceId, portId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error get ECS port[%s/%s] details", instanceId, portId))
+	}
+
+	var aErr error
+	if _, ok := d.GetOk("assume_role"); ok {
+		assumeRole := make([]map[string]any, 0)
+		assumeRole = append(assumeRole, map[string]any{
+			"agency_name": d.Get("assume_role.0.agency_name").(string),
+			"domain_name": d.Get("assume_role.0.domain_name").(string),
+			"domain_id":   d.Get("assume_role.0.domain_id").(string),
+		})
+		aErr = d.Set("assume_role", assumeRole)
+	}
+
+	interfaceAttachment := rst.Get("interfaceAttachment")
+	mErr := multierror.Append(aErr,
+		d.Set("region", wrapper.Config.GetRegion(d)),
+		d.Set("port_id", interfaceAttachment.Get("port_id").String()),
+		d.Set("net_id", interfaceAttachment.Get("net_id").String()),
+		d.Set("port_state", interfaceAttachment.Get("port_state").String()),
+		d.Set("api_version", d.Get("api_version")),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceComputePortAttachDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	wrapper := newComputePortAttachWrapper(d, meta)
+	_, err := wrapper.DetachPort(ctx)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			err,
+			fmt.Sprintf("error deleting ECS port[%s/%s]", d.Get("instance_id").(string), d.Get("port_id").(string)),
+		)
+	}
+	d.SetId("")
+	return nil
+}
+
+func resourceComputeInstancePortAttachImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.SplitN(importedId, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<port_id>', but got '%s'", importedId)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("instance_id", parts[0]),
+		d.Set("port_id", parts[1]),
+		d.Set("api_version", "v2.1"),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}
+
+func (w *ComputePortAttachWrapper) AttachPort() (*gjson.Result, error) {
+	client, err := w.NewClient(w.Config, "ecs")
+	if err != nil {
+		return nil, err
+	}
+
+	uri := fmt.Sprintf("/%s/{project_id}/servers/%s/os-interface", w.ApiVersion, w.Get("instance_id"))
+
+	interfaceAttachment := map[string]any{
+		"port_id": w.Get("port_id"),
+		"net_id":  w.Get("net_id"),
+	}
+	if _, ok := w.ResourceData.GetOk("assume_role"); ok {
+		verifyToken, err := w.getAssumeToken()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get assume token: %s", err)
+		}
+		interfaceAttachment["verify_token_for_port"] = verifyToken
+	}
+	params := map[string]any{
+		"interfaceAttachment": interfaceAttachment,
+	}
+	params = utils.RemoveNil(params)
+	hc := httphelper.New(client)
+	rst, err := hc.Method("POST").
+		URI(uri).
+		Body(params).
+		Request().
+		Result()
+
+	if hc.Response.StatusCode > 400 {
+		err = fmt.Errorf("statusCode: %v", hc.Response.StatusCode)
+		if rst != nil {
+			err = fmt.Errorf("%s", rst.String())
+		}
+		return nil, err
+	}
+	return rst, err
+}
+
+func (w *ComputePortAttachWrapper) GetPort(instanceId, portId string) (*gjson.Result, error) {
+	client, err := w.NewClient(w.Config, "ecs")
+	if err != nil {
+		return nil, err
+	}
+
+	uri := fmt.Sprintf("/%s/{project_id}/servers/%s/os-interface/%s", w.ApiVersion, instanceId, portId)
+	hc := httphelper.New(client)
+	rst, err := hc.Method("GET").
+		URI(uri).
+		Request().
+		Result()
+
+	if hc.Response.StatusCode == 404 {
+		return rst, golangsdk.ErrDefault404{}
+	}
+
+	if hc.Response.StatusCode > 400 {
+		err = fmt.Errorf("failed to query port details, statusCode: %v", hc.Response.StatusCode)
+		if rst != nil {
+			err = fmt.Errorf("failed to query port details: %s", rst.String())
+		}
+		return nil, err
+	}
+	if err == nil {
+		return rst, nil
+	}
+	return nil, err
+}
+
+func (w *ComputePortAttachWrapper) DetachPort(ctx context.Context) (*gjson.Result, error) {
+	client, err := w.NewClient(w.Config, "ecs")
+	if err != nil {
+		return nil, err
+	}
+	instanceId := w.Get("instance_id").(string)
+	portId := w.Get("port_id").(string)
+	uri := fmt.Sprintf("/%s/{project_id}/servers/%s/os-interface/%s", w.ApiVersion, instanceId, portId)
+	hc := httphelper.New(client)
+
+	rst, err := hc.Method("DELETE").URI(uri).Send()
+	if err != nil {
+		return nil, err
+	}
+
+	if hc.Response.StatusCode == 404 {
+		w.SetId("")
+		return nil, golangsdk.ErrDefault404{}
+	}
+	if hc.Response.StatusCode > 400 {
+		err = fmt.Errorf("failed to detach port, statusCode: %v", hc.Response.StatusCode)
+		if rst != nil {
+			err = fmt.Errorf("failed to detach port: %s", rst.String())
+		}
+		return nil, err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"ACTIVE"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      w.waitToBeDeleted(instanceId, portId),
+		Timeout:      w.Timeout(schema.TimeoutDelete),
+		Delay:        10 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	w.SetId("")
+	return nil, nil
+}
+
+func (w *ComputePortAttachWrapper) waitToBeDeleted(instanceId, portId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		r, err := w.GetPort(instanceId, portId)
+		log.Printf("[DEBUG] Attempting to delete ECS Port %#v", err)
+		if err == nil {
+			return nil, "ACTIVE", nil
+		}
+
+		var err404 golangsdk.ErrDefault404
+		if errors.As(err, &err404) {
+			log.Printf("[DEBUG] The ECS Port (%s) has been deleted.", portId)
+			return r, "COMPLETED", nil
+		}
+
+		if err != nil {
+			return nil, "ERROR", err
+		}
+		return r, "ACTIVE", nil
+	}
+}
+func (w *ComputePortAttachWrapper) getAssumeToken() (*string, error) {
+	client, err := w.NewClient(w.Config, "iam")
+	if err != nil {
+		return nil, err
+	}
+
+	uri := "/v3/auth/tokens"
+	params := map[string]any{
+		"auth": map[string]any{
+			"identity": map[string]any{
+				"methods": []string{"assume_role"},
+				"assume_role": map[string]any{
+					"agency_name": w.Get("assume_role.0.agency_name"),
+					"domain_name": w.Get("assume_role.0.domain_name"),
+					"domain_id":   w.Get("assume_role.0.domain_id"),
+				},
+			},
+			"scope": map[string]any{
+				"project": map[string]any{
+					"name": w.Config.GetRegion(w.ResourceData),
+				},
+			},
+		},
+	}
+	params = utils.RemoveNil(params)
+	hp := httphelper.New(client).
+		Method("POST").
+		URI(uri).
+		Body(params).
+		Request()
+	if hp.ErrorOrNil() != nil {
+		return nil, hp.ErrorOrNil()
+	}
+
+	token := hp.Response.Header.Get("X-Subject-Token")
+	return &token, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

[Beta] Supports attach a port to ECS an instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
=== RUN   TestAccComputePortAttach_basic
=== PAUSE TestAccComputePortAttach_basic
=== CONT  TestAccComputePortAttach_basic
--- PASS: TestAccComputePortAttach_basic (184.80s)
PASS
```

* [ ] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.
