### PR TITLE
feat(workspace/app): add new data source to get schedule tasks

### DIFF
--- a/docs/data-sources/workspace_app_schedule_tasks.md
+++ b/docs/data-sources/workspace_app_schedule_tasks.md
@@ -1,0 +1,104 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_schedule_tasks"
+description: |-
+  Use this data source to get the schedule task list of the Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_schedule_tasks
+
+Use this data source to get the schedule task list of the Workspace APP within HuaweiCloud.
+
+## Example Usage
+
+### Query all schedule tasks
+
+```hcl
+data "huaweicloud_workspace_app_schedule_tasks" "test" {}
+```
+
+### Query schedule task by specified name
+
+```hcl
+variable "task_name" {}
+
+data "huaweicloud_workspace_app_schedule_tasks" "test" {
+  task_name = var.task_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the schedule tasks are located.  
+  If omitted, the provider-level region will be used.
+
+* `task_name` - (Optional, String) Specifies the name of the schedule task.
+
+* `task_type` - (Optional, String) Specifies the type of the schedule task.  
+  The valid values are as follows:
+  + **RESTART_SERVER**
+  + **START_SERVER**
+  + **STOP_SERVER**
+  + **REINSTALL_OS**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tasks` - All schedule tasks that match the filter parameters.  
+  The [tasks](#data_schedule_tasks) structure is documented below.
+
+<a name="data_schedule_tasks"></a>
+The `tasks` block supports:
+
+* `id` - The ID of the schedule task.
+
+* `task_name` - The name of the schedule task.
+
+* `scheduled_type` - The execution cycle of the schedule task.
+  + **FIXED_TIME**
+  + **DAY**
+  + **WEEK**
+  + **MONTH**
+
+* `task_type` - The type of the schedule task.
+
+* `scheduled_time` - The scheduled time of the schedule task.  
+  The format is `HH:MM:SS`.
+
+* `day_interval` - The interval in days of the schedule task.
+
+* `week_list` - The days of the week of the schedule task.
+
+* `month_list` - The month of the schedule task.
+
+* `date_list` - The days of the month of the schedule task.
+
+* `scheduled_date` - The fixed time of the schedule task.  
+  The format is `YYYY-MM-DD`.
+
+* `time_zone` - The time zone of the schedule task.
+
+* `expire_time` - The expire time of the schedule task.
+
+* `description` - The description of the schedule task.
+
+* `is_enable` - Whether the schedule task is enabled.
+
+* `task_cron` - The cron expression of the schedule task.
+
+* `next_execution_time` - The next execution time of the schedule task.
+
+* `created_at` - The create time of the schedule task, in RFC3339 format.
+
+* `updated_at` - The latest update time of the schedule task, in RFC3339 format.
+
+* `last_status` - The last execution status of the schedule task.
+  + **RUNNING**
+  + **SUCCESS**
+  + **FAILED**

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1593,6 +1593,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_image_servers":                   workspace.DataSourceWorkspaceAppImageServers(),
 			"huaweicloud_workspace_app_nas_storages":                    workspace.DataSourceAppNasStorages(),
 			"huaweicloud_workspace_app_publishable_apps":                workspace.DataSourceWorkspaceAppPublishableApps(),
+			"huaweicloud_workspace_app_schedule_tasks":                  workspace.DataSourceAppScheduleTasks(),
 			"huaweicloud_workspace_app_schedule_task_future_executions": workspace.DataSourceAppScheduleTaskFutureExecutions(),
 			"huaweicloud_workspace_app_servers":                         workspace.DataSourceAppServers(),
 			"huaweicloud_workspace_app_server_groups":                   workspace.DataSourceAppServerGroups(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_schedule_tasks_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_schedule_tasks_test.go
@@ -1,0 +1,232 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAppScheduleTasks_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		dataSourceName = "data.huaweicloud_workspace_app_schedule_tasks.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byTaskName   = "data.huaweicloud_workspace_app_schedule_tasks.filter_by_task_name"
+		dcByTaskName = acceptance.InitDataSourceCheck(byTaskName)
+
+		byWeekTaskName   = "data.huaweicloud_workspace_app_schedule_tasks.filter_by_week_task_name"
+		dcByWeekTaskName = acceptance.InitDataSourceCheck(byWeekTaskName)
+
+		byMonthTaskName   = "data.huaweicloud_workspace_app_schedule_tasks.filter_by_month_task_name"
+		dcByMonthTaskName = acceptance.InitDataSourceCheck(byMonthTaskName)
+
+		byFixedTimeTaskName   = "data.huaweicloud_workspace_app_schedule_tasks.filter_by_fixed_time_task_name"
+		dcByFixedTimeTaskName = acceptance.InitDataSourceCheck(byFixedTimeTaskName)
+
+		byTaskType   = "data.huaweicloud_workspace_app_schedule_tasks.filter_by_task_type"
+		dcByTaskType = acceptance.InitDataSourceCheck(byTaskType)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAppScheduleTasks_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "tasks.#", regexp.MustCompile(`^[0-9]+$`)),
+					dcByTaskName.CheckResourceExists(),
+					resource.TestCheckOutput("is_task_name_filter_useful", "true"),
+					resource.TestCheckResourceAttr(byTaskName, "tasks.0.scheduled_type", "DAY"),
+					resource.TestCheckResourceAttr(byTaskName, "tasks.0.is_enable", "true"),
+					resource.TestCheckResourceAttr(byTaskName, "tasks.0.time_zone", "Asia/Shanghai"),
+					resource.TestCheckResourceAttrPair(byTaskName, "tasks.0.scheduled_time",
+						"huaweicloud_workspace_app_schedule_task.with_day", "scheduled_time"),
+					resource.TestCheckResourceAttrPair(byTaskName, "tasks.0.day_interval",
+						"huaweicloud_workspace_app_schedule_task.with_day", "day_interval"),
+					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.id"),
+					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.expire_time"),
+					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.description"),
+					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.next_execution_time"),
+					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.task_cron"),
+					resource.TestMatchResourceAttr(byTaskName, "tasks.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(byTaskName, "tasks.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					dcByWeekTaskName.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byWeekTaskName, "tasks.0.scheduled_type", "WEEK"),
+					resource.TestCheckResourceAttrSet(byWeekTaskName, "tasks.0.week_list"),
+					dcByMonthTaskName.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byMonthTaskName, "tasks.0.scheduled_type", "MONTH"),
+					resource.TestCheckResourceAttrSet(byMonthTaskName, "tasks.0.month_list"),
+					resource.TestCheckResourceAttrSet(byMonthTaskName, "tasks.0.date_list"),
+					dcByFixedTimeTaskName.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byFixedTimeTaskName, "tasks.0.scheduled_type", "FIXED_TIME"),
+					resource.TestCheckResourceAttrSet(byFixedTimeTaskName, "tasks.0.scheduled_date"),
+					dcByTaskType.CheckResourceExists(),
+					resource.TestCheckOutput("is_task_type_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAppScheduleTasks_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_workspace_app_schedule_tasks" "test" {
+  depends_on = [huaweicloud_workspace_app_schedule_task.with_day]
+}
+
+locals {
+  task_name = huaweicloud_workspace_app_schedule_task.with_day.task_name
+  task_type = huaweicloud_workspace_app_schedule_task.with_day.task_type
+}
+
+# Exact match by task name.
+data "huaweicloud_workspace_app_schedule_tasks" "filter_by_task_name" {
+  task_name = local.task_name
+
+  depends_on = [huaweicloud_workspace_app_schedule_task.with_day]
+}
+
+data "huaweicloud_workspace_app_schedule_tasks" "filter_by_week_task_name" {
+  task_name = huaweicloud_workspace_app_schedule_task.with_week.task_name
+
+  depends_on = [huaweicloud_workspace_app_schedule_task.with_week]
+}
+
+data "huaweicloud_workspace_app_schedule_tasks" "filter_by_month_task_name" {
+  task_name = huaweicloud_workspace_app_schedule_task.with_month.task_name
+
+  depends_on = [huaweicloud_workspace_app_schedule_task.with_month]
+}
+
+data "huaweicloud_workspace_app_schedule_tasks" "filter_by_fixed_time_task_name" {
+  task_name = huaweicloud_workspace_app_schedule_task.with_fixed_time.task_name
+
+  depends_on = [huaweicloud_workspace_app_schedule_task.with_fixed_time]
+}
+
+locals {
+  task_name_filter_result = [for v in data.huaweicloud_workspace_app_schedule_tasks.filter_by_task_name.tasks : v.task_name == local.task_name]
+}
+
+output "is_task_name_filter_useful" {
+  value = length(local.task_type_filter_result) > 0 && alltrue(local.task_type_filter_result)
+}
+
+# Filter by task type.
+data "huaweicloud_workspace_app_schedule_tasks" "filter_by_task_type" {
+  task_type = local.task_type
+
+  depends_on = [huaweicloud_workspace_app_schedule_task.with_day]
+}
+
+locals {
+  task_type_filter_result = [for v in data.huaweicloud_workspace_app_schedule_tasks.filter_by_task_type.tasks : v.task_type == local.task_type]
+}
+
+output "is_task_type_filter_useful" {
+  value = length(local.task_type_filter_result) > 0 && alltrue(local.task_type_filter_result)
+}
+`, testAccResourceAppScheduleTasks_base(name))
+}
+
+func testAccResourceAppScheduleTasks_base(name string) string {
+	scheduledTime := time.Now().AddDate(0, 1, 0)
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_service" "test" {}
+
+resource "huaweicloud_workspace_app_server_group" "test" {
+  name             = "%[1]s"
+  os_type          = "Windows"
+  flavor_id        = "%[2]s"
+  vpc_id           = data.huaweicloud_workspace_service.test.vpc_id
+  subnet_id        = try(data.huaweicloud_workspace_service.test.network_ids[0], "")
+  system_disk_type = "SATA"
+  system_disk_size = 80
+  is_vdi           = true
+  image_id         = "%[3]s"
+  image_type       = "gold"
+  image_product_id = "%[4]s"
+}
+
+resource "huaweicloud_workspace_app_schedule_task" "with_day" {
+  task_name      = "%[1]s-day"
+  task_type      = "RESTART_SERVER"
+  scheduled_time = "09:00:00"
+  scheduled_type = "DAY"
+  day_interval   = 2
+  expire_time    = "%[5]s"
+  description    = "Created by terraform script"
+
+  target_infos {
+    target_type = "SERVER_GROUP"
+    target_id   = huaweicloud_workspace_app_server_group.test.id
+  }
+}
+
+resource "huaweicloud_workspace_app_schedule_task" "with_week" {
+  task_name      = "%[1]s-week"
+  task_type      = "RESTART_SERVER"
+  scheduled_time = "09:00:00"
+  scheduled_type = "WEEK"
+  week_list      = "7,1"
+  description    = "Created by terraform script"
+
+  target_infos {
+    target_type = "SERVER_GROUP"
+    target_id   = huaweicloud_workspace_app_server_group.test.id
+  }
+}
+
+resource "huaweicloud_workspace_app_schedule_task" "with_month" {
+  task_name      = "%[1]s-month"
+  task_type      = "RESTART_SERVER"
+  scheduled_time = "09:00:00"
+  scheduled_type = "MONTH"
+  month_list     = "%[6]s"
+  date_list      = "24,28"
+  description    = "Created by terraform script"
+  is_enable      = false
+
+  target_infos {
+    target_type = "SERVER_GROUP"
+    target_id   = huaweicloud_workspace_app_server_group.test.id
+  }
+}
+
+resource "huaweicloud_workspace_app_schedule_task" "with_fixed_time" {
+  task_name      = "%[1]s-fixed-time"
+  task_type      = "RESTART_SERVER"
+  scheduled_time = "09:00:00"
+  scheduled_type = "FIXED_TIME"
+  scheduled_date = "%[7]s"
+  description    = "Created by terraform script"
+
+  target_infos {
+    target_type = "SERVER_GROUP"
+    target_id   = huaweicloud_workspace_app_server_group.test.id
+  }
+}
+`, name,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID,
+		scheduledTime.Format("2006-01-02T15:04:05Z"),
+		fmt.Sprintf("%d", scheduledTime.Month()),
+		scheduledTime.Format("2006-01-02"))
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_schedule_tasks.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_schedule_tasks.go
@@ -1,0 +1,261 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/schedule-task
+func DataSourceAppScheduleTasks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppScheduleTasksRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The region where the schedule tasks are located.",
+			},
+			"task_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the schedule task.",
+			},
+			"task_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The type of the schedule task.",
+			},
+			"tasks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the schedule task.",
+						},
+						"task_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the schedule task.",
+						},
+						"task_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of the schedule task.",
+						},
+						"scheduled_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The execution cycle of the schedule task.",
+						},
+						"scheduled_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The scheduled time of the schedule task.",
+						},
+						"day_interval": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The interval in days of the schedule task.",
+						},
+						"week_list": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The days of the week of the schedule task.",
+						},
+						"month_list": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The month of the schedule task.",
+						},
+						"date_list": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The days of the month of the schedule task.",
+						},
+						"scheduled_date": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The fixed time of the schedule task.",
+						},
+						"time_zone": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The time zone of the schedule task.",
+						},
+						"expire_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The expire time of the schedule task.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The description of the schedule task.",
+						},
+						"is_enable": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether the schedule task is enabled.",
+						},
+						"task_cron": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The cron expression of the schedule task.",
+						},
+						"next_execution_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The next execution time of the schedule task.",
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The create time of the schedule task, in RFC3339 format.",
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The lastest update time of the schedule task, in RFC3339 format.",
+						},
+						"last_status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The last execution status of the schedule task.",
+						},
+					},
+				},
+				Description: "All schedule tasks that match the filter parameters.",
+			},
+		},
+	}
+}
+
+func buildAppScheduleTasksQueryParams(d *schema.ResourceData) string {
+	params := ""
+	if v, ok := d.GetOk("task_type"); ok {
+		params += fmt.Sprintf("&task_type=%s", v)
+	}
+
+	if v, ok := d.GetOk("task_name"); ok {
+		params += fmt.Sprintf("&task_name=%s", v)
+	}
+
+	return params
+}
+
+func queryAppScheduleTasks(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		listPath = "v1/{project_id}/schedule-task"
+		offset   = 0
+		// For API, limit default value is 10.
+		limit   = 100
+		results = make([]interface{}, 0)
+		listOpt = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+	)
+
+	listPath = client.Endpoint + listPath
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = fmt.Sprintf("%s?limit=%d", listPath, limit)
+	listPath += buildAppScheduleTasksQueryParams(d)
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		listResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(listResp)
+		if err != nil {
+			return nil, err
+		}
+
+		scheduleTasks := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		results = append(results, scheduleTasks...)
+		if len(scheduleTasks) < limit {
+			break
+		}
+
+		offset += len(scheduleTasks)
+	}
+
+	return results, nil
+}
+
+func dataSourceAppScheduleTasksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	items, err := queryAppScheduleTasks(client, d)
+	if err != nil {
+		return diag.Errorf("error getting Workspace APP schedule tasks: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate data source ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("tasks", flattenAppScheduleTasks(items)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAppScheduleTasks(tasks []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(tasks))
+	for i, v := range tasks {
+		result[i] = map[string]interface{}{
+			"id":                  utils.PathSearch("id", v, nil),
+			"task_name":           utils.PathSearch("task_name", v, nil),
+			"task_type":           utils.PathSearch("task_type", v, nil),
+			"scheduled_type":      utils.PathSearch("scheduled_type", v, nil),
+			"scheduled_time":      utils.PathSearch("scheduled_time", v, nil),
+			"day_interval":        utils.PathSearch("day_interval", v, nil),
+			"week_list":           utils.PathSearch("week_list", v, nil),
+			"month_list":          utils.PathSearch("month_list", v, nil),
+			"date_list":           utils.PathSearch("date_list", v, nil),
+			"scheduled_date":      utils.PathSearch("scheduled_date", v, nil),
+			"time_zone":           utils.PathSearch("time_zone", v, nil),
+			"expire_time":         utils.PathSearch("expire_time", v, nil),
+			"description":         utils.PathSearch("description", v, nil),
+			"is_enable":           utils.PathSearch("is_enable", v, nil),
+			"task_cron":           utils.PathSearch("task_cron", v, nil),
+			"next_execution_time": utils.PathSearch("next_execution_time", v, nil),
+			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("create_time",
+				v, "").(string))/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("update_time",
+				v, "").(string))/1000, false),
+			"last_status": utils.PathSearch("last_status", v, nil),
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source(**huaweicloud_workspace_app_schedule_tasks**) to query schedule tasks of the Workspace APP.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataSourceAppScheduleTasks_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataSourceAppScheduleTasks_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAppScheduleTasks_basic
=== PAUSE TestAccDataSourceAppScheduleTasks_basic
=== CONT  TestAccDataSourceAppScheduleTasks_basic
--- PASS: TestAccDataSourceAppScheduleTasks_basic (23.50s)
PASS
coverage: 7.8% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 23.673scoverage: 7.8% of statements in ./huaweicloud/services/workspace
```

<img width="1083" height="300" alt="image" src="https://github.com/user-attachments/assets/d570a3a4-1c56-42c6-bed4-aa6a2a111bd9" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
