### PR TITLE
feat(sdrs): new resource to delete sdrs failure job

### DIFF
--- a/docs/resources/sdrs_delete_failure_job.md
+++ b/docs/resources/sdrs_delete_failure_job.md
@@ -1,0 +1,39 @@
+---
+subcategory: "Storage Disaster Recovery Service (SDRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_sdrs_delete_failure_job"
+description: |-
+  Using this resource to delete a failure job in SDRS within HuaweiCloud.
+---
+
+# huaweicloud_sdrs_delete_failure_job
+
+Using this resource to delete a failure job in SDRS within HuaweiCloud.
+
+-> This is a one-time action resource to delete a failure job. Deleting this resource will
+not change the current configuration, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "failure_job_id" {}
+
+resource "huaweicloud_sdrs_delete_failure_job" "test" {
+  failure_job_id = var.failure_job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `failure_job_id` - (Required, String, NonUpdatable) Specifies the ID of the failure job to delete.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2602,15 +2602,16 @@ func Provider() *schema.Provider {
 			"huaweicloud_rms_remediation_exception":              rms.ResourceRemediationException(),
 			"huaweicloud_rms_remediation_execution":              rms.ResourceRemediationExecution(),
 
-			"huaweicloud_sdrs_drill":                                sdrs.ResourceDrill(),
+			"huaweicloud_sdrs_delete_failure_job":                   sdrs.ResourceDeleteFailureJob(),
 			"huaweicloud_sdrs_delete_protected_groups_failed_tasks": sdrs.ResourceDeleteProtectedGroupsFailedTasks(),
-			"huaweicloud_sdrs_replication_pair":                     sdrs.ResourceReplicationPair(),
+			"huaweicloud_sdrs_drill":                                sdrs.ResourceDrill(),
 			"huaweicloud_sdrs_protection_group":                     sdrs.ResourceProtectionGroup(),
 			"huaweicloud_sdrs_protected_instance":                   sdrs.ResourceProtectedInstance(),
 			"huaweicloud_sdrs_protected_instance_add_nic":           sdrs.ResourceProtectedInstanceAddNIC(),
 			"huaweicloud_sdrs_protected_instance_delete_nic":        sdrs.ResourceProtectedInstanceDeleteNIC(),
 			"huaweicloud_sdrs_protected_instance_resize":            sdrs.ResourceProtectedInstanceResize(),
 			"huaweicloud_sdrs_replication_attach":                   sdrs.ResourceReplicationAttach(),
+			"huaweicloud_sdrs_replication_pair":                     sdrs.ResourceReplicationPair(),
 
 			"huaweicloud_secmaster_incident":                    secmaster.ResourceIncident(),
 			"huaweicloud_secmaster_indicator":                   secmaster.ResourceIndicator(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -321,6 +321,7 @@ var (
 	HW_SDRS_PROTECTION_INSTANCE_ID = os.Getenv("HW_SDRS_PROTECTION_INSTANCE_ID")
 	HW_SDRS_NIC_ID                 = os.Getenv("HW_SDRS_NIC_ID")
 	HW_SDRS_RESIZE_FLAVOR_ID       = os.Getenv("HW_SDRS_RESIZE_FLAVOR_ID")
+	HW_SDRS_FAILURE_JOB_ID         = os.Getenv("HW_SDRS_FAILURE_JOB_ID")
 
 	HW_IDENTITY_CENTER_ACCOUNT_ID                = os.Getenv("HW_IDENTITY_CENTER_ACCOUNT_ID")
 	HW_IDENTITY_CENTER_IDENTITY_POLICY_ID        = os.Getenv("HW_IDENTITY_CENTER_IDENTITY_POLICY_ID")
@@ -812,6 +813,13 @@ func TestAccPreCheckSDRSDeleteNic(t *testing.T) {
 func TestAccPreCheckSDRSInstanceResize(t *testing.T) {
 	if HW_SDRS_PROTECTION_INSTANCE_ID == "" {
 		t.Skip("HW_SDRS_PROTECTION_INSTANCE_ID must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckSDRSFailureJob(t *testing.T) {
+	if HW_SDRS_FAILURE_JOB_ID == "" {
+		t.Skip("HW_SDRS_FAILURE_JOB_ID must be set for this acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/sdrs/resource_huaweicloud_sdrs_delete_failure_job_test.go
+++ b/huaweicloud/services/acceptance/sdrs/resource_huaweicloud_sdrs_delete_failure_job_test.go
@@ -1,0 +1,34 @@
+package sdrs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDeleteFailureJob_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSDRSFailureJob(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDeleteFailureJob_basic(),
+			},
+		},
+	})
+}
+
+func testDeleteFailureJob_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_sdrs_delete_failure_job" "test" {
+  failure_job_id = "%[1]s"
+}
+`, acceptance.HW_SDRS_FAILURE_JOB_ID)
+}

--- a/huaweicloud/services/sdrs/resource_huaweicloud_sdrs_delete_failure_job.go
+++ b/huaweicloud/services/sdrs/resource_huaweicloud_sdrs_delete_failure_job.go
@@ -1,0 +1,108 @@
+package sdrs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SDRS DELETE /v1/{project_id}/task-center/failure-jobs/{failure_job_id}
+func ResourceDeleteFailureJob() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDeleteFailureJobCreate,
+		ReadContext:   resourceDeleteFailureJobRead,
+		UpdateContext: resourceDeleteFailureJobUpdate,
+		DeleteContext: resourceDeleteFailureJobDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"failure_job_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"failure_job_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the failure job to delete.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceDeleteFailureJobCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/task-center/failure-jobs/{failure_job_id}"
+		product = "sdrs"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating SDRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{failure_job_id}", d.Get("failure_job_id").(string))
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting SDRS failure job: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	return resourceDeleteFailureJobRead(ctx, d, meta)
+}
+
+func resourceDeleteFailureJobRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDeleteFailureJobUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDeleteFailureJobDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to delete a failure job. Deleting this 
+resource will not change the current configuration, but will only remove the resource information from the 
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to delete sdrs failure job.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o sdrs -f TestAccDeleteFailureJob_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/sdrs" -v -coverprofile="./huaweicloud/services/acceptance/sdrs/sdrs_coverage.cov" -coverpkg="./huaweicloud/services/sdrs" -run TestAccDeleteFailureJob_basic -timeout 360m -parallel 10
=== RUN   TestAccDeleteFailureJob_basic
=== PAUSE TestAccDeleteFailureJob_basic
=== CONT  TestAccDeleteFailureJob_basic
--- PASS: TestAccDeleteFailureJob_basic (8.82s)
PASS
coverage: 5.5% of statements in ./huaweicloud/services/sdrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sdrs      8.908s  coverage: 5.5% of statements in ./huaweicloud/services/sdrs
```
<img width="1315" height="97" alt="image" src="https://github.com/user-attachments/assets/338a19f8-4815-4114-9e14-2a77f712ec5f" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
