### PR TITLE
docs: Fix misleading description in cce_node_pool_scale.md

### DIFF
--- a/docs/resources/cce_node_pool_scale.md
+++ b/docs/resources/cce_node_pool_scale.md
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `desired_node_count` - (Required, Int, NonUpdatable) Specifies the number of desired nodes.
 
-* `scale_groups` - (Required, List, NonUpdatable) Specifies the IDs of scale groups to scale.
+* `scale_groups` - (Required, List, NonUpdatable) Specifies the names of scale groups to scale.
   **default** indicates the default group.
 
 * `scalable_checking` - (Optional, String, NonUpdatable) Specifies the scalable checking.


### PR DESCRIPTION
**What this PR does / why we need it**: According to [the CCE API document](https://support.huaweicloud.com/intl/en-us/api-cce/ScaleNodePool.html#section3), names should be passed to the `scale_groups`, not IDs.

**Which issue this PR fixes**: fixes #7279