### PR TITLE
feat(CodeArts/Pipeline): support resource parameter group and associate pipeline with groups

### DIFF
--- a/docs/resources/codearts_pipeline.md
+++ b/docs/resources/codearts_pipeline.md
@@ -167,6 +167,8 @@ The following arguments are supported:
 
 * `banned` - (Optional, Bool) Specifies whether the pipeline is banned. Defaults to **false**.
 
+* `parameter_groups` - (Optional, List) Specifies the parameter groups associated with.
+
 <a name="block--sources"></a>
 The `sources` block supports:
 

--- a/docs/resources/codearts_pipeline_by_template.md
+++ b/docs/resources/codearts_pipeline_by_template.md
@@ -89,6 +89,8 @@ The following arguments are supported:
 * `variables` - (Optional, List) Specifies the custom variables.
   The [variables](#block--variables) structure is documented below.
 
+* `parameter_groups` - (Optional, List) Specifies the parameter groups associated with.
+
 <a name="block--sources"></a>
 The `sources` block supports:
 

--- a/docs/resources/codearts_pipeline_parameter_group.md
+++ b/docs/resources/codearts_pipeline_parameter_group.md
@@ -1,0 +1,91 @@
+---
+subcategory: "CodeArts Pipeline"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_codearts_pipeline_parameter_group"
+description: |-
+  Manages a CodeArts pipeline parameter group resource within HuaweiCloud.
+---
+
+# huaweicloud_codearts_pipeline_parameter_group
+
+Manages a CodeArts pipeline parameter group resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "codearts_project_id" {}
+variable "name" {}
+
+resource "huaweicloud_codearts_pipeline_parameter_group" "test" {
+  project_id = var.codearts_project_id
+  name       = var.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `project_id` - (Required, String, NonUpdatable) Specifies the CodeArts project ID.
+
+* `name` - (Required, String) Specifies the parameter group name.
+
+* `description` - (Optional, String) Specifies the parameter group description.
+
+* `variables` - (Optional, List) Specifies the permission information.
+  The [variables](#block--variables) structure is documented below.
+
+<a name="block--variables"></a>
+The `variables` block supports:
+
+* `description` - (Optional, String) Specifies the parameter description.
+
+* `is_secret` - (Optional, Bool) Specifies whether it is a private parameter.
+
+* `name` - (Optional, String) Specifies the custom variable name.
+
+* `sequence` - (Optional, Int) Specifies the parameter sequence, starting from 1.
+
+* `type` - (Optional, String) Specifies the custom parameter type.
+
+* `value` - (Optional, String) Specifies the custom parameter default value.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `related_pipelines` - Indicates the associated pipeline.
+  The [related_pipelines](#attrblock--related_pipelines) structure is documented below.
+
+* `creator_id` - Indicates the creator ID.
+
+* `updater_id` - Indicates the updater ID.
+
+* `create_time` - Indicates the create time.
+
+* `update_time` - Indicates the update time.
+
+* `creator_name` - Indicates the creator name.
+
+* `updater_name` - Indicates the updater name.
+
+<a name="attrblock--related_pipelines"></a>
+The `related_pipelines` block supports:
+
+* `id` - Indicates the pipeline ID.
+
+* `name` - Indicates the pipeline name.
+
+## Import
+
+The parameter group can be imported using `project_id` and `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_codearts_pipeline_parameter_group.test <project_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2805,6 +2805,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_codearts_pipeline_by_template":      codeartspipeline.ResourceCodeArtsPipelineByTemplate(),
 			"huaweicloud_codearts_pipeline_template":         codeartspipeline.ResourceCodeArtsPipelineTemplate(),
 			"huaweicloud_codearts_pipeline_service_endpoint": codeartspipeline.ResourceCodeArtsPipelineServiceEndpoint(),
+			"huaweicloud_codearts_pipeline_parameter_group":  codeartspipeline.ResourceCodeArtsPipelineParameterGroup(),
 			"huaweicloud_codearts_pipeline_micro_service":    codeartspipeline.ResourceCodeArtsPipelineMicroService(),
 
 			"huaweicloud_codearts_build_task":         codeartsbuild.ResourceCodeArtsBuildTask(),

--- a/huaweicloud/services/acceptance/codeartspipeline/resource_huaweicloud_codearts_pipeline_by_template_test.go
+++ b/huaweicloud/services/acceptance/codeartspipeline/resource_huaweicloud_codearts_pipeline_by_template_test.go
@@ -80,13 +80,16 @@ func testPipelineByTemplate_basic(name string) string {
 
 %[3]s
 
+%[4]s
+
 resource "huaweicloud_codearts_pipeline_by_template" "test" {
-  project_id  = huaweicloud_codearts_project.test.id
-  template_id = huaweicloud_codearts_pipeline_template.test.id
-  name        = "%[4]s"
-  is_publish  = false
-  banned      = true
-  description = "test"
+  project_id       = huaweicloud_codearts_project.test.id
+  template_id      = huaweicloud_codearts_pipeline_template.test.id
+  name             = "%[5]s"
+  is_publish       = false
+  banned           = true
+  description      = "test"
+  parameter_groups = [huaweicloud_codearts_pipeline_parameter_group.test.id]
 
   sources {
     type = "code"
@@ -101,7 +104,7 @@ resource "huaweicloud_codearts_pipeline_by_template" "test" {
     }
   }
 }
-`, testProject_basic(name), testRepository_basic(name), testPipelineTemplate_basic(name), name)
+`, testProject_basic(name), testRepository_basic(name), testPipelineTemplate_basic(name), testPipeline_parameterGroup(name), name)
 }
 
 func testPipelineByTemplate_update(name string) string {

--- a/huaweicloud/services/acceptance/codeartspipeline/resource_huaweicloud_codearts_pipeline_parameter_group_test.go
+++ b/huaweicloud/services/acceptance/codeartspipeline/resource_huaweicloud_codearts_pipeline_parameter_group_test.go
@@ -1,0 +1,105 @@
+package codeartspipeline
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/codeartspipeline"
+)
+
+func getPipelineParameterGroupResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("codearts_pipeline", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CodeArts Pipeline client: %s", err)
+	}
+
+	return codeartspipeline.GetPipelineParameterGroup(client, state.Primary.Attributes["project_id"], state.Primary.ID)
+}
+
+func TestAccPipelineParameterGroup_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_codearts_pipeline_parameter_group.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPipelineParameterGroupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testPipelineParameterGroup_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "project_id", "huaweicloud_codearts_project.test", "id"),
+					resource.TestCheckResourceAttr(rName, "description", "test"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testPipelineImportState(rName),
+			},
+			{
+				Config: testPipelineParameterGroup_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
+					resource.TestCheckResourceAttrPair(rName, "project_id", "huaweicloud_codearts_project.test", "id"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+				),
+			},
+		},
+	})
+}
+
+func testPipeline_parameterGroup(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_codearts_pipeline_parameter_group" "test" {
+  project_id  = huaweicloud_codearts_project.test.id
+  name        = "%[1]s"
+  description = "test"
+
+  variables {
+    description = "test"
+    is_secret   = false
+    name        = "test"
+    sequence    = 1
+    type        = "string"
+    value       = "1"
+  }
+}
+`, name)
+}
+
+func testPipelineParameterGroup_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+`, testProject_basic(name), testPipeline_parameterGroup(name))
+}
+
+func testPipelineParameterGroup_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_codearts_pipeline_parameter_group" "test" {
+  project_id = huaweicloud_codearts_project.test.id
+  name       = "%[2]s_update"
+}
+`, testProject_basic(name), name)
+}

