### PR TITLE
refactor(RDS): refactor rds read replica instance resource

### DIFF
--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_read_replica_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_read_replica_instance_test.go
@@ -291,7 +291,7 @@ resource "huaweicloud_rds_read_replica_instance" "test" {
   flavor              = data.huaweicloud_rds_flavors.replica.flavors[0].name
   primary_instance_id = huaweicloud_rds_instance.test.id
   availability_zone   = data.huaweicloud_availability_zones.test.names[0]
-  security_group_id   = huaweicloud_networking_secgroup.test.id
+  security_group_id   = data.huaweicloud_networking_secgroup.test.id
   ssl_enable          = true
   maintain_begin      = "06:00"
   maintain_end        = "09:00"
@@ -333,7 +333,7 @@ resource "huaweicloud_rds_read_replica_instance" "test" {
   flavor              = data.huaweicloud_rds_flavors.replica.flavors[0].name
   primary_instance_id = huaweicloud_rds_instance.test.id
   availability_zone   = data.huaweicloud_availability_zones.test.names[0]
-  security_group_id   = huaweicloud_networking_secgroup.test.id
+  security_group_id   = data.huaweicloud_networking_secgroup.test.id
 
   db {
     port = 8889

--- a/huaweicloud/services/rds/common.go
+++ b/huaweicloud/services/rds/common.go
@@ -276,7 +276,7 @@ func updateRdsInstanceField(ctx context.Context, d *schema.ResourceData, client 
 	}
 
 	updateRespBody, err := utils.FlattenResponse(res.(*http.Response))
-	if err != nil {
+	if err != nil && err.Error() != "EOF" {
 		return nil, err
 	}
 	if params.checkJobExpression == "" && params.checkOrderExpression == "" && !params.isWaitInstanceReady {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  refactor rds read replica instance resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  refactor rds read replica instance resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccReadReplicaInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccReadReplicaInstance_ -timeout 360m -parallel 4
=== RUN   TestAccReadReplicaInstance_basic
=== PAUSE TestAccReadReplicaInstance_basic
=== RUN   TestAccReadReplicaInstance_prePaid
=== PAUSE TestAccReadReplicaInstance_prePaid
=== CONT  TestAccReadReplicaInstance_basic
=== CONT  TestAccReadReplicaInstance_prePaid
--- PASS: TestAccReadReplicaInstance_prePaid (1843.92s)
--- PASS: TestAccReadReplicaInstance_basic (2366.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2366.655s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
