### PR TITLE
feat(workspace): add new data source for query desktop sysprep

### DIFF
--- a/docs/data-sources/workspace_desktop_sysprep.md
+++ b/docs/data-sources/workspace_desktop_sysprep.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_desktop_sysprep"
+description: |-
+  Use this data source to get the sysprep information of a Workspace desktop within HuaweiCloud.
+---
+
+# huaweicloud_workspace_desktop_sysprep
+
+Use this data source to get the sysprep information of a Workspace desktop within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "desktop_id" {}
+
+data "huaweicloud_workspace_desktop_sysprep" "test" {
+  desktop_id = var.desktop_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the desktop sysprep is located.  
+  If omitted, the provider-level region will be used.
+
+* `desktop_id` - (Required, String) Specifies the ID of the desktop to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `sysprep_info` - The sysprep information of the desktop.  
+  The [sysprep_info](#workspace_desktop_sysprep_info) structure is documented below.
+
+<a name="workspace_desktop_sysprep_info"></a>
+The `sysprep_info` block supports:
+
+* `sysprep_version` - The sysprep version of the desktop.
+
+* `support_create_image` - Whether the desktop supports creating image.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1564,6 +1564,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_desktops":               workspace.DataSourceDesktops(),
 			"huaweicloud_workspace_desktop_connections":    workspace.DataSourceDesktopConnections(),
 			"huaweicloud_workspace_desktop_remote_console": workspace.DataSourceDesktopRemoteConsole(),
+			"huaweicloud_workspace_desktop_sysprep":        workspace.DataSourceDesktopSysprep(),
 			"huaweicloud_workspace_desktop_tags":           workspace.DataSourceDesktopTags(),
 			"huaweicloud_workspace_desktop_tags_filter":    workspace.DataSourceDesktopTagsFilter(),
 			"huaweicloud_workspace_desktop_pools":          workspace.DataSourceDesktopPools(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktop_sysprep_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktop_sysprep_test.go
@@ -1,0 +1,105 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDesktopSysprepDataSource_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		dcName = "data.huaweicloud_workspace_desktop_sysprep.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDesktopSysprepDataSource_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dcName, "sysprep_info.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dcName, "sysprep_info.0.sysprep_version"),
+					resource.TestCheckResourceAttrSet(dcName, "sysprep_info.0.support_create_image"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDesktopSysprepDataSource_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_service" "test" {}
+
+data "huaweicloud_workspace_flavors" "test" {
+  os_type = "Windows"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_images_images" "test" {
+  name_regex = "WORKSPACE"
+  visibility = "market"
+}
+
+resource "huaweicloud_workspace_desktop" "test" {
+  flavor_id         = try(data.huaweicloud_workspace_flavors.test.flavors[0].id, "NOT_FOUND")
+  image_type        = "market"
+  image_id          = try(data.huaweicloud_images_images.test.images[0].id, "NOT_FOUND")
+  availability_zone = try(data.huaweicloud_availability_zones.test.names[0], "NOT_FOUND")
+  vpc_id            = data.huaweicloud_workspace_service.test.vpc_id
+
+  security_groups = [
+    try(data.huaweicloud_workspace_service.test.desktop_security_group[0].id, "NOT_FOUND"),
+    try(data.huaweicloud_workspace_service.test.infrastructure_security_group[0].id, "NOT_FOUND"),
+  ]
+  
+  nic {
+    network_id = try(data.huaweicloud_workspace_service.test.network_ids[0], "NOT_FOUND")
+  }
+
+  name       = "%[1]s"
+  user_name  = "%[1]s-user"
+  user_email = "terraform@example.com"
+  user_group = "administrators"
+
+  root_volume {
+    type = "SAS"
+    size = 80
+  }
+
+  data_volume {
+    type = "SAS"
+    size = 50
+  }
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+
+  email_notification = true
+  delete_user        = true
+}
+`, name)
+}
+
+func testAccDesktopSysprepDataSource_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_workspace_desktop_sysprep" "test" {
+  desktop_id = huaweicloud_workspace_desktop.test.id
+}
+`, testAccDesktopSysprepDataSource_base(name))
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_desktop_sysprep.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_desktop_sysprep.go
@@ -1,0 +1,121 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v2/{project_id}/desktops/{desktop_id}/sysprep
+func DataSourceDesktopSysprep() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDesktopSysprepRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the desktop sysprep is located.`,
+			},
+			"desktop_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the desktop to be queried.`,
+			},
+			"sysprep_info": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        sysprepInfoSchema(),
+				Description: `The sysprep information of the desktop.`,
+			},
+		},
+	}
+}
+
+func sysprepInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"sysprep_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The sysprep version of the desktop.`,
+			},
+			"support_create_image": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the desktop supports creating image.`,
+			},
+		},
+	}
+}
+
+func queryDesktopSysprep(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	var (
+		httpUrl   = "v2/{project_id}/desktops/{desktop_id}/sysprep"
+		desktopId = d.Get("desktop_id").(string)
+	)
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{desktop_id}", desktopId)
+
+	requestOpts := &golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", getPath, requestOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func flattenSysprepInfo(respBody interface{}) []interface{} {
+	if respBody == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"sysprep_version":      utils.PathSearch("sysprep_version", respBody, nil),
+			"support_create_image": utils.PathSearch("support_create_image", respBody, nil),
+		},
+	}
+}
+
+func dataSourceDesktopSysprepRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating WorkSpace client: %s", err)
+	}
+
+	respBody, err := queryDesktopSysprep(client, d)
+	if err != nil {
+		return diag.Errorf("error querying desktop sysprep information: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("sysprep_info", flattenSysprepInfo(respBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(workspace): add new data source for query desktop sysprep

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDesktopSysprepDataSource_basic -timeout 360m -parallel 10
=== RUN   TestAccDesktopSysprepDataSource_basic
--- PASS: TestAccDesktopSysprepDataSource_basic (443.09s)
PASS
coverage: 8.7% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 443.189s        coverage: 8.7% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.