### PR TITLE
fix(RDS): fix resource instance mysql proxy restart

### DIFF
--- a/docs/resources/rds_mysql_proxy_restart.md
+++ b/docs/resources/rds_mysql_proxy_restart.md
@@ -29,11 +29,9 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `instance_id` - (Required, String, ForceNew) Specifies the ID of the RDS MySQL instance. Changing this parameter will
-  create a new resource.
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the RDS MySQL instance.
 
-* `proxy_id` - (Required, String, ForceNew) Specifies the ID of the RDS MySQL proxy. Changing this parameter will create
-  a new resource.
+* `proxy_id` - (Required, String, NonUpdatable) Specifies the ID of the RDS MySQL proxy.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_mysql_proxy_restart.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_mysql_proxy_restart.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -16,13 +17,18 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+var mysqlProxyRestartNonUpdatableParams = []string{"instance_id", "proxy_id"}
+
 // @API RDS POST /v3/{project_id}/instances/{instance_id}/proxy/{proxy_id}/restart
 // @API RDS GET /v3/{project_id}/jobs
 func ResourceMysqlProxyRestart() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceMysqlProxyRestartCreate,
 		ReadContext:   resourceMysqlProxyRestartRead,
+		UpdateContext: resourceMysqlProxyRestartUpdate,
 		DeleteContext: resourceMysqlProxyRestartDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(mysqlProxyRestartNonUpdatableParams),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
@@ -38,12 +44,16 @@ func ResourceMysqlProxyRestart() *schema.Resource {
 			"instance_id": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"proxy_id": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
 			},
 		},
 	}
@@ -113,6 +123,10 @@ func resourceMysqlProxyRestartCreate(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceMysqlProxyRestartRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceMysqlProxyRestartUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix instance mysql proxy restart resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fix instance mysql proxy restart resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test /mnt/d/projects/go_projects/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds -v -run=TestAccMysqlProxyRestart_basic -timeout 360m -parallel 4
=== RUN   TestAccMysqlProxyRestart_basic
=== PAUSE TestAccMysqlProxyRestart_basic
=== CONT  TestAccMysqlProxyRestart_basic
--- PASS: TestAccMysqlProxyRestart_basic (2534.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2534.533s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
