### PR TITLE
feat(hss/hss_antivirus_statistic): support `hss_antivirus_statistic` data source

### DIFF
--- a/docs/data-sources/hss_antivirus_statistic.md
+++ b/docs/data-sources/hss_antivirus_statistic.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_antivirus_statistic"
+description: |-
+  Use this data source to get the list of HSS antivirus statistic within HuaweiCloud.
+---
+# huaweicloud_hss_antivirus_statistic
+
+Use this data source to get the list of HSS antivirus statistic within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_antivirus_statistic" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `total_malware_num` - The total number of viruses.
+
+* `malware_host_num` - Affects the number of hosts.
+
+* `total_task_num` - Accumulated number of scanning tasks.
+
+* `scanning_task_num` - The number of running tasks.
+
+* `latest_scan_time` - The start time in milliseconds.
+
+* `scan_type` - The scan type.  
+  The valid values are as follows:
+  + **quick**: Quick scan.
+  + **full**: Full scan.
+  + **custom**: Custom scan.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1099,6 +1099,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_antivirus_custom_scan_policies": hss.DataSourceAntivirusCustomScanPolicies(),
 			"huaweicloud_hss_antivirus_available_hosts":      hss.DataSourceAntivirusAvailableHosts(),
 			"huaweicloud_hss_backup_policy":                  hss.DataSourceBackupPolicy(),
+			"huaweicloud_hss_antivirus_statistic":            hss.DataSourceAntivirusStatistic(),
 
 			"huaweicloud_identity_permissions": iam.DataSourceIdentityPermissions(),
 			"huaweicloud_identity_role":        iam.DataSourceIdentityRole(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_antivirus_statistic_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_antivirus_statistic_test.go
@@ -1,0 +1,45 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAntivirusStatistic_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_antivirus_statistic.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting a host ID with container version host protection enabled.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAntivirusStatistic_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "total_malware_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "malware_host_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "total_task_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "scanning_task_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "latest_scan_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "scan_type"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAntivirusStatistic_basic string = `
+data "huaweicloud_hss_antivirus_statistic" "test" {
+  enterprise_project_id = "all_granted_eps"
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_antivirus_statistic.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_antivirus_statistic.go
@@ -1,0 +1,112 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/antivirus/statistic
+func DataSourceAntivirusStatistic() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAntivirusStatisticRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"total_malware_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"malware_host_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"total_task_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"scanning_task_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"latest_scan_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"scan_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAntivirusStatisticRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v5/{project_id}/antivirus/statistic"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	if epsId != "" {
+		requestPath += fmt.Sprintf("?enterprise_project_id=%s", epsId)
+	}
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS antivirus statistic: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_malware_num", utils.PathSearch("total_malware_num", respBody, nil)),
+		d.Set("malware_host_num", utils.PathSearch("malware_host_num", respBody, nil)),
+		d.Set("total_task_num", utils.PathSearch("total_task_num", respBody, nil)),
+		d.Set("scanning_task_num", utils.PathSearch("scanning_task_num", respBody, nil)),
+		d.Set("latest_scan_time", utils.PathSearch("latest_scan_time", respBody, nil)),
+		d.Set("scan_type", utils.PathSearch("scan_type", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_antivirus_statistic` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_antivirus_statistic` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceAntivirusStatistic_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceAntivirusStatistic_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAntivirusStatistic_basic
=== PAUSE TestAccDataSourceAntivirusStatistic_basic
=== CONT  TestAccDataSourceAntivirusStatistic_basic
--- PASS: TestAccDataSourceAntivirusStatistic_basic (8.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       8.987s

```
<img width="873" height="54" alt="image" src="https://github.com/user-attachments/assets/c06e11a5-3897-4c3d-93b2-76c47c9134db" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
