### PR TITLE
chore(sdrs): modify sdrs resource error check deleted logic

### DIFF
--- a/huaweicloud/services/sdrs/resource_huaweicloud_sdrs_protection_group.go
+++ b/huaweicloud/services/sdrs/resource_huaweicloud_sdrs_protection_group.go
@@ -152,14 +152,9 @@ func resourceProtectionGroupRead(_ context.Context, d *schema.ResourceData, meta
 
 	n, err := protectiongroups.Get(client, d.Id()).Extract()
 	if err != nil {
-		if errCode, ok := err.(golangsdk.ErrDefault400); ok {
-			if resp, pErr := common.ParseErrorMsg(errCode.Body); pErr == nil && resp.ErrorCode == "SDRS.1013" {
-				// `SDRS.1013` means protection group not found
-				return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{},
-					"error retrieving SDRS protection group")
-			}
-		}
-		return diag.FromErr(err)
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error.code", "SDRS.1013"),
+			"error retrieving SDRS protection group")
 	}
 
 	mErr := multierror.Append(
@@ -221,14 +216,9 @@ func resourceProtectionGroupDelete(_ context.Context, d *schema.ResourceData, me
 
 	n, err := protectiongroups.Delete(client, d.Id()).ExtractJobResponse()
 	if err != nil {
-		if errCode, ok := err.(golangsdk.ErrDefault400); ok {
-			if resp, pErr := common.ParseErrorMsg(errCode.Body); pErr == nil && resp.ErrorCode == "SDRS.0207" {
-				// `SDRS.0207` means invalid protection group ID
-				return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{},
-					"error deleting SDRS protection group")
-			}
-		}
-		return diag.FromErr(err)
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error.code", "SDRS.1013"),
+			"error deleting SDRS protection group")
 	}
 
 	deleteTimeoutSec := int(d.Timeout(schema.TimeoutDelete).Seconds())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

commit1: modify sdrs drill resource error check deleted logic.
commit2: modify sdrs instance resource error check deleted logic.
commit3: modify sdrs group resource error check deleted logic.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o sdrs -f TestAccProtectionGroup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/sdrs" -v -coverprofile="./huaweicloud/services/acceptance/sdrs/sdrs_coverage.cov" -coverpkg="./huaweicloud/services/sdrs" -run TestAccProtectionGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccProtectionGroup_basic
=== PAUSE TestAccProtectionGroup_basic
=== CONT  TestAccProtectionGroup_basic
--- PASS: TestAccProtectionGroup_basic (65.13s)
PASS
coverage: 11.7% of statements in ./huaweicloud/services/sdrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sdrs      65.242s coverage: 11.7% of statements in ./huaweicloud/services/sdrs
```

```
./scripts/coverage.sh -o sdrs -f TestAccProtectedInstance_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/sdrs" -v -coverprofile="./huaweicloud/services/acceptance/sdrs/sdrs_coverage.cov" -coverpkg="./huaweicloud/services/sdrs" -run TestAccProtectedInstance_basic -timeout 360m -parallel 10
=== RUN   TestAccProtectedInstance_basic
=== PAUSE TestAccProtectedInstance_basic
=== CONT  TestAccProtectedInstance_basic
--- PASS: TestAccProtectedInstance_basic (301.29s)
PASS
coverage: 16.6% of statements in ./huaweicloud/services/sdrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sdrs      301.405s        coverage: 16.6% of statements in ./huaweicloud/services/sdrs
```

```
./scripts/coverage.sh -o sdrs -f TestAccDrill_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/sdrs" -v -coverprofile="./huaweicloud/services/acceptance/sdrs/sdrs_coverage.cov" -coverpkg="./huaweicloud/services/sdrs" -run TestAccDrill_basic -timeout 360m -parallel 10
=== RUN   TestAccDrill_basic
=== PAUSE TestAccDrill_basic
=== CONT  TestAccDrill_basic
--- PASS: TestAccDrill_basic (390.91s)
PASS
coverage: 20.6% of statements in ./huaweicloud/services/sdrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sdrs      390.984s        coverage: 20.6% of statements in ./huaweicloud/services/sdrs
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
<img width="739" height="188" alt="image" src="https://github.com/user-attachments/assets/af74f823-48ec-4901-8337-008c7e6b5b1a" />

<img width="738" height="174" alt="image" src="https://github.com/user-attachments/assets/a121c535-dece-4020-809b-5c2c2b23163a" />

<img width="719" height="374" alt="image" src="https://github.com/user-attachments/assets/bf073ea8-2210-4a3a-a07a-57b2162644de" />


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
<img width="720" height="155" alt="image" src="https://github.com/user-attachments/assets/9dacbb01-b77c-4270-a265-a27b9be1fe21" />

<img width="719" height="157" alt="image" src="https://github.com/user-attachments/assets/c7b084e1-a8d8-4bfa-8795-99a7871aaf5b" />

<img width="722" height="165" alt="image" src="https://github.com/user-attachments/assets/d2afa94c-14f3-49f2-9884-bd412fc3b992" />


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