--- a/huaweicloud/services/acceptance/codeartspipeline/resource_huaweicloud_codearts_pipeline_test.go
+++ b/huaweicloud/services/acceptance/codeartspipeline/resource_huaweicloud_codearts_pipeline_test.go
@@ -124,13 +124,16 @@ func testPipeline_basic(name string) string {
 
 %[2]s
 
+%[3]s
+
 resource "huaweicloud_codearts_pipeline" "test" {
-  project_id  = huaweicloud_codearts_project.test.id
-  name        = "%[3]s"
-  description = "test"
-  is_publish  = false
-  banned      = true
-  definition  = jsonencode({
+  project_id       = huaweicloud_codearts_project.test.id
+  name             = "%[4]s"
+  description      = "test"
+  is_publish       = false
+  banned           = true
+  parameter_groups = [huaweicloud_codearts_pipeline_parameter_group.test.id]
+  definition       = jsonencode({
     "stages": [
       {
         "name": "Stage_1",
@@ -188,7 +191,7 @@ resource "huaweicloud_codearts_pipeline" "test" {
                   },
                   {
                     "key": "approvers",
-                    "value": "%[4]s"
+                    "value": "%[5]s"
                   },
                   {
                     "key": "audit_role",
@@ -292,7 +295,7 @@ resource "huaweicloud_codearts_pipeline" "test" {
     ]
   }
 }
-`, testProject_basic(name), testRepository_basic(name), name, acceptance.HW_USER_ID)
+`, testProject_basic(name), testRepository_basic(name), testPipeline_parameterGroup(name), name, acceptance.HW_USER_ID)
 }
 
 //nolint:revive

--- a/huaweicloud/services/codeartspipeline/common.go
+++ b/huaweicloud/services/codeartspipeline/common.go
@@ -15,13 +15,14 @@ import (
 )
 
 const (
-	pipelineNotFoundError = "DEVPIPE.00011401"
-	templateNotFoundError = "DEVPIPE.00011203"
-	projectNotFoundError  = "DEV_21_100169"
-	projectNotFoundError2 = "DEVPIPE.00011412"
-	projectNotFoundError3 = "DEVPIPE.30021001"
-	groupNotFoundError    = "DEVPIPE.00014007"
-	tagNotFoundError      = "DEVPIPE.00014024"
+	pipelineNotFoundError       = "DEVPIPE.00011401"
+	templateNotFoundError       = "DEVPIPE.00011203"
+	projectNotFoundError        = "DEV_21_100169"
+	projectNotFoundError2       = "DEVPIPE.00011412"
+	projectNotFoundError3       = "DEVPIPE.30021001"
+	groupNotFoundError          = "DEVPIPE.00014007"
+	tagNotFoundError            = "DEVPIPE.00014024"
+	parameterGroupNotFoundError = "DEVPIPE.00014033"
 )
 
 // checkResponseError use to check whether the CodeArts Pipeline API response body contains error code.

--- a/huaweicloud/services/codeartspipeline/resource_huaweicloud_codearts_pipeline_parameter_group.go
+++ b/huaweicloud/services/codeartspipeline/resource_huaweicloud_codearts_pipeline_parameter_group.go
@@ -1,0 +1,394 @@
+package codeartspipeline
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var parameterGroupNonUpdatableParams = []string{
+	"project_id",
+}
+
+// @API CodeArtsPipeline POST /v5/{project_id}/api/pipeline/variable/group/create
+// @API CodeArtsPipeline GET /v5/{project_id}/api/pipeline/variable/group/{id}
+// @API CodeArtsPipeline PUT /v5/{project_id}/api/pipeline/variable/group/update
+// @API CodeArtsPipeline DELETE /v5/{project_id}/api/pipeline/variable/group/delete
+func ResourceCodeArtsPipelineParameterGroup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePipelineParameterGroupCreate,
+		ReadContext:   resourcePipelineParameterGroupRead,
+		UpdateContext: resourcePipelineParameterGroupUpdate,
+		DeleteContext: resourcePipelineParameterGroupDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceImportStateFuncWithProjectIdAndId,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(parameterGroupNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the CodeArts project ID.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the parameter group name.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the parameter group description.`,
+			},
+			"variables": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: `Specifies the permission information.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the custom variable name.`,
+						},
+						"sequence": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: `Specifies the parameter sequence, starting from 1.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the custom parameter type.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the custom parameter default value.`,
+						},
+						"is_secret": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: `Specifies whether it is a private parameter.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the parameter description.`,
+						},
+					},
+				},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"related_pipelines": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Indicates the associated pipeline.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the pipeline name.`,
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the pipeline ID.`,
+						},
+					},
+				},
+			},
+			"creator_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the creator ID.`,
+			},
+			"updater_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the updater ID.`,
+			},
+			"creator_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the creator name.`,
+			},
+			"updater_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the updater name.`,
+			},
+			"create_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Indicates the create time.`,
+			},
+			"update_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Indicates the update time.`,
+			},
+		},
+	}
+}
+
+func resourcePipelineParameterGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("codearts_pipeline", region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts Pipeline client: %s", err)
+	}
+
+	httpUrl := "v5/{project_id}/api/pipeline/variable/group/create"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", d.Get("project_id").(string))
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateOrUpdatePipelineParameterGroupBodyParams(d)),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts Pipeline parameter group: %s", err)
+	}
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkResponseError(createRespBody, ""); err != nil {
+		return diag.Errorf("error creating CodeArts Pipeline parameter group: %s", err)
+	}
+
+	id := utils.PathSearch("pipeline_variable_group_id", createRespBody, "").(string)
+	if id == "" {
+		return diag.Errorf("unable to find the CodeArts Pipeline parameter group ID from the API response")
+	}
+
+	d.SetId(id)
+
+	return resourcePipelineParameterGroupRead(ctx, d, meta)
+}
+
+func buildCreateOrUpdatePipelineParameterGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"project_id":  d.Get("project_id"),
+		"name":        d.Get("name"),
+		"description": d.Get("description"),
+		"variables":   buildPipelineParameterGroupVariables(d),
+		"id":          utils.ValueIgnoreEmpty(d.Id()),
+	}
+
+	return bodyParams
+}
+
+func buildPipelineParameterGroupVariables(d *schema.ResourceData) interface{} {
+	rawVariables := d.Get("variables").(*schema.Set).List()
+	if len(rawVariables) == 0 {
+		return nil
+	}
+
+	variables := make([]map[string]interface{}, 0, len(rawVariables))
+	for _, v := range rawVariables {
+		if variable, ok := v.(map[string]interface{}); ok {
+			customVar := map[string]interface{}{
+				"name":        utils.ValueIgnoreEmpty(variable["name"]),
+				"sequence":    utils.ValueIgnoreEmpty(variable["sequence"]),
+				"type":        utils.ValueIgnoreEmpty(variable["type"]),
+				"value":       utils.ValueIgnoreEmpty(variable["value"]),
+				"is_secret":   utils.ValueIgnoreEmpty(variable["is_secret"]),
+				"description": utils.ValueIgnoreEmpty(variable["description"]),
+			}
+			variables = append(variables, customVar)
+		}
+	}
+
+	return variables
+}
+
+func resourcePipelineParameterGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("codearts_pipeline", region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts Pipeline client: %s", err)
+	}
+
+	getRespBody, err := GetPipelineParameterGroup(client, d.Get("project_id").(string), d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CodeArts Pipeline parameter group")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("project_id", utils.PathSearch("project_id", getRespBody, nil)),
+		d.Set("name", utils.PathSearch("name", getRespBody, nil)),
+		d.Set("description", utils.PathSearch("description", getRespBody, nil)),
+		d.Set("creator_id", utils.PathSearch("creator_id", getRespBody, nil)),
+		d.Set("updater_id", utils.PathSearch("updater_id", getRespBody, nil)),
+		d.Set("creator_name", utils.PathSearch("creator_name", getRespBody, nil)),
+		d.Set("updater_name", utils.PathSearch("updater_name", getRespBody, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", getRespBody, nil)),
+		d.Set("update_time", utils.PathSearch("update_time", getRespBody, nil)),
+		d.Set("variables", flattenPipelineParameterGroupVariables(getRespBody)),
+		d.Set("related_pipelines", flattenPipelineParameterGroupRelatedPipelines(getRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func GetPipelineParameterGroup(client *golangsdk.ServiceClient, projectId, id string) (interface{}, error) {
+	httpUrl := "v5/{project_id}/api/pipeline/variable/group/{id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", projectId)
+	getPath = strings.ReplaceAll(getPath, "{id}", id)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkResponseError(getRespBody, parameterGroupNotFoundError); err != nil {
+		return nil, err
+	}
+
+	return getRespBody, nil
+}
+
+func flattenPipelineParameterGroupVariables(resp interface{}) []interface{} {
+	variablesList, ok := utils.PathSearch("variables", resp, make([]interface{}, 0)).([]interface{})
+	if ok && len(variablesList) > 0 {
+		result := make([]interface{}, 0, len(variablesList))
+		for _, v := range variablesList {
+			variable := v.(map[string]interface{})
+			customVar := map[string]interface{}{
+				"name":        utils.PathSearch("name", variable, nil),
+				"sequence":    utils.PathSearch("sequence", variable, nil),
+				"type":        utils.PathSearch("type", variable, nil),
+				"value":       utils.PathSearch("value", variable, nil),
+				"is_secret":   utils.PathSearch("is_secret", variable, nil),
+				"description": utils.PathSearch("description", variable, nil),
+			}
+			result = append(result, customVar)
+		}
+		return result
+	}
+
+	return nil
+}
+
+func flattenPipelineParameterGroupRelatedPipelines(resp interface{}) []interface{} {
+	relatedPipelinesList, ok := utils.PathSearch("related_pipelines", resp, make([]interface{}, 0)).([]interface{})
+	if ok && len(relatedPipelinesList) > 0 {
+		result := make([]interface{}, 0, len(relatedPipelinesList))
+		for _, v := range relatedPipelinesList {
+			relatedPipeline := v.(map[string]interface{})
+			m := map[string]interface{}{
+				"name": utils.PathSearch("name", relatedPipeline, nil),
+				"id":   utils.PathSearch("id", relatedPipeline, nil),
+			}
+			result = append(result, m)
+		}
+		return result
+	}
+
+	return nil
+}
+
+func resourcePipelineParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("codearts_pipeline", region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts Pipeline client: %s", err)
+	}
+
+	httpUrl := "v5/{project_id}/api/pipeline/variable/group/update"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", d.Get("project_id").(string))
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateOrUpdatePipelineParameterGroupBodyParams(d)),
+	}
+
+	updateResp, err := client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating CodeArts Pipeline parameter group: %s", err)
+	}
+	updateRespBody, err := utils.FlattenResponse(updateResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkResponseError(updateRespBody, ""); err != nil {
+		return diag.Errorf("error updating CodeArts Pipeline parameter group: %s", err)
+	}
+
+	return resourcePipelineParameterGroupRead(ctx, d, meta)
+}
+
+func resourcePipelineParameterGroupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("codearts_pipeline", region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts Pipeline client: %s", err)
+	}
+
+	projectId := d.Get("project_id").(string)
+	httpUrl := "v5/{project_id}/api/pipeline/variable/group/delete?id={id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", projectId)
+	deletePath = strings.ReplaceAll(deletePath, "{id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         map[string]interface{}{},
+	}
+
+	deleteResp, err := client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting CodeArts Pipeline parameter group")
+	}
+	deleteRespBody, err := utils.FlattenResponse(deleteResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkResponseError(deleteRespBody, parameterGroupNotFoundError); err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting CodeArts Pipeline parameter group")
+	}
+
+	return nil
+}

