### PR TITLE
feat(workspace): add one time resource to operate desktop pool

### DIFF
--- a/docs/resources/workspace_desktop_pool_action.md
+++ b/docs/resources/workspace_desktop_pool_action.md
@@ -1,0 +1,67 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_desktop_pool_action"
+description: |-
+  Use this resource to operate desktop pool within HuaweiCloud.
+---
+
+# huaweicloud_workspace_desktop_pool_action
+
+Use this resource to dispatch desktop pool operation within HuaweiCloud.
+
+-> This resource is only a one-time action resource for operate desktop pool. Deleting this resource  
+  will not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "desktop_pool_id" {}
+variable "desktop_pool_op_type" {}
+variable "action_type" {}
+
+resource "huaweicloud_workspace_desktop_pool_action" "test" {
+  pool_id = var.desktop_pool_id
+  op_type = var.desktop_pool_op_type
+  type    = var.action_type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the desktop pool is located.  
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `pool_id` - (Required, String, NonUpdatable) Specifies the ID of the desktop pool.
+
+* `op_type` - (Required, String, NonUpdatable) Specifies the type of desktop pool operation.  
+  The valid values are as follows:
+  + **os-start**
+  + **os-stop**
+  + **reboot**
+  + **hibernate**
+
+* `type` - (Required, String, NonUpdatable) Specifies whether the operation is mandatory.  
+  The valid values are as follows:
+  + **SOFT**
+  + **HARD**
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - The status of operation dispatch task.  
+  The valid values are as follows:
+  + **SUCCESS**
+  + **FAIL**
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2708,6 +2708,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_desktop_name_rule":         workspace.ResourceDesktopNameRule(),
 			"huaweicloud_workspace_desktop":                   workspace.ResourceDesktop(),
 			"huaweicloud_workspace_desktop_pool":              workspace.ResourceDesktopPool(),
+			"huaweicloud_workspace_desktop_pool_action":       workspace.ResourceDesktopPoolAction(),
 			"huaweicloud_workspace_desktop_pool_notification": workspace.ResourceDesktopPoolNotification(),
 			"huaweicloud_workspace_policy_group":              workspace.ResourcePolicyGroup(),
 			"huaweicloud_workspace_service":                   workspace.ResourceService(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_desktop_pool_action_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_desktop_pool_action_test.go
@@ -34,18 +34,6 @@ func TestAccDesktopPoolAction_basic(t *testing.T) {
 	})
 }
 
-func testAccDesktopPoolAction_basic(name string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_workspace_desktop_pool_action" "test" {
-  pool_id = huaweicloud_workspace_desktop_pool.test.id
-  op_type = "os-start"
-  type    = "SOFT"
-}
-`, testAccDesktopPoolAction_base(name))
-}
-
 func testAccDesktopPoolAction_base(name string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_workspace_service" "test" {}
@@ -100,4 +88,16 @@ resource "huaweicloud_workspace_desktop_pool" "test" {
   }
 }
 `, name)
