### PR TITLE
feat(hss): new datasource to query cluster asset statistics

### DIFF
--- a/docs/data-sources/hss_cluster_asset_statistics.md
+++ b/docs/data-sources/hss_cluster_asset_statistics.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_cluster_asset_statistics"
+description: |-
+  Use this data source to get HSS cluster asset statistics within HuaweiCloud.
+---
+
+# huaweicloud_hss_cluster_asset_statistics
+
+Use this data source to get HSS cluster asset statistics within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_cluster_asset_statistics" "test" {
+  enterprise_project_id = "0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `cluster_num` - The number of clusters.
+
+* `work_load_num` - The number of workloads.
+
+* `service_num` - The number of services.
+
+* `pod_num` - The number of pods.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1080,6 +1080,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_asset_users":                          hss.DataSourceAssetUsers(),
 			"huaweicloud_hss_auto_launch_statistics":               hss.DataSourceAutoLaunchStatistics(),
 			"huaweicloud_hss_auto_launchs":                         hss.DataSourceAutoLaunchs(),
+			"huaweicloud_hss_cluster_asset_statistics":             hss.DataSourceClusterAssetStatistics(),
 			"huaweicloud_hss_container_kubernetes":                 hss.DataSourceContainerKubernetes(),
 			"huaweicloud_hss_container_nodes":                      hss.DataSourceContainerNodes(),
 			"huaweicloud_hss_container_node_statistics":            hss.DataSourceContainerNodeStatistics(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_cluster_asset_statistics_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_cluster_asset_statistics_test.go
@@ -1,0 +1,41 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceClusterAssetStatistics_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_cluster_asset_statistics.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceClusterAssetStatistics_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "cluster_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "work_load_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "service_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "pod_num"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceClusterAssetStatistics_basic = `
+data "huaweicloud_hss_cluster_asset_statistics" "test" {
+  enterprise_project_id = "0"
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_cluster_asset_statistics.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_cluster_asset_statistics.go
@@ -1,0 +1,102 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/cluster/asset/statistics
+func DataSourceClusterAssetStatistics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceClusterAssetStatisticsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// Attributes
+			"cluster_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"work_load_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"service_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"pod_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceClusterAssetStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v5/{project_id}/cluster/asset/statistics"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	if epsId != "" {
+		requestPath = fmt.Sprintf("%s?enterprise_project_id=%v", requestPath, epsId)
+	}
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS cluster asset statistics: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("cluster_num", utils.PathSearch("cluster_num", respBody, nil)),
+		d.Set("work_load_num", utils.PathSearch("work_load_num", respBody, nil)),
+		d.Set("service_num", utils.PathSearch("service_num", respBody, nil)),
+		d.Set("pod_num", utils.PathSearch("pod_num", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query cluster asset statistics.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccDataSourceClusterAssetStatistics_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccDataSourceClusterAssetStatistics_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceClusterAssetStatistics_basic
=== PAUSE TestAccDataSourceClusterAssetStatistics_basic
=== CONT  TestAccDataSourceClusterAssetStatistics_basic
--- PASS: TestAccDataSourceClusterAssetStatistics_basic (18.73s)
PASS
coverage: 3.1% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       18.846s coverage: 3.1% of statements in ./huaweicloud/services/hss
```
<img width="1330" height="80" alt="image" src="https://github.com/user-attachments/assets/9ca05aea-1e84-4778-adf6-52fd8376eb44" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
