### PR TITLE
feat(hss): new resource to handle password complexity check

### DIFF
--- a/docs/resources/hss_ignore_failed_pcc.md
+++ b/docs/resources/hss_ignore_failed_pcc.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_ignore_failed_pcc"
+description: |-
+  Using this resource to ignore or cancel the ignorance of servers that fail the password complexity check within HuaweiCloud.
+---
+
+# huaweicloud_hss_ignore_failed_pcc
+
+Using this resource to ignore or cancel the ignorance of servers that fail the password complexity check within HuaweiCloud.
+
+-> This resource is a stateless operation resource. Deleting this resource will not affect the ignore status of the hosts,
+but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_hss_ignore_failed_pcc" "test" {
+  action      = "ignore"
+  operate_all = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `action` - (Required, String, NonUpdatable) Specifies the action type to perform.
+  The valid values are:
+  + **ignore**: Ignore the servers that fail the password complexity check.
+  + **unignore**: Unignore the servers that fail the password complexity check.
+
+* `operate_all` - (Optional, Bool, NonUpdatable) Specifies whether the operation is a full operation. A maximum of
+  `1,000` hosts can be processed at a time. Defaults to **false**.
+
+* `host_ids` - (Optional, List, NonUpdatable) Specifies the list of host IDs to perform the action on.
+  This parameter is ignored when `operate_all` is set to **true**.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the ID of the enterprise project that the server
+  belongs to. The value **0** indicates the default enterprise project. To query servers in all enterprise projects,
+  set this parameter to **all_granted_eps**. If you have only the permission on an enterprise project, you need to
+  transfer the enterprise project ID to query the server in the enterprise project. Otherwise, an error is reported due
+  to insufficient permission.
+
+  -> An enterprise project can be configured only after the enterprise project function is enabled.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2294,6 +2294,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_image_batch_scan":                 hss.ResourceImageBatchScan(),
 			"huaweicloud_hss_vulnerability_information_export": hss.ResourceVulnerabilityInformationExport(),
 			"huaweicloud_hss_file_download":                    hss.ResourceFileDownload(),
+			"huaweicloud_hss_ignore_failed_pcc":                hss.ResourceIgnoreFailedPCC(),
 
 			"huaweicloud_identity_access_key":            iam.ResourceIdentityKey(),
 			"huaweicloud_identity_acl":                   iam.ResourceIdentityACL(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_ignore_failed_pcc_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_ignore_failed_pcc_test.go
@@ -1,0 +1,32 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccIgnoreFailedPCC_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIgnoreFailedPCC_basic,
+			},
+		},
+	})
+}
+
+const testAccIgnoreFailedPCC_basic string = `
+resource "huaweicloud_hss_ignore_failed_pcc" "test" {
+  action                = "ignore"
+  operate_all           = true
+  enterprise_project_id = "0"
+}
+`

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_ignore_failed_pcc.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_ignore_failed_pcc.go
@@ -1,0 +1,143 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var ignoreFailedPCCNonUpdatableParams = []string{
+	"action", "host_ids", "operate_all", "enterprise_project_id",
+}
+
+// @API HSS POST /v5/{project_id}/baseline/password-complexity/action
+func ResourceIgnoreFailedPCC() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIgnoreFailedPCCCreate,
+		ReadContext:   resourceIgnoreFailedPCCRead,
+		UpdateContext: resourceIgnoreFailedPCCUpdate,
+		DeleteContext: resourceIgnoreFailedPCCDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(ignoreFailedPCCNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Specifies the region where the resource is located. If omitted, the provider-level region will be used.",
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the action type to perform.",
+			},
+			"operate_all": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Specifies whether to perform the action on all hosts.",
+			},
+			"host_ids": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Specifies the list of host IDs to perform the action on.",
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the enterprise project ID.",
+			},
+		},
+	}
+}
+
+func buildIgnoreFailedPCCQueryParams(d *schema.ResourceData, cfg *config.Config) string {
+	rst := fmt.Sprintf("?action=%s", d.Get("action").(string))
+
+	if epsID := cfg.GetEnterpriseProjectID(d); epsID != "" {
+		return fmt.Sprintf("%s&enterprise_project_id=%s", rst, epsID)
+	}
+
+	return rst
+}
+
+func buildIgnoreFailedPCCBodyParams(d *schema.ResourceData) map[string]interface{} {
+	rst := map[string]interface{}{
+		// Customize its default value to false.
+		"operate_all": d.Get("operate_all"),
+	}
+
+	if rawArray, ok := d.Get("host_ids").([]interface{}); ok && len(rawArray) > 0 {
+		rst["host_ids"] = utils.ExpandToStringList(rawArray)
+	}
+
+	return rst
+}
+
+func resourceIgnoreFailedPCCCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		action  = d.Get("action").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v5/{project_id}/baseline/password-complexity/action"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildIgnoreFailedPCCQueryParams(d, cfg)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildIgnoreFailedPCCBodyParams(d),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error operating (%s) action to HSS ignore failed password complexity check: %s", action, err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID: %s", err)
+	}
+	d.SetId(id)
+
+	return resourceIgnoreFailedPCCRead(ctx, d, meta)
+}
+
+func resourceIgnoreFailedPCCRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceIgnoreFailedPCCUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceIgnoreFailedPCCDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to ignore failed password complexity check. Deleting
+	this resource will not clear the corresponding ignore records, but will only remove the resource information from
+	the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

New resource to ignore or cancel the ignorance of servers that fail the password complexity check.

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccIgnoreFailedPCC_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccIgnoreFailedPCC_basic -timeout 360m -parallel 10
=== RUN   TestAccIgnoreFailedPCC_basic
=== PAUSE TestAccIgnoreFailedPCC_basic
=== CONT  TestAccIgnoreFailedPCC_basic
--- PASS: TestAccIgnoreFailedPCC_basic (9.63s)
PASS
coverage: 3.1% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       9.728s  coverage: 3.1% of statements in ./huaweicloud/services/hss
```
<img width="1303" height="113" alt="image" src="https://github.com/user-attachments/assets/375a179f-e70d-4111-8332-b9f08a1377f1" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
