### PR TITLE
feat(workspace/app): add new data source to get workspace app service information

### DIFF
--- a/docs/data-sources/workspace_app_service.md
+++ b/docs/data-sources/workspace_app_service.md
@@ -1,0 +1,44 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_service"
+description: |-
+  Use this data source to get the service information of Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_service
+
+Use this data source to get the service information of Workspace APP within HuaweiCloud.
+
+-> Before using this data source, please ensure that the Workspace service is enabled.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_workspace_app_service" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `service_status` - The status of the APP service.
+  + **active**
+  + **inactive**
+
+* `open_with_ad` - Whether the APP service is connected to AD.
+
+* `tenant_domain_id` - The domain ID to which the APP service belongs.
+
+* `tenant_domain_name` - The domain name to which the APP service belongs.
+
+* `created_at` - The creation time of the Workspace service, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1611,6 +1611,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_schedule_tasks":                  workspace.DataSourceAppScheduleTasks(),
 			"huaweicloud_workspace_app_schedule_task_future_executions": workspace.DataSourceAppScheduleTaskFutureExecutions(),
 			"huaweicloud_workspace_app_servers":                         workspace.DataSourceAppServers(),
+			"huaweicloud_workspace_app_service":                         workspace.DataSourceAppService(),
 			"huaweicloud_workspace_app_server_groups":                   workspace.DataSourceAppServerGroups(),
 			"huaweicloud_workspace_app_server_group_restrict":           workspace.DataSourceAppServerGroupRestrict(),
 			"huaweicloud_workspace_app_server_group_status":             workspace.DataSourceAppServerGroupStatus(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_service_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_service_test.go
@@ -1,0 +1,42 @@
+package workspace
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAppService_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_workspace_app_service.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAppService_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_open_with_ad_set_and_valid", "true"),
+					resource.TestCheckResourceAttrSet(dataSource, "service_status"),
+					resource.TestCheckResourceAttrSet(dataSource, "tenant_domain_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "tenant_domain_name"),
+					resource.TestMatchResourceAttr(dataSource, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAppService_basic = `
+data "huaweicloud_workspace_app_service" "test" {}
+
+output "is_open_with_ad_set_and_valid" {
+  value = data.huaweicloud_workspace_app_service.test.open_with_ad != null
+}
+`

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_service.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_service.go
@@ -1,0 +1,107 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/tenant/profile
+func DataSourceAppService() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppServiceRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the APP service is located.`,
+			},
+			"service_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the APP service.`,
+			},
+			"open_with_ad": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the APP service is connected to AD.`,
+			},
+			"tenant_domain_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The domain ID to which the APP service belongs.`,
+			},
+			"tenant_domain_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The domain name to which the APP service belongs.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the Workspace service, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func dataSourceAppServiceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/tenant/profile"
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.Errorf("error getting APP service information: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("service_status", utils.PathSearch("service_status", respBody, nil)),
+		d.Set("open_with_ad", utils.PathSearch("open_with_ad", respBody, nil)),
+		d.Set("tenant_domain_id", utils.PathSearch("tenant_domain_id", respBody, nil)),
+		d.Set("tenant_domain_name", utils.PathSearch("tenant_domain_name", respBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("create_time",
+			respBody, "").(string))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new data source(**huaweicloud_workspace_app_service**) to get workspace app service information.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new data source and corresponding ducument and corresponding acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataSourceAppService_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataSourceAppService_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAppService_basic
=== PAUSE TestAccDataSourceAppService_basic
=== CONT  TestAccDataSourceAppService_basic
--- PASS: TestAccDataSourceAppService_basic (12.01s)
PASS
coverage: 2.7% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 12.178s coverage: 2.7% of statements in ./huaweicloud/services/workspace
```
<img width="1125" height="435" alt="image" src="https://github.com/user-attachments/assets/3aa5e456-c964-4ab5-a9fe-947da29d2fed" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