+}
+
+func testAccDesktopPoolAction_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_desktop_pool_action" "test" {
+  pool_id = huaweicloud_workspace_desktop_pool.test.id
+  op_type = "os-start"
+  type    = "SOFT"
+}
+`, testAccDesktopPoolAction_base(name))
 }

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_desktop_pool_action_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_desktop_pool_action_test.go
@@ -1,0 +1,103 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDesktopPoolAction_basic(t *testing.T) {
+	var (
+		name         = acceptance.RandomAccResourceNameWithDash()
+		resourceName = "huaweicloud_workspace_desktop_pool_action.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDesktopPoolAction_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "status", "FAIL"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDesktopPoolAction_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_desktop_pool_action" "test" {
+  pool_id = huaweicloud_workspace_desktop_pool.test.id
+  op_type = "os-start"
+  type    = "SOFT"
+}
+`, testAccDesktopPoolAction_base(name))
+}
+
+func testAccDesktopPoolAction_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_service" "test" {}
+
+data "huaweicloud_workspace_flavors" "test" {
+  os_type = "Windows"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_images_images" "test" {
+  name_regex = "WORKSPACE"
+  visibility = "market"
+}
+
+resource "huaweicloud_workspace_desktop_pool" "test" {
+  name                          = "%[1]s"
+  type                          = "DYNAMIC"
+  size                          = 1
+  product_id                    = try(data.huaweicloud_workspace_flavors.test.flavors[0].id, "NOT_FOUND")
+  image_type                    = "gold"
+  image_id                      = try(data.huaweicloud_images_images.test.images[0].id, "NOT_FOUND")
+  subnet_ids                    = data.huaweicloud_workspace_service.test.network_ids
+  vpc_id                        = data.huaweicloud_workspace_service.test.vpc_id
+  availability_zone             = try(data.huaweicloud_availability_zones.test.names[0], "NOT_FOUND")
+  disconnected_retention_period = 10
+  enable_autoscale              = true
+  in_maintenance_mode           = true
+
+  security_groups {
+    id = data.huaweicloud_workspace_service.test.desktop_security_group.0.id
+  }
+  security_groups {
+    id = data.huaweicloud_workspace_service.test.infrastructure_security_group.0.id
+  }
+
+  root_volume {
+    type = "SAS"
+    size = 80
+  }
+
+  data_volumes {
+    type = "SAS"
+    size = 20
+  }
+
+  autoscale_policy {
+    autoscale_type    = "AUTO_CREATED"
+    min_idle          = 1
+    max_auto_created  = 2
+    once_auto_created = 1
+  }
+}
+`, name)
+}

--- a/huaweicloud/services/workspace/common.go
+++ b/huaweicloud/services/workspace/common.go
@@ -1,0 +1,85 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func waitForJobCompleted(ctx context.Context, client *golangsdk.ServiceClient, jobId string,
+	timeout time.Duration) (string, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshJobStatusFunc(client, jobId),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 15 * time.Second,
+	}
+
+	resp, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return "ERROR", err
+	}
+
+	status := "SUCCESS"
+	// Check whether the latest sub job is success.
+	subJobs := utils.PathSearch("sub_jobs", resp, make([]interface{}, 0)).([]interface{})
+	for _, subJob := range subJobs {
+		subJobStatus := utils.PathSearch("status", subJob, "NONE").(string)
+		if subJobStatus != "SUCCESS" {
+			status = "FAIL"
+			log.Printf("[ERROR] error waiting for the job(ID: %s, type: %s) to become complete: %s",
+				utils.PathSearch("id", subJob, "NOT_FOUND").(string),
+				utils.PathSearch("job_type", subJob, "NOT_FOUND").(string),
+				utils.PathSearch("fail_reason", subJob, "").(string))
+		}
+	}
+
+	return status, nil
+}
+
+func refreshJobStatusFunc(client *golangsdk.ServiceClient, jobId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		var (
+			httpUrl  = "v2/{project_id}/workspace-jobs/{job_id}"
+			listOpts = golangsdk.RequestOpts{
+				KeepResponseBody: true,
+				MoreHeaders: map[string]string{
+					"Content-Type": "application/json",
+				},
+			}
+		)
+
+		listPath := client.Endpoint + httpUrl
+		listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+		listPath = strings.ReplaceAll(listPath, "{job_id}", jobId)
+		resp, err := client.Request("GET", listPath, &listOpts)
+		if err != nil {
+			return resp, "ERROR", err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return resp, "ERROR", err
+		}
+
+		status := utils.PathSearch("status", respBody, "").(string)
+		if status == "" {
+			return respBody, "ERROR", errors.New("dispatch operation job failed")
+		}
+
+		if utils.StrSliceContains([]string{"COMPLETE", "SUCCESS", "FAIL"}, status) {
+			return respBody, "COMPLETED", nil
+		}
+		return respBody, "PENDING", nil
+	}
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop_pool_action.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop_pool_action.go
@@ -1,0 +1,147 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var desktopPoolActionNonUpdateParams = []string{"pool_id", "op_type", "type"}
+
+// @API Workspace POST /v2/{project_id}/desktop-pools/{pool_id}/action
+// @API Workspace GET /v2/{project_id}/workspace-jobs/{job_id}
+func ResourceDesktopPoolAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDesktopPoolActionCreate,
+		ReadContext:   resourceDesktopPoolActionRead,
+		UpdateContext: resourceDesktopPoolActionUpdate,
+		DeleteContext: resourceDesktopPoolActionDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(desktopPoolActionNonUpdateParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the desktop pool is located.`,
+			},
+			"pool_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the desktop pool.`,
+			},
+			"op_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of desktop pool operation.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Whether the operation is mandatory.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of operation dispatch task.`,
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildDesktopPoolActionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"op_type": d.Get("op_type"),
+		"type":    d.Get("type"),
+	}
+}
+
+func resourceDesktopPoolActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/desktop-pools/{pool_id}/action"
+		poolID  = d.Get("pool_id").(string)
+	)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace App client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{pool_id}", poolID)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildDesktopPoolActionBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error dispatching desktop pool operation: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable find job ID from API response")
+	}
+	// Backup job ID proves that the request was successful
+	d.SetId(jobId)
+
+	status, err := waitForJobCompleted(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for the job (%s) to completed: %s", jobId, err)
+	}
+	d.Set("status", status)
+
+	return resourceDesktopPoolActionRead(ctx, d, meta)
+}
+
+func resourceDesktopPoolActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDesktopPoolActionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDesktopPoolActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to operate desktop pool. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add one time resource to operate desktop pool

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
implement resource
add test case
add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDesktopPoolAction_basic -timeout 360m -parallel 10
=== RUN   TestAccDesktopPoolAction_basic
--- PASS: TestAccDesktopPoolAction_basic (493.71s)
PASS
coverage: 11.8% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 493.849s        coverage: 11.8% of statements in ./huaweicloud/services/workspace
```

![image](https://github.com/user-attachments/assets/d71d6f28-754a-45a5-b929-3daf1abfb702)

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

