### PR TITLE
feat(DCS): add dcs instance expired scan task resource

### DIFF
--- a/docs/resources/dcs_instance_expired_key_scan_task.md
+++ b/docs/resources/dcs_instance_expired_key_scan_task.md
@@ -1,0 +1,54 @@
+---
+subcategory: "Distributed Cache Service (DCS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dcs_instance_expired_key_scan_task"
+description: |-
+  Manages a DCS instance expired key scan task resource within HuaweiCloud.
+---
+
+# huaweicloud_dcs_instance_expired_key_scan_task
+
+Manages a DCS instance expired key scan task resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_dcs_instance_expired_key_scan_task" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the DCS instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - Indicates the status of the expired key scan task.
+
+* `scan_type` - Indicates the scan mode.
+
+* `num` - Indicates the number of expired keys scanned at a time.
+
+* `created_at` - Indicates the time when a scan task is created.
+
+* `started_at` - Indicates the time when a scan task started.
+
+* `finished_at` - Indicates the time when a scan task is complete.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2030,6 +2030,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dcs_instance_shard_bandwidth":           dcs.ResourceDcsInstanceShardBandwidth(),
 			"huaweicloud_dcs_instance_bandwidth_modify":          dcs.ResourceDcsInstanceBandwidthModify(),
 			"huaweicloud_dcs_instance_node_ip_remove":            dcs.ResourceDcsInstanceNodeIpRemove(),
+			"huaweicloud_dcs_instance_expired_key_scan_task":     dcs.ResourceDcsInstanceExpiredKeyScanTask(),
 			"huaweicloud_dcs_master_standby_switch":              dcs.ResourceDcsMasterStandbySwitch(),
 			"huaweicloud_dcs_cluster_replica_switch":             dcs.ResourceDcsClusterReplicaSwitch(),
 			"huaweicloud_dcs_backup":                             dcs.ResourceDcsBackup(),

