### PR TITLE
feat(workspace/app): add new resource to operate workspace app service

### DIFF
--- a/docs/resources/workspace_app_service_action.md
+++ b/docs/resources/workspace_app_service_action.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_service_action"
+description: |-
+  Use this resource to active or deactive the Workspace APP service within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_service_action
+
+Use this resource to active or deactive the Workspace APP service within HuaweiCloud.
+
+-> 1. Before using this resource, ensure that the Workspace service has been registered.
+   <br>2. This resource is a one-time action resource for activating or deactivating the Workspace APP service. Deleting
+   this resource will not clear the corresponding request record, but will only remove the resource information from
+   the tfstate file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_workspace_app_service_action" "test" {
+  service_status = "active"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the Workspace APP service is located.  
+  If omitted, the provider-level region will be used. Changing this will create new resource.
+
+* `service_status` - (Required, String, NonUpdatable) Specifies the status of the Workspace APP service.  
+  The valid values are as follows:
+  + **active**: Activate the service.
+  + **inactive**: Deactivate the service.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2760,6 +2760,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_desktop_pool_notification": workspace.ResourceDesktopPoolNotification(),
 			"huaweicloud_workspace_policy_group":              workspace.ResourcePolicyGroup(),
 			"huaweicloud_workspace_service":                   workspace.ResourceService(),
+			"huaweicloud_workspace_app_service_action":        workspace.ResourceAppServiceAction(),
 			"huaweicloud_workspace_terminal_binding":          workspace.ResourceTerminalBinding(),
 			"huaweicloud_workspace_user":                      workspace.ResourceUser(),
 			"huaweicloud_workspace_eip_associate":             workspace.ResourceEipAssociate(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_service_action_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_service_action_test.go
@@ -1,0 +1,29 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this acceptance, please ensure the Workspace service is enabled.
+// lintignore:AT001
+func TestAccAppServiceAction_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppServiceAction_basic,
+			},
+		},
+	})
+}
+
+const testAccAppServiceAction_basic = `
+resource "huaweicloud_workspace_app_service_action" "test" {
+  service_status = "active"
+}
+`

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_service_action.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_service_action.go
@@ -1,0 +1,106 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var appServiceActionNonUpdatableParams = []string{"service_status"}
+
+// @API Workspace POST /v1/{project_id}/tenant/action/active
+func ResourceAppServiceAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppServiceActionCreate,
+		ReadContext:   resourceAppServiceActionRead,
+		UpdateContext: resourceAppServiceActionUpdate,
+		DeleteContext: resourceAppServiceActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(appServiceActionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the Workspace APP service is located.`,
+			},
+			"service_status": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The status of the Workspace APP service.`,
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceAppServiceActionCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		httpUrl       = "v1/{project_id}/tenant/action/active"
+		serviceStatus = d.Get("service_status").(string)
+	)
+
+	client, err := cfg.NewServiceClient("appstream", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	actionPath := client.Endpoint + httpUrl
+	actionPath = strings.ReplaceAll(actionPath, "{project_id}", client.ProjectID)
+	actionOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"service_status": serviceStatus,
+		},
+	}
+	_, err = client.Request("POST", actionPath, &actionOpt)
+	if err != nil {
+		return diag.Errorf("unable to %s Workspace APP service: %s", serviceStatus, err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomId)
+
+	return nil
+}
+
+func resourceAppServiceActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppServiceActionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppServiceActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource for activating or deactivating the Workspace APP service. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

 Add new resource(**huaweicloud_workspace_app_service_action**) to active or deactive workspace app service.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource.
2. add related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccAppAction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppAction_basic -timeout 360m -parallel 10
=== RUN   TestAccAppAction_basic
=== PAUSE TestAccAppAction_basic
=== CONT  TestAccAppAction_basic
--- PASS: TestAccAppAction_basic (18.06s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 18.150s coverage: 3.8% of statements in ./huaweicloud/services/workspace
```
<img width="1038" height="516" alt="image" src="https://github.com/user-attachments/assets/0dac6634-898e-40f1-ad06-191422ad7b17" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
