### PR TITLE
refactor(object/diff): using customize diff to refresh origin values

### DIFF
--- a/huaweicloud/services/evs/resource_huaweicloud_evs_snapshot.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_snapshot.go
@@ -87,9 +87,11 @@ func ResourceEvsSnapshot() *schema.Resource {
 				Computed: true,
 			},
 			"metadata_origin": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:             schema.TypeMap,
+				Optional:         true,
+				Computed:         true,
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: utils.SuppressDiffAll,
 				Description: utils.SchemaDesc(
 					`The script configuration value of this change is also the original value used for comparison with
  the new value next time the change is made. The corresponding parameter name is 'metadata'.`,

--- a/huaweicloud/services/evs/resource_huaweicloud_evsv3_snapshot.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evsv3_snapshot.go
@@ -97,9 +97,11 @@ func ResourceV3Snapshot() *schema.Resource {
 				Computed: true,
 			},
 			"metadata_origin": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:             schema.TypeMap,
+				Optional:         true,
+				Computed:         true,
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: utils.SuppressDiffAll,
 				Description: utils.SchemaDesc(
 					`The script configuration value of this change is also the original value used for
 					comparison with the new value next time the change is made. The corresponding parameter name is

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -597,6 +597,7 @@ CIDR blocks used by the service.`,
 			"lts_custom_tag": {
 				Type:             schema.TypeMap,
 				Optional:         true,
+				Computed:         true,
 				Elem:             &schema.Schema{Type: schema.TypeString},
 				DiffSuppressFunc: utils.SuppressMapDiffs(),
 				// The custom tags can be set to empty, so computed behavior cannot be supported.
@@ -646,9 +647,11 @@ CIDR blocks used by the service.`,
 				Description: `The version of the function.`,
 			},
 			"lts_custom_tag_origin": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:             schema.TypeMap,
+				Optional:         true,
+				Computed:         true,
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: utils.SuppressDiffAll,
 				Description: utils.SchemaDesc(
 					`The script configuration value of this change is also the original value used for comparison with
  the new value next time the change is made. The corresponding parameter name is 'lts_custom_tag'.`,

--- a/huaweicloud/utils/resource_diff_test.go
+++ b/huaweicloud/utils/resource_diff_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func TestDiffSuppressFunc_ContainsAllKeyValues(t *testing.T) {
+func TestResourceDiffunc_ContainsAllKeyValues(t *testing.T) {
 	var (
 		compareObject = map[string]interface{}{
 			"A": map[string]interface{}{
@@ -81,7 +81,7 @@ func TestDiffSuppressFunc_ContainsAllKeyValues(t *testing.T) {
 	t.Logf("All processing results of the ContainsAllKeyValues method meets expectation")
 }
 
-func TestDiffSuppressFunc_FindDecreaseKeys(t *testing.T) {
+func TestResourceDiffunc_FindDecreaseKeys(t *testing.T) {
 	var (
 		decreaseCacls = []map[string]interface{}{
 			{
@@ -124,7 +124,7 @@ func TestDiffSuppressFunc_FindDecreaseKeys(t *testing.T) {
 	t.Logf("All processing results of the FindDecreaseKeys method meets expectation")
 }
 
-func TestDiffSuppressFunc_TakeObjectsDifferent(t *testing.T) {
+func TestResourceDiffunc_TakeObjectsDifferent(t *testing.T) {
 	var (
 		diffCacls = []map[string]interface{}{
 			{

--- a/huaweicloud/utils/state_management.go
+++ b/huaweicloud/utils/state_management.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-cty/cty"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -171,92 +170,99 @@ func getNestedObject(obj cty.Value, paths []string) interface{} {
 	}
 }
 
+// RefreshObjectParamOriginValues updates origin values after all diff calculations are completed.
+// This function captures the final configuration values that will be used for comparison in DiffSuppressFunc.
+// It handles both direct field changes and length changes (e.g., lts_custom_tag_origin.%).
+// Origin values are used to store the current configuration state for subsequent diff suppression.
 func RefreshObjectParamOriginValues(d *schema.ResourceData, objectParamKeys []string) error {
-	var mErr *multierror.Error
+	log.Printf("[DEBUG][RefreshObjectParamOriginValues] Starting with %d object param keys: %v",
+		len(objectParamKeys), objectParamKeys)
 
-	for _, key := range objectParamKeys {
-		parts := strings.Split(key, ".")
+	rawConfig := d.GetRawConfig()
+	for _, absParamKeyPath := range objectParamKeys {
 		// Construct the corresponding _origin path.
-		originParts := make([]string, len(parts))
-		copy(originParts, parts)
-		lastIdx := len(originParts) - 1
-		originParts[lastIdx] += "_origin"
+		absOriginParamKeyPath := fmt.Sprintf("%s_origin", absParamKeyPath)
+		log.Printf("[DEBUG][RefreshObjectParamOriginValues] Processing '%s' -> '%s'",
+			absParamKeyPath, absOriginParamKeyPath)
 
-		// Obtain the origin value
-		rawVal, err := getNestedValue(d, parts)
-		if err != nil {
-			log.Printf("[DEBUG] failed to get origin value for the parameter '%s': %v", key, err)
+		// Get current configuration value from rawConfig
+		rawVal := GetNestedObjectFromRawConfig(rawConfig, absParamKeyPath)
+
+		if rawVal == nil {
+			log.Printf("[DEBUG] Failed to get origin value for the parameter '%s'", absParamKeyPath)
 			// If the acquisition fails, the subsequent operation of the current parameter is skipped because this
 			// parameter may not be configured.
 			continue
 		}
 
-		// Setting the origin value
-		if err := setNestedValue(d, originParts, rawVal); err != nil {
-			mErr = multierror.Append(mErr, fmt.Errorf("failed to set origin value for '%s': %v", key, err))
+		// Set the origin value to match the configuration
+		log.Printf("[DEBUG][RefreshObjectParamOriginValues] Setting origin value for '%s'", absOriginParamKeyPath)
+
+		// Set the actual value using setNestedValueSafelyForResourceData to ensure nested safety
+		if err := setNestedValueSafelyForResourceData(d, absOriginParamKeyPath, rawVal); err != nil {
+			log.Printf("[ERROR][RefreshObjectParamOriginValues] Failed to set origin value for '%s': %v",
+				absOriginParamKeyPath, err)
+			return fmt.Errorf("failed to set origin value for '%s': %v", absOriginParamKeyPath, err)
 		}
+
+		log.Printf("[DEBUG][RefreshObjectParamOriginValues] Successfully set origin value for '%s'",
+			absOriginParamKeyPath)
 	}
 
-	return mErr.ErrorOrNil()
+	return nil
 }
 
-// getNestedValue method that used to obtain nested values ​​based on the path recursively, because the nested parameter
-// must ensure that the complete structure nesting of its corresponding subscript is obtained (only the corresponding
-// index is covered)
-func getNestedValue(d *schema.ResourceData, parts []string) (interface{}, error) {
-	var current interface{}
-	current = d.Get(parts[0])
-
-	for i := 1; i < len(parts); i++ {
-		part := parts[i]
-		switch cv := current.(type) {
-		case []interface{}:
-			if len(cv) == 0 {
-				return nil, fmt.Errorf("empty list at '%s'", strings.Join(parts[:i+1], "."))
-			}
-			// Processing lists/collections (automatically taking the first element if the index number is missing).
-			current = cv[0]
-			if index, err := strconv.Atoi(part); err == nil {
-				if index >= len(cv) {
-					return nil, fmt.Errorf("index %d out of range", index)
-				}
-				current = cv[index]
-			} else {
-				elem, ok := current.(map[string]interface{})
-				if !ok {
-					return nil, fmt.Errorf("invalid nested path at '%s'", strings.Join(parts[:i+1], "."))
-				}
-				current = elem[part]
-			}
-		case map[string]interface{}:
-			var ok bool
-			current, ok = cv[part]
-			if !ok {
-				return nil, fmt.Errorf("missing key '%s'", part)
-			}
-		default:
-			return nil, fmt.Errorf("unsupported type at '%s'", strings.Join(parts[:i+1], "."))
-		}
-	}
-	return current, nil
-}
-
-// setNestedValue method that used to set nested value recursively, because nested parameters must set their full
-// structure nesting according to their index (only overwrite the corresponding index).
-func setNestedValue(d *schema.ResourceData, parts []string, value interface{}) error {
+// setNestedValueSafelyForResourceData safely sets nested values in a ResourceData
+func setNestedValueSafelyForResourceData(d *schema.ResourceData, absOriginParamKeyPath string, value interface{}) error {
+	parts := strings.Split(absOriginParamKeyPath, ".")
 	rootKey := parts[0]
-	current := d.Get(rootKey)
 
-	updated, err := updateNestedStructure(current, parts[1:], value)
+	// Get current value and create a deep copy to avoid affecting other references
+	current := d.Get(rootKey)
+	currentCopy := deepCopyInterface(current)
+
+	// Update the copy
+	updated, err := updateNestedStructureSafely(currentCopy, parts[1:], value)
 	if err != nil {
 		return err
 	}
 
+	// Set the updated value
 	// lintignore:R001
-	return d.Set(rootKey, updated)
+	err = d.Set(rootKey, updated)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
-func updateNestedStructure(current interface{}, parts []string, value interface{}) (interface{}, error) {
+// deepCopyInterface creates a deep copy of an interface{} value
+func deepCopyInterface(value interface{}) interface{} {
+	if value == nil {
+		return nil
+	}
+
+	switch v := value.(type) {
+	case map[string]interface{}:
+		result := make(map[string]interface{})
+		for key, val := range v {
+			result[key] = deepCopyInterface(val)
+		}
+		return result
+	case []interface{}:
+		result := make([]interface{}, len(v))
+		for i, val := range v {
+			result[i] = deepCopyInterface(val)
+		}
+		return result
+	default:
+		// For primitive types, return as is
+		return value
+	}
+}
+
+// updateNestedStructureSafely safely updates nested structure without affecting other parts
+func updateNestedStructureSafely(current interface{}, parts []string, value interface{}) (interface{}, error) {
 	if len(parts) == 0 {
 		return value, nil
 	}
@@ -267,26 +273,51 @@ func updateNestedStructure(current interface{}, parts []string, value interface{
 		if len(cv) == 0 {
 			return nil, errors.New("cannot update empty list")
 		}
-		// Considering that the index of the Set type is inconsistent during the change before and after, currently only
-		// the first element of the List type is automatically processed (applicable to the MaxItems=1 scenario).
-		updatedElem, err := updateNestedStructure(cv[0], parts[1:], value)
-		if err != nil {
-			return nil, err
+
+		// Handle list indexing
+		if index, err := strconv.Atoi(part); err == nil {
+			if index < 0 || index >= len(cv) {
+				return nil, fmt.Errorf("index %d out of range for list of length %d", index, len(cv))
+			}
+
+			// Create a copy of the slice
+			result := make([]interface{}, len(cv))
+			copy(result, cv)
+
+			// Update the specific index
+			updatedElem, err := updateNestedStructureSafely(result[index], parts[1:], value)
+			if err != nil {
+				return nil, err
+			}
+			result[index] = updatedElem
+			return result, nil
 		}
-		cv[0] = updatedElem
-		return cv, nil
+
+		// If not a valid index, treat as property access (for tuple types)
+		return nil, fmt.Errorf("invalid list index: %s", part)
+
 	case map[string]interface{}:
-		subVal, ok := cv[part]
+		// Create a copy of the map
+		result := make(map[string]interface{})
+		for key, val := range cv {
+			result[key] = deepCopyInterface(val)
+		}
+
+		// Check if the key exists
+		subVal, ok := result[part]
 		if !ok {
 			return nil, fmt.Errorf("the parameter key '%s' not found", part)
 		}
-		updatedSubVal, err := updateNestedStructure(subVal, parts[1:], value)
+
+		// Update the specific key
+		updatedSubVal, err := updateNestedStructureSafely(subVal, parts[1:], value)
 		if err != nil {
 			return nil, err
 		}
-		cv[part] = updatedSubVal
-		return cv, nil
+		result[part] = updatedSubVal
+		return result, nil
+
 	default:
-		return nil, fmt.Errorf("unsupported type at '%s'", part)
+		return nil, fmt.Errorf("unsupported type at '%s': %T", part, current)
 	}
 }

--- a/huaweicloud/utils/state_management_test.go
+++ b/huaweicloud/utils/state_management_test.go
@@ -1,0 +1,570 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+)
+
+func TestStateManagementFunc_GetNestedObjectFromRawConfig(t *testing.T) {
+	// Create a comprehensive test object with various data types and nesting levels
+	complexObj := cty.ObjectVal(map[string]cty.Value{
+		"string_field": cty.StringVal("simple_string"),
+		"number_field": cty.NumberIntVal(42),
+		"bool_field":   cty.BoolVal(true),
+		"null_field":   cty.NullVal(cty.String),
+		"list_field": cty.ListVal([]cty.Value{
+			cty.StringVal("item1"),
+			cty.StringVal("item2"),
+			cty.StringVal("item3"),
+		}),
+		"nested_object": cty.ObjectVal(map[string]cty.Value{
+			"level1_string": cty.StringVal("level1_value"),
+			"level1_number": cty.NumberIntVal(100),
+			"level1_list": cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"id":   cty.NumberIntVal(1),
+					"name": cty.StringVal("nested_item_1"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"id":   cty.NumberIntVal(2),
+					"name": cty.StringVal("nested_item_2"),
+				}),
+			}),
+		}),
+		"deep_nested": cty.ObjectVal(map[string]cty.Value{
+			"level1": cty.ObjectVal(map[string]cty.Value{
+				"level2": cty.ObjectVal(map[string]cty.Value{
+					"level3": cty.ObjectVal(map[string]cty.Value{
+						"final_value": cty.StringVal("deep_nested_value"),
+					}),
+				}),
+			}),
+		}),
+		"mixed_types": cty.ObjectVal(map[string]cty.Value{
+			"strings": cty.ListVal([]cty.Value{
+				cty.StringVal("str1"),
+				cty.StringVal("str2"),
+			}),
+			"numbers": cty.ListVal([]cty.Value{
+				cty.NumberIntVal(10),
+				cty.NumberIntVal(20),
+				cty.NumberIntVal(30),
+			}),
+			"booleans": cty.ListVal([]cty.Value{
+				cty.BoolVal(true),
+				cty.BoolVal(false),
+			}),
+		}),
+	})
+
+	tests := []struct {
+		name     string
+		input    cty.Value
+		path     string
+		expected interface{}
+	}{
+		// Test empty path - should return entire object
+		{
+			name:  "empty path returns entire object",
+			input: complexObj,
+			path:  "",
+			expected: map[string]interface{}{
+				"string_field": "simple_string",
+				"number_field": float64(42),
+				"bool_field":   true,
+				"null_field":   nil,
+				"list_field": []interface{}{
+					"item1",
+					"item2",
+					"item3",
+				},
+				"nested_object": map[string]interface{}{
+					"level1_string": "level1_value",
+					"level1_number": float64(100),
+					"level1_list": []interface{}{
+						map[string]interface{}{
+							"id":   float64(1),
+							"name": "nested_item_1",
+						},
+						map[string]interface{}{
+							"id":   float64(2),
+							"name": "nested_item_2",
+						},
+					},
+				},
+				"deep_nested": map[string]interface{}{
+					"level1": map[string]interface{}{
+						"level2": map[string]interface{}{
+							"level3": map[string]interface{}{
+								"final_value": "deep_nested_value",
+							},
+						},
+					},
+				},
+				"mixed_types": map[string]interface{}{
+					"strings": []interface{}{
+						"str1",
+						"str2",
+					},
+					"numbers": []interface{}{
+						float64(10),
+						float64(20),
+						float64(30),
+					},
+					"booleans": []interface{}{
+						true,
+						false,
+					},
+				},
+			},
+		},
+		// Test simple field access
+		{
+			name:     "simple string field access",
+			input:    complexObj,
+			path:     "string_field",
+			expected: "simple_string",
+		},
+		{
+			name:     "simple number field access",
+			input:    complexObj,
+			path:     "number_field",
+			expected: float64(42),
+		},
+		{
+			name:     "simple boolean field access",
+			input:    complexObj,
+			path:     "bool_field",
+			expected: true,
+		},
+		{
+			name:     "null field access",
+			input:    complexObj,
+			path:     "null_field",
+			expected: nil,
+		},
+		// Test list access
+		{
+			name:     "list field access",
+			input:    complexObj,
+			path:     "list_field",
+			expected: []interface{}{"item1", "item2", "item3"},
+		},
+		{
+			name:     "list element access by index",
+			input:    complexObj,
+			path:     "list_field.0",
+			expected: "item1",
+		},
+		{
+			name:     "list element access by index 1",
+			input:    complexObj,
+			path:     "list_field.1",
+			expected: "item2",
+		},
+		{
+			name:     "list element access by index 2",
+			input:    complexObj,
+			path:     "list_field.2",
+			expected: "item3",
+		},
+		// Test nested object access
+		{
+			name:  "nested object access",
+			input: complexObj,
+			path:  "nested_object",
+			expected: map[string]interface{}{
+				"level1_string": "level1_value",
+				"level1_number": float64(100),
+				"level1_list": []interface{}{
+					map[string]interface{}{
+						"id":   float64(1),
+						"name": "nested_item_1",
+					},
+					map[string]interface{}{
+						"id":   float64(2),
+						"name": "nested_item_2",
+					},
+				},
+			},
+		},
+		{
+			name:     "nested object property access",
+			input:    complexObj,
+			path:     "nested_object.level1_string",
+			expected: "level1_value",
+		},
+		{
+			name:     "nested object number property access",
+			input:    complexObj,
+			path:     "nested_object.level1_number",
+			expected: float64(100),
+		},
+		// Test nested list access
+		{
+			name:  "nested list access",
+			input: complexObj,
+			path:  "nested_object.level1_list",
+			expected: []interface{}{
+				map[string]interface{}{
+					"id":   float64(1),
+					"name": "nested_item_1",
+				},
+				map[string]interface{}{
+					"id":   float64(2),
+					"name": "nested_item_2",
+				},
+			},
+		},
+		{
+			name:  "nested list element access",
+			input: complexObj,
+			path:  "nested_object.level1_list.0",
+			expected: map[string]interface{}{
+				"id":   float64(1),
+				"name": "nested_item_1",
+			},
+		},
+		{
+			name:     "nested list element property access",
+			input:    complexObj,
+			path:     "nested_object.level1_list.0.name",
+			expected: "nested_item_1",
+		},
+		{
+			name:     "nested list element property access 2",
+			input:    complexObj,
+			path:     "nested_object.level1_list.1.id",
+			expected: float64(2),
+		},
+		// Test deep nesting
+		{
+			name:  "deep nested access level1",
+			input: complexObj,
+			path:  "deep_nested.level1",
+			expected: map[string]interface{}{
+				"level2": map[string]interface{}{
+					"level3": map[string]interface{}{
+						"final_value": "deep_nested_value",
+					},
+				},
+			},
+		},
+		{
+			name:  "deep nested access level2",
+			input: complexObj,
+			path:  "deep_nested.level1.level2",
+			expected: map[string]interface{}{
+				"level3": map[string]interface{}{
+					"final_value": "deep_nested_value",
+				},
+			},
+		},
+		{
+			name:  "deep nested access level3",
+			input: complexObj,
+			path:  "deep_nested.level1.level2.level3",
+			expected: map[string]interface{}{
+				"final_value": "deep_nested_value",
+			},
+		},
+		{
+			name:     "deep nested final value access",
+			input:    complexObj,
+			path:     "deep_nested.level1.level2.level3.final_value",
+			expected: "deep_nested_value",
+		},
+		// Test mixed types
+		{
+			name:     "mixed types strings access",
+			input:    complexObj,
+			path:     "mixed_types.strings",
+			expected: []interface{}{"str1", "str2"},
+		},
+		{
+			name:     "mixed types numbers access",
+			input:    complexObj,
+			path:     "mixed_types.numbers",
+			expected: []interface{}{float64(10), float64(20), float64(30)},
+		},
+		{
+			name:     "mixed types booleans access",
+			input:    complexObj,
+			path:     "mixed_types.booleans",
+			expected: []interface{}{true, false},
+		},
+		{
+			name:     "mixed types specific string element",
+			input:    complexObj,
+			path:     "mixed_types.strings.0",
+			expected: "str1",
+		},
+		{
+			name:     "mixed types specific number element",
+			input:    complexObj,
+			path:     "mixed_types.numbers.1",
+			expected: float64(20),
+		},
+		{
+			name:     "mixed types specific boolean element",
+			input:    complexObj,
+			path:     "mixed_types.booleans.1",
+			expected: false,
+		},
+		// Test edge cases and error conditions
+		{
+			name:     "non-existent path returns nil",
+			input:    complexObj,
+			path:     "non.existent.path",
+			expected: nil,
+		},
+		{
+			name:     "invalid list index returns nil",
+			input:    complexObj,
+			path:     "list_field.999",
+			expected: nil,
+		},
+		{
+			name:     "negative list index returns nil",
+			input:    complexObj,
+			path:     "list_field.-1",
+			expected: nil,
+		},
+		{
+			name:     "non-numeric list index returns nil",
+			input:    complexObj,
+			path:     "list_field.invalid",
+			expected: nil,
+		},
+		{
+			name:     "accessing property on primitive type returns primitive value",
+			input:    complexObj,
+			path:     "string_field.property",
+			expected: "simple_string",
+		},
+		{
+			name:     "accessing property on null value returns nil",
+			input:    complexObj,
+			path:     "null_field.property",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetNestedObjectFromRawConfig(tt.input, tt.path)
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("GetNestedObjectFromRawConfig(%v, %q) = %v, want %v",
+					tt.input, tt.path, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStateManagementFunc_RefreshObjectParamOriginValues(t *testing.T) {
+	// Test the core logic of RefreshObjectParamOriginValues by testing its components
+
+	// Test 1: Test deepCopyInterface functionality
+	originalData := map[string]interface{}{
+		"policy": map[string]interface{}{
+			"annotations": []interface{}{
+				map[string]interface{}{
+					"key1": "value1",
+					"key2": "value2",
+				},
+				map[string]interface{}{
+					"key1": "value3",
+					"key2": "value4",
+				},
+			},
+			"config": map[string]interface{}{
+				"setting1": "setting_value1",
+				"setting2": "setting_value2",
+			},
+		},
+	}
+
+	// Test deep copy
+	copiedData := deepCopyInterface(originalData)
+	if !reflect.DeepEqual(originalData, copiedData) {
+		t.Fatalf("deepCopyInterface failed to create identical copy")
+	}
+
+	// Modify copied data to verify deep copy
+	copiedMap := copiedData.(map[string]interface{})
+	policyMap := copiedMap["policy"].(map[string]interface{})
+	annotations := policyMap["annotations"].([]interface{})
+	firstAnnotation := annotations[0].(map[string]interface{})
+	firstAnnotation["key1"] = "modified_value"
+
+	// Verify original data was not affected
+	originalPolicyMap := originalData["policy"].(map[string]interface{})
+	originalAnnotations := originalPolicyMap["annotations"].([]interface{})
+	originalFirstAnnotation := originalAnnotations[0].(map[string]interface{})
+
+	if originalFirstAnnotation["key1"] != "value1" {
+		t.Errorf("deepCopyInterface did not create a deep copy, modifying result affected input")
+	}
+
+	// Test 2: Test updateNestedStructureSafely functionality
+	testCases := []struct {
+		name        string
+		current     interface{}
+		parts       []string
+		value       interface{}
+		expected    interface{}
+		expectError bool
+	}{
+		{
+			name: "update nested map key",
+			current: map[string]interface{}{
+				"level1": map[string]interface{}{
+					"level2": map[string]interface{}{
+						"key": "old_value",
+					},
+				},
+			},
+			parts: []string{"level1", "level2", "key"},
+			value: "new_value",
+			expected: map[string]interface{}{
+				"level1": map[string]interface{}{
+					"level2": map[string]interface{}{
+						"key": "new_value",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "update list element",
+			current: []interface{}{
+				map[string]interface{}{
+					"id":   1,
+					"name": "old_name",
+				},
+				map[string]interface{}{
+					"id":   2,
+					"name": "item2",
+				},
+			},
+			parts: []string{"0", "name"},
+			value: "new_name",
+			expected: []interface{}{
+				map[string]interface{}{
+					"id":   1,
+					"name": "new_name",
+				},
+				map[string]interface{}{
+					"id":   2,
+					"name": "item2",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "error on non-existent map key",
+			current: map[string]interface{}{
+				"existing_key": "value",
+			},
+			parts:       []string{"non_existent", "sub_key"},
+			value:       "new_value",
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a deep copy of current to avoid modifying the test data
+			currentCopy := deepCopyInterface(tt.current)
+
+			result, err := updateNestedStructureSafely(currentCopy, tt.parts, tt.value)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("updateNestedStructureSafely(%v, %v, %v) expected error but got none",
+						tt.current, tt.parts, tt.value)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("updateNestedStructureSafely(%v, %v, %v) unexpected error: %v",
+					tt.current, tt.parts, tt.value, err)
+				return
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("updateNestedStructureSafely(%v, %v, %v) = %v, want %v",
+					tt.current, tt.parts, tt.value, result, tt.expected)
+			}
+
+			// Verify that the original current was not modified
+			if !reflect.DeepEqual(tt.current, currentCopy) {
+				t.Errorf("updateNestedStructureSafely modified the original input")
+			}
+		})
+	}
+
+	// Test 3: Test GetNestedObjectFromRawConfig with cty values
+	// This simulates what RefreshObjectParamOriginValues would do
+	ctyObj := cty.ObjectVal(map[string]cty.Value{
+		"policy": cty.ObjectVal(map[string]cty.Value{
+			"annotations": cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"key1": cty.StringVal("value1"),
+					"key2": cty.StringVal("value2"),
+				}),
+				cty.ObjectVal(map[string]cty.Value{
+					"key1": cty.StringVal("value3"),
+					"key2": cty.StringVal("value4"),
+				}),
+			}),
+			"config": cty.ObjectVal(map[string]cty.Value{
+				"setting1": cty.StringVal("setting_value1"),
+				"setting2": cty.StringVal("setting_value2"),
+			}),
+		}),
+	})
+
+	// Test extracting nested objects
+	annotationsResult := GetNestedObjectFromRawConfig(ctyObj, "policy.annotations")
+	expectedAnnotations := []interface{}{
+		map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+		},
+		map[string]interface{}{
+			"key1": "value3",
+			"key2": "value4",
+		},
+	}
+
+	if !reflect.DeepEqual(annotationsResult, expectedAnnotations) {
+		t.Errorf("GetNestedObjectFromRawConfig(policy.annotations) = %v, want %v",
+			annotationsResult, expectedAnnotations)
+	}
+
+	configResult := GetNestedObjectFromRawConfig(ctyObj, "policy.config")
+	expectedConfig := map[string]interface{}{
+		"setting1": "setting_value1",
+		"setting2": "setting_value2",
+	}
+
+	if !reflect.DeepEqual(configResult, expectedConfig) {
+		t.Errorf("GetNestedObjectFromRawConfig(policy.config) = %v, want %v",
+			configResult, expectedConfig)
+	}
+
+	// Test extracting non-existent path
+	nonExistentResult := GetNestedObjectFromRawConfig(ctyObj, "policy.non_existent")
+	if nonExistentResult != nil {
+		t.Errorf("GetNestedObjectFromRawConfig(policy.non_existent) = %v, want nil",
+			nonExistentResult)
+	}
+
+	t.Logf("All RefreshObjectParamOriginValues component tests passed successfully")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The current function `SuppressMapDiff()` is incorrect for our resource's usage.
Because of the origin value cannot be obtain in the import phase.
For all origin attributes with the `_origin` suffix are both support optional behavior and `DiffSuppressFunc` function to hide the `(known after apply)` report.

Supports two function to get the script configurion (all and specified nested parameters).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports compose function to allow mutiple customize diff function
2. using customize diff to refresh origin values
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
go test -v -run TestResourceDiffunc
=== RUN   TestResourceDiffunc_ContainsAllKeyValues
    resource_diff_test.go:81: All processing results of the ContainsAllKeyValues method meets expectation
--- PASS: TestResourceDiffunc_ContainsAllKeyValues (0.00s)
=== RUN   TestResourceDiffunc_FindDecreaseKeys
    resource_diff_test.go:124: All processing results of the FindDecreaseKeys method meets expectation
--- PASS: TestResourceDiffunc_FindDecreaseKeys (0.00s)
=== RUN   TestResourceDiffunc_TakeObjectsDifferent
    resource_diff_test.go:167: All processing results of the TakeObjectsDifferent method meets expectation
--- PASS: TestResourceDiffunc_TakeObjectsDifferent (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils 0.010s
```
```
go test -v -run TestStateManagementFunc
=== RUN   TestStateManagementFunc_GetObjectFromRawConfig
=== RUN   TestStateManagementFunc_GetObjectFromRawConfig/null_value
=== RUN   TestStateManagementFunc_GetObjectFromRawConfig/string_value
=== RUN   TestStateManagementFunc_GetObjectFromRawConfig/number_value
=== RUN   TestStateManagementFunc_GetObjectFromRawConfig/float_value
=== RUN   TestStateManagementFunc_GetObjectFromRawConfig/bool_value
=== RUN   TestStateManagementFunc_GetObjectFromRawConfig/simple_object
=== RUN   TestStateManagementFunc_GetObjectFromRawConfig/nested_object
=== RUN   TestStateManagementFunc_GetObjectFromRawConfig/list_of_objects
=== RUN   TestStateManagementFunc_GetObjectFromRawConfig/complex_nested_structure
=== CONT  TestStateManagementFunc_GetObjectFromRawConfig
    state_management_test.go:159: All processing results of the GetObjectFromRawConfig method meets expectation
--- PASS: TestStateManagementFunc_GetObjectFromRawConfig (0.00s)
    --- PASS: TestStateManagementFunc_GetObjectFromRawConfig/null_value (0.00s)
    --- PASS: TestStateManagementFunc_GetObjectFromRawConfig/string_value (0.00s)
    --- PASS: TestStateManagementFunc_GetObjectFromRawConfig/number_value (0.00s)
    --- PASS: TestStateManagementFunc_GetObjectFromRawConfig/float_value (0.00s)
    --- PASS: TestStateManagementFunc_GetObjectFromRawConfig/bool_value (0.00s)
    --- PASS: TestStateManagementFunc_GetObjectFromRawConfig/simple_object (0.00s)
    --- PASS: TestStateManagementFunc_GetObjectFromRawConfig/nested_object (0.00s)
    --- PASS: TestStateManagementFunc_GetObjectFromRawConfig/list_of_objects (0.00s)
    --- PASS: TestStateManagementFunc_GetObjectFromRawConfig/complex_nested_structure (0.00s)
=== RUN   TestStateManagementFunc_GetNestedObjectFromRawConfig
=== RUN   TestStateManagementFunc_GetNestedObjectFromRawConfig/simple_property_access
=== RUN   TestStateManagementFunc_GetNestedObjectFromRawConfig/nested_object_access
=== RUN   TestStateManagementFunc_GetNestedObjectFromRawConfig/list_element_access
=== RUN   TestStateManagementFunc_GetNestedObjectFromRawConfig/list_element_access_with_number
=== RUN   TestStateManagementFunc_GetNestedObjectFromRawConfig/non-existent_path
=== RUN   TestStateManagementFunc_GetNestedObjectFromRawConfig/empty_path
=== RUN   TestStateManagementFunc_GetNestedObjectFromRawConfig/get_policy_object
=== RUN   TestStateManagementFunc_GetNestedObjectFromRawConfig/get_annotations_list
=== RUN   TestStateManagementFunc_GetNestedObjectFromRawConfig/get_first_annotation
=== RUN   TestStateManagementFunc_GetNestedObjectFromRawConfig/get_second_annotation_key1
=== RUN   TestStateManagementFunc_GetNestedObjectFromRawConfig/get_config_key1
=== RUN   TestStateManagementFunc_GetNestedObjectFromRawConfig/get_first_owner_name
=== RUN   TestStateManagementFunc_GetNestedObjectFromRawConfig/GetAttrFromRawConfig_limitation
=== CONT  TestStateManagementFunc_GetNestedObjectFromRawConfig
    state_management_test.go:418: All processing results of the GetNestedObjectFromRawConfig method meets expectation
--- PASS: TestStateManagementFunc_GetNestedObjectFromRawConfig (0.00s)
    --- PASS: TestStateManagementFunc_GetNestedObjectFromRawConfig/simple_property_access (0.00s)
    --- PASS: TestStateManagementFunc_GetNestedObjectFromRawConfig/nested_object_access (0.00s)
    --- PASS: TestStateManagementFunc_GetNestedObjectFromRawConfig/list_element_access (0.00s)
    --- PASS: TestStateManagementFunc_GetNestedObjectFromRawConfig/list_element_access_with_number (0.00s)
    --- PASS: TestStateManagementFunc_GetNestedObjectFromRawConfig/non-existent_path (0.00s)
    --- PASS: TestStateManagementFunc_GetNestedObjectFromRawConfig/empty_path (0.00s)
    --- PASS: TestStateManagementFunc_GetNestedObjectFromRawConfig/get_policy_object (0.00s)
    --- PASS: TestStateManagementFunc_GetNestedObjectFromRawConfig/get_annotations_list (0.00s)
    --- PASS: TestStateManagementFunc_GetNestedObjectFromRawConfig/get_first_annotation (0.00s)
    --- PASS: TestStateManagementFunc_GetNestedObjectFromRawConfig/get_second_annotation_key1 (0.00s)
    --- PASS: TestStateManagementFunc_GetNestedObjectFromRawConfig/get_config_key1 (0.00s)
    --- PASS: TestStateManagementFunc_GetNestedObjectFromRawConfig/get_first_owner_name (0.00s)
    --- PASS: TestStateManagementFunc_GetNestedObjectFromRawConfig/GetAttrFromRawConfig_limitation (0.00s)
=== RUN   TestStateManagementFunc_RefreshObjectParamOriginValues
=== RUN   TestStateManagementFunc_RefreshObjectParamOriginValues/update_map_nested_key
=== RUN   TestStateManagementFunc_RefreshObjectParamOriginValues/update_list_element
=== CONT  TestStateManagementFunc_RefreshObjectParamOriginValues
    state_management_test.go:533: All RefreshObjectParamOriginValues safety tests passed
--- PASS: TestStateManagementFunc_RefreshObjectParamOriginValues (0.00s)
    --- PASS: TestStateManagementFunc_RefreshObjectParamOriginValues/update_map_nested_key (0.00s)
    --- PASS: TestStateManagementFunc_RefreshObjectParamOriginValues/update_list_element (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils 0.011s
```

1. plan output (the remote tags configuration more than the local tags configuration)
<img width="2149" height="1210" alt="image" src="https://github.com/user-attachments/assets/4ecc145f-3b0b-4d0b-8223-e15be5ea327a" />

2. plan output (the local tags configuration more than the remote tags configuration)
<img width="2176" height="1105" alt="image" src="https://github.com/user-attachments/assets/488433fd-fbf3-4751-badd-dd4efd9185ff" />

3. plan output (the local tags configuration have a new key/value pair and the remote tags configuration also have a new one)
<img width="2096" height="1097" alt="image" src="https://github.com/user-attachments/assets/174d63eb-36ce-407d-aae0-6bf12a1360b7" />

4. plan output (the local tags configuration want to add a new key/value pair and remove a key/value pair compared with history and the remote tags configuration have a new key/value pair)
<img width="2228" height="1112" alt="image" src="https://github.com/user-attachments/assets/449d191c-7aaf-43fb-b5f9-61bca3ed1377" />

5. plan output (import function and the local tags configuration missing a key/value pair compared with the remote tags configuration)
<img width="2070" height="1069" alt="image" src="https://github.com/user-attachments/assets/8af62edb-b4a7-415d-b93e-18138b33caf0" />

6. plan output (import function and the local tags configuration have a new key/value pair and missing a key/value pair compared with the remote tags configuration)
<img width="2168" height="1241" alt="image" src="https://github.com/user-attachments/assets/5985845b-b19f-4049-a84d-a4063c908e9c" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
