### PR TITLE
feat(hss): add new datasource to get the list of used tags

### DIFF
--- a/docs/data-sources/hss_tags.md
+++ b/docs/data-sources/hss_tags.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_tags"
+description: |-
+  Use this data source to get the list of used tags.
+---
+
+# huaweicloud_hss_tags
+
+Use this data source to get the list of used tags.
+
+## Example Usage
+
+```hcl
+variable "resource_type" {}
+
+data "huaweicloud_hss_tags" "test" {
+  resource_type = var.resource_type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `resource_type` - (Required, String) Specifies the resource type.
+  The value only can be **hss**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tags` - The list of tags.
+  The [tags](#tags_struct) structure is documented below.
+
+<a name="tags_struct"></a>
+The `tags` block supports:
+
+* `key` - The tags key
+
+* `values` - The tags value list.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1080,6 +1080,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_ransomware_protection_policies": hss.DataSourceRansomwareProtectionPolicies(),
 			"huaweicloud_hss_rasp_status":                    hss.DataSourceRaspStatus(),
 			"huaweicloud_hss_resource_quotas":                hss.DataSourceResourceQuotas(),
+			"huaweicloud_hss_tags":                           hss.DataSourceHssTags(),
 			"huaweicloud_hss_vulnerabilities":                hss.DataSourceVulnerabilities(),
 			"huaweicloud_hss_vulnerability_hosts":            hss.DataSourceVulnerabilityHosts(),
 			"huaweicloud_hss_vulnerability_statistics":       hss.DataSourceVulnerabilityStatistics(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_tags_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_tags_test.go
@@ -1,0 +1,40 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceHssTags_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_tags.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+
+			{
+				Config: testAccDataSourceHssTags_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "tags.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "tags.0.key"),
+					resource.TestCheckResourceAttrSet(dataSource, "tags.0.values.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceHssTags_basic = `
+data "huaweicloud_hss_tags" "test" {
+  resource_type = "hss"
+}`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_tags.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_tags.go
@@ -1,0 +1,112 @@
+package hss
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/{resource_type}/tags
+func DataSourceHssTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceHssTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"resource_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceHssTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		resourceType = d.Get("resource_type").(string)
+		httpUrl      = "v5/{project_id}/{resource_type}/tags"
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{resource_type}", resourceType)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving tags: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tagList := utils.PathSearch("tags", getRespBody, make([]interface{}, 0)).([]interface{})
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("tags", flattenHssTags(tagList)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenHssTags(hostsResp []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(hostsResp))
+	for _, v := range hostsResp {
+		rst = append(rst, map[string]interface{}{
+			"key":    utils.PathSearch("key", v, nil),
+			"values": utils.PathSearch("values", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new datasource to get the list of used tags.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceHssTags_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceHssTags_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceHssTags_basic
=== PAUSE TestAccDataSourceHssTags_basic
=== CONT  TestAccDataSourceHssTags_basic
--- PASS: TestAccDataSourceHssTags_basic (10.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       10.392s
```
<img width="940" height="33" alt="image" src="https://github.com/user-attachments/assets/d38f25dd-5920-4b1d-9b2e-7210e3c66f33" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
