### PR TITLE
feat(DCS): dcs instance support expire key auto scan

### DIFF
--- a/docs/resources/dcs_instance.md
+++ b/docs/resources/dcs_instance.md
@@ -206,6 +206,21 @@ The following arguments are supported:
 
 * `hot_key_schedule_at` - (Optional, List) Specifies the UTC time of the day that cache analysis is scheduled for hot key.
 
+* `expire_key_enable_auto_scan` - (Optional, Bool) Specifies whether to enable scheduled cache analysis for expire key.
+
+* `expire_key_first_scan_at` - (Optional, String) Specifies the first scan time for expire key, for example,
+  **2023-07-07T15:00:05.000z**. It is mandatory when `expire_key_enable_auto_scan` is set to **true**.
+
+* `expire_key_interval` - (Optional, Int) Specifies the scan interval for expire key, in seconds. It is mandatory when
+  `expire_key_enable_auto_scan` is set to **true**.
+
+* `expire_key_timeout` - (Optional, Int) Specifies the Scan timeout for expire key, in seconds. If one scan times out, a
+  failure message is returned, and the next scan can continue. The value at least twice the interval. It is mandatory when
+  `expire_key_enable_auto_scan` is set to **true**.
+
+* `expire_key_scan_keys_count` - (Optional, Int) Specifies the number of keys scanned in iteration for expire key. It is
+  mandatory when `expire_key_enable_auto_scan` is set to **true**.
+
 * `enterprise_project_id` - (Optional, String) The enterprise project id of the dcs instance.
 
 * `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the redis instance.
@@ -337,6 +352,8 @@ In addition to all arguments above, the following attributes are exported:
 * `big_key_updated_at` - Indicates the time when the configuration is updated for big key.
 
 * `hot_key_updated_at` - Indicates the time when the configuration is updated for hot key.
+
+* `expire_key_updated_at` - Indicates the time when the configuration is updated for expire key.
 
 <a name="dcs_bandwidth_info"></a>
 The `bandwidth_info` block supports:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  dcs instance support expire key auto scan
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  dcs instance support expire key auto scan
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dcs/ TESTARGS='-run TestAccDcsInstances_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs/ -v -run TestAccDcsInstances_basic -timeout 360m -parallel 4
=== RUN   TestAccDcsInstances_basic
=== PAUSE TestAccDcsInstances_basic
=== CONT  TestAccDcsInstances_basic
--- PASS: TestAccDcsInstances_basic (366.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       366.196s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
