### PR TITLE
fix(workspace): desktop supports case ignore for name parameter

### DIFF
--- a/docs/resources/workspace_desktop.md
+++ b/docs/resources/workspace_desktop.md
@@ -121,6 +121,10 @@ The following arguments are supported:
   The name must start with a letter or digit and cannot end with a hyphen.
   Changing this will create a new resource.
 
+  ~> Some images will cause the names in `.tfstate` file to be set to uppercase.
+     Although this will not cause changes by terraform commands, special processing is required when subsequent
+     resources reference this field.
+
 * `email_notification` - (Optional, Bool, ForceNew) Specifies whether to send emails to user mailbox during important
   operations.  
   Defaults to **false**. Changing this will create a new resource.

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop.go
@@ -164,10 +164,11 @@ func ResourceDesktop() *schema.Resource {
 				},
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: utils.SuppressCaseDiffs(),
 			},
 			"email_notification": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The name value of workspace desktop API response will returns a uppercase string as follows:
![8cd710711d6ace258dcde5fd858e3f6](https://github.com/user-attachments/assets/e5e151f7-c63c-4989-8597-a9e9719a69a7)
Because the workspace image install some tools and will change desktop name now.
So we should ignore case in desktop resource using DiffSuppressFunc and when we fixed, the plan(apply also) command will not display the change info:
![ea1bd48bc94fd39decf2b0be1e5519f](https://github.com/user-attachments/assets/23814951-e20f-4dcb-83cc-fc4ba55a87aa)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. desktop supports case ignore for name parameter
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

Maunully test

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
