### PR TITLE
docs(modelarts/node_pool_nodes|resource_pool_nodes): modify description of the fields

### DIFF
--- a/docs/data-sources/modelartsv2_node_pool_nodes.md
+++ b/docs/data-sources/modelartsv2_node_pool_nodes.md
@@ -64,16 +64,16 @@ The `metadata` block supports:
 
 * `creation_timestamp` - The creation timestamp of the node.
 
-* `labels` - The labels of the node.
+* `labels` - The labels of the node, in JSON format.
 
-* `annotations` - The annotation configuration of the node.
+* `annotations` - The annotation configuration of the node, in JSON format.
 
 <a name="v2modelarts_node_pool_nodes_spec"></a>
 The `spec` block supports:
 
 * `flavor` - The flavor of the node.
 
-* `extend_params` - The extend parameters of the node.
+* `extend_params` - The extend parameters of the node, in JSON format.
 
 * `host_network` - The network configuration of the node.  
   The [host_network](#v2modelarts_node_pool_nodes_spec_host_network) structure is documented below.

--- a/docs/data-sources/modelartsv2_resource_pool_nodes.md
+++ b/docs/data-sources/modelartsv2_resource_pool_nodes.md
@@ -57,16 +57,16 @@ The `metadata` block supports:
 
 * `creation_timestamp` - The creation timestamp of the node.
 
-* `labels` - The labels of the node.
+* `labels` - The labels of the node, in JSON format.
 
-* `annotations` - The annotation configuration of the node.
+* `annotations` - The annotation configuration of the node, in JSON format.
 
 <a name="modelartsv2_resource_pool_nodes_spec"></a>
 The `spec` block supports:
 
 * `flavor` - The flavor of the node.
 
-* `extend_params` - The extend parameters of the node.
+* `extend_params` - The extend parameters of the node, in JSON format.
 
 * `host_network` - The network configuration of the node.  
   The [host_network](#modelartsv2_resource_pool_nodes_spec_host_network) structure is documented below.

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_node_pool_nodes.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_node_pool_nodes.go
@@ -88,12 +88,12 @@ func dataSourceV2NodePoolNodeMetadataSchema() *schema.Resource {
 			"labels": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `The labels of the node.`,
+				Description: `The labels of the node, in JSON format.`,
 			},
 			"annotations": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `The annotation configuration of the node.`,
+				Description: `The annotation configuration of the node, in JSON format.`,
 			},
 		},
 	}
@@ -110,7 +110,7 @@ func dataSourceV2NodePoolNodeSpecSchema() *schema.Resource {
 			"extend_params": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `The extend parameters of the node.`,
+				Description: `The extend parameters of the node, in JSON format.`,
 			},
 			"host_network": {
 				Type:        schema.TypeList,

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_resource_pool_nodes.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_resource_pool_nodes.go
@@ -105,7 +105,7 @@ func dataSourceV2ResourcePoolNodeSpecSchema() *schema.Resource {
 			"extend_params": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `The extend parameters of the node.`,
+				Description: `The extend parameters of the node, in JSON format.`,
 			},
 			"host_network": {
 				Type:        schema.TypeList,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Improve the description of some fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