--- a/huaweicloud/services/codeartspipeline/resource_huaweicloud_codearts_pipeline_service_endpoint.go
+++ b/huaweicloud/services/codeartspipeline/resource_huaweicloud_codearts_pipeline_service_endpoint.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -80,6 +81,12 @@ func ResourceCodeArtsPipelineServiceEndpoint() *schema.Resource {
 						},
 					},
 				},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
 			},
 			"created_by": {
 				Type:        schema.TypeList,


### PR DESCRIPTION
…te pipeline with groups

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support resource parameter group and associate pipeline with groups
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support resource parameter group and associate pipeline with groups
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/codeartspipeline' TESTARGS='-run TestAccPipeline_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codeartspipeline -v -run TestAccPipeline_basic -timeout 360m -parallel 4
=== RUN   TestAccPipeline_basic
=== PAUSE TestAccPipeline_basic
=== CONT  TestAccPipeline_basic
--- PASS: TestAccPipeline_basic (54.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codeartspipeline  54.295s

make testacc TEST='./huaweicloud/services/acceptance/codeartspipeline' TESTARGS='-run TestAccPipelineByTemplate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codeartspipeline -v -run TestAccPipelineByTemplate_basic -timeout 360m -parallel 4
=== RUN   TestAccPipelineByTemplate_basic
=== PAUSE TestAccPipelineByTemplate_basic
=== CONT  TestAccPipelineByTemplate_basic
--- PASS: TestAccPipelineByTemplate_basic (54.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codeartspipeline  54.521s

make testacc TEST='./huaweicloud/services/acceptance/codeartspipeline' TESTARGS='-run TestAccPipelineParameterGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codeartspipeline -v -run TestAccPipelineParameterGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccPipelineParameterGroup_basic
=== PAUSE TestAccPipelineParameterGroup_basic
=== CONT  TestAccPipelineParameterGroup_basic
--- PASS: TestAccPipelineParameterGroup_basic (37.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codeartspipeline  37.948s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/1b1d93d4-e59a-4575-8e8b-c0e68981f28b)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/e6941714-4ee2-405c-b926-796c32a166b5)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
