### PR TITLE
feat(hss): new resource to sync multi cloud clusters status

### DIFF
--- a/docs/resources/hss_container_kubernetes_sync_mccs.md
+++ b/docs/resources/hss_container_kubernetes_sync_mccs.md
@@ -1,0 +1,66 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_container_kubernetes_sync_mccs"
+description: |-  
+  Manages a container kubernetes cluster status synchronization task within HuaweiCloud.
+---
+
+# huaweicloud_hss_container_kubernetes_sync_mccs
+
+Manages a container kubernetes cluster status synchronization task within HuaweiCloud.
+
+-> This resource is only a one-time action resource for HSS container kubernetes cluster status synchronization. Deleting
+   this resource will not clear the synchronization status, but will only remove the resource information from the tf
+   state file.
+
+## Example Usage
+
+```hcl
+variable "cluster_id1" {}
+variable "cluster_id2" {}
+
+resource "huaweicloud_hss_container_kubernetes_sync_mccs" "test" {
+  total_num             = 2
+  enterprise_project_id = "0"
+
+  data_list {
+    cluster_id = var.cluster_id1
+  }
+
+  data_list {
+    cluster_id = var.cluster_id2
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `total_num` - (Required, Int, NonUpdatable) Specifies the total number of clusters to synchronize.
+
+* `data_list` - (Required, List, NonUpdatable) Specifies the list of clusters to synchronize.
+  The [data_list](#data_list_object) structure is documented below.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the ID of the enterprise project that the server
+  belongs to. The value **0** indicates the default enterprise project. To query servers in all enterprise projects,
+  set this parameter to **all_granted_eps**. If you have only the permission on an enterprise project, you need to
+  transfer the enterprise project ID to query the server in the enterprise project.
+  Otherwise, an error is reported due to insufficient permission.
+
+  -> An enterprise project can be configured only after the enterprise project function is enabled.
+
+<a name="data_list_object"></a>
+The `data_list` block supports:
+
+* `cluster_id` - (Required, String) Specifies the ID of the cluster to synchronize.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2301,6 +2301,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_host_group":                       hss.ResourceHostGroup(),
 			"huaweicloud_hss_cce_protection":                   hss.ResourceCCEProtection(),
 			"huaweicloud_hss_container_export_task":            hss.ResourceContainerExportTask(),
+			"huaweicloud_hss_container_kubernetes_sync_mccs":   hss.ResourceContainerKubernetesSyncMccs(),
 			"huaweicloud_hss_host_protection":                  hss.ResourceHostProtection(),
 			"huaweicloud_hss_webtamper_protection":             hss.ResourceWebTamperProtection(),
 			"huaweicloud_hss_quota":                            hss.ResourceQuota(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_container_kubernetes_sync_mccs_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_container_kubernetes_sync_mccs_test.go
@@ -1,0 +1,39 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccHSSContainerKubernetesSyncMCCS_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testContainerKubernetesSyncMCCS_basic,
+			},
+		},
+	})
+}
+
+const testContainerKubernetesSyncMCCS_basic = `
+resource "huaweicloud_hss_container_kubernetes_sync_mccs" "test" {
+  total_num             = 2
+  enterprise_project_id = "0"
+
+  data_list {
+    cluster_id = "cluster1-id"
+  }
+
+  data_list {
+    cluster_id = "cluster2-id"
+  }
+}
+`

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_container_kubernetes_sync_mccs.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_container_kubernetes_sync_mccs.go
@@ -1,0 +1,163 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var syncClusterStatusNonUpdatableParams = []string{
+	"total_num", "data_list", "data_list.*.cluster_id", "enterprise_project_id",
+}
+
+// @API HSS POST /v5/{project_id}/container/kubernetes/multi-cloud/clusters/status-synchronize
+func ResourceContainerKubernetesSyncMccs() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceContainerKubernetesSyncMccsCreate,
+		ReadContext:   resourceContainerKubernetesSyncMccsRead,
+		UpdateContext: resourceContainerKubernetesSyncMccsUpdate,
+		DeleteContext: resourceContainerKubernetesSyncMccsDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(syncClusterStatusNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Specifies the region where the resource is located. If omitted, the provider-level region will be used.",
+			},
+			"total_num": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "The total number of clusters to synchronize.",
+			},
+			// Fields "data_list" and "data_list.*.cluster_id" are optional in the API documentation, but are actually required.
+			"data_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Description: utils.SchemaDesc("The list of cluster IDs to synchronize.",
+					utils.SchemaDescInput{
+						Required: true,
+					}),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cluster_id": {
+							Type:     schema.TypeString,
+							Required: true,
+							Description: utils.SchemaDesc("The ID of the cluster to synchronize.",
+								utils.SchemaDescInput{
+									Required: true,
+								}),
+						},
+					},
+				},
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the enterprise project ID.",
+			},
+		},
+	}
+}
+
+func buildContainerKubernetesSyncMccsQueryParams(d *schema.ResourceData, cfg *config.Config) string {
+	rst := ""
+	if epsID := cfg.GetEnterpriseProjectID(d); epsID != "" {
+		rst = fmt.Sprintf("?enterprise_project_id=%s", epsID)
+	}
+	return rst
+}
+
+func buildContainerKubernetesSyncMccsDataListBodyParams(d *schema.ResourceData) []map[string]interface{} {
+	rawArray, ok := d.Get("data_list").([]interface{})
+	if !ok {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, item := range rawArray {
+		cluster, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		rst = append(rst, map[string]interface{}{
+			"cluster_id": cluster["cluster_id"],
+		})
+	}
+	return rst
+}
+
+func buildContainerKubernetesSyncMccsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"total_num": d.Get("total_num"),
+		"data_list": buildContainerKubernetesSyncMccsDataListBodyParams(d),
+	}
+}
+
+func resourceContainerKubernetesSyncMccsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v5/{project_id}/container/kubernetes/multi-cloud/clusters/status-synchronize"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildContainerKubernetesSyncMccsQueryParams(d, cfg)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildContainerKubernetesSyncMccsBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error synchronizing multi-cloud cluster status for container kubernetes: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID: %s", err)
+	}
+	d.SetId(id)
+
+	return resourceContainerKubernetesSyncMccsRead(ctx, d, meta)
+}
+
+func resourceContainerKubernetesSyncMccsRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceContainerKubernetesSyncMccsUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceContainerKubernetesSyncMccsDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to synchronize multi-cloud cluster status. Deleting
+	this resource will not affect the synchronization status, but will only remove the resource information from
+	the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to sync multi cloud clusters status

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccHSSContainerKubernetesSyncMCCS_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccHSSContainerKubernetesSyncMCCS_basic -timeout 360m -parallel 10
=== RUN   TestAccHSSContainerKubernetesSyncMCCS_basic
=== PAUSE TestAccHSSContainerKubernetesSyncMCCS_basic
=== CONT  TestAccHSSContainerKubernetesSyncMCCS_basic
--- PASS: TestAccHSSContainerKubernetesSyncMCCS_basic (10.10s)
PASS
coverage: 3.5% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       10.212s coverage: 3.5% of statements in ./huaweicloud/services/hss
```
<img width="1292" height="99" alt="image" src="https://github.com/user-attachments/assets/f8f5d729-109e-4e98-aaa3-fc0f89982261" />


* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
