### PR TITLE
refactor(cce): save extension_scale_groups in cce cluster

### DIFF
--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -605,6 +605,20 @@ In addition to all arguments above, the following attributes are exported:
 
 * `current_node_count` - The current number of the nodes.
 
+* `extension_scale_groups` - The configurations of extended scaling groups in the node pool.
+  The [object](#extension_scale_groups--attribute) structure is documented below.
+
+<a name="extension_scale_groups--attribute"></a>
+The `extension_scale_groups` block supports:
+
+* `metadata` - The basic information about the extended scaling group.
+  The [object](#metadata--attribute) structure is documented below.
+
+<a name="metadata--attribute"></a>
+The `metadata` block supports:
+
+* `uid` - The ID of the extended scaling group.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:
@@ -622,7 +636,7 @@ $ terraform import huaweicloud_cce_node_pool.my_node_pool <cluster_id>/<id>
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include:
-`password`, `extend_params`, `taints`, `initial_node_count`, `pod_security_groups` and `extension_scale_groups`.
+`password`, `extend_params`, `taints`, `initial_node_count` and `pod_security_groups`.
 It is generally recommended running `terraform plan` after importing a node pool.
 You can then decide if changes should be applied to the node pool, or the resource
 definition should be updated to align with the node pool. Also you can ignore changes as below.

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
@@ -981,7 +981,7 @@ func TestAccNodePool_extensionScaleGroups(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					// extension_scale_groups not saved, nothing to check, just ensure there is no error
+					// the order of extension_scale_groups returned by API could be different, so don't need to check
 				),
 			},
 			{
@@ -989,7 +989,7 @@ func TestAccNodePool_extensionScaleGroups(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
-					// extension_scale_groups not saved, nothing to check, just ensure there is no error
+					// the order of extension_scale_groups returned by API could be different, so don't need to check
 				),
 			},
 			{
@@ -998,7 +998,7 @@ func TestAccNodePool_extensionScaleGroups(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccNodePoolImportStateIdFunc(resourceName),
 				ImportStateVerifyIgnore: []string{
-					"initial_node_count", "extension_scale_groups",
+					"initial_node_count",
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccNodePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccNodePool_basic -timeout 360m -parallel 4
=== RUN   TestAccNodePool_basic
=== PAUSE TestAccNodePool_basic
=== CONT  TestAccNodePool_basic
--- PASS: TestAccNodePool_basic (1810.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1810.884s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccNodePool_extensionScaleGroups'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccNodePool_extensionScaleGroups -timeout 360m -parallel 4
=== RUN   TestAccNodePool_extensionScaleGroups
=== PAUSE TestAccNodePool_extensionScaleGroups
=== CONT  TestAccNodePool_extensionScaleGroups
--- PASS: TestAccNodePool_extensionScaleGroups (748.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       748.716s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
