### PR TITLE
feat(workspace): add new data source for query app rules

### DIFF
--- a/docs/data-sources/workspace_app_rules.md
+++ b/docs/data-sources/workspace_app_rules.md
@@ -1,0 +1,100 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_rules"
+description: |-
+  Use this data source to get the list of the Workspace application rules within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_rules
+
+Use this data source to get the list of the Workspace application rules within HuaweiCloud.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+data "huaweicloud_workspace_app_rules" "test" {}
+```
+
+### Filter app rules by name
+
+```hcl
+variable "rule_name" {}
+
+data "huaweicloud_workspace_app_rules" "test" {
+  name = var.rule_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the application rules are located.
+
+* `name` - (Optional, String) Specifies the name of the application rule to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `app_rules` - The list of application rules that match the filter parameters.  
+  The [app_rules](#workspace_app_rules_attr) structure is documented below.
+
+<a name="workspace_app_rules_attr"></a>
+The `app_rules` block supports:
+
+* `id` - The ID of the application rule.
+
+* `name` - The name of the application rule.
+
+* `description` - The description of the application rule.
+
+* `rule_source` - The source of the application rule.
+
+* `create_time` - The create time of the application rule, in RFC3339 format.
+
+* `update_time` - The update time of the application rule, in RFC3339 format.
+
+* `rule` - The rule configuration.  
+  The [rule](#workspace_app_rule_attr) structure is documented below.
+
+<a name="workspace_app_rule_attr"></a>
+The `rule` block supports:
+
+* `scope` - The scope of the rule.  
+  The valid values are as follows:
+  + **PRODUCT**
+  + **PATH**
+
+* `product_rule` - The product rule configuration.  
+  The [product_rule](#workspace_app_rule_product_rule_attr) structure is documented below.
+
+* `path_rule` - The path rule configuration.  
+  The [path_rule](#workspace_app_rule_path_rule_attr) structure is documented below.
+
+<a name="workspace_app_rule_product_rule_attr"></a>
+The `product_rule` block supports:
+
+* `identify_condition` - The identification condition.
+
+* `publisher` - The publisher name.
+
+* `product_name` - The product name.
+
+* `process_name` - The process name.
+
+* `support_os` - The supported operating system type, defaults to **Windows**
+
+* `version` - The version number.
+
+* `product_version` - The product version number.
+
+<a name="workspace_app_rule_path_rule_attr"></a>
+The `path_rule` block supports:
+
+* `path` - The complete path.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1599,6 +1599,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_workload_queues":                 dws.DataSourceWorkloadQueues(),
 
 			// Workspace
+			"huaweicloud_workspace_app_rules":              workspace.DataSourceAppRules(),
 			"huaweicloud_workspace_available_ip_number":    workspace.DataSourceAvailableIpNumber(),
 			"huaweicloud_workspace_desktops":               workspace.DataSourceDesktops(),
 			"huaweicloud_workspace_desktop_connections":    workspace.DataSourceDesktopConnections(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_rules_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_rules_test.go
@@ -1,0 +1,113 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccAppRulesDataSource_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		dcName = "data.huaweicloud_workspace_app_rules.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+
+		filterByName   = "data.huaweicloud_workspace_app_rules.filter_by_name"
+		dcFilterByName = acceptance.InitDataSourceCheck(filterByName)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppRulesDataSource_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dcName, "app_rules.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(dcName, "app_rules.0.id"),
+					resource.TestCheckResourceAttrSet(dcName, "app_rules.0.name"),
+					resource.TestCheckResourceAttrSet(dcName, "app_rules.0.rule_source"),
+					resource.TestCheckResourceAttrSet(dcName, "app_rules.0.create_time"),
+					resource.TestCheckResourceAttrSet(dcName, "app_rules.0.update_time"),
+					resource.TestCheckResourceAttrSet(dcName, "app_rules.0.rule.0.scope"),
+					dcFilterByName.CheckResourceExists(),
+					resource.TestMatchResourceAttr(filterByName, "app_rules.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAppRulesDataSource_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_app_rule" "with_product_rule" {
+  name        = "%[1]s"
+  description = "Created by terraform script"
+
+  rule {
+    scope = "PRODUCT"
+
+    product_rule {
+      identify_condition = "process"
+      publisher          = "Microsoft Corporation"
+      product_name       = "Microsoft Office"
+      process_name       = "WINWORD.EXE"
+      support_os         = "Windows"
+      version            = "1.0"
+      product_version    = "2019"
+    }
+  }
+}
+
+resource "huaweicloud_workspace_app_rule" "with_path_rule" {
+  name        = "%[1]s_path"
+  description = "Created by terraform script for path rule"
+
+  rule {
+    scope = "PATH"
+
+    path_rule {
+      path = "C:\\Program Files\\Microsoft Office\\root\\Office16\\WINWORD.EXE"
+    }
+  }
+}
+`, name)
+}
+
+func testAccAppRulesDataSource_basic(name string) string {
+	// the name filter case need validate the context is contain the filter parameter?
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_workspace_app_rules" "test" {
+  depends_on = [
+    huaweicloud_workspace_app_rule.with_product_rule,
+    huaweicloud_workspace_app_rule.with_path_rule
+  ]
+}
+
+data "huaweicloud_workspace_app_rules" "filter_by_name" {
+  name = "%[2]s"
+
+  depends_on = [
+    huaweicloud_workspace_app_rule.with_product_rule,
+    huaweicloud_workspace_app_rule.with_path_rule
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(data.huaweicloud_workspace_app_rules.filter_by_name.app_rules) > 0 && alltrue(
+    [for v in data.huaweicloud_workspace_app_rules.filter_by_name.app_rules[*].name : strcontains(v, "%[2]s") == true]
+  )
+}
+`, testAccAppRulesDataSource_base(name), name)
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_rules.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_rules.go
@@ -1,0 +1,210 @@
+package workspace
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/app-center/app-rules
+func DataSourceAppRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the application rules are located.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the application rule to be queried.`,
+			},
+			"app_rules": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        appRuleItemSchema(),
+				Description: `The list of application rules that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func appRuleItemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the application rule.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the application rule.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the application rule.`,
+			},
+			"rule_source": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The source of the application rule.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The create time of the application rule, in RFC3339 format.`,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time of the application rule, in RFC3339 format.`,
+			},
+			"rule": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        appRuleSchema(),
+				Description: `The application rule configuration.`,
+			},
+		},
+	}
+}
+
+func appRuleSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"scope": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The scope of the application rule.`,
+			},
+			"product_rule": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        appProductRule(),
+				Description: `The detail of the product rule.`,
+			},
+			"path_rule": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        appPathRule(),
+				Description: `The detail of the path rule.`,
+			},
+		},
+	}
+}
+
+func appProductRule() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"identify_condition": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The identify condition of the product rule.`,
+			},
+			"publisher": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The publisher of the product.`,
+			},
+			"product_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the product.`,
+			},
+			"process_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The process name of the product.`,
+			},
+			"support_os": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The list of the supported operating system types.`,
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The version of the product rule.`,
+			},
+			"product_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The version of the product.`,
+			},
+		},
+	}
+}
+
+func appPathRule() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The path where the product is installed.`,
+			},
+		},
+	}
+}
+
+func flattenAppRules(appRules []interface{}) []interface{} {
+	if len(appRules) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(appRules))
+	for _, item := range appRules {
+		result = append(result, map[string]interface{}{
+			"id":          utils.PathSearch("id", item, nil),
+			"name":        utils.PathSearch("name", item, nil),
+			"description": utils.PathSearch("description", item, nil),
+			"rule_source": utils.PathSearch("rule_source", item, nil),
+			"create_time": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(
+				utils.PathSearch("create_time", item, "").(string))/1000, false),
+			"update_time": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(
+				utils.PathSearch("update_time", item, "").(string))/1000, false),
+			"rule": flattenAppRuleConfig(utils.PathSearch("rule", item, nil)),
+		})
+	}
+	return result
+}
+
+func dataSourceAppRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	appRules, err := listAppRules(client, d)
+	if err != nil {
+		return diag.Errorf("error querying Workspace application rules: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("app_rules", flattenAppRules(appRules)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(workspace): add new data source for query app rules

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add the provider implement
2. add test case 
3. add the document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppRulesDataSource_basic -timeout 360m -parallel 10
=== RUN   TestAccAppRulesDataSource_basic
--- PASS: TestAccAppRulesDataSource_basic (55.78s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 55.891s coverage: 4.5% of statements in ./huaweicloud/services/workspace
```

<img width="1428" height="837" alt="image" src="https://github.com/user-attachments/assets/5280acd4-1592-4274-843e-a77d973788d0" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.