### PR TITLE
fix(modelarts): fix some issues for resource pool

### DIFF
--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool.go
@@ -46,7 +46,7 @@ func ResourceModelartsResourcePool() *schema.Resource {
 		UpdateContext: resourceModelartsResourcePoolUpdate,
 		DeleteContext: resourceModelartsResourcePoolDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceResourcePoolImport,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(90 * time.Minute),
@@ -1892,7 +1892,8 @@ func buildUpdateResourcePoolResourceRootVolume(resourceElem cty.Value, oldResour
 }
 
 func buildUpdateResourcePoolResourceDataVolumes(resourceElem cty.Value, oldResource interface{}) interface{} {
-	if !isRawConfigListExist(resourceElem, "data_volumes") {
+	raw := getRawConfigSetValueByKey(resourceElem, "data_volumes")
+	if raw == nil {
 		return buildCreateResourcePoolResourcesDataVolumes(utils.PathSearch("data_volumes", oldResource,
 			schema.NewSet(schema.HashString, nil)).(*schema.Set))
 	}
@@ -2260,4 +2261,8 @@ func deleteResourcePoolWaitingForStateCompleted(ctx context.Context, d *schema.R
 	}
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err
+}
+
+func resourceResourcePoolImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	return []*schema.ResourceData{d}, d.Set("resources_order_origin", nil)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fixed the following two issues：
1. Resources were changed due to not setting resources_order_origin during import.
2. `data_volumes` were not obtained due to class assertion errors during update.
<img width="1181" height="335" alt="image" src="https://github.com/user-attachments/assets/4103fd80-2f45-452c-93b5-58a1eab062f4" />


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
