### PR TITLE
feat(hss): new datasource to query backup policy

### DIFF
--- a/docs/data-sources/hss_backup_policy.md
+++ b/docs/data-sources/hss_backup_policy.md
@@ -1,0 +1,100 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_backup_policy"
+description: |-
+  Use this data source to get the HSS backup policy within HuaweiCloud.
+---
+
+# huaweicloud_hss_backup_policy
+
+Use this data source to get the HSS backup policy within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "policy_id" {}
+
+data "huaweicloud_hss_backup_policy" "test" {
+  policy_id = var.policy_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource. If omitted, the provider-level
+  region will be used.
+
+* `policy_id` - (Required, String) Specifies the backup policy ID.
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project that the server belongs to.
+  The value **0** indicates the default enterprise project. To query servers in all enterprise projects, set this parameter
+  to **all_granted_eps**. If you have only the permission on an enterprise project, you need to transfer the enterprise
+  project ID to query the server in the enterprise project. Otherwise, an error is reported due to insufficient permission.
+
+  -> An enterprise project can be configured only after the enterprise project function is enabled.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `enabled` - Indicates whether the backup policy is enabled.
+
+* `name` - The name of the backup policy.
+
+* `operation_type` - The backup type. Currently, only **backup** is supported.
+
+* `operation_definition` - The policy attribute.
+  The [operation_definition](#operation_definition_struct) structure is documented below.
+
+* `trigger` - The backup policy scheduling rule.
+  The [trigger](#trigger_struct) structure is documented below.
+
+<a name="operation_definition_struct"></a>
+The `operation_definition` block supports:
+
+* `day_backups` - The maximum number of daily backups that can be retained.
+
+* `max_backups` - The maximum number of backups that can be automatically created for a backup object.
+  If the value is `-1`, backups will not be cleared by quantity limit. If this parameter and `retention_duration_days`
+  are left blank at the same time, the backups will be retained permanently. Minimum value: `1`. Maximum value: `99999`.
+  Default value: `-1`.
+
+* `month_backups` - The maximum number of monthly backups that can be retained.
+
+* `retention_duration_days` - The duration of retaining a backup, in days. The maximum value is 99999. If the value is
+  `-1`, backups will not be cleared by retention duration. If this parameter and `max_backups` are left blank at the
+  same time, the backups will be retained permanently.
+
+* `timezone` - The time zone where the user is located. For example, **UTC+08:00**.
+
+* `week_backups` - The maximum number of weekly backups that can be retained.
+
+* `year_backups` - The maximum number of yearly backups that can be retained.
+
+<a name="trigger_struct"></a>
+The `trigger` block supports:
+
+* `id` - The scheduler ID.
+
+* `name` - The scheduler name.
+
+* `type` - The scheduler type. Currently, only **time** is supported.
+
+* `properties` - The scheduler attribute.
+  The [properties](#properties_struct) structure is documented below.
+
+<a name="properties_struct"></a>
+The `properties` block supports:
+
+* `pattern` - The scheduling policy. The value contains a maximum of `10,240` characters and complies with iCalendar RFC
+  `2445`. However, only FREQ, BYDAY, BYHOUR, and BYMINUTE are supported. FREQ can be set to only WEEKLY or DAILY. BYDAY
+  can be set to the seven days in a week (MO, TU, WE, TH, FR, SA and SU). BYHOUR can be set to `0` to `23` hours. BYMINUTE
+  can be set to `0` to `59` minutes. The interval between time points cannot be less than one hour. Multiple backup time
+  points can be set in a backup policy, and up to `24` time points can be set for a day.
+
+* `start_time` - The scheduler start time. Example: **2020-01-08 09:59:49**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1096,6 +1096,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_webtamper_hosts":                hss.DataSourceWebTamperHosts(),
 			"huaweicloud_hss_antivirus_custom_scan_policies": hss.DataSourceAntivirusCustomScanPolicies(),
 			"huaweicloud_hss_antivirus_available_hosts":      hss.DataSourceAntivirusAvailableHosts(),
+			"huaweicloud_hss_backup_policy":                  hss.DataSourceBackupPolicy(),
 
 			"huaweicloud_identity_permissions": iam.DataSourceIdentityPermissions(),
 			"huaweicloud_identity_role":        iam.DataSourceIdentityRole(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_backup_policy_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_backup_policy_test.go
@@ -1,0 +1,63 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceBackupPolicy_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_backup_policy.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceBackupPolicy_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "enabled"),
+					resource.TestCheckResourceAttrSet(dataSource, "name"),
+					resource.TestCheckResourceAttrSet(dataSource, "operation_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "operation_definition.0.day_backups"),
+					resource.TestCheckResourceAttrSet(dataSource, "operation_definition.0.max_backups"),
+					resource.TestCheckResourceAttrSet(dataSource, "operation_definition.0.month_backups"),
+					resource.TestCheckResourceAttrSet(dataSource, "operation_definition.0.retention_duration_days"),
+					resource.TestCheckResourceAttrSet(dataSource, "operation_definition.0.timezone"),
+					resource.TestCheckResourceAttrSet(dataSource, "operation_definition.0.week_backups"),
+					resource.TestCheckResourceAttrSet(dataSource, "operation_definition.0.year_backups"),
+					resource.TestCheckResourceAttrSet(dataSource, "trigger.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceBackupPolicy_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cbr_policy" "test" {
+  name        = "%s"
+  type        = "backup"
+  time_period = 20
+
+  backup_cycle {
+    days            = "MO,TU"
+    execution_times = ["06:00", "18:00"]
+  }
+}
+
+data "huaweicloud_hss_backup_policy" "test" {
+  policy_id             = huaweicloud_cbr_policy.test.id
+  enterprise_project_id = "all_granted_eps"
+}
+`, acceptance.RandomAccResourceName())
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_backup_policy.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_backup_policy.go
@@ -1,0 +1,263 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/backup/{policy_id}
+func DataSourceBackupPolicy() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBackupPolicyRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Specifies the region in which to query the resource. If omitted, the provider-level region will be used.",
+			},
+			"policy_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the backup policy ID.",
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the enterprise project ID.",
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates whether the backup policy is enabled.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the backup policy.",
+			},
+			"operation_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The backup type.",
+			},
+			"operation_definition": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataOperationDefinitionSchema(),
+				Description: "The policy attribute.",
+			},
+			"trigger": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataTriggerSchema(),
+				Description: "The backup policy scheduling rule.",
+			},
+		},
+	}
+}
+
+func dataOperationDefinitionSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"day_backups": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The maximum number of daily backups that can be retained.",
+			},
+			"max_backups": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The maximum number of backups that can be automatically created for a backup object.",
+			},
+			"month_backups": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The maximum number of monthly backups that can be retained.",
+			},
+			"retention_duration_days": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The duration of retaining a backup, in days.",
+			},
+			"timezone": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The time zone where the user is located.",
+			},
+			"week_backups": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The maximum number of weekly backups that can be retained.",
+			},
+			"year_backups": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The maximum number of yearly backups that can be retained.",
+			},
+		},
+	}
+}
+
+func dataTriggerSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The scheduler ID.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The scheduler name.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The scheduler type.",
+			},
+			"properties": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataTriggerPropertiesSchema(),
+				Description: "The scheduler attribute.",
+			},
+		},
+	}
+}
+
+func dataTriggerPropertiesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"pattern": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The scheduling policy.",
+			},
+			"start_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The scheduler start time.",
+			},
+		},
+	}
+}
+
+func buildBackupPolicyQueryParams(d *schema.ResourceData, cfg *config.Config) string {
+	epsId := cfg.GetEnterpriseProjectID(d)
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+	}
+
+	return ""
+}
+
+func dataSourceBackupPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		httpUrl  = "v5/{project_id}/backup/{policy_id}"
+		policyId = d.Get("policy_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{policy_id}", policyId)
+	getPath += buildBackupPolicyQueryParams(d, cfg)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the HSS backup policy: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("enabled", utils.PathSearch("enabled", respBody, nil)),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("operation_type", utils.PathSearch("operation_type", respBody, nil)),
+		d.Set("operation_definition", flattenOperationDefinitionAttribute(utils.PathSearch("operation_definition", respBody, nil))),
+		d.Set("trigger", flattenTriggerAttribute(utils.PathSearch("trigger", respBody, nil))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenOperationDefinitionAttribute(rawMap interface{}) []interface{} {
+	if rawMap == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"day_backups":             utils.PathSearch("day_backups", rawMap, nil),
+			"max_backups":             utils.PathSearch("max_backups", rawMap, nil),
+			"month_backups":           utils.PathSearch("month_backups", rawMap, nil),
+			"retention_duration_days": utils.PathSearch("retention_duration_days", rawMap, nil),
+			"timezone":                utils.PathSearch("timezone", rawMap, nil),
+			"week_backups":            utils.PathSearch("week_backups", rawMap, nil),
+			"year_backups":            utils.PathSearch("year_backups", rawMap, nil),
+		},
+	}
+}
+
+func flattenTriggerAttribute(rawMap interface{}) []interface{} {
+	if rawMap == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"id":         utils.PathSearch("id", rawMap, nil),
+			"name":       utils.PathSearch("name", rawMap, nil),
+			"type":       utils.PathSearch("type", rawMap, nil),
+			"properties": flattenTriggerPropertiesAttribute(utils.PathSearch("properties", rawMap, nil)),
+		},
+	}
+}
+
+func flattenTriggerPropertiesAttribute(rawMap interface{}) []interface{} {
+	if rawMap == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"pattern":    utils.PathSearch("pattern", rawMap, nil),
+			"start_time": utils.PathSearch("start_time", rawMap, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query backup policy.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccDataSourceBackupPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccDataSourceBackupPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceBackupPolicy_basic
--- PASS: TestAccDataSourceBackupPolicy_basic (13.46s)
PASS
coverage: 3.4% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       13.559s coverage: 3.4% of statements in ./huaweicloud/services/hss
```
<img width="1289" height="88" alt="image" src="https://github.com/user-attachments/assets/e6fa05b7-3e05-4be9-919e-cfb68bcac320" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
