### PR TITLE
feat(workspacce/app): add new data source to get APP eps system configs

### DIFF
--- a/docs/data-sources/workspace_app_configurations.md
+++ b/docs/data-sources/workspace_app_configurations.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_configurations"
+description: |-
+  Use this data source to get enterprise system configuration list of the Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_configurations
+
+Use this data source to get enterprise system configuration list of the Workspace APP within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "items" {
+  type = list(string)
+}
+
+data "huaweicloud_workspace_app_configurations" "test" {
+  items = var.items
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the Workspace APP are located.  
+  If omitted, the provider-level region will be used.
+
+* `items` - (Required, List) Specifies the list of configuration keys to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `configurations` - The list of configuration information.  
+  The [configurations](#data_attr_app_configurations) structure is documented below.
+
+<a name="data_attr_app_configurations"></a>
+The `configurations` block supports:
+
+* `config_key` - The key of the configuration.
+
+* `config_value` - The value corresponding to the configuration key.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1601,6 +1601,7 @@ func Provider() *schema.Provider {
 			// Workspace APP
 			"huaweicloud_workspace_app_available_volumes":               workspace.DataSourceAppAvailableVolumes(),
 			"huaweicloud_workspace_app_center_availability_zones":       workspace.DataSourceAvailabilityZones(),
+			"huaweicloud_workspace_app_configurations":                  workspace.DataSourceAppConfigurations(),
 			"huaweicloud_workspace_app_flavors":                         workspace.DataSourceAppFlavors(),
 			"huaweicloud_workspace_app_group_authorizations":            workspace.DataSourceWorkspaceAppGroupAuthorizations(),
 			"huaweicloud_workspace_app_groups":                          workspace.DataSourceWorkspaceAppGroups(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_configurations_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_configurations_test.go
@@ -1,0 +1,37 @@
+package workspace
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAppConfigurations_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_workspace_app_configurations.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAppConfigurations_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "configurations.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "configurations.0.config_key"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "configurations.0.config_value"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAppConfigurations_basic = `
+data "huaweicloud_workspace_app_configurations" "test" {
+  items = ["help_center_origin", "IP_VIRTUAL_ENABLE"]
+}
+`

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_configurations.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_configurations.go
@@ -1,0 +1,117 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace POST /v1/{project_id}/bundles/batch-query-config-info
+func DataSourceAppConfigurations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppConfigurationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The region where the Workspace APP are located.",
+			},
+			"items": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The list of configuration keys to be queried.",
+			},
+			"configurations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"config_key": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The key of the configuration.",
+						},
+						"config_value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The value corresponding to the configuration key.",
+						},
+					},
+				},
+				Description: "The list of configuration information.",
+			},
+		},
+	}
+}
+
+func dataSourceAppConfigurationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/bundles/batch-query-config-info"
+	)
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"items": d.Get("items"),
+		},
+	}
+
+	requestResp, err := client.Request("POST", getPath, &opt)
+	if err != nil {
+		return diag.Errorf("error querying Workspace APP configurations: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("configurations", flattenAppConfigurations(utils.PathSearch("config_infos", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAppConfigurations(configurations []interface{}) []map[string]interface{} {
+	if len(configurations) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(configurations))
+	for i, v := range configurations {
+		result[i] = map[string]interface{}{
+			"config_key":   utils.PathSearch("config_key", v, nil),
+			"config_value": utils.PathSearch("config_value", v, nil),
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source(**huaweicloud_workspace_app_configurations) to query Workspace APP  enterprise system configurations.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new data source and corresponding document and corresponding acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataSourceAppConfigurations_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataSourceAppConfigurations_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAppConfigurations_basic
=== PAUSE TestAccDataSourceAppConfigurations_basic
=== CONT  TestAccDataSourceAppConfigurations_basic
--- PASS: TestAccDataSourceAppConfigurations_basic (15.18s)
PASS
coverage: 2.7% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 15.270s coverage: 2.7% of statements in ./huaweicloud/services/workspace
```
<img width="1118" height="123" alt="image" src="https://github.com/user-attachments/assets/72bc6f5f-1d24-4b85-b4ff-b059b833d737" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
