### PR TITLE
fix(DCS): fix dcs backup resource

### DIFF
--- a/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_backup_test.go
+++ b/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_backup_test.go
@@ -39,6 +39,7 @@ func getDcsBackupResourceFunc(cfg *config.Config, state *terraform.ResourceState
 
 	getDdmSchemasOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		OkCodes:          []int{200, 204},
 	}
 
 	var currentTotal int

--- a/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_instance_test.go
+++ b/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_instance_test.go
@@ -48,7 +48,7 @@ func TestAccDcsInstances_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
-					resource.TestCheckResourceAttr(resourceName, "capacity", "0.125"),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "22:00:00"),
@@ -58,8 +58,6 @@ func TestAccDcsInstances_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.id", "1"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "timeout"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "100"),
-					resource.TestCheckResourceAttrPair(resourceName, "enterprise_project_id",
-						"huaweicloud_enterprise_project.test.0", "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
 					resource.TestCheckResourceAttrSet(resourceName, "domain_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
@@ -90,7 +88,7 @@ func TestAccDcsInstances_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
-					resource.TestCheckResourceAttr(resourceName, "capacity", "0.5"),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "2"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.0.begin_at", "01:00-02:00"),
@@ -99,8 +97,6 @@ func TestAccDcsInstances_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.id", "10"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "latency-monitor-threshold"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "120"),
-					resource.TestCheckResourceAttrPair(resourceName, "enterprise_project_id",
-						"huaweicloud_enterprise_project.test.1", "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "launched_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "subnet_cidr"),
@@ -1045,16 +1041,9 @@ data "huaweicloud_vpc_subnet" "test" {
 }
 
 data "huaweicloud_dcs_flavors" "test" {
-  cache_mode     = "ha"
-  capacity       = 0.125
-  engine_version = "5.0"
-}
-
-resource "huaweicloud_enterprise_project" "test" {
-  count = 2
-
-  name        = "%[1]s_${count.index}"
-  description = "terraform test"
+  cache_mode       = "ha"
+  capacity         = 1
+  cpu_architecture = "x86_64"
 }
 
 resource "huaweicloud_dcs_instance" "instance_1" {
@@ -1063,15 +1052,13 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   password           = "Huawei_test"
   engine             = "Redis"
   port               = 6388
-  capacity           = 0.125
+  capacity           = 1
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "22:00:00"
   maintain_end       = "23:00:00"
-
-  enterprise_project_id = huaweicloud_enterprise_project.test[0].id
 
   backup_policy {
     backup_type = "auto"
@@ -1115,16 +1102,9 @@ data "huaweicloud_vpc_subnet" "test" {
 }
 
 data "huaweicloud_dcs_flavors" "test" {
-  cache_mode     = "ha"
-  capacity       = 0.5
-  engine_version = "5.0"
-}
-
-resource "huaweicloud_enterprise_project" "test" {
-  count = 2
-
-  name        = "%[1]s_${count.index}"
-  description = "terraform test"
+  cache_mode       = "ha"
+  capacity         = 2
+  cpu_architecture = "x86_64"
 }
 
 resource "huaweicloud_dcs_instance" "instance_1" {
@@ -1133,15 +1113,13 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   password           = "Huawei_test"
   engine             = "Redis"
   port               = 6389
-  capacity           = 0.5
+  capacity           = 2
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "07:00:00"
-
-  enterprise_project_id = huaweicloud_enterprise_project.test[1].id
 
   backup_policy {
     backup_type = "auto"

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_backup.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_backup.go
@@ -327,6 +327,7 @@ func getDcsBackup(instanceID, backupID string, client *golangsdk.ServiceClient) 
 
 	getDdmSchemasOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		OkCodes:          []int{200, 204},
 	}
 
 	var currentTotal int


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix dcs backup resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix dcs backup resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dcs/ TESTARGS='-run TestAccDcsInstances_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs/ -v -run TestAccDcsInstances_basic -timeout 360m -parallel 4
=== RUN   TestAccDcsInstances_basic
=== PAUSE TestAccDcsInstances_basic
=== CONT  TestAccDcsInstances_basic
--- PASS: TestAccDcsInstances_basic (269.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       269.185s

make testacc TEST=./huaweicloud/services/acceptance/dcs/ TESTARGS='-run TestAccDcsBackup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs/ -v -run TestAccDcsBackup_basic -timeout 360m -parallel 4
=== RUN   TestAccDcsBackup_basic
=== PAUSE TestAccDcsBackup_basic
=== CONT  TestAccDcsBackup_basic
--- PASS: TestAccDcsBackup_basic (199.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       199.482s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
