### PR TITLE
feat(EVS): add datasource to query evs snapshot chains

### DIFF
--- a/docs/data-sources/evs_snapshot_chains.md
+++ b/docs/data-sources/evs_snapshot_chains.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Elastic Volume Service (EVS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_evs_snapshot_chains"
+description: |-
+  Use this data source to query the list of EVS snapshot chains within HuaweiCloud.
+---
+
+# huaweicloud_evs_snapshot_chains
+
+Use this data source to query the list of EVS snapshot chains within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_evs_snapshot_chains" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `id` - (Optional, String) Specifies the snapshot chain ID.
+
+* `volume_id` - (Optional, String) Specifies the disk ID to which the snapshot chains belong.
+
+* `category` - (Optional, String) Specifies the category of snapshot chain.
+  The valid values are **standard**, **backup** and **server_backup**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `snapshot_chains` - The snapshot chain list.
+  The [snapshot_chains](#snapshot_chains_structure) structure is documented below.
+
+<a name="snapshot_chains_structure"></a>
+The `snapshot_chains` block supports:
+
+* `id` - The snapshot chain ID.
+
+* `availability_zone` - The AZ to which the snapshot chain belongs.
+
+* `snapshot_count` - The number of snapshots on the snapshot chain.
+
+* `capacity` - The total size of the snapshot chain.
+
+* `volume_id` - The ID of disk to which the snapshot chain belongs.
+
+* `category` - The category of snapshot chain.
+
+* `created_at` - The time when the snapshot chain was created.
+
+* `updated_at` - The time when the snapshot chain was updated.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -958,6 +958,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_evsv3_volume_type_detail":      evs.DataSourceEvsv3VolumeTypeDetail(),
 			"huaweicloud_evsv3_availability_zones":      evs.DataSourceEvsV3AvailabilityZones(),
 			"huaweicloud_evs_tags":                      evs.DataSourceEvsTags(),
+			"huaweicloud_evs_snapshot_chains":           evs.DataSourceEvsSnapshotChains(),
 			"huaweicloud_evs_quotas":                    evs.DataSourceEvsQuotas(),
 			"huaweicloud_evsv3_quotas":                  evs.DataSourceEvsV3Quotas(),
 

--- a/huaweicloud/services/acceptance/evs/data_source_huaweicloud_evs_snapshot_chains_test.go
+++ b/huaweicloud/services/acceptance/evs/data_source_huaweicloud_evs_snapshot_chains_test.go
@@ -1,0 +1,42 @@
+package evs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceEvsSnapshotChains_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_evs_snapshot_chains.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test needs to create an EVS standard snapshot with tags before running.
+			acceptance.TestAccPreCheckEVSFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceEvsSnapshotChains_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "snapshot_chains.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "snapshot_chains.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "snapshot_chains.0.availability_zone"),
+					resource.TestCheckResourceAttrSet(dataSource, "snapshot_chains.0.snapshot_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "snapshot_chains.0.capacity"),
+					resource.TestCheckResourceAttrSet(dataSource, "snapshot_chains.0.volume_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "snapshot_chains.0.category"),
+					resource.TestCheckResourceAttrSet(dataSource, "snapshot_chains.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "snapshot_chains.0.updated_at"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceEvsSnapshotChains_basic = `data "huaweicloud_evs_snapshot_chains" "test" {}`

--- a/huaweicloud/services/evs/data_source_huaweicloud_evs_snapshot_chains.go
+++ b/huaweicloud/services/evs/data_source_huaweicloud_evs_snapshot_chains.go
@@ -1,0 +1,179 @@
+package evs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EVS GET /v5/{project_id}/snapshot-chains
+func DataSourceEvsSnapshotChains() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEvsSnapshotChainsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"snapshot_chains": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     snapshotChainSchema(),
+			},
+		},
+	}
+}
+
+func snapshotChainSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"snapshot_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"capacity": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceEvsSnapshotChainsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v5/{project_id}/snapshot-chains"
+		product = "evs"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	var allChains []interface{}
+	marker := ""
+	for {
+		pagedPath := fmt.Sprintf("%s?limit=1000%s", requestPath, buildEvsSnapshotChainsQueryParams(d))
+		if marker != "" {
+			pagedPath += fmt.Sprintf("&marker=%s", marker)
+		}
+		requestOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+		resp, err := client.Request("GET", pagedPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error querying EVS snapshot chains: %s", err)
+		}
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		chains := utils.PathSearch("snapshot_chains", respBody, []interface{}{}).([]interface{})
+		if len(chains) == 0 {
+			break
+		}
+		allChains = append(allChains, chains...)
+
+		marker = utils.PathSearch("[-1].id", chains, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("snapshot_chains", flattenEvsSnapshotChains(allChains)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildEvsSnapshotChainsQueryParams(d *schema.ResourceData) string {
+	params := ""
+	if v, ok := d.GetOk("id"); ok {
+		params += fmt.Sprintf("&id=%v", v)
+	}
+	if v, ok := d.GetOk("volume_id"); ok {
+		params += fmt.Sprintf("&volume_id=%v", v)
+	}
+	if v, ok := d.GetOk("category"); ok {
+		params += fmt.Sprintf("&category=%v", v)
+	}
+	return params
+}
+
+func flattenEvsSnapshotChains(chains []interface{}) []map[string]interface{} {
+	if len(chains) == 0 {
+		return nil
+	}
+	rst := make([]map[string]interface{}, 0, len(chains))
+	for _, c := range chains {
+		rst = append(rst, map[string]interface{}{
+			"id":                utils.PathSearch("id", c, nil),
+			"availability_zone": utils.PathSearch("availability_zone", c, nil),
+			"snapshot_count":    utils.PathSearch("snapshot_count", c, nil),
+			"capacity":          utils.PathSearch("capacity", c, nil),
+			"volume_id":         utils.PathSearch("volume_id", c, nil),
+			"category":          utils.PathSearch("category", c, nil),
+			"created_at":        utils.PathSearch("created_at", c, nil),
+			"updated_at":        utils.PathSearch("updated_at", c, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add datasource to query evs snapshot chains
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add datasource to query evs snapshot chains
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
<img width="1539" height="298" alt="image" src="https://github.com/user-attachments/assets/c4b2f30a-0d84-4415-8f27-097bda353657" />
<img width="1286" height="49" alt="image" src="https://github.com/user-attachments/assets/d99295c6-4868-47f5-a54a-652268a0ea43" />


* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
