### PR TITLE
feat(sdrs): new resource to resize sdrs protected instance

### DIFF
--- a/docs/resources/sdrs_protected_instance_resize.md
+++ b/docs/resources/sdrs_protected_instance_resize.md
@@ -1,0 +1,97 @@
+---
+subcategory: "Storage Disaster Recovery Service (SDRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_sdrs_protected_instance_resize"
+description: |-
+  Using this resource to resize a protected instance in SDRS within HuaweiCloud.
+---
+
+# huaweicloud_sdrs_protected_instance_resize
+
+Using this resource to resize a protected instance in SDRS within HuaweiCloud.
+
+-> This is a one-time action resource to resize a protected instance. Deleting this resource will
+not change the current configuration, but will only remove the resource information from the tfstate file. You can use
+this resource in the following scenarios:
+<br/>1. Modify the specifications of both the production and DR site servers.
+<br/>2. Modify the specifications of only the production site server.
+<br/>3. Modify the specifications of only the DR site server.
+<br/>4. Running this resource may cause unexpected change to the `flavor_id` field of the `huaweicloud_compute_instance`.
+Please using `lifecycle` to control the `flavor_id` field of the `huaweicloud_compute_instance`.
+
+-> Servers of different specifications have different performance, which may affect applications running on the servers.
+To ensure the server performance after a planned failover or failover, you are recommended to use servers of
+specifications (CPU and memory) same or higher than the specifications of the production site servers at the DR site.
+
+-> Before using this resource, please note the following restrictions:
+<br/>1. The status of the protected group must be **available** or **protected**.
+<br/>2. The status of the protected instance must be **available** or **protected** or **error-resizing**.
+<br/>3. The ECS to be resized must be in the shutdown state.
+
+## Example Usage
+
+```hcl
+variable "protected_instance_id" {}
+variable "flavor_ref" {}
+
+resource "huaweicloud_sdrs_protected_instance_resize" "test" {
+  protected_instance_id = var.protected_instance_id
+  flavor_ref            = var.flavor_ref
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource. If omitted,
+  the provider-level region will be used. Changing this will create a new resource.
+
+* `protected_instance_id` - (Required, String, NonUpdatable) Specifies the ID of the protected instance to resize.
+  You can obtain this value by calling the datasource `huaweicloud_sdrs_protected_instances`.
+
+* `flavor_ref` - (Optional, String, NonUpdatable) Specifies the flavor ID of the production and DR site servers after
+  the modification.
+
+  -> If you specify this parameter, the system modifies the specifications of both the production and DR site servers.
+  After the modification, the production site server and DR site server use the same specifications.
+
+* `production_flavor_ref` - (Optional, String, NonUpdatable) Specifies the flavor ID of the production site server after
+  the modification.
+
+  -> 1. If you specify this parameter, the system modifies the specifications of only the production site server.
+  <br/>2. If `flavor_ref` is specified, `production_flavor_ref` does not take effect.
+
+* `dr_flavor_ref` - (Optional, String, NonUpdatable) Specifies the flavor ID of the DR site server after the modification.
+
+  -> 1. If you specify this parameter, the system modifies the specifications of only the DR site server.
+  <br/>2. If `flavor_ref` is specified, `dr_flavor_ref` does not take effect.
+
+-> You can obtain the values of fields `flavor_ref`, `production_flavor_ref`, and `dr_flavor_ref` by calling the API
+  [Querying the Target ECS Flavors to Which a Flavor Can Be Changed](https://support.huaweicloud.com/intl/en-us/api-ecs/ecs_02_0402.html).
+
+* `production_dedicated_host_id` - (Optional, String, NonUpdatable) Specifies the new DeH ID for the production site.
+
+  -> 1. If the production site server is created on a DeH, this parameter must be specified when you modify the specifications
+  of the production site server.
+  <br/>2. You can set this parameter to the ID of the DeH where the production site server is currently located or the ID
+  of another DeH.
+
+* `dr_dedicated_host_id` - (Optional, String, NonUpdatable) Specifies the new DeH ID for the DR site.
+
+  -> 1. If the DR site server is created on a DeH, this parameter must be specified when you modify the specifications of
+  the DR site server.
+  <br/>2. You can set this parameter to the ID of the DeH where the DR site server is currently located or the ID of
+  another DeH.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2608,6 +2608,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_sdrs_protected_instance":                   sdrs.ResourceProtectedInstance(),
 			"huaweicloud_sdrs_protected_instance_add_nic":           sdrs.ResourceProtectedInstanceAddNIC(),
 			"huaweicloud_sdrs_protected_instance_delete_nic":        sdrs.ResourceProtectedInstanceDeleteNIC(),
+			"huaweicloud_sdrs_protected_instance_resize":            sdrs.ResourceProtectedInstanceResize(),
 			"huaweicloud_sdrs_replication_attach":                   sdrs.ResourceReplicationAttach(),
 
 			"huaweicloud_secmaster_incident":                    secmaster.ResourceIncident(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -320,6 +320,7 @@ var (
 
 	HW_SDRS_PROTECTION_INSTANCE_ID = os.Getenv("HW_SDRS_PROTECTION_INSTANCE_ID")
 	HW_SDRS_NIC_ID                 = os.Getenv("HW_SDRS_NIC_ID")
+	HW_SDRS_RESIZE_FLAVOR_ID       = os.Getenv("HW_SDRS_RESIZE_FLAVOR_ID")
 
 	HW_IDENTITY_CENTER_ACCOUNT_ID                = os.Getenv("HW_IDENTITY_CENTER_ACCOUNT_ID")
 	HW_IDENTITY_CENTER_IDENTITY_POLICY_ID        = os.Getenv("HW_IDENTITY_CENTER_IDENTITY_POLICY_ID")
@@ -804,6 +805,20 @@ func TestAccPreCheckRGCBlueprint(t *testing.T) {
 func TestAccPreCheckSDRSDeleteNic(t *testing.T) {
 	if HW_SDRS_PROTECTION_INSTANCE_ID == "" || HW_SDRS_NIC_ID == "" {
 		t.Skip("HW_SDRS_PROTECTION_INSTANCE_ID and HW_SDRS_NIC_ID must be set for acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckSDRSInstanceResize(t *testing.T) {
+	if HW_SDRS_PROTECTION_INSTANCE_ID == "" {
+		t.Skip("HW_SDRS_PROTECTION_INSTANCE_ID must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckSDRSInstanceResizeFlavor(t *testing.T) {
+	if HW_SDRS_RESIZE_FLAVOR_ID == "" {
+		t.Skip("HW_SDRS_RESIZE_FLAVOR_ID must be set for this acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/sdrs/resource_huaweicloud_sdrs_protected_instance_resize_test.go
+++ b/huaweicloud/services/acceptance/sdrs/resource_huaweicloud_sdrs_protected_instance_resize_test.go
@@ -1,0 +1,36 @@
+package sdrs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccProtectedInstanceResize_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSDRSInstanceResize(t)
+			acceptance.TestAccPreCheckSDRSInstanceResizeFlavor(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testProtectedInstanceResize_basic(),
+			},
+		},
+	})
+}
+
+func testProtectedInstanceResize_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_sdrs_protected_instance_resize" "test" {
+  protected_instance_id = "%[1]s"
+  flavor_ref            = "%[2]s"
+}
+`, acceptance.HW_SDRS_PROTECTION_INSTANCE_ID, acceptance.HW_SDRS_RESIZE_FLAVOR_ID)
+}

