### PR TITLE
feat(modelarts/resource_pool_node_batch_resize|resource_pool): add server_ids attribute

### DIFF
--- a/docs/resources/modelarts_resource_pool.md
+++ b/docs/resources/modelarts_resource_pool.md
@@ -475,6 +475,8 @@ In addition to all arguments above, the following attributes are exported:
 * `clusters` - The list of the CCE clusters.  
   The [clusters](#ModelartsResourcePool_Clusters_attr) structure is documented below.
 
+* `server_ids` - The list of service IDs corresponding to the currently expanded nodes.
+
 <a name="ModelartsResourcePool_Resources_attr"></a>
 The `resources` block supports:
 

--- a/docs/resources/modelarts_resource_pool.md
+++ b/docs/resources/modelarts_resource_pool.md
@@ -475,7 +475,7 @@ In addition to all arguments above, the following attributes are exported:
 * `clusters` - The list of the CCE clusters.  
   The [clusters](#ModelartsResourcePool_Clusters_attr) structure is documented below.
 
-* `server_ids` - The list of service IDs corresponding to the currently expanded nodes.
+* `server_ids` - The list of service IDs corresponding to the latest expanded nodes.
 
 <a name="ModelartsResourcePool_Resources_attr"></a>
 The `resources` block supports:

--- a/docs/resources/modelarts_resource_pool_node_batch_resize.md
+++ b/docs/resources/modelarts_resource_pool_node_batch_resize.md
@@ -132,3 +132,5 @@ This resource provides the following timeouts configuration options:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
+
+* `server_ids` - The list of service IDs corresponding to the currently upgraded specification nodes.

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool.go
@@ -180,7 +180,7 @@ func ResourceModelartsResourcePool() *schema.Resource {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: `The list of service IDs corresponding to the currently expanded nodes.`,
+				Description: `The list of service IDs corresponding to the latest expanded nodes.`,
 			},
 			// Internal attributes(s).
 			"resources_order_origin": {

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool_node_batch_resize.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool_node_batch_resize.go
@@ -238,7 +238,7 @@ func resourceResourcePoolNodeBatchResizeCreate(ctx context.Context, d *schema.Re
 		return diag.Errorf("error getting the scaling node names by order name (%s): %s", orderName, err)
 	}
 
-	err = waitForNodesDriverStatusCompleted(ctx, client, resourcePoolName, actionNodeNames, d.Timeout(schema.TimeoutCreate))
+	_, err = waitForNodesDriverStatusCompleted(ctx, client, resourcePoolName, actionNodeNames, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("error waiting for the scaling nodes driver status under the resource pool (%s) to complete: %s", resourcePoolName, err)
 	}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool_node_batch_resize.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool_node_batch_resize.go
@@ -2,6 +2,7 @@ package modelarts
 
 import (
 	"context"
+	"log"
 	"strings"
 	"time"
 
@@ -111,6 +112,12 @@ func ResourceResourcePoolNodeBatchResize() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
 				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"server_ids": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of service IDs corresponding to the currently upgraded specification nodes.`,
 			},
 		},
 	}
@@ -238,9 +245,13 @@ func resourceResourcePoolNodeBatchResizeCreate(ctx context.Context, d *schema.Re
 		return diag.Errorf("error getting the scaling node names by order name (%s): %s", orderName, err)
 	}
 
-	_, err = waitForNodesDriverStatusCompleted(ctx, client, resourcePoolName, actionNodeNames, d.Timeout(schema.TimeoutCreate))
+	actionNodes, err := waitForNodesDriverStatusCompleted(ctx, client, resourcePoolName, actionNodeNames, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("error waiting for the scaling nodes driver status under the resource pool (%s) to complete: %s", resourcePoolName, err)
+	}
+
+	if err := d.Set("server_ids", getServerIdsByNodeNames(actionNodeNames, actionNodes.([]interface{}))); err != nil {
+		log.Printf("[ERROR] error setting the server IDs for updating resource pool (%s): %s", resourcePoolName, err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**huaweicloud_modelarts_resource_pool**
**1. For a resource pool with step `1`**.
- **Create resource pool stage(count: 1)**

   <img width="1672" height="916" alt="image" src="https://github.com/user-attachments/assets/2739de78-fd60-4c9d-a072-f3b0e15bf886" />

+ **Count expanded from `1` to `3`**

  <img width="1870" height="915" alt="image" src="https://github.com/user-attachments/assets/4e65a7fb-a31b-4813-83f6-f835bea645fe" />

**2. For a resource pool with step `2`**.
+ **Create resource pool stage(count: 2)**

  <img width="1676" height="945" alt="image" src="https://github.com/user-attachments/assets/b114519a-443d-466e-8559-db1662a9ac8f" />
+ **Count expanded from `2` to `4`**
  
  <img width="1576" height="922" alt="image" src="https://github.com/user-attachments/assets/26241946-edc1-4ea5-bee6-3a53963bd120" />

**3. Expanding 2 A2 nodes**
   
  <img width="1442" height="928" alt="image" src="https://github.com/user-attachments/assets/5b6c2ba6-d91d-49a0-8af9-fa0ece1480f4" />


**4. Import validation**
   <img width="1621" height="377" alt="image" src="https://github.com/user-attachments/assets/fa03ab2b-495c-448b-a2bf-fbff4fe9103c" />

**huaweicloud_modelarts_resource_pool_node_batch_resize**
 + **step from `1` to `2`**
<img width="1582" height="661" alt="image" src="https://github.com/user-attachments/assets/7aaeed6c-428a-430d-b930-e6610777d7bd" />

  

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
