### PR TITLE
feat(workspace): supports new data source to query VNC remote information

### DIFF
--- a/docs/data-sources/workspace_app_vnc_remote.md
+++ b/docs/data-sources/workspace_app_vnc_remote.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_vnc_remote"
+description: |-
+  Use this data source to get the VNC remote information of a Workspace APP server within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_vnc_remote
+
+Use this data source to get the VNC remote information of a Workspace APP server within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "server_id" {}
+
+data "huaweicloud_workspace_app_vnc_remote" "test" {
+  server_id = var.server_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the APP server is located.
+  If omitted, the provider-level region will be used.
+
+* `server_id` - (Required, String) Specifies the ID of the APP server to get VNC remote information.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `url` - The remote login console address.
+
+* `type` - The login type.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1556,6 +1556,22 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_workload_queue_associated_users": dws.DataSourceDwsWorkloadQueueAssociatedUsers(),
 			"huaweicloud_dws_workload_queues":                 dws.DataSourceWorkloadQueues(),
 
+			// Workspace
+			"huaweicloud_workspace_available_ip_number":    workspace.DataSourceAvailableIpNumber(),
+			"huaweicloud_workspace_desktops":               workspace.DataSourceDesktops(),
+			"huaweicloud_workspace_desktop_connections":    workspace.DataSourceDesktopConnections(),
+			"huaweicloud_workspace_desktop_remote_console": workspace.DataSourceDesktopRemoteConsole(),
+			"huaweicloud_workspace_desktop_tags":           workspace.DataSourceDesktopTags(),
+			"huaweicloud_workspace_desktop_tags_filter":    workspace.DataSourceDesktopTagsFilter(),
+			"huaweicloud_workspace_desktop_pools":          workspace.DataSourceDesktopPools(),
+			"huaweicloud_workspace_hour_packages":          workspace.DataSourceHourPackages(),
+			"huaweicloud_workspace_flavors":                workspace.DataSourceWorkspaceFlavors(),
+			"huaweicloud_workspace_policy_groups":          workspace.DataSourcePolicyGroups(),
+			"huaweicloud_workspace_service":                workspace.DataSourceService(),
+			"huaweicloud_workspace_tags":                   workspace.DataSourceTags(),
+			"huaweicloud_workspace_volume_products":        workspace.DataSourceVolumeProducts(),
+
+			// Workspace APP
 			"huaweicloud_workspace_app_available_volumes":         workspace.DataSourceAppAvailableVolumes(),
 			"huaweicloud_workspace_app_center_availability_zones": workspace.DataSourceAvailabilityZones(),
 			"huaweicloud_workspace_app_flavors":                   workspace.DataSourceAppFlavors(),
@@ -1571,19 +1587,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_server_group_status":       workspace.DataSourceAppServerGroupStatus(),
 			"huaweicloud_workspace_app_session_types":             workspace.DataSourceSessionTypes(),
 			"huaweicloud_workspace_app_storage_policies":          workspace.DataSourceAppStoragePolicies(),
-			"huaweicloud_workspace_available_ip_number":           workspace.DataSourceAvailableIpNumber(),
-			"huaweicloud_workspace_desktops":                      workspace.DataSourceDesktops(),
-			"huaweicloud_workspace_desktop_connections":           workspace.DataSourceDesktopConnections(),
-			"huaweicloud_workspace_desktop_remote_console":        workspace.DataSourceDesktopRemoteConsole(),
-			"huaweicloud_workspace_desktop_tags":                  workspace.DataSourceDesktopTags(),
-			"huaweicloud_workspace_desktop_tags_filter":           workspace.DataSourceDesktopTagsFilter(),
-			"huaweicloud_workspace_desktop_pools":                 workspace.DataSourceDesktopPools(),
-			"huaweicloud_workspace_hour_packages":                 workspace.DataSourceHourPackages(),
-			"huaweicloud_workspace_flavors":                       workspace.DataSourceWorkspaceFlavors(),
-			"huaweicloud_workspace_policy_groups":                 workspace.DataSourcePolicyGroups(),
-			"huaweicloud_workspace_service":                       workspace.DataSourceService(),
-			"huaweicloud_workspace_tags":                          workspace.DataSourceTags(),
-			"huaweicloud_workspace_volume_products":               workspace.DataSourceVolumeProducts(),
+			"huaweicloud_workspace_app_vnc_remote":                workspace.DataSourceAppVncRemote(),
 
 			"huaweicloud_cpts_projects": cpts.DataSourceCptsProjects(),
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -282,6 +282,7 @@ var (
 	HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID         = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID")
 	HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID")
 	HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_SPEC_CODE  = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_SPEC_CODE")
+	HW_WORKSPACE_APP_SERVER_ID                     = os.Getenv("HW_WORKSPACE_APP_SERVER_ID")
 	HW_WORKSPACE_OU_NAME                           = os.Getenv("HW_WORKSPACE_OU_NAME")
 	HW_WORKSPACE_APP_FILE_NAME                     = os.Getenv("HW_WORKSPACE_APP_FILE_NAME")
 	HW_WORKSPACE_USER_NAMES                        = os.Getenv("HW_WORKSPACE_USER_NAMES")
@@ -1940,6 +1941,13 @@ func TestAccPreCheckWorkspaceAppImageSpecCode(t *testing.T) {
 func TestAccPreCheckWorkspaceAppServerGroupId(t *testing.T) {
 	if HW_WORKSPACE_APP_SERVER_GROUP_ID == "" {
 		t.Skip("HW_WORKSPACE_APP_SERVER_GROUP_ID must be set for Workspace APP acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckWorkspaceAppServerID(t *testing.T) {
+	if HW_WORKSPACE_APP_SERVER_ID == "" {
+		t.Skip("HW_WORKSPACE_APP_SERVER_ID must be set for Workspace APP acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_vnc_remote_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_vnc_remote_test.go
@@ -1,0 +1,48 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAppVncRemote_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_workspace_app_vnc_remote.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAppVncRemote_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "url", regexp.MustCompile(`^https?://.*$`)),
+					resource.TestCheckOutput("is_type_valid", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAppVncRemote_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_app_vnc_remote" "test" {
+  server_id = "%[1]s"
+}
+
+output "is_type_valid" {
+  value = strcontains(data.huaweicloud_workspace_app_vnc_remote.test.type, "vnc")
+}
+`, acceptance.HW_WORKSPACE_APP_SERVER_ID)
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_vnc_remote.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_vnc_remote.go
@@ -1,0 +1,111 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/app-servers/{server_id}/actions/vnc
+func DataSourceAppVncRemote() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppVncRemoteRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the APP server is located.`,
+			},
+			// Required parameters.
+			"server_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the APP server to get VNC remote information.`,
+			},
+			// Attributes.
+			"url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The remote login console address.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The login type.`,
+			},
+			// Internal parameters.
+			"protocol": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`The login protocol.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func getAppVncRemote(client *golangsdk.ServiceClient, serverId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/app-servers/{server_id}/actions/vnc"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{server_id}", serverId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func dataSourceAppVncRemoteRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	serverId := d.Get("server_id").(string)
+	resp, err := getAppVncRemote(client, serverId)
+	if err != nil {
+		return diag.Errorf("error getting VNC remote information: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("url", utils.PathSearch("url", resp, nil)),
+		d.Set("type", utils.PathSearch("type", resp, nil)),
+		d.Set("protocol", utils.PathSearch("protocol", resp, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new data source that used to query the VNC remote information.
<img width="1243" height="1002" alt="image" src="https://github.com/user-attachments/assets/5fa82aa5-93f4-4433-9495-a49cf98f9b11" />

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new resource to query VNC remote information
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataSourceAppVncRemote_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataSourceAppVncRemote_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAppVncRemote_basic
=== PAUSE TestAccDataSourceAppVncRemote_basic
=== CONT  TestAccDataSourceAppVncRemote_basic
--- PASS: TestAccDataSourceAppVncRemote_basic (15.17s)
PASS
coverage: 2.6% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 15.245s coverage: 2.6% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
