### PR TITLE
refactor(RDS): refactor rds instance resource

### DIFF
--- a/huaweicloud/services/rds/resource_huaweicloud_rds_read_replica_instance.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_read_replica_instance.go
@@ -389,11 +389,7 @@ func resourceRdsReadReplicaInstanceCreate(ctx context.Context, d *schema.Resourc
 
 	// Set Parameters
 	if parametersRaw := d.Get("parameters").(*schema.Set); parametersRaw.Len() > 0 {
-		clientV31, err := config.RdsV31Client(config.GetRegion(d))
-		if err != nil {
-			return diag.Errorf("error creating RDS V3.1 client: %s", err)
-		}
-		if err = initializeParameters(ctx, d, client, clientV31, instanceID, parametersRaw); err != nil {
+		if err = initializeParameters(ctx, d, client, parametersRaw); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -451,7 +447,7 @@ func resourceRdsReadReplicaInstanceRead(ctx context.Context, d *schema.ResourceD
 		mErr = multierror.Append(mErr, d.Set("maintain_end", maintainWindow[1]))
 	}
 
-	diagErr := setRdsInstanceParameters(ctx, d, client, instanceID)
+	diagErr := setRdsInstanceParameters(ctx, d, client)
 	resErr := append(diag.FromErr(mErr.ErrorOrNil()), diagErr...)
 
 	return resErr
@@ -473,10 +469,6 @@ func resourceRdsReadReplicaInstanceUpdate(ctx context.Context, d *schema.Resourc
 	client, err := cfg.RdsV3Client(region)
 	if err != nil {
 		return diag.Errorf("error creating rds v3 client: %s ", err)
-	}
-	clientV31, err := cfg.RdsV31Client(region)
-	if err != nil {
-		return diag.Errorf("error creating RDS V3.1 client: %s", err)
 	}
 
 	instanceID := d.Id()
@@ -521,7 +513,7 @@ func resourceRdsReadReplicaInstanceUpdate(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 
-	if ctx, err = updateRdsParameters(ctx, d, client, clientV31, instanceID); err != nil {
+	if ctx, err = updateRdsParameters(ctx, d, client); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  refactor rds instance resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  refactor rds instance resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_basic
--- PASS: TestAccRdsInstance_basic (828.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       828.158s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_mysql'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_mysql -timeout 360m -parallel 4
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_mysql_power_action
=== PAUSE TestAccRdsInstance_mysql_power_action
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_mysql_power_action
--- PASS: TestAccRdsInstance_mysql_power_action (1066.79s)
--- PASS: TestAccRdsInstance_mysql (1714.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1714.745s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_sqlserver_msdtc_hosts'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_sqlserver_msdtc_hosts -timeout 360m -parallel 4
=== RUN   TestAccRdsInstance_sqlserver_msdtc_hosts
=== PAUSE TestAccRdsInstance_sqlserver_msdtc_hosts
=== CONT  TestAccRdsInstance_sqlserver_msdtc_hosts
--- PASS: TestAccRdsInstance_sqlserver_msdtc_hosts (1672.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1672.304s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccReadReplicaInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccReadReplicaInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccReadReplicaInstance_basic
=== PAUSE TestAccReadReplicaInstance_basic
=== CONT  TestAccReadReplicaInstance_basic
--- PASS: TestAccReadReplicaInstance_basic (2344.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2344.603s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
