### PR TITLE
feat(CodeArts/Pipeline): support permission management for creating pipeline by template

### DIFF
--- a/docs/resources/codearts_pipeline_by_template.md
+++ b/docs/resources/codearts_pipeline_by_template.md
@@ -93,6 +93,9 @@ The following arguments are supported:
 
 * `tags` - (Optional, List) Specifies the tag IDs.
 
+* `resource_level_permission_switch` - (Optional, Bool) Specifies whether to use resource level permission.
+  Default to **false**, which means project level permission will be used.
+
 <a name="block--sources"></a>
 The `sources` block supports:
 
@@ -224,6 +227,11 @@ In addition to all arguments above, the following attributes are exported:
 * `triggers` - Specifies the pipeline trigger settings.
   The [triggers](#attrblock--triggers) structure is documented below.
 
+* `role_permissions` - Indicates the role permissions.
+  The [role_permissions](#attrblock--role_permissions) structure is documented below.
+
+* `is_allow_edit` - Indicates whether the user is allowed to edit the permission.
+
 * `update_time` - Indicates the last update time.
 
 * `updater_id` - Indicates the last updater ID.
@@ -237,6 +245,23 @@ The `schedules` block supports:
 The `triggers` block supports:
 
 * `hook_id` - Indicates the callback ID.
+
+<a name="attrblock--role_permissions"></a>
+The `role_permissions` block supports:
+
+* `operation_authorize` - Indicates whether the role has the permission to authorize.
+
+* `operation_delete` - Indicates whether the role has the permission to delete.
+
+* `operation_execute` - Indicates whether the role has the permission to execute.
+
+* `operation_query` - Indicates whether the role has the permission to query.
+
+* `operation_update` - Indicates whether the role has the permission to update.
+
+* `role_id` - Indicates the role ID.
+
+* `role_name` - Indicates the role name.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/codeartspipeline/resource_huaweicloud_codearts_pipeline_by_template_test.go
+++ b/huaweicloud/services/acceptance/codeartspipeline/resource_huaweicloud_codearts_pipeline_by_template_test.go
@@ -248,12 +248,13 @@ func testPipelineByTemplate_createWithUpdate(name string) string {
 %[3]s
 
 resource "huaweicloud_codearts_pipeline_by_template" "test" {
-  project_id  = huaweicloud_codearts_project.test.id
-  template_id = huaweicloud_codearts_pipeline_template.test.id
-  name        = "%[4]s"
-  is_publish  = false
-  banned      = true
-  description = "test"
+  project_id                       = huaweicloud_codearts_project.test.id
+  template_id                      = huaweicloud_codearts_pipeline_template.test.id
+  name                             = "%[4]s"
+  is_publish                       = false
+  banned                           = true
+  description                      = "test"
+  resource_level_permission_switch = true
 
   sources {
     type = "code"

--- a/huaweicloud/services/codeartspipeline/data_source_huaweicloud_codearts_pipeline_user_permissions.go
+++ b/huaweicloud/services/codeartspipeline/data_source_huaweicloud_codearts_pipeline_user_permissions.go
@@ -125,7 +125,7 @@ func dataSourceCodeArtsPipelineUserPermissionsRead(_ context.Context, d *schema.
 		currentPath := getPath + fmt.Sprintf("&offset=%d", offset)
 		getResp, err := client.Request("GET", currentPath, &getOpt)
 		if err != nil {
-			return diag.Errorf("error retrieving pipeline users: %s", err)
+			return diag.Errorf("error retrieving pipeline user permissions: %s", err)
 		}
 		getRespBody, err := utils.FlattenResponse(getResp)
 		if err != nil {
@@ -133,7 +133,7 @@ func dataSourceCodeArtsPipelineUserPermissionsRead(_ context.Context, d *schema.
 		}
 
 		if err := checkResponseError(getRespBody, ""); err != nil {
-			return diag.Errorf("error retrieving pipeline users: %s", err)
+			return diag.Errorf("error retrieving pipeline permissions: %s", err)
 		}
 
 		users := utils.PathSearch("users", getRespBody, make([]interface{}, 0)).([]interface{})


### PR DESCRIPTION
…mplate

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
support permission management for creating pipeline by template
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support permission management for creating pipeline by template
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/codeartspipeline' TESTARGS='-run TestAccPipelineByTemplate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codeartspipeline -v -run TestAccPipelineByTemplate_ -timeout 360m -parallel 4
=== RUN   TestAccPipelineByTemplate_basic
=== PAUSE TestAccPipelineByTemplate_basic
=== RUN   TestAccPipelineByTemplate_createWithUpdate
=== PAUSE TestAccPipelineByTemplate_createWithUpdate
=== CONT  TestAccPipelineByTemplate_basic
=== CONT  TestAccPipelineByTemplate_createWithUpdate
--- PASS: TestAccPipelineByTemplate_createWithUpdate (37.58s)
--- PASS: TestAccPipelineByTemplate_basic (54.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codeartspipeline  54.290s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
