### PR TITLE
feat(hss): new resource to export container task

### DIFF
--- a/docs/resources/hss_container_export_task.md
+++ b/docs/resources/hss_container_export_task.md
@@ -1,0 +1,123 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_container_export_task"
+description: |-
+  Manages an HSS container export task resource within HuaweiCloud.
+---
+
+# huaweicloud_hss_container_export_task
+
+Manages an HSS container export task resource within HuaweiCloud.
+
+-> This resource is only a one-time action resource for HSS container export. Deleting this resource
+   will not clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_hss_container_export_task" "test" {
+  export_headers = [
+    ["container_name", "Container Name"],
+    ["cluster_name", "Cluster Name"],
+    ["status", "Status"]
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `export_headers` - (Required, List, NonUpdatable) Specifies the header information list for exporting container
+  data. The type of this field is an `Array<Array<string>>`. Please refer to Example Usage for the format of valid values.
+  Valid key values and their corresponding table header names (table header names can be customized): **container_id**,
+  **container_name**, **image_name**, **pod_name**, **cluster_name**, **cluster_type**, **status**, **risky**, **low_risk**,
+  **medium_risk**, **high_risk**, **fatal_risk**, **create_time**, **restart_count**, **cpu_limit**, and **memory_limit**.
+
+* `cluster_container` - (Optional, String, NonUpdatable) Specifies whether the container is in a cluster. The valid
+  values are:
+  + **true**: Only containers in a cluster are exported.
+  + **false**: Only non-cluster containers are exported.
+
+  This field does not involve a default value.
+
+* `cluster_type` - (Optional, String, NonUpdatable) Specifies the cluster type. Options:
+  + **cce**: CCE cluster.
+  + **ali**: Alibaba Cloud cluster.
+  + **tencent**: Tencent Cloud cluster.
+  + **azure**: Microsoft Azure Cloud cluster.
+  + **aws**: AWS Cloud cluster.
+  + **self_built_hw**: Customer-built cluster on Huawei Cloud.
+  + **self_built_idc**: IDC on-premises cluster.
+
+* `cluster_name` - (Optional, String, NonUpdatable) Specifies the name of the cluster to which the container belongs.
+  The value contains `1` to `255` characters.
+
+* `container_name` - (Optional, String, NonUpdatable) Specifies the name of the container to export.
+  The value contains `1` to `255` characters.
+
+* `pod_name` - (Optional, String, NonUpdatable) Specifies the name of the pod to which the container belongs.
+  The value can contain `1` to `512` characters.
+
+* `image_name` - (Optional, String, NonUpdatable) Specifies the name of the container image.
+  The value contains `1` to `255` characters.
+
+* `status` - (Optional, String, NonUpdatable) Specifies the container status. Valid values are **Running**, **Waiting**,
+  **Terminated**, **Isolated**, and **Paused**.
+
+* `risky` - (Optional, String, NonUpdatable) Specifies whether the container has security risks. Options:
+  + **true**: Only containers with security risks are to be exported.
+  + **false**: Only containers without security risks are to be exported.
+
+* `create_time` - (Optional, List, NonUpdatable) Specifies the time range for filtering containers.
+  The [create_time](#create_time_object) structure is documented below.
+
+* `cpu_limit` - (Optional, String, NonUpdatable) Specifies the CPU limit for the container.
+  You can enter `0` to `64` characters. The unit is m, for example, **100m**.
+
+* `memory_limit` - (Optional, String, NonUpdatable) Specifies the memory limit for the container.
+  You can enter `0` to `64` characters. The unit is Mi or Gi, for example, **300Mi**.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the ID of the enterprise project that the server
+  belongs to. The value **0** indicates the default enterprise project. To query servers in all enterprise projects,
+  set this parameter to **all_granted_eps**. If you have only the permission on an enterprise project, you need to
+  transfer the enterprise project ID to query the server in the enterprise project.
+  Otherwise, an error is reported due to insufficient permission.
+
+  -> An enterprise project can be configured only after the enterprise project function is enabled.
+
+* `export_size` - (Optional, Int, NonUpdatable) Specifies the number of containers to export.
+  The value ranges from `1` to `100,000`.
+
+<a name="create_time_object"></a>
+The `create_time` block supports:
+
+* `start_time` - (Optional, Int) Specifies the start time for filtering containers.
+
+* `end_time` - (Optional, Int) Specifies the end time for filtering containers.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID same as `task_id`.
+
+* `task_id` - The export task ID.
+
+* `task_name` - The export task name.
+
+* `task_status` - The export task status. The valid values are **success**, **failure**, and **running**.
+
+* `file_id` - The export file ID.
+
+* `file_name` - The export file name.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 3 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2290,6 +2290,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_asset_manual_collect":             hss.ResourceAssetManualCollect(),
 			"huaweicloud_hss_host_group":                       hss.ResourceHostGroup(),
 			"huaweicloud_hss_cce_protection":                   hss.ResourceCCEProtection(),
+			"huaweicloud_hss_container_export_task":            hss.ResourceContainerExportTask(),
 			"huaweicloud_hss_host_protection":                  hss.ResourceHostProtection(),
 			"huaweicloud_hss_webtamper_protection":             hss.ResourceWebTamperProtection(),
 			"huaweicloud_hss_quota":                            hss.ResourceQuota(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_container_export_task_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_container_export_task_test.go
@@ -1,0 +1,61 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccHSSContainerExportTask_basic(t *testing.T) {
+	rName := "huaweicloud_hss_container_export_task.test"
+
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testContainerExportTask_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rName, "task_id"),
+					resource.TestCheckResourceAttrSet(rName, "task_name"),
+					resource.TestCheckResourceAttrSet(rName, "task_status"),
+					resource.TestCheckResourceAttrSet(rName, "file_id"),
+					resource.TestCheckResourceAttrSet(rName, "file_name"),
+				),
+			},
+		},
+	})
+}
+
+const testContainerExportTask_basic = `
+resource "huaweicloud_hss_container_export_task" "test" {
+  export_headers = [
+    ["container_name", "Container Name"],
+    ["cluster_name", "Cluster Name"],
+    ["status", "Status"]
+  ]
+
+  cluster_container     = "true"
+  cluster_type          = "cce"
+  cluster_name          = "test-cluster-name"
+  container_name        = "test-container-name"
+  pod_name              = "test-pod-name"
+  image_name            = "test-image-name"
+  status                = "Running"
+  risky                 = "true"
+  cpu_limit             = "100m"
+  memory_limit          = "300Mi"
+  enterprise_project_id = "0"
+  export_size           = 100
+
+  create_time {
+    start_time = 1690348800
+    end_time   = 1690435200
+  }
+}
+`

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_container_export_task.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_container_export_task.go
@@ -1,0 +1,345 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var containerExportTaskNonUpdatableParams = []string{
+	"export_headers",
+	"cluster_container",
+	"cluster_type",
+	"cluster_name",
+	"container_name",
+	"pod_name",
+	"image_name",
+	"status",
+	"risky",
+	"create_time",
+	"create_time.*.start_time",
+	"create_time.*.end_time",
+	"cpu_limit",
+	"memory_limit",
+	"enterprise_project_id",
+	"export_size",
+}
+
+// @API HSS POST /v5/{project_id}/container/export-task
+// @API HSS GET /v5/{project_id}/export-task/{task_id}
+func ResourceContainerExportTask() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceContainerExportTaskCreate,
+		ReadContext:   resourceContainerExportTaskRead,
+		UpdateContext: resourceContainerExportTaskUpdate,
+		DeleteContext: resourceContainerExportTaskDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(3 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(containerExportTaskNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Specifies the region where the resource is located.",
+			},
+			// Body Params
+			"export_headers": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: "Specifies the headers for the exported container list.",
+				Elem: &schema.Schema{
+					Type: schema.TypeList,
+					Elem: &schema.Schema{Type: schema.TypeString},
+				},
+			},
+			// This field is defined as a Boolean value in the API. Since this field has no special meaning, its type is
+			// adjusted to a string.
+			"cluster_container": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies whether the container is in a cluster.",
+			},
+			"cluster_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the cluster type.",
+			},
+			"cluster_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the name of the cluster to which the container belongs.",
+			},
+			"container_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the name of the container to export.",
+			},
+			"pod_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the name of the Pod to which the container belongs.",
+			},
+			"image_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the name of the container image.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the container status.",
+			},
+			// This field is defined as a Boolean value in the API. Since this field has no special meaning, its type is
+			// adjusted to a string.
+			"risky": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies whether the container has security risks.",
+			},
+			"create_time": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Specifies the time range for filtering containers.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"start_time": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Specifies the start time for filtering containers.",
+						},
+						"end_time": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Specifies the end time for filtering containers.",
+						},
+					},
+				},
+			},
+			"cpu_limit": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the CPU limit for the container.",
+			},
+			"memory_limit": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the memory limit for the container.",
+			},
+			// Query Params
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the ID of the enterprise project to which the resource belongs.",
+			},
+			"export_size": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the number of containers to export.",
+			},
+			// Computed Attributes
+			"task_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the export task.",
+			},
+			"task_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the export task.",
+			},
+			"task_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The status of the export task.",
+			},
+			"file_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the exported file.",
+			},
+			"file_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the exported file.",
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildCreateContainerExportTaskQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := ""
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("export_size"); ok {
+		queryParams = fmt.Sprintf("%s&export_size=%v", queryParams, v)
+	}
+
+	if queryParams != "" {
+		queryParams = "?" + queryParams[1:]
+	}
+
+	return queryParams
+}
+
+func buildContainerExportTaskClusterContainerParam(d *schema.ResourceData) interface{} {
+	rawValue := d.Get("cluster_container").(string)
+	if rawValue == "" {
+		return nil
+	}
+
+	return utils.StringToBool(rawValue)
+}
+
+func buildContainerExportTaskCreateTimeBodyParam(d *schema.ResourceData) interface{} {
+	rawArray := d.Get("create_time").([]interface{})
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"start_time": rawMap["start_time"],
+		"end_time":   rawMap["end_time"],
+	}
+}
+
+func buildContainerExportTaskExportHeadersBodyParam(d *schema.ResourceData) interface{} {
+	rst := make([]interface{}, 0)
+	for _, v := range d.Get("export_headers").([]interface{}) {
+		row := utils.ExpandToStringList(v.([]interface{}))
+		rst = append(rst, row)
+	}
+	return rst
+}
+
+func buildContainerExportTaskRiskyParam(d *schema.ResourceData) interface{} {
+	rawValue := d.Get("risky").(string)
+	if rawValue == "" {
+		return nil
+	}
+
+	return utils.StringToBool(rawValue)
+}
+
+func buildCreateContainerExportTaskBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"export_headers":    buildContainerExportTaskExportHeadersBodyParam(d),
+		"cluster_container": buildContainerExportTaskClusterContainerParam(d),
+		"cluster_type":      utils.ValueIgnoreEmpty(d.Get("cluster_type")),
+		"cluster_name":      utils.ValueIgnoreEmpty(d.Get("cluster_name")),
+		"container_name":    utils.ValueIgnoreEmpty(d.Get("container_name")),
+		"pod_name":          utils.ValueIgnoreEmpty(d.Get("pod_name")),
+		"image_name":        utils.ValueIgnoreEmpty(d.Get("image_name")),
+		"status":            utils.ValueIgnoreEmpty(d.Get("status")),
+		"risky":             buildContainerExportTaskRiskyParam(d),
+		"create_time":       buildContainerExportTaskCreateTimeBodyParam(d),
+		"cpu_limit":         utils.ValueIgnoreEmpty(d.Get("cpu_limit")),
+		"memory_limit":      utils.ValueIgnoreEmpty(d.Get("memory_limit")),
+	}
+}
+
+func resourceContainerExportTaskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v5/{project_id}/container/export-task"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildCreateContainerExportTaskQueryParams(d, epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateContainerExportTaskBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error exporting HSS container task: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	taskId := utils.PathSearch("task_id", respBody, "").(string)
+	if taskId == "" {
+		return diag.Errorf("error exporting HSS container task: task ID is not found in API response")
+	}
+
+	d.SetId(taskId)
+
+	queryTaskRespBody, err := waitingForExportTaskSuccess(ctx, client, d.Timeout(schema.TimeoutCreate), taskId)
+	if err != nil {
+		return diag.Errorf("error waiting for the HSS container export task to complete: %s", err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("task_id", taskId),
+		d.Set("task_name", utils.PathSearch("task_name", queryTaskRespBody, nil)),
+		d.Set("task_status", utils.PathSearch("task_status", queryTaskRespBody, nil)),
+		d.Set("file_id", utils.PathSearch("file_id", queryTaskRespBody, nil)),
+		d.Set("file_name", utils.PathSearch("file_name", queryTaskRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceContainerExportTaskRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceContainerExportTaskUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceContainerExportTaskDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to export HSS container task. Deleting this resource
+	will not clear the corresponding exported record, but will only remove the resource information from the tf state
+	file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to export container task.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccHSSContainerExportTask_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccHSSContainerExportTask_basic -timeout 360m -parallel 10
=== RUN   TestAccHSSContainerExportTask_basic
=== PAUSE TestAccHSSContainerExportTask_basic
=== CONT  TestAccHSSContainerExportTask_basic
--- PASS: TestAccHSSContainerExportTask_basic (15.10s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       15.203s coverage: 4.6% of statements in ./huaweicloud/services/hss
```
<img width="1316" height="89" alt="image" src="https://github.com/user-attachments/assets/6eb71333-ea8f-46cc-a4ea-9324e1854409" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
