### PR TITLE
feat(sdrs): new resource to resize sdrs replication pair

### DIFF
--- a/docs/resources/sdrs_resize_replication.md
+++ b/docs/resources/sdrs_resize_replication.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Storage Disaster Recovery Service (SDRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_sdrs_resize_replication"
+description: |-
+  Using this resource to resize a replication pair's disk in SDRS within HuaweiCloud.
+---
+
+# huaweicloud_sdrs_resize_replication
+
+Using this resource to resize a replication pair's disk in SDRS within HuaweiCloud.
+
+-> This is a one-time action resource to resize a replication pair's disk. Deleting this resource will
+not change the current configuration, but will only remove the resource information from the tfstate file.
+
+-> Before using this resource, please note the following restrictions:
+<br/>1. The status of the replication pair must be **available** or **protected** or **error-extending**.
+<br/>2. The status of the cloud disks must be **available** or **in-use**.
+<br/>3. If the cloud disks are pay-per-use, they can be resized directly.
+<br/>4. If the cloud disks are prepaid, they cannot be resized directly. You need to delete the replication pair first,
+resize the cloud disks, and then create a new replication pair.
+<br/>5. Running this resource may cause unexpected change to the `size` field of the `huaweicloud_evs_volume`.
+Please using `lifecycle` to control the `size` field of the `huaweicloud_evs_volume`.
+
+## Example Usage
+
+```hcl
+variable "replication_id" {}
+variable "new_size" {}
+
+resource "huaweicloud_sdrs_resize_replication" "test" {
+  replication_id = var.replication_id
+  new_size       = var.new_size
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `replication_id` - (Required, String, NonUpdatable) Specifies the ID of the replication pair to resize.
+
+* `new_size` - (Required, Integer, NonUpdatable) Specifies the new size of the replication pair's disk in GB.
+  Must be greater than the current size.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the resource.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2618,6 +2618,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_sdrs_protected_instance_resize":           sdrs.ResourceProtectedInstanceResize(),
 			"huaweicloud_sdrs_replication_attach":                  sdrs.ResourceReplicationAttach(),
 			"huaweicloud_sdrs_replication_pair":                    sdrs.ResourceReplicationPair(),
+			"huaweicloud_sdrs_resize_replication":                  sdrs.ResourceResizeReplication(),
 
 			"huaweicloud_secmaster_incident":                    secmaster.ResourceIncident(),
 			"huaweicloud_secmaster_indicator":                   secmaster.ResourceIndicator(),

--- a/huaweicloud/services/acceptance/sdrs/resource_huaweicloud_sdrs_resize_replication_test.go
+++ b/huaweicloud/services/acceptance/sdrs/resource_huaweicloud_sdrs_resize_replication_test.go
@@ -1,0 +1,70 @@
+package sdrs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccResizeReplication_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testResizeReplication_basic(),
+			},
+		},
+	})
+}
+
+func testResizeReplication_basic() string {
+	name := acceptance.RandomAccResourceName()
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+data "huaweicloud_sdrs_domain" "test" {}
+
+resource "huaweicloud_sdrs_protection_group" "test" {
+  name                     = "%[2]s"
+  source_availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  target_availability_zone = data.huaweicloud_availability_zones.test.names[1]
+  domain_id                = data.huaweicloud_sdrs_domain.test.id
+  source_vpc_id            = huaweicloud_vpc.test.id
+  description              = "test description"
+}
+
+resource "huaweicloud_evs_volume" "test" {
+  name              = "%[2]s"
+  description       = "test volume for sdrs replication pair"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  volume_type       = "SSD"
+  size              = 100
+
+  lifecycle {
+    ignore_changes = [size]
+  }
+}
+
+resource "huaweicloud_sdrs_replication_pair" "test" {
+  name                 = "%[2]s"
+  group_id             = huaweicloud_sdrs_protection_group.test.id
+  volume_id            = huaweicloud_evs_volume.test.id
+  description          = "test description"
+  delete_target_volume = true
+}
+
+resource "huaweicloud_sdrs_resize_replication" "test" {
+  replication_id = huaweicloud_sdrs_replication_pair.test.id
+  new_size       = 150
+}
+`, common.TestVpc(name), name)
+}

--- a/huaweicloud/services/sdrs/resource_huaweicloud_sdrs_resize_replication.go
+++ b/huaweicloud/services/sdrs/resource_huaweicloud_sdrs_resize_replication.go
@@ -1,0 +1,176 @@
+package sdrs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SDRS POST /v1/{project_id}/replications/{replication_id}/action
+// @API SDRS GET /v1/{project_id}/jobs/{job_id}
+func ResourceResizeReplication() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceResizeReplicationCreate,
+		ReadContext:   resourceResizeReplicationRead,
+		UpdateContext: resourceResizeReplicationUpdate,
+		DeleteContext: resourceResizeReplicationDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"replication_id",
+			"new_size",
+		}),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"replication_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the replication pair to resize.`,
+			},
+			"new_size": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the new size of the replication pair's disk in GB. Must be greater than the current size.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceResizeReplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/replications/{replication_id}/action"
+		product = "sdrs"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating SDRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{replication_id}", d.Get("replication_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"extend-replication": map[string]interface{}{
+				"new_size": d.Get("new_size"),
+			},
+		},
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error resizing replication pair: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobID := utils.PathSearch("job_id", respBody, "").(string)
+	if jobID == "" {
+		return diag.Errorf("error resizing replication pair: job ID not found in API response")
+	}
+
+	if err := waitingForResizeReplicationSuccess(ctx, client, d.Timeout(schema.TimeoutCreate), jobID); err != nil {
+		return diag.Errorf("error waiting for replication resize to complete: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	return resourceResizeReplicationRead(ctx, d, meta)
+}
+
+func waitingForResizeReplicationSuccess(ctx context.Context, client *golangsdk.ServiceClient, timeout time.Duration, jobID string) error {
+	unexpectedStatus := []string{"FAIL"}
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			respBody, err := queryJobStatus(client, jobID)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			status := utils.PathSearch("status", respBody, "").(string)
+			if status == "" {
+				return nil, "ERROR", errors.New("status is not found in API response")
+			}
+
+			if status == "SUCCESS" {
+				return respBody, "COMPLETED", nil
+			}
+
+			if utils.StrSliceContains(unexpectedStatus, status) {
+				return respBody, status, fmt.Errorf("job failed with status: %s", status)
+			}
+
+			return respBody, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceResizeReplicationRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceResizeReplicationUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceResizeReplicationDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to resize a replication pair. Deleting this 
+resource will not change the current configuration, but will only remove the resource information from the 
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to resize sdrs replication pair.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o sdrs -f TestAccResizeReplication_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/sdrs" -v -coverprofile="./huaweicloud/services/acceptance/sdrs/sdrs_coverage.cov" -coverpkg="./huaweicloud/services/sdrs" -run TestAccResizeReplication_basic -timeout 360m -parallel 10
=== RUN   TestAccResizeReplication_basic
=== PAUSE TestAccResizeReplication_basic
=== CONT  TestAccResizeReplication_basic
--- PASS: TestAccResizeReplication_basic (114.94s)
PASS
coverage: 17.8% of statements in ./huaweicloud/services/sdrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sdrs      115.024s        coverage: 17.8% of statements in ./huaweicloud/services/sdrs
```
<img width="1319" height="102" alt="image" src="https://github.com/user-attachments/assets/3fdc39bc-40ba-44f7-98bf-ca5395f8bfe6" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
