### PR TITLE
feat(workspace/app): add new resource to manage schedule task

### DIFF
--- a/docs/resources/workspace_app_schedule_task.md
+++ b/docs/resources/workspace_app_schedule_task.md
@@ -1,0 +1,140 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_schedule_task"
+description: |-
+  Manages a workspace APP schedule task resource within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_schedule_task
+
+Manages a workspace APP schedule task resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "schedule_task_name" {}
+variable "scheduled_time" {}
+variable "target_objects" {
+  type = list(object({
+    target_type = string
+    target_id   = string
+  }))
+}
+
+resource "huaweicloud_workspace_app_schedule_task" "test" {
+  task_name      = var.schedule_task_name
+  task_type      = "STOP_SERVER"
+  scheduled_type = "WEEK"
+  week_list      = "1,3" # Sunday, Tuesday
+  scheduled_time = var.scheduled_time
+  time_zone      = "Asia/Shanghai"
+
+  dynamic "target_infos" {
+    for_each = var.target_objects
+
+    content {
+      target_type = target_infos.value.target_type
+      target_id   = target_infos.value.target_id
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the schedule task is located.  
+  If omitted, the provider-level region will be used.  
+  Changing this parameter will create a new resource.
+
+* `task_name` - (Required, String) Specifies the name of the schedule task.  
+  The name must be `1` to `64` characters, only letters, digits, and underscores (_) are allowed, and the name
+  cannot contain spaces.
+
+* `task_type` - (Required, String) Specifies the type of the schedule task.  
+  The valid values are as follows:
+  + **RESTART_SERVER**: Restart servers.
+  + **START_SERVER**: Start servers.
+  + **STOP_SERVER**: Stop servers.
+  + **REINSTALL_OS**: Reinstall operating system.
+
+* `scheduled_type` - (Required, String) Specifies the execution cycle of the schedule task.  
+  The valid values are as follows:
+  + **FIXED_TIME**
+  + **DAY**
+  + **WEEK**
+  + **MONTH**
+
+* `scheduled_time` - (Required, String) Specifies the execution time of the schedule task.  
+  The format is `HH:mm:ss`.
+
+* `target_infos` - (Required, List) Specifies the target object list of the schedule task.  
+  The [target_infos](#app_schedule_task_target_infos) structure is documented below.
+
+* `day_interval` - (Optional, Int) Specifies the execution interval of the scheduled task, in day.
+  The valid value ranges from `1` to `31`.  
+  This parameter is **required** when `scheduled_type` is set to **DAY**.
+
+* `week_list` - (Optional, String) Specifies the days of week of the schedule task.  
+  The valid value ranges from `1` to `7`, separated by commas, e.g. `1,2,7`.  
+  `1` means Sunday, `2` means Monday, and so on.  
+  This parameter is **required** when `scheduled_type` is set to **WEEK**.
+
+* `month_list` - (Optional, String) Specifies the months of the schedule task.  
+  The valid value ranges from `1` to `12`, separated by commas, e.g. `1,3,12`.  
+  This parameter is **required** when `scheduled_type` is set to **MONTH**.
+
+* `date_list` - (Optional, String) Specifies the days of month of the schedule task.  
+  The valid value ranges from `1` to `31` and `L` (means the last day), separated by commas, e.g. `1,2,28` or `L`.  
+  `L` can only be used alone, and cannot be used together with other values.  
+  This parameter is **required** when `scheduled_type` is set to **MONTH**.
+
+* `scheduled_date` - (Optional, String) Specifies the fixed date of the schedule task.  
+  The format is `YYYY-MM-dd`.  
+  This parameter is **required** when `scheduled_type` is set to **FIXED_TIME**.
+
+* `time_zone` - (Optional, String) Specifies the time zone of the schedule task.  
+  Defaults to **Asia/Shanghai**.
+
+* `expire_time` - (Optional, String) Specifies the expiration time of the schedule task, in UTC format.
+
+* `description` - (Optional, String) Specifies the description of the schedule task.
+
+* `schedule_task_policy` - (Optional, List) Specifies the policy of the schedule task.
+  The [schedule_task_policy](#app_schedule_task_policy) structure is documented below.
+
+* `is_enable` - (Optional, Bool) Specifies whether to enable the schedule task.
+  Defaults to **true**.
+
+<a name="app_schedule_task_target_infos"></a>
+The `target_infos` block supports:
+
+* `target_id` - (Required, String) Specifies the ID of the target object.
+
+* `target_type` - (Required, String) Specifies the type of the target object.  
+  The valid values are as follows:
+  + **SERVER**
+  + **SERVER_GROUP**
+
+<a name="app_schedule_task_policy"></a>
+The `schedule_task_policy` block supports:
+
+* `enforcement_enable` - (Required, Bool) Specifies whether to forcefully execute the task when there are
+  active sessions.  
+  Defaults to **false**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also the schedule task ID.
+
+## Import
+
+Schedule tasks can be imported using the `id`, e.g.:
+
+```bash
+$ terraform import huaweicloud_workspace_app_schedule_task.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2712,6 +2712,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_personal_folders":      workspace.ResourceAppPersonalFolders(),
 			"huaweicloud_workspace_app_policy_group":          workspace.ResourceAppPolicyGroup(),
 			"huaweicloud_workspace_app_publishment":           workspace.ResourceAppPublishment(),
+			"huaweicloud_workspace_app_schedule_task":         workspace.ResourceAppScheduleTask(),
 			"huaweicloud_workspace_app_server_group":          workspace.ResourceAppServerGroup(),
 			"huaweicloud_workspace_app_server":                workspace.ResourceAppServer(),
 			"huaweicloud_workspace_app_shared_folder":         workspace.ResourceAppSharedFolder(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_schedule_task_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_schedule_task_test.go
@@ -1,0 +1,244 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/workspace"
+)
+
+func getResourceAppScheduleTaskFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("appstream", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	return workspace.GetAppScheduleTaskById(client, state.Primary.ID)
+}
+
+func TestAccResourceAppScheduleTask_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		withDayToMonth        = "huaweicloud_workspace_app_schedule_task.with_day_to_month"
+		withWeekToFixedTime   = "huaweicloud_workspace_app_schedule_task.with_week_to_fixed_time"
+		scheduleTask          interface{}
+		rcWithDayToMonth      = acceptance.InitResourceCheck(withDayToMonth, &scheduleTask, getResourceAppScheduleTaskFunc)
+		rcWithWeekToFixedTime = acceptance.InitResourceCheck(withWeekToFixedTime, &scheduleTask, getResourceAppScheduleTaskFunc)
+
+		scheduledTime = time.Now().AddDate(0, 1, 0)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcWithDayToMonth.CheckResourceDestroy(),
+			rcWithWeekToFixedTime.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceAppScheduleTask_basic_step1(name, scheduledTime),
+				Check: resource.ComposeTestCheckFunc(
+					rcWithDayToMonth.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withDayToMonth, "task_name", name),
+					resource.TestCheckResourceAttr(withDayToMonth, "task_type", "STOP_SERVER"),
+					resource.TestCheckResourceAttr(withDayToMonth, "scheduled_type", "DAY"),
+					resource.TestCheckResourceAttr(withDayToMonth, "scheduled_time", "00:00:00"),
+					resource.TestCheckResourceAttr(withDayToMonth, "day_interval", "2"),
+					resource.TestCheckResourceAttr(withDayToMonth, "time_zone", "Asia/Shanghai"),
+					resource.TestCheckResourceAttr(withDayToMonth, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(withDayToMonth, "schedule_task_policy.#", "0"),
+					resource.TestCheckResourceAttr(withDayToMonth, "target_infos.#", "2"),
+					resource.TestCheckResourceAttr(withDayToMonth, "is_enable", "true"),
+					rcWithWeekToFixedTime.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "task_type", "RESTART_SERVER"),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "scheduled_type", "WEEK"),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "scheduled_time", "02:00:00"),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "week_list", "1,2,3,4,5"),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "time_zone", "Asia/Shanghai"),
+					resource.TestCheckResourceAttrSet(withWeekToFixedTime, "expire_time"),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "schedule_task_policy.0.enforcement_enable", "false"),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "target_infos.#", "1"),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "target_infos.0.target_type", "SERVER_GROUP"),
+					resource.TestCheckResourceAttrPair(withWeekToFixedTime, "target_infos.0.target_id",
+						"huaweicloud_workspace_app_server_group.test.0", "id"),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "is_enable", "false"),
+				),
+			},
+			{
+				Config: testAccResourceAppScheduleTask_basic_step2(name, updateName, scheduledTime),
+				Check: resource.ComposeTestCheckFunc(
+					rcWithDayToMonth.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withDayToMonth, "task_name", updateName),
+					resource.TestCheckResourceAttr(withDayToMonth, "task_type", "START_SERVER"),
+					resource.TestCheckResourceAttr(withDayToMonth, "scheduled_type", "MONTH"),
+					resource.TestCheckResourceAttr(withDayToMonth, "scheduled_time", "01:00:00"),
+					resource.TestCheckResourceAttrSet(withDayToMonth, "month_list"),
+					resource.TestCheckResourceAttr(withDayToMonth, "week_list", ""),
+					resource.TestCheckResourceAttr(withDayToMonth, "date_list", "L"),
+					resource.TestCheckResourceAttr(withDayToMonth, "scheduled_date", ""),
+					resource.TestCheckResourceAttr(withDayToMonth, "time_zone", "Asia/Shanghai"),
+					resource.TestCheckResourceAttr(withDayToMonth, "description", ""),
+					resource.TestCheckResourceAttr(withDayToMonth, "target_infos.#", "1"),
+					resource.TestCheckResourceAttrPair(withDayToMonth, "target_infos.0.target_id",
+						"huaweicloud_workspace_app_server_group.test.1", "id"),
+					resource.TestCheckResourceAttr(withDayToMonth, "is_enable", "false"),
+					rcWithWeekToFixedTime.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "task_type", "REINSTALL_OS"),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "scheduled_type", "FIXED_TIME"),
+					resource.TestCheckResourceAttrSet(withWeekToFixedTime, "scheduled_date"),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "week_list", ""),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "month_list", ""),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "date_list", ""),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "expire_time", ""),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "description", "Updated by terraform script"),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "schedule_task_policy.0.enforcement_enable", "true"),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "target_infos.#", "1"),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "target_infos.0.target_type", "SERVER_GROUP"),
+					resource.TestCheckResourceAttrPair(withWeekToFixedTime, "target_infos.0.target_id",
+						"huaweicloud_workspace_app_server_group.test.1", "id"),
+					resource.TestCheckResourceAttr(withWeekToFixedTime, "is_enable", "true"),
+				),
+			},
+			{
+				ResourceName:      withDayToMonth,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			{
+				ResourceName:      withWeekToFixedTime,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccResourceAppScheduleTask_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_service" "test" {}
+
+resource "huaweicloud_workspace_app_server_group" "test" {
+  count = 2
+
+  name             = "%[1]s${count.index}"
+  os_type          = "Windows"
+  flavor_id        = "%[2]s"
+  vpc_id           = data.huaweicloud_workspace_service.test.vpc_id
+  subnet_id        = try(data.huaweicloud_workspace_service.test.network_ids[0], "")
+  system_disk_type = "SATA"
+  system_disk_size = 80
+  is_vdi           = true
+  image_id         = "%[3]s"
+  image_type       = "gold"
+  image_product_id = "%[4]s"
+}
+`, name,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID)
+}
+
+func testAccResourceAppScheduleTask_basic_step1(name string, scheduledTime time.Time) string {
+	expireTime := scheduledTime.Format("2006-01-02T15:04:05Z")
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_schedule_task" "with_day_to_month" {
+  task_name      = "%[2]s"
+  task_type      = "STOP_SERVER"
+  scheduled_type = "DAY"
+  scheduled_time = "00:00:00"
+  day_interval   = 2
+  description    = "Created by terraform script"
+
+  dynamic "target_infos" {
+    for_each = huaweicloud_workspace_app_server_group.test[*].id
+
+    content {
+      target_type = "SERVER_GROUP"
+      target_id   = target_infos.value
+    }
+  }
+}
+
+resource "huaweicloud_workspace_app_schedule_task" "with_week_to_fixed_time" {
+  task_name      = "%[2]s_week"
+  task_type      = "RESTART_SERVER"
+  scheduled_type = "WEEK"
+  scheduled_time = "02:00:00"
+  week_list      = "1,2,3,4,5"
+  time_zone      = "Asia/Shanghai"
+  description    = "Created by terraform script"
+  expire_time    = "%[3]s"
+  is_enable      = false
+
+  schedule_task_policy {
+    enforcement_enable = false
+  }
+
+  target_infos {
+    target_type = "SERVER_GROUP"
+    target_id   = huaweicloud_workspace_app_server_group.test[0].id
+  }
+}
+`, testAccResourceAppScheduleTask_base(name), name, expireTime)
+}
+
+func testAccResourceAppScheduleTask_basic_step2(name, updateName string, scheduledTime time.Time) string {
+	scheduledMonth := fmt.Sprintf("%d", scheduledTime.Month())
+	scheduledDate := scheduledTime.Format("2006-01-02")
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_schedule_task" "with_day_to_month" {
+  task_name      = "%[2]s"
+  task_type      = "START_SERVER"
+  scheduled_type = "MONTH"
+  scheduled_time = "01:00:00"
+  month_list     = "%[3]s"
+  date_list      = "L"
+  is_enable      = false
+
+  schedule_task_policy {
+    enforcement_enable = true
+  }
+
+  target_infos {
+    target_type = "SERVER_GROUP"
+    target_id   = huaweicloud_workspace_app_server_group.test[1].id
+  }
+}
+
+resource "huaweicloud_workspace_app_schedule_task" "with_week_to_fixed_time" {
+  task_name      = "%[2]s_fixed"
+  task_type      = "REINSTALL_OS"
+  scheduled_type = "FIXED_TIME"
+  scheduled_time = "03:00:00"
+  scheduled_date = "%[4]s"
+  time_zone      = "Asia/Shanghai"
+  description    = "Updated by terraform script"
+
+  schedule_task_policy {
+    enforcement_enable = true
+  }
+
+  target_infos {
+    target_type = "SERVER_GROUP"
+    target_id   = huaweicloud_workspace_app_server_group.test[1].id
+  }
+}
+`, testAccResourceAppScheduleTask_base(name), updateName, scheduledMonth, scheduledDate)
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_schedule_task.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_schedule_task.go
@@ -1,0 +1,454 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WORKSPACEAPP POST /v1/{project_id}/schedule-task
+// @API WORKSPACEAPP GET /v1/{project_id}/schedule-task/{task_id}
+// @API WORKSPACEAPP PATCH /v1/{project_id}/schedule-task/{task_id}
+// @API WORKSPACEAPP DELETE /v1/{project_id}/schedule-task/{task_id}
+func ResourceAppScheduleTask() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppScheduleTaskCreate,
+		ReadContext:   resourceAppScheduleTaskRead,
+		UpdateContext: resourceAppScheduleTaskUpdate,
+		DeleteContext: resourceAppScheduleTaskDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the schedule task is located.`,
+			},
+			"task_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the schedule task.`,
+			},
+			"task_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the schedule task.`,
+			},
+			"scheduled_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The execution cycle of the schedule task.`,
+			},
+			"scheduled_time": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The execution time of the schedule task.`,
+			},
+			"target_infos": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"target_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The ID of the target object.`,
+						},
+						"target_type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The type of the target object.`,
+						},
+					},
+				},
+				Description: `The target object list of the schedule task.`,
+			},
+			"day_interval": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The execution interval of the scheduled task, in days.`,
+				DiffSuppressFunc: func(_, _, newRaw string, d *schema.ResourceData) bool {
+					// When scheduled_type is not "DAY", the update interface cannot update `day_interval` to null.
+					// so the change needs to be suppressed.
+					return newRaw == "0" && d.Get("scheduled_type") != "DAY"
+				},
+			},
+			"week_list": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The days of week of the schedule task.`,
+			},
+			"month_list": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The months of the schedule task.`,
+			},
+			"date_list": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The days of month of the schedule task.`,
+			},
+			"scheduled_date": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The fixed date of the schedule task.`,
+			},
+			"time_zone": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The time zone of the schedule task.`,
+			},
+			"expire_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The expiration time of the schedule task, in UTC format.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the schedule task.`,
+			},
+			"schedule_task_policy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enforcement_enable": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							Description: `Whether to forcefully execute the task when there are active sessions.`,
+						},
+					},
+				},
+				Description: `The policy of the schedule task.`,
+			},
+			"is_enable": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Whether to enable the schedule task.`,
+			},
+		},
+	}
+}
+
+func buildAppScheduleTaskPolicy(scheduleTaskPolicy []interface{}) map[string]interface{} {
+	if len(scheduleTaskPolicy) < 1 {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"enforcement_enable": utils.PathSearch("enforcement_enable", scheduleTaskPolicy[0], nil),
+	}
+}
+
+func buildAppScheduleTaskTargetInfos(rawTargetInfos *schema.Set) []map[string]interface{} {
+	if rawTargetInfos.Len() < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, rawTargetInfos.Len())
+	for i, v := range rawTargetInfos.List() {
+		result[i] = map[string]interface{}{
+			"target_type": utils.PathSearch("target_type", v, nil),
+			"target_id":   utils.PathSearch("target_id", v, nil),
+		}
+	}
+
+	return result
+}
+
+func buildCreateAppScheduleTaskBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"task_name":            d.Get("task_name"),
+		"task_type":            d.Get("task_type"),
+		"scheduled_time":       d.Get("scheduled_time"),
+		"scheduled_type":       d.Get("scheduled_type"),
+		"target_infos":         buildAppScheduleTaskTargetInfos(d.Get("target_infos").(*schema.Set)),
+		"day_interval":         utils.ValueIgnoreEmpty(d.Get("day_interval")),
+		"week_list":            utils.ValueIgnoreEmpty(d.Get("week_list")),
+		"month_list":           utils.ValueIgnoreEmpty(d.Get("month_list")),
+		"date_list":            utils.ValueIgnoreEmpty(d.Get("date_list")),
+		"time_zone":            utils.ValueIgnoreEmpty(d.Get("time_zone")),
+		"scheduled_date":       utils.ValueIgnoreEmpty(d.Get("scheduled_date")),
+		"expire_time":          utils.ValueIgnoreEmpty(d.Get("expire_time")),
+		"description":          utils.ValueIgnoreEmpty(d.Get("description")),
+		"schedule_task_policy": buildAppScheduleTaskPolicy(d.Get("schedule_task_policy").([]interface{})),
+	}
+}
+
+func resourceAppScheduleTaskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("appstream", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	createPath := "v1/{project_id}/schedule-task"
+	createPath = client.Endpoint + createPath
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateAppScheduleTaskBodyParams(d)),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP schedule task: %s", err)
+	}
+	respBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP schedule task: %s", err)
+	}
+
+	scheduleTaskId := utils.PathSearch("id", respBody, "").(string)
+	if scheduleTaskId == "" {
+		return diag.Errorf("unable to find schedule task ID in the response")
+	}
+	d.SetId(scheduleTaskId)
+
+	isEnabled := d.Get("is_enable").(bool)
+	if !isEnabled {
+		params := map[string]interface{}{
+			"is_enable": isEnabled,
+		}
+		err = updateAppScheduleTask(client, scheduleTaskId, params)
+		if err != nil {
+			return diag.Errorf("unable to update the status of the schedule task (%s): %s", scheduleTaskId, err)
+		}
+	}
+
+	return resourceAppScheduleTaskRead(ctx, d, meta)
+}
+
+// GetAppScheduleTaskById is a method is used to get the schedule task by its ID.
+func GetAppScheduleTaskById(client *golangsdk.ServiceClient, scheduleTaskId string) (interface{}, error) {
+	getPath := "v1/{project_id}/schedule-task/{task_id}"
+	getPath = client.Endpoint + getPath
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{task_id}", scheduleTaskId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+func resourceAppScheduleTaskRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		scheduleTaskId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	respBody, err := GetAppScheduleTaskById(client, scheduleTaskId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving Workspace APP schedule task")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		// Required parameters.
+		d.Set("task_name", utils.PathSearch("task_name", respBody, nil)),
+		d.Set("task_type", utils.PathSearch("task_type", respBody, nil)),
+		d.Set("scheduled_type", utils.PathSearch("scheduled_type", respBody, nil)),
+		d.Set("scheduled_time", utils.PathSearch("scheduled_time", respBody, nil)),
+		d.Set("target_infos", flattenAppScheduleTaskTargetInfos(utils.PathSearch("target_infos", respBody, make([]interface{}, 0)).([]interface{}))),
+		// Optional parameters.
+		d.Set("day_interval", utils.PathSearch("day_interval", respBody, nil)),
+		d.Set("week_list", utils.PathSearch("week_list", respBody, nil)),
+		d.Set("month_list", utils.PathSearch("month_list", respBody, nil)),
+		d.Set("date_list", utils.PathSearch("date_list", respBody, nil)),
+		d.Set("time_zone", utils.PathSearch("time_zone", respBody, nil)),
+		d.Set("scheduled_date", utils.PathSearch("scheduled_date", respBody, nil)),
+		d.Set("expire_time", utils.PathSearch("expire_time", respBody, nil)),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("schedule_task_policy", flattenAppScheduleTaskPolicy(utils.PathSearch("schedule_task_policy", respBody, nil))),
+		d.Set("is_enable", utils.PathSearch("is_enable", respBody, nil)),
+	)
+
+	scheduleTasks, err := getAppScheduleTasks(client, d.Get("task_type").(string))
+	if err != nil {
+		return diag.Errorf("error getting Workspace APP schedule task by its ID (%s): %s", scheduleTaskId, err)
+	}
+
+	isEnabled := utils.PathSearch(fmt.Sprintf("[?id=='%s']|[0].is_enable", scheduleTaskId), scheduleTasks, false)
+	mErr = multierror.Append(
+		mErr,
+		d.Set("is_enable", isEnabled),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAppScheduleTaskPolicy(policy interface{}) []map[string]interface{} {
+	if policy == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"enforcement_enable": utils.PathSearch("enforcement_enable", policy, nil),
+		},
+	}
+}
+
+func getAppScheduleTasks(client *golangsdk.ServiceClient, taskType string) ([]interface{}, error) {
+	var (
+		listPath = "v1/{project_id}/schedule-task"
+		offset   = 0
+		limit    = 100
+		results  = make([]interface{}, 0)
+	)
+
+	listPath = client.Endpoint + listPath
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = fmt.Sprintf("%s?limit=%d&task_type=%s", listPath, limit, taskType)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		listResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(listResp)
+		if err != nil {
+			return nil, err
+		}
+
+		scheduleTasks := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		results = append(results, scheduleTasks...)
+		if len(scheduleTasks) < limit {
+			break
+		}
+
+		offset += len(scheduleTasks)
+	}
+
+	return results, nil
+}
+
+func flattenAppScheduleTaskTargetInfos(targetInfos []interface{}) []map[string]interface{} {
+	if len(targetInfos) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(targetInfos))
+	for i, targetObj := range targetInfos {
+		result[i] = map[string]interface{}{
+			"target_type": utils.PathSearch("target_type", targetObj, nil),
+			"target_id":   utils.PathSearch("target_id", targetObj, nil),
+		}
+	}
+
+	return result
+}
+
+func buildUpdateAppScheduleTaskBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		// Required parameters.
+		"task_name":      d.Get("task_name"),
+		"task_type":      d.Get("task_type"),
+		"scheduled_type": d.Get("scheduled_type"),
+		"scheduled_time": d.Get("scheduled_time"),
+		"target_infos":   buildAppScheduleTaskTargetInfos(d.Get("target_infos").(*schema.Set)),
+		// Optional parameters.
+		"day_interval":         utils.ValueIgnoreEmpty(d.Get("day_interval")),
+		"week_list":            d.Get("week_list"),
+		"month_list":           d.Get("month_list"),
+		"date_list":            d.Get("date_list"),
+		"time_zone":            d.Get("time_zone"),
+		"scheduled_date":       d.Get("scheduled_date"),
+		"expire_time":          d.Get("expire_time"),
+		"description":          d.Get("description"),
+		"schedule_task_policy": buildAppScheduleTaskPolicy(d.Get("schedule_task_policy").([]interface{})),
+		"is_enable":            d.Get("is_enable"),
+	}
+}
+
+func updateAppScheduleTask(client *golangsdk.ServiceClient, scheduleTaskId string, params map[string]interface{}) error {
+	updatePath := "v1/{project_id}/schedule-task/{task_id}"
+	updatePath = client.Endpoint + updatePath
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{task_id}", scheduleTaskId)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(params),
+	}
+	_, err := client.Request("PATCH", updatePath, &updateOpt)
+	return err
+}
+
+func resourceAppScheduleTaskUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	scheduleTaskId := d.Id()
+	client, err := cfg.NewServiceClient("appstream", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	err = updateAppScheduleTask(client, scheduleTaskId, buildUpdateAppScheduleTaskBodyParams(d))
+	if err != nil {
+		return diag.Errorf("error updating Workspace APP schedule task (%s): %s", scheduleTaskId, err)
+	}
+
+	return resourceAppScheduleTaskRead(ctx, d, meta)
+}
+
+func resourceAppScheduleTaskDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		deletePath     = "v1/{project_id}/schedule-task/{task_id}"
+		scheduleTaskId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("appstream", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	deletePath = client.Endpoint + deletePath
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{task_id}", scheduleTaskId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting Workspace APP schedule task (%s)", scheduleTaskId))
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource(`huaweicloud_workspace_app_schedule_task`) to manage schedule task.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccResourceAppScheduleTask_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceAppScheduleTask_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceAppScheduleTask_basic
=== PAUSE TestAccResourceAppScheduleTask_basic
=== CONT  TestAccResourceAppScheduleTask_basic
--- PASS: TestAccResourceAppScheduleTask_basic (57.40s)
PASS
coverage: 7.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 57.492s coverage: 7.0% of statements in ./huaweicloud/services/workspace
```

<img width="1032" height="518" alt="image" src="https://github.com/user-attachments/assets/c4479ca2-969f-494b-804f-12c850dade81" />



* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found   
![image](https://github.com/user-attachments/assets/a1524a46-153e-45d3-8718-056ab6fb28f4)


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found   
    <img width="1708" height="948" alt="image" src="https://github.com/user-attachments/assets/b5a2ceb9-65e5-44de-b51c-d77c625e44de" />