--- a/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_instance_expired_key_scan_task_test.go
+++ b/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_instance_expired_key_scan_task_test.go
@@ -1,0 +1,137 @@
+package dcs
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getInstanceExpiredKeyScanTaskFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	var (
+		httpUrl = "v2/{project_id}/instances/{instance_id}/auto-expire/histories"
+		product = "dcs"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DCS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", state.Primary.Attributes["instance_id"])
+
+	getResp, err := pagination.ListAllItems(
+		client,
+		"offset",
+		getPath,
+		&pagination.QueryOpts{MarkerField: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	getRespJson, err := json.Marshal(getResp)
+	if err != nil {
+		return nil, err
+	}
+	var getRespBody interface{}
+	err = json.Unmarshal(getRespJson, &getRespBody)
+	if err != nil {
+		return nil, err
+	}
+
+	task := utils.PathSearch(fmt.Sprintf("records[?id=='%s']|[0]", state.Primary.ID), getRespBody, nil)
+	if task == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return getRespBody, nil
+}
+
+func TestAccDcsInstanceExpiredKeyScanTask_basic(t *testing.T) {
+	var obj interface{}
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_dcs_instance_expired_key_scan_task.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getInstanceExpiredKeyScanTaskFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testDcsInstanceExpiredKeyScanTask_baic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_dcs_instance.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "scan_type"),
+					resource.TestCheckResourceAttrSet(rName, "num"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "started_at"),
+					resource.TestCheckResourceAttrSet(rName, "finished_at"),
+				),
+			},
+		},
+	})
+}
+
+func testDcsInstanceExpiredKeyScanTask_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
+
+data "huaweicloud_dcs_flavors" "test" {
+  engine         = "Redis"
+  engine_version = "5.0"
+  capacity       = 4
+  name           = "redis.cluster.xu1.large.r4.4"
+}
+
+resource "huaweicloud_dcs_instance" "test" {
+  name               = "%[1]s"
+  engine_version     = "5.0"
+  password           = "Huawei_test"
+  engine             = "Redis"
+  capacity           = 4
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
+  availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
+  flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
+}
+`, name)
+}
+
+func testDcsInstanceExpiredKeyScanTask_baic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dcs_instance_expired_key_scan_task" "test" {
+  instance_id = huaweicloud_dcs_instance.test.id
+}
+`, testDcsInstanceExpiredKeyScanTask_base(name))
+}

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance_expired_scan_task.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance_expired_scan_task.go
@@ -1,0 +1,231 @@
+package dcs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var instanceExpiredKeyScanTaskNonUpdatableParams = []string{"instance_id"}
+
+// @API DCS POST /v2/{project_id}/instances/{instance_id}/scan-expire-keys-task
+// @API DCS GET /v2/{project_id}/instances/{instance_id}/auto-expire/histories
+func ResourceDcsInstanceExpiredKeyScanTask() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDcsInstanceExpiredKeyScanTaskCreate,
+		ReadContext:   resourceDcsInstanceExpiredKeyScanTaskRead,
+		UpdateContext: resourceDcsInstanceExpiredKeyScanTaskUpdate,
+		DeleteContext: resourceDcsInstanceExpiredKeyScanTaskDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(instanceExpiredKeyScanTaskNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"scan_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"started_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"finished_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDcsInstanceExpiredKeyScanTaskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v2/{project_id}/instances/{instance_id}/scan-expire-keys-task"
+		product = "dcs"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DCS client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating DCS instance(%s) expired key scan task: %s", instanceId, err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	taskId := utils.PathSearch("id", createRespBody, "").(string)
+	if taskId == "" {
+		return diag.Errorf("error creating DCS instance(%s) expired key scan task: id is not found in API response", instanceId)
+	}
+
+	d.SetId(taskId)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"pending"},
+		Target:       []string{"success"},
+		Refresh:      instanceExpiredKeyScanTaskRefreshFunc(client, instanceId, taskId),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return diag.Errorf("error waiting for expired key scan task(%s) to be completed: %s ", taskId, err)
+	}
+	return resourceDcsInstanceExpiredKeyScanTaskRead(ctx, d, meta)
+}
+
+func instanceExpiredKeyScanTaskRefreshFunc(client *golangsdk.ServiceClient, instanceId, taskId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		getRespBody, err := getInstanceExpiredKeyScanTaskHistories(client, instanceId)
+		if err != nil {
+			return nil, "error", err
+		}
+		task := utils.PathSearch(fmt.Sprintf("records[?id=='%s']|[0]", taskId), getRespBody, nil)
+		if task == nil {
+			return nil, "error", golangsdk.ErrDefault404{}
+		}
+
+		status := utils.PathSearch("status", task, "").(string)
+		if status == "success" || status == "failed" {
+			return getRespBody, status, nil
+		}
+
+		return getRespBody, "pending", nil
+	}
+}
+
+func getInstanceExpiredKeyScanTaskHistories(client *golangsdk.ServiceClient, instanceId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/instances/{instance_id}/auto-expire/histories"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+
+	getResp, err := pagination.ListAllItems(
+		client,
+		"offset",
+		getPath,
+		&pagination.QueryOpts{MarkerField: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	getRespJson, err := json.Marshal(getResp)
+	if err != nil {
+		return nil, err
+	}
+	var getRespBody interface{}
+	err = json.Unmarshal(getRespJson, &getRespBody)
+	if err != nil {
+		return nil, err
+	}
+	return getRespBody, nil
+}
+
+func resourceDcsInstanceExpiredKeyScanTaskRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		product = "dcs"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DCS client: %s", err)
+	}
+
+	getRespBody, err := getInstanceExpiredKeyScanTaskHistories(client, d.Get("instance_id").(string))
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error getting DCS instance expired key scan task")
+	}
+	task := utils.PathSearch(fmt.Sprintf("records[?id=='%s']|[0]", d.Id()), getRespBody, nil)
+	if task == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error getting DCS instance expired key scan task")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("instance_id", utils.PathSearch("instance_id", task, nil)),
+		d.Set("status", utils.PathSearch("status", task, nil)),
+		d.Set("scan_type", utils.PathSearch("scan_type", task, nil)),
+		d.Set("num", utils.PathSearch("num", task, nil)),
+		d.Set("created_at", utils.PathSearch("created_at", task, nil)),
+		d.Set("started_at", utils.PathSearch("started_at", task, nil)),
+		d.Set("finished_at", utils.PathSearch("finished_at", task, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDcsInstanceExpiredKeyScanTaskUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDcsInstanceExpiredKeyScanTaskDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting DCS instance expired key scan task resource is not supported. The resource is only removed " +
+		"from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add dcs isntance expired scan task resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add dcs isntance expired scan task resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dcs/ TESTARGS='-run TestAccDcsInstanceExpiredKeyScanTask_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs/ -v -run TestAccDcsInstanceExpiredKeyScanTask_basic -timeout 360m -parallel 4
=== RUN   TestAccDcsInstanceExpiredKeyScanTask_basic
=== PAUSE TestAccDcsInstanceExpiredKeyScanTask_basic
=== CONT  TestAccDcsInstanceExpiredKeyScanTask_basic
--- PASS: TestAccDcsInstanceExpiredKeyScanTask_basic (366.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       366.432s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