--- a/huaweicloud/services/sdrs/resource_huaweicloud_sdrs_protected_instance_resize.go
+++ b/huaweicloud/services/sdrs/resource_huaweicloud_sdrs_protected_instance_resize.go
@@ -1,0 +1,210 @@
+package sdrs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SDRS POST /v1/{project_id}/protected-instances/{protected_instance_id}/resize
+// @API SDRS GET /v1/{project_id}/jobs/{job_id}
+func ResourceProtectedInstanceResize() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceProtectedInstanceResizeCreate,
+		ReadContext:   resourceProtectedInstanceResizeRead,
+		UpdateContext: resourceProtectedInstanceResizeUpdate,
+		DeleteContext: resourceProtectedInstanceResizeDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"protected_instance_id",
+			"flavor_ref",
+			"production_flavor_ref",
+			"dr_flavor_ref",
+			"production_dedicated_host_id",
+			"dr_dedicated_host_id",
+		}),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"protected_instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the protected instance to resize.`,
+			},
+			"flavor_ref": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the flavor ID of the production and DR site servers after the modification.`,
+			},
+			"production_flavor_ref": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the flavor ID of the production site server after the modification.`,
+			},
+			"dr_flavor_ref": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the flavor ID of the DR site server after the modification.`,
+			},
+			"production_dedicated_host_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the new DeH ID for the production site.`,
+			},
+			"dr_dedicated_host_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the new DeH ID for the DR site.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildResizeBodyParams(d *schema.ResourceData) map[string]interface{} {
+	resizeMap := map[string]interface{}{
+		"flavorRef":                    utils.ValueIgnoreEmpty(d.Get("flavor_ref")),
+		"production_flavorRef":         utils.ValueIgnoreEmpty(d.Get("production_flavor_ref")),
+		"dr_flavorRef":                 utils.ValueIgnoreEmpty(d.Get("dr_flavor_ref")),
+		"production_dedicated_host_id": utils.ValueIgnoreEmpty(d.Get("production_dedicated_host_id")),
+		"dr_dedicated_host_id":         utils.ValueIgnoreEmpty(d.Get("dr_dedicated_host_id")),
+	}
+
+	return map[string]interface{}{
+		"resize": resizeMap,
+	}
+}
+
+func resourceProtectedInstanceResizeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/protected-instances/{protected_instance_id}/resize"
+		product = "sdrs"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating SDRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{protected_instance_id}", d.Get("protected_instance_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildResizeBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error resizing SDRS protected instance: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobID := utils.PathSearch("job_id", respBody, "").(string)
+	if jobID == "" {
+		return diag.Errorf("error resizing SDRS protected instance: job ID not found in API response")
+	}
+
+	if err := waitingForResizeSuccess(ctx, client, d.Timeout(schema.TimeoutCreate), jobID); err != nil {
+		return diag.Errorf("error waiting for SDRS resize to complete: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	return resourceProtectedInstanceResizeRead(ctx, d, meta)
+}
+
+func waitingForResizeSuccess(ctx context.Context, client *golangsdk.ServiceClient, timeout time.Duration, jobID string) error {
+	unexpectedStatus := []string{"FAIL"}
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			respBody, err := queryJobStatus(client, jobID)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			status := utils.PathSearch("status", respBody, "").(string)
+			if status == "" {
+				return nil, "ERROR", errors.New("status is not found in API response")
+			}
+
+			if status == "SUCCESS" {
+				return respBody, "COMPLETED", nil
+			}
+
+			if utils.StrSliceContains(unexpectedStatus, status) {
+				return respBody, status, fmt.Errorf("job failed with status: %s", status)
+			}
+
+			return respBody, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceProtectedInstanceResizeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceProtectedInstanceResizeUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceProtectedInstanceResizeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to resize a protected instance. Deleting this 
+resource will not change the current configuration, but will only remove the resource information from the 
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to resize sdrs protected instance

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o sdrs -f TestAccProtectedInstanceResize_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/sdrs" -v -coverprofile="./huaweicloud/services/acceptance/sdrs/sdrs_coverage.cov" -coverpkg="./huaweicloud/services/sdrs" -run TestAccProtectedInstanceResize_basic -timeout 360m -parallel 10
=== RUN   TestAccProtectedInstanceResize_basic
=== PAUSE TestAccProtectedInstanceResize_basic
=== CONT  TestAccProtectedInstanceResize_basic
--- PASS: TestAccProtectedInstanceResize_basic (76.68s)
PASS
coverage: 8.6% of statements in ./huaweicloud/services/sdrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sdrs      76.745s coverage: 8.6% of statements in ./huaweicloud/services/sdrs
```
<img width="1333" height="88" alt="image" src="https://github.com/user-attachments/assets/ed328d73-63ab-4046-8125-021ee416ee23" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
