### PR TITLE
feat(hss): new datasource to query container node statistics

### DIFF
--- a/docs/data-sources/hss_container_node_statistics.md
+++ b/docs/data-sources/hss_container_node_statistics.md
@@ -1,0 +1,53 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_container_node_statistics"
+description: |-
+  Use this data source to get HSS container node protection statistics within HuaweiCloud.
+---
+
+# huaweicloud_hss_container_node_statistics
+
+Use this data source to get HSS container node protection statistics within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_container_node_statistics" "test" {
+  enterprise_project_id = "0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+  -> An enterprise project can be configured only after the enterprise project function is enabled.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `unprotected_num` - The number of unprotected servers.
+
+* `protected_num` - The total number of protected nodes.
+
+* `protected_num_on_demand` - The number of nodes protected on demand.
+
+* `protected_num_packet_cycle` - The number of nodes protected by quota.
+
+* `cluster_node_not_installed_num` - The number of uninstalled cluster nodes.
+
+* `not_cluster_node_not_installed_num` - The number of uninstalled non-cluster nodes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1074,6 +1074,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_auto_launchs":                   hss.DataSourceAutoLaunchs(),
 			"huaweicloud_hss_container_kubernetes":           hss.DataSourceContainerKubernetes(),
 			"huaweicloud_hss_container_nodes":                hss.DataSourceContainerNodes(),
+			"huaweicloud_hss_container_node_statistics":      hss.DataSourceContainerNodeStatistics(),
 			"huaweicloud_hss_event_system_user_white_lists":  hss.DataSourceEventSystemUserWhiteLists(),
 			"huaweicloud_hss_event_login_white_lists":        hss.DataSourceEventLoginWhiteLists(),
 			"huaweicloud_hss_event_alarm_white_lists":        hss.DataSourceEventAlarmWhiteLists(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_node_statistics_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_node_statistics_test.go
@@ -1,0 +1,43 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceContainerNodeStatistics_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_container_node_statistics.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceContainerNodeStatistics_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "unprotected_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "protected_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "protected_num_on_demand"),
+					resource.TestCheckResourceAttrSet(dataSource, "protected_num_packet_cycle"),
+					resource.TestCheckResourceAttrSet(dataSource, "cluster_node_not_installed_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "not_cluster_node_not_installed_num"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceContainerNodeStatistics_basic string = `
+data "huaweicloud_hss_container_node_statistics" "test" {
+  enterprise_project_id = "0"
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_container_node_statistics.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_container_node_statistics.go
@@ -1,0 +1,112 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/container/node-statistics
+func DataSourceContainerNodeStatistics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceContainerNodeStatisticsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// Attribute.
+			"unprotected_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"protected_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"protected_num_on_demand": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"protected_num_packet_cycle": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"cluster_node_not_installed_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"not_cluster_node_not_installed_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceContainerNodeStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v5/{project_id}/container/node-statistics"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	if epsId != "" {
+		requestPath = fmt.Sprintf("%s?enterprise_project_id=%v", requestPath, epsId)
+	}
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS container node statistics: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("unprotected_num", utils.PathSearch("unprotected_num", respBody, nil)),
+		d.Set("protected_num", utils.PathSearch("protected_num", respBody, nil)),
+		d.Set("protected_num_on_demand", utils.PathSearch("protected_num_on_demand", respBody, nil)),
+		d.Set("protected_num_packet_cycle", utils.PathSearch("protected_num_packet_cycle", respBody, nil)),
+		d.Set("cluster_node_not_installed_num", utils.PathSearch("cluster_node_not_installed_num", respBody, nil)),
+		d.Set("not_cluster_node_not_installed_num", utils.PathSearch("not_cluster_node_not_installed_num", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query container node statistics.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccDataSourceContainerNodeStatistics_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccDataSourceContainerNodeStatistics_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceContainerNodeStatistics_basic
=== PAUSE TestAccDataSourceContainerNodeStatistics_basic
=== CONT  TestAccDataSourceContainerNodeStatistics_basic
--- PASS: TestAccDataSourceContainerNodeStatistics_basic (9.50s)
PASS
coverage: 3.1% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       9.608s  coverage: 3.1% of statements in ./huaweicloud/services/hss
```
<img width="1300" height="72" alt="image" src="https://github.com/user-attachments/assets/13c30ca5-8616-4d81-8e7f-81e4865f18ac" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
