### PR TITLE
feat(cbr): new resource to set vault resource

### DIFF
--- a/docs/resources/cbr_vault_set_resource.md
+++ b/docs/resources/cbr_vault_set_resource.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbr_vault_set_resource"
+description: |-
+  Using this resource to configure resource backup settings for a CBR vault within HuaweiCloud.
+---
+
+# huaweicloud_cbr_vault_set_resource
+
+Using this resource to configure resource backup settings for a CBR vault within HuaweiCloud.
+
+-> This resource is only a one-time action resource to configure resource backup settings. Deleting this resource will
+not change the backup settings of the resources, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "vault_id" {}
+variable "resource_ids" {
+  type = list(string)
+}
+variable "action" {}
+
+resource "huaweicloud_cbr_vault_set_resource" "test" {
+  vault_id     = var.vault_id
+  resource_ids = var.resource_ids
+  action       = var.action
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource. If omitted,
+  the provider-level region will be used. Changing this will create new resource.
+
+* `vault_id` - (Required, String, NonUpdatable) Specifies the ID of the CBR vault to configure resource backup settings.
+
+* `resource_ids` - (Required, List, NonUpdatable) Specifies the list of resource IDs for which to configure backup settings.
+
+* `action` - (Required, String, NonUpdatable) Specifies the action to configure backup settings. Valid values:
+  + **suspend**: Enable backup for the resources.
+  + **unsuspend**: Disable backup for the resources.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The UUID of the resource.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1772,6 +1772,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbr_vault_change_charge_mode": cbr.ResourceVaultChangeChargeMode(),
 			"huaweicloud_cbr_change_order":             cbr.ResourceChangeOrder(),
 			"huaweicloud_cbr_update_backup":            cbr.ResourceUpdateBackup(),
+			"huaweicloud_cbr_vault_set_resource":       cbr.ResourceVaultSetResource(),
 
 			"huaweicloud_cbh_instance":                   cbh.ResourceCBHInstance(),
 			"huaweicloud_cbh_ha_instance":                cbh.ResourceCBHHAInstance(),

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_set_resource_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_set_resource_test.go
@@ -1,0 +1,66 @@
+package cbr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceVaultSetResource_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceVaultSetResource_basic(name),
+			},
+		},
+	})
+}
+
+func testResourceVaultSetResource_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name              = "%[1]s"
+  size              = 20
+  description       = "test description"
+  volume_type       = "GPSSD"
+  device_type       = "SCSI"
+  multiattach       = false
+}
+
+resource "huaweicloud_cbr_vault" "test" {
+  name            = "%[1]s"
+  type            = "disk"
+  protection_type = "backup"
+  size            = 50
+
+  resources {
+    includes = [huaweicloud_evs_volume.test.id]
+  }
+}
+`, name)
+}
+
+func testResourceVaultSetResource_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cbr_vault_set_resource" "test" {
+  vault_id     = huaweicloud_cbr_vault.test.id
+  resource_ids = [huaweicloud_evs_volume.test.id]
+  action       = "suspend"
+}
+`, testResourceVaultSetResource_base(name))
+}

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault_set_resource.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault_set_resource.go
@@ -1,0 +1,131 @@
+package cbr
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableVaultSetResourceParams = []string{
+	"vault_id",
+	"resource_ids",
+	"action",
+}
+
+// @API CBR PUT /v3/{project_id}/vaults/{vault_id}/set-resources
+func ResourceVaultSetResource() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVaultSetResourceCreate,
+		ReadContext:   resourceVaultSetResourceRead,
+		UpdateContext: resourceVaultSetResourceUpdate,
+		DeleteContext: resourceVaultSetResourceDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableVaultSetResourceParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level
+region will be used.`,
+			},
+			"vault_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies ID of the CBR vault to configure resource backup settings.`,
+			},
+			"resource_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Specifies the list of resource IDs for which to configure backup settings.`,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the action to configure backup settings.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildVaultResourceBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"resource_ids": d.Get("resource_ids"),
+		"action":       d.Get("action"),
+	}
+}
+
+func resourceVaultSetResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v3/{project_id}/vaults/{vault_id}/set-resources"
+		region  = cfg.GetRegion(d)
+		vaultId = d.Get("vault_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("cbr", region)
+	if err != nil {
+		return diag.Errorf("error creating CBR client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{vault_id}", vaultId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildVaultResourceBodyParams(d),
+	}
+
+	_, err = client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error configuring resource backup settings: %s", err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(resourceId)
+
+	return resourceVaultSetResourceRead(ctx, d, meta)
+}
+
+func resourceVaultSetResourceRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceVaultSetResourceUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceVaultSetResourceDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to configure resource backup settings for a CBR vault.
+Deleting this resource will not change the backup settings of the resources, but will only remove the resource
+information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to set vault resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cbr -f TestAccResourceVaultSetResource_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccResourceVaultSetResource_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceVaultSetResource_basic
=== PAUSE TestAccResourceVaultSetResource_basic
=== CONT  TestAccResourceVaultSetResource_basic
--- PASS: TestAccResourceVaultSetResource_basic (57.63s)
PASS
coverage: 10.6% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       57.722s coverage: 10.6% of statements in ./huaweicloud/services/cbr
```
<img width="1258" height="114" alt="image" src="https://github.com/user-attachments/assets/570af974-e1c0-43ce-a4ca-cfc1405e3c2e" />


* [X] Documentation updated.
* [X] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
