### PR TITLE
feat(EVS): add one time resource to retype volume

### DIFF
--- a/docs/resources/evs_volume_retype.md
+++ b/docs/resources/evs_volume_retype.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Elastic Volume Service (EVS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_evs_volume_retype"
+description: |-
+  Manages an EVS volume retype resource within HuaweiCloud.
+---
+
+# huaweicloud_evs_volume_retype
+
+Manages an EVS volume retype resource within HuaweiCloud.
+
+-> 1. The current resource is a one-time resource, and destroying this resource will not recover the volume type,
+but will only remove the resource information from the tfstate file.<br>2. The `new_type` parameters of this resource
+will affect other resource with `volume_type` parameter, such as `huaweicloud_evs_volume`. You can handle the changes
+in the affected resource by `lifecycle.ignore_changes`.
+
+## Example Usage
+
+```hcl
+variable "volume_id" {}
+variable "snapshot_id" {}
+
+resource "huaweicloud_evs_volume_retype" "test" {
+  volume_id   = var.volume_id
+  snapshot_id = var.snapshot_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `volume_id` - (Required, String, NonUpdatable) Specifies the target volume ID for snapshot rollback.
+  Changing this parameter will create a new resource.
+
+* `new_type` - (Required, String, NonUpdatable) Specifies the cloud disk type which change to. Possible values are:
+  + **SAS**: High I/O type.
+  + **SSD**: Ultra-high I/O type.
+  + **GPSSD**: General purpose SSD type.
+  + **ESSD**: Extreme SSD type.
+  + **GPSSD2**: General purpose SSD V2 type.
+  + **ESSD2**: Extreme SSD V2 type.
+
+  -> The field has the following restrictions:
+  <br/>1. When the specified cloud disk type does not exist in the availability_zone, the cloud disk type change
+  fails.
+  <br/>2. When the original type is SAS, it can be changed to any of the other types mentioned above.
+  <br/>3. When the original type includes SSD, it can be retyped to other types including SSD, but cannot be
+  retyped to SAS.
+
+* `is_auto_pay` - (Optional, String, NonUpdatable) Specifies whether to pay immediately. This parameter is valid only
+  when chargingMode is set to prePaid. Possible values are:
+  + **true**: An order is immediately paid from the account balance.
+  + **false**: An order is not paid immediately after being created.
+
+* `iops` - (Optional, String, NonUpdatable) Specifies the new maximum IOPS of the disk. This parameter is supported
+  only for general purpose SSD V2 and extreme SSD V2 disks.
+
+* `throughput` - (Optional, String, NonUpdatable) Specifies the new maximum throughput of the disk, in the unit of
+  MiB/s. This parameter is supported only for general purpose SSD V2 disks.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2126,6 +2126,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_evs_volume":                     evs.ResourceEvsVolume(),
 			"huaweicloud_evs_snapshot_rollback":          evs.ResourceSnapshotRollBack(),
 			"huaweicloud_evs_volume_metadata":            evs.ResourceVolumeMetadata(),
+			"huaweicloud_evs_volume_retype":              evs.ResourceVolumeRetype(),
 			"huaweicloud_evs_volume_transfer":            evs.ResourceVolumeTransfer(),
 			"huaweicloud_evsv3_volume_transfer":          evs.ResourceV3VolumeTransfer(),
 			"huaweicloud_evs_volume_transfer_accepter":   evs.ResourceVolumeTransferAccepter(),

--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_retype_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_retype_test.go
@@ -1,0 +1,39 @@
+package evs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccEvsVolumeRetype_basic(t *testing.T) {
+	// Avoid CheckDestroy because this resource is a one-time action resource and there is nothing in the destroy
+	// method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test needs to create an EVS SAS volume before running.
+			acceptance.TestAccPreCheckEVSVolumeID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// One-time action resource do not need to be checked and no processing is performed in the Read method.
+				Config: testAccEvsVolumeRetype_basic(),
+			},
+		},
+	})
+}
+
+func testAccEvsVolumeRetype_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_evs_volume_retype" "test1" {
+  volume_id = "%s"
+  new_type  = "ESSD"
+}
+`, acceptance.HW_EVS_VOLUME_ID)
+}

--- a/huaweicloud/services/evs/resource_huaweicloud_evs_volume_retype.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_volume_retype.go
@@ -1,0 +1,152 @@
+package evs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var volumeRetypeNonUpdatableParams = []string{
+	"volume_id",
+	"is_auto_pay",
+	"new_type",
+	"iops",
+	"throughput",
+}
+
+// @API EVS POST /v2/{project_id}/volumes/{volume_id}/retype
+func ResourceVolumeRetype() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVolumeRetypeCreate,
+		ReadContext:   resourceVolumeRetypeRead,
+		UpdateContext: resourceVolumeRetypeUpdate,
+		DeleteContext: resourceVolumeRetypeDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(volumeRetypeNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"new_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"is_auto_pay": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"iops": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"throughput": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildVolumeRetypeBodyParams(d *schema.ResourceData) map[string]interface{} {
+	osRetype := map[string]interface{}{}
+	if v, ok := d.GetOk("new_type"); ok {
+		osRetype["new_type"] = v
+	}
+	if v, ok := d.GetOk("iops"); ok {
+		osRetype["iops"] = v
+	}
+	if v, ok := d.GetOk("throughput"); ok {
+		osRetype["throughput"] = v
+	}
+	bodyParams := map[string]interface{}{
+		"os-retype": osRetype,
+	}
+	bssParam := map[string]interface{}{}
+	if v, ok := d.GetOk("is_auto_pay"); ok {
+		bssParam["isAutoPay"] = v
+	}
+	if len(bssParam) > 0 {
+		bodyParams["bssParam"] = bssParam
+	}
+
+	return bodyParams
+}
+
+func resourceVolumeRetypeCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		product  = "evs"
+		httpUrl  = "v2/{project_id}/volumes/{volume_id}/retype"
+		volumeID = d.Get("volume_id").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	url := client.Endpoint + httpUrl
+	url = strings.ReplaceAll(url, "{project_id}", client.ProjectID)
+	url = strings.ReplaceAll(url, "{volume_id}", volumeID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildVolumeRetypeBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", url, &opt)
+	if err != nil {
+		return diag.Errorf("failed to retype volume: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	return nil
+}
+
+func resourceVolumeRetypeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceVolumeRetypeUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceVolumeRetypeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to retype the volume.  Deleting this resource will
+not reset the volume type, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add one time resource to retype volume
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add one time resource to retype volume
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
<img width="1751" height="275" alt="image" src="https://github.com/user-attachments/assets/c09d939b-a01a-4f2f-9dea-c431385eccc0" />
<img width="1220" height="46" alt="image" src="https://github.com/user-attachments/assets/62ad35dc-945d-439b-a10f-4ffd3d6a1150" />


* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
