### PR TITLE
chore(waf): impore dedicated domain resource test case coverage

### DIFF
--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
@@ -112,12 +112,7 @@ func TestAccDedicateDomain_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "website_name", fmt.Sprintf("%s_update", randName)),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description update"),
 					resource.TestCheckResourceAttr(resourceName, "redirect_url", "${http_host}/error.html"),
-					resource.TestCheckResourceAttr(resourceName, "server.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
-					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
-					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8443"),
-					resource.TestCheckResourceAttr(resourceName, "server.0.address", "119.8.0.14"),
-					resource.TestCheckResourceAttr(resourceName, "server.1.address", "119.8.0.15"),
+					resource.TestCheckResourceAttr(resourceName, "server.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key2", "$request_length"),
 					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key3", "$remote_addr"),
 					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.error_threshold", "1000"),
@@ -141,6 +136,7 @@ func TestAccDedicateDomain_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "custom_page.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.error_threshold", "2147483647"),
 					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.error_percentage", "99"),
 					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.initial_downtime", "2147483647"),
@@ -205,13 +201,102 @@ func TestAccDedicateDomain_basic(t *testing.T) {
 
 func testAccWafDedicatedDomain_base(name, certificateBody string) string {
 	return fmt.Sprintf(`
-%[1]s
+resource "huaweicloud_waf_certificate" "test" {
+  name                  = "%[1]s"
+  enterprise_project_id = "%[2]s"
+
+  certificate = <<EOT
+%[3]s
+EOT
+
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCvmuH5ViGtGOle
+vJ8vOoN3Ak4pp3SescdAfQa/r4cOz/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc
+8OrcaIsjns92XITVDpFW0ThGyjhTZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK
+73OUYQY2E6l44U9G8Id763Bnws9NRn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu
+9zu8c8i2+8qLjEsonx5PrwzNlYP3JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd
+5F4Rdxl+SAIY+6mr7qu1dAlcVMLSQcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iK
+aedPo2GfAgMBAAECggEAeMAvDS3uAEI2Dx/y8h3xUn9yUfBFH+6tTanrXxoK6+OT
+Kj96O64qL4l3eQRflkdJiGx74FFomglCtDXxudflfXvxurkJ2hunUySQ5xScwLQt
+mB6w8kP6a8IqD+bVdbn32ohk6u5dU0JZ+ErJlklVZRAGJAoCYox5DXwrEh6CP+bJ
+pItgjv71tEEnX5sScQwV7FMRbjsPzXoJp8vCQjlUdetM1fk9rs3R2WSeFbPgLLtC
+xY0+8Hexy0q6BLmyPZvFCaVIAzAHCYeCyzPK3xcm4odbrBmRL/amOg24CCny065N
+MU9RFhEjQsY1RaK7dgkvjsntUZvU+aDcL8o6djOTuQKBgQDlDN/j2ntpGCtbTWH0
+cVTW13Ze7U7iE3BfDO3m4VYP3Xi/v5FI8nHlmLrcl30H1dPKvMTec0dCBOqD1wzF
+KiqHy8ELowO2CbXMYJpjuPzXH40/AE3eOJVTJM8mOeuFdeFgYCd/9cB7o5jfTA5Y
+4zj8EmcRzsH1rNSnvo7/O9q6+wKBgQDERDSvP8RScEbzDKuN6uhzj1K2CAEnY6//
+rDA1so18UhAie9NcAvlKa46jQTOcYD77g5h0WSlNt9ZbK9Plq9CY9psI0KNqN3Fl
+YVKOKdD5m6Rifmg+lt8KLc/WocQ10DXpPTXzzuRlN/TaMDdN2pedEre/0AAMs8Ia
+MIUnu4oyrQKBgQC6b6BNdqi9Ak9IIdR5g0XrGbXfzolGu0vcEkoSg5fpkfuXF/bJ
+yY2rtIVkyGmc1w9tFfmol2yI8Ddy2LgsRAYaQl7/edCre3vev0LrqMck0ynE/hpj
+purkojF6i+qI10p7h8ie/wmNmbv1BZMoBst7Yf9DH2gA8IynfRQn7DA9wQKBgGaU
+M2kJDgX8UsjDbYKuLTIAzb0AMAIzUxBxIX1fRh2dEnvDdjOYBk1EK/fdoyjvENwJ
+6ouc8j6BgBKEtKpMg6j+8wbHbTGdqrHPDQPqjSN4mpEz+i4EUqySRxep0tBBc3vl
+FybHko3okhvbqXwSbL2Ww90HzI7XAPMJOv8KQO+9AoGBAJxxftNWvypBXGkPCdH2
+f3ikvT2Vef9QZjqkvtipCecAkjM6ReLshVsdqFSv/ZmsVUeNKoTHvX2GnhweJM44
+x7N2mFK4skBzVtMVbjAHVjG78UitVu+FrzqGreaJXHaduhgUH2iFWfw09joOotAM
+X7ioLbTeWGBqFM+C80PkdBNp
+-----END PRIVATE KEY-----
+EOT
+}
+
+resource "huaweicloud_waf_certificate" "test-update" {
+  name                  = "%[1]s_update"
+  enterprise_project_id = "%[2]s"
+
+  certificate = <<EOT
+%[4]s
+EOT
+
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCvmuH5ViGtGOle
+vJ8vOoN3Ak4pp3SescdAfQa/r4cOz/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc
+8OrcaIsjns92XITVDpFW0ThGyjhTZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK
+73OUYQY2E6l44U9G8Id763Bnws9NRn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu
+9zu8c8i2+8qLjEsonx5PrwzNlYP3JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd
+5F4Rdxl+SAIY+6mr7qu1dAlcVMLSQcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iK
+aedPo2GfAgMBAAECggEAeMAvDS3uAEI2Dx/y8h3xUn9yUfBFH+6tTanrXxoK6+OT
+Kj96O64qL4l3eQRflkdJiGx74FFomglCtDXxudflfXvxurkJ2hunUySQ5xScwLQt
+mB6w8kP6a8IqD+bVdbn32ohk6u5dU0JZ+ErJlklVZRAGJAoCYox5DXwrEh6CP+bJ
+pItgjv71tEEnX5sScQwV7FMRbjsPzXoJp8vCQjlUdetM1fk9rs3R2WSeFbPgLLtC
+xY0+8Hexy0q6BLmyPZvFCaVIAzAHCYeCyzPK3xcm4odbrBmRL/amOg24CCny065N
+MU9RFhEjQsY1RaK7dgkvjsntUZvU+aDcL8o6djOTuQKBgQDlDN/j2ntpGCtbTWH0
+cVTW13Ze7U7iE3BfDO3m4VYP3Xi/v5FI8nHlmLrcl30H1dPKvMTec0dCBOqD1wzF
+KiqHy8ELowO2CbXMYJpjuPzXH40/AE3eOJVTJM8mOeuFdeFgYCd/9cB7o5jfTA5Y
+4zj8EmcRzsH1rNSnvo7/O9q6+wKBgQDERDSvP8RScEbzDKuN6uhzj1K2CAEnY6//
+rDA1so18UhAie9NcAvlKa46jQTOcYD77g5h0WSlNt9ZbK9Plq9CY9psI0KNqN3Fl
+YVKOKdD5m6Rifmg+lt8KLc/WocQ10DXpPTXzzuRlN/TaMDdN2pedEre/0AAMs8Ia
+MIUnu4oyrQKBgQC6b6BNdqi9Ak9IIdR5g0XrGbXfzolGu0vcEkoSg5fpkfuXF/bJ
+yY2rtIVkyGmc1w9tFfmol2yI8Ddy2LgsRAYaQl7/edCre3vev0LrqMck0ynE/hpj
+purkojF6i+qI10p7h8ie/wmNmbv1BZMoBst7Yf9DH2gA8IynfRQn7DA9wQKBgGaU
+M2kJDgX8UsjDbYKuLTIAzb0AMAIzUxBxIX1fRh2dEnvDdjOYBk1EK/fdoyjvENwJ
+6ouc8j6BgBKEtKpMg6j+8wbHbTGdqrHPDQPqjSN4mpEz+i4EUqySRxep0tBBc3vl
+FybHko3okhvbqXwSbL2Ww90HzI7XAPMJOv8KQO+9AoGBAJxxftNWvypBXGkPCdH2
+f3ikvT2Vef9QZjqkvtipCecAkjM6ReLshVsdqFSv/ZmsVUeNKoTHvX2GnhweJM44
+x7N2mFK4skBzVtMVbjAHVjG78UitVu+FrzqGreaJXHaduhgUH2iFWfw09joOotAM
+X7ioLbTeWGBqFM+C80PkdBNp
+-----END PRIVATE KEY-----
+EOT
+
+  lifecycle {
+    ignore_changes = [
+      certificate,
+    ]
+  }
+}
+
+resource "huaweicloud_waf_policy" "test" {
+  name                  = "%[1]s"
+  enterprise_project_id = "%[2]s"
+}
 
 # Using this datasource to get the vpc_id to which the dedicated instance belongs.
 data "huaweicloud_waf_dedicated_instances" "test" {
   enterprise_project_id = "%[2]s"
 }
-`, testAccWafCertificate_basic(name, certificateBody), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, certificateBody, generateCertificateBody())
 }
 
 func testAccWafDedicatedDomain_basic(name, certificateBody string) string {
@@ -277,6 +362,7 @@ func testAccWafDedicatedDomain_update1(name, certificateBody string) string {
 resource "huaweicloud_waf_dedicated_domain" "test" {
   domain                = "www.%[2]s.com"
   certificate_id        = huaweicloud_waf_certificate.test.id
+  policy_id             = huaweicloud_waf_policy.test.id
   keep_policy           = false
   proxy                 = true
   tls                   = "TLS v1.2"
@@ -293,16 +379,7 @@ resource "huaweicloud_waf_dedicated_domain" "test" {
     client_protocol = "HTTPS"
     server_protocol = "HTTP"
     address         = "119.8.0.14"
-    port            = 8443
-    type            = "ipv4"
-    vpc_id          = data.huaweicloud_waf_dedicated_instances.test.instances[0].vpc_id
-  }
-
-  server {
-    client_protocol = "HTTPS"
-    server_protocol = "HTTP"
-    address         = "119.8.0.15"
-    port            = 8443
+    port            = 8080
     type            = "ipv4"
     vpc_id          = data.huaweicloud_waf_dedicated_instances.test.instances[0].vpc_id
   }
@@ -343,7 +420,8 @@ func testAccWafDedicatedDomain_update2(name, certificateBody string) string {
 
 resource "huaweicloud_waf_dedicated_domain" "test" {
   domain                = "www.%[2]s.com"
-  certificate_id        = huaweicloud_waf_certificate.test.id
+  certificate_id        = huaweicloud_waf_certificate.test-update.id
+  policy_id             = huaweicloud_waf_policy.test.id
   keep_policy           = false
   proxy                 = true
   tls                   = "TLS v1.2"
@@ -353,27 +431,28 @@ resource "huaweicloud_waf_dedicated_domain" "test" {
   protect_status        = 0
   website_name          = "%[2]s_update"
   description           = "test description update"
-  redirect_url          = "$${http_host}/error.html"
   enterprise_project_id = "%[3]s"
 
   server {
     client_protocol = "HTTPS"
     server_protocol = "HTTP"
     address         = "119.8.0.14"
-    port            = 8443
+    port            = 8080
     type            = "ipv4"
     vpc_id          = data.huaweicloud_waf_dedicated_instances.test.instances[0].vpc_id
   }
 
-  server {
-    client_protocol = "HTTPS"
-    server_protocol = "HTTP"
-    address         = "119.8.0.15"
-    port            = 8443
-    type            = "ipv4"
-    vpc_id          = data.huaweicloud_waf_dedicated_instances.test.instances[0].vpc_id
+  custom_page {
+    http_return_code = "404"
+    block_page_type  = "application/json"
+    page_content     = <<EOF
+{
+  "event_id": "$${waf_event_id}",
+  "error_msg": "error message"
+}
+EOF
   }
-
+  
   forward_header_map = {
     "key2" = "$request_length"
     "key3" = "$remote_addr"
@@ -405,6 +484,7 @@ func testAccWafDedicatedDomain_update3(name, certificateBody string) string {
 resource "huaweicloud_waf_dedicated_domain" "test" {
   domain                = "www.%[2]s.com"
   certificate_id        = huaweicloud_waf_certificate.test.id
+  policy_id             = huaweicloud_waf_policy.test.id
   keep_policy           = false
   proxy                 = true
   tls                   = "TLS v1.2"
@@ -421,16 +501,7 @@ resource "huaweicloud_waf_dedicated_domain" "test" {
     client_protocol = "HTTPS"
     server_protocol = "HTTP"
     address         = "119.8.0.14"
-    port            = 8443
-    type            = "ipv4"
-    vpc_id          = data.huaweicloud_waf_dedicated_instances.test.instances[0].vpc_id
-  }
-
-  server {
-    client_protocol = "HTTPS"
-    server_protocol = "HTTP"
-    address         = "119.8.0.15"
-    port            = 8443
+    port            = 8080
     type            = "ipv4"
     vpc_id          = data.huaweicloud_waf_dedicated_instances.test.instances[0].vpc_id
   }
@@ -462,11 +533,6 @@ resource "huaweicloud_waf_dedicated_domain" "test" {
 func testAccWafDedicatedDomain_policy(name, certificateBody string) string {
 	return fmt.Sprintf(`
 %[1]s
-
-resource "huaweicloud_waf_policy" "test" {
-  name                  = "%[2]s"
-  enterprise_project_id = "%[3]s"
-}
 
 resource "huaweicloud_waf_dedicated_domain" "test" {
   domain         = "www.%[2]s.com"

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_domain.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_domain.go
@@ -3,6 +3,7 @@ package waf
 import (
 	"context"
 	"fmt"
+	"log"
 	"strconv"
 
 	"github.com/hashicorp/go-multierror"
@@ -11,10 +12,19 @@ import (
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/domains"
+	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/policies"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	protectStatusEnable = 1
+
+	defaultBlockPageTemplate  = "default"
+	customBlockPageTemplate   = "custom"
+	redirectBlockPageTemplate = "redirect"
 )
 
 // @API WAF GET /v1/{project_id}/waf/instance/{instance_id}
@@ -126,7 +136,7 @@ func ResourceWafDomain() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				MaxItems: 1,
-				Elem:     dedicatedDomainTrafficMarkSchema(),
+				Elem:     domainTrafficMarkSchema(),
 			},
 			"website_name": {
 				Type:     schema.TypeString,
@@ -189,6 +199,73 @@ func ResourceWafDomain() *schema.Resource {
 	}
 }
 
+func domainCustomPageSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"http_return_code": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"block_page_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"page_content": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func domainTimeoutSettingSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"connection_timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"read_timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"write_timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func domainTrafficMarkSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"ip_tags": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				Computed: true,
+			},
+			"session_tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"user_tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
 func domainServerSchema() *schema.Resource {
 	sc := schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -238,6 +315,13 @@ func buildCreateDomainHostOpts(d *schema.ResourceData, cfg *config.Config) *doma
 		WebTag:              d.Get("website_name").(string),
 		EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
 	}
+}
+
+func buildHostForwardHeaderMapOpts(d *schema.ResourceData) map[string]string {
+	if v, ok := d.GetOk("forward_header_map"); ok {
+		return utils.ExpandToStringMap(v.(map[string]interface{}))
+	}
+	return nil
 }
 
 func buildWafDomainServers(d *schema.ResourceData) []domains.ServerOpts {
@@ -596,6 +680,34 @@ func resourceWafDomainUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	return resourceWafDomainRead(ctx, d, meta)
+}
+
+func updateWafDomainPolicyHost(d *schema.ResourceData, cfg *config.Config) error {
+	client, err := cfg.WafV1Client(cfg.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating WAF client: %s", err)
+	}
+
+	oVal, nVal := d.GetChange("policy_id")
+	newPolicyId := nVal.(string)
+	oldPolicyId := oVal.(string)
+
+	epsID := cfg.GetEnterpriseProjectID(d)
+	updateHostsOpts := policies.UpdateHostsOpts{
+		Hosts:               []string{d.Id()},
+		EnterpriseProjectId: epsID,
+	}
+	log.Printf("[DEBUG] Bind WAF domain %s to policy %s", d.Id(), newPolicyId)
+
+	if _, err := policies.UpdateHosts(client, newPolicyId, updateHostsOpts).Extract(); err != nil {
+		return fmt.Errorf("error updating WAF policy hosts: %s", err)
+	}
+
+	if err := policies.DeleteWithEpsID(client, oldPolicyId, epsID).ExtractErr(); err != nil {
+		// If other domains are using this policy, the deletion will fail.
+		log.Printf("[WARN] error deleting WAF policy %s: %s", oldPolicyId, err)
+	}
+	return nil
 }
 
 func resourceWafDomainDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Impore dedicated domain resource test case coverage.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- impore dedicate domain resource test case coverage upon 80%.
- This modification requires synchronization of test resource (huaweicloud_waf_domain) and data source (huaweicloud_waf_dedicated_domains).

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccDedicateDomain_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccDedicateDomain_basic -timeout 360m -parallel 10
=== RUN   TestAccDedicateDomain_basic
=== PAUSE TestAccDedicateDomain_basic
=== CONT  TestAccDedicateDomain_basic
--- PASS: TestAccDedicateDomain_basic (56.16s)
PASS
coverage: 13.2% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       56.251s coverage: 13.2% of statements in ./huaweicloud/services/waf
```
![image](https://github.com/user-attachments/assets/0da02dd9-17bf-4de5-979d-932590d052ff)

```
./scripts/coverage.sh -o waf -f TestAccDataSourceDedicatedDomains_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccDataSourceDedicatedDomains_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDedicatedDomains_basic
=== PAUSE TestAccDataSourceDedicatedDomains_basic
=== CONT  TestAccDataSourceDedicatedDomains_basic
--- PASS: TestAccDataSourceDedicatedDomains_basic (15.43s)
PASS
coverage: 11.9% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       15.512s coverage: 11.9% of statements in ./huaweicloud/services/waf
```
![image](https://github.com/user-attachments/assets/2bd4aeb3-5f80-4d08-9db3-8d92c232a93e)


* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
