### PR TITLE
feat(cce): add new source cce_nodes_remove

### DIFF
--- a/docs/resources/cce_nodes_remove.md
+++ b/docs/resources/cce_nodes_remove.md
@@ -1,0 +1,64 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cce_nodes_remove"
+description: |-
+  Use this resource to remove nodes from a CCE cluster within HuaweiCloud.
+---
+
+# huaweicloud_cce_nodes_remove
+
+Use this resource to remove nodes from a CCE cluster within HuaweiCloud.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+variable "cluster_id" {}
+variable "node_id_1" {}
+variable "node_id_2" {}
+
+resource "huaweicloud_cce_nodes_remove" "test" {
+  cluster_id  = var.cluster_id
+
+  nodes {
+    uid = node_id_1
+  }
+  nodes {
+    uid = node_id_2
+  }
+}
+
+```
+
+~> Deleting nodes remove resource is not supported, it will only be removed from the state.  
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the CCE pool nodes add resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the cluster ID.
+
+* `nodes` - (Required, List, NonUpdatable) Specifies the list of nodes to remove form the cluster.
+  The [nodes](#nodes) structure is documented below.
+
+<a name="nodes"></a>
+The `nodes` block supports:
+
+* `uid` - (Required, String, NonUpdatable) Specifies the node ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1881,6 +1881,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cce_cluster_certificate_revoke":            cce.ResourceCertificateRevoke(),
 			"huaweicloud_cce_node_pool_scale":                       cce.ResourceNodePoolScale(),
 			"huaweicloud_cce_cluster_certificate_rotatecredentials": cce.ResourceRotatecredentials(),
+			"huaweicloud_cce_nodes_remove":                          cce.ResourceNodesRemove(),
 
 			"huaweicloud_cts_tracker":      cts.ResourceCTSTracker(),
 			"huaweicloud_cts_data_tracker": cts.ResourceCTSDataTracker(),

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_nodes_remove_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_nodes_remove_test.go
@@ -1,0 +1,88 @@
+package cce
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccNodesRemove_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	baseConfig := testAccNodePool_base(name)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNodesRemove_basic(baseConfig, name),
+				// there is nothing to check, if no error occurred, that means the test is successful
+				ExpectError: regexp.MustCompile("Insufficient nodes blocks"),
+			},
+		},
+	})
+}
+
+func testAccNodesRemove_base(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cce_node_pool" "test" {
+  cluster_id               = huaweicloud_cce_cluster.test.id
+  name                     = "%[2]s"
+  os                       = "EulerOS 2.9"
+  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
+  initial_node_count       = 2
+  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  key_pair                 = huaweicloud_kps_keypair.test.name
+  scall_enable             = false
+  min_node_count           = 0
+  max_node_count           = 0
+  scale_down_cooldown_time = 0
+  priority                 = 0
+  type                     = "vm"
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+}
+  `, baseConfig, name)
+}
+
+func testAccNodesRemove_basic(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_cce_nodes" "test" {
+  cluster_id = huaweicloud_cce_cluster.test.id
+
+  depends_on = [ huaweicloud_cce_node_pool.test ]
+}
+
+resource "huaweicloud_cce_nodes_remove" "test" {
+  cluster_id = huaweicloud_cce_cluster.test.id
+
+  dynamic "nodes" {
+    for_each = data.huaweicloud_cce_nodes.test.ids
+    content {
+      uid = nodes.value
+    }
+  }
+}
+`, testAccNodesRemove_base(baseConfig, name), name)
+}

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_nodes_remove.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_nodes_remove.go
@@ -1,0 +1,196 @@
+package cce
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	ccenodes "github.com/chnsz/golangsdk/openstack/cce/v3/nodes"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CCE PUT /api/v3/projects/{project_id}/clusters/{cluster_id}/nodes/operation/remove
+var NodesRemoveNonUpdatableParams = []string{"cluster_id", "nodes", "nodes.*.uid"}
+
+func ResourceNodesRemove() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNodesRemoveCreate,
+		ReadContext:   resourceNodesRemoveRead,
+		UpdateContext: resourceNodesRemoveUpdate,
+		DeleteContext: resourceNodesRemoveDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(NodesRemoveNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"nodes": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"uid": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					}},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildNodesRemoveCreateOpts(d *schema.ResourceData) map[string]interface{} {
+	result := map[string]interface{}{
+		"kind":       "RemoveNodesTask",
+		"apiVersion": "v3",
+		"spec":       buildNodesRemoveSpec(d),
+	}
+	return result
+}
+
+func buildNodesRemoveSpec(d *schema.ResourceData) map[string]interface{} {
+	result := map[string]interface{}{
+		"nodes": buildNodesRemoveSpecNodes(d),
+	}
+	return result
+}
+
+func buildNodesRemoveSpecNodes(d *schema.ResourceData) []map[string]interface{} {
+	nodesRaw := d.Get("nodes").([]interface{})
+	if len(nodesRaw) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(nodesRaw))
+
+	for i, v := range nodesRaw {
+		nodes := v.(map[string]interface{})
+		result[i] = map[string]interface{}{
+			"uid": nodes["uid"],
+		}
+	}
+	return result
+}
+
+func resourceNodesRemoveCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.CceV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CCE v3 client: %s", err)
+	}
+
+	// Wait for the cce cluster to become available
+	clusterID := d.Get("cluster_id").(string)
+	stateCluster := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      clusterStateRefreshFunc(client, clusterID, []string{"Available"}),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	_, err = stateCluster.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for CCE cluster to become available: %s", err)
+	}
+
+	var (
+		createNodesRemoveHttpUrl = "api/v3/projects/{project_id}/clusters/{cluster_id}/nodes/operation/remove"
+	)
+
+	createNodesRemovePath := client.Endpoint + createNodesRemoveHttpUrl
+	createNodesRemovePath = strings.ReplaceAll(createNodesRemovePath, "{project_id}", client.ProjectID)
+	createNodesRemovePath = strings.ReplaceAll(createNodesRemovePath, "{cluster_id}", d.Get("cluster_id").(string))
+
+	createNodesRemoveOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	createNodesRemoveOpt.JSONBody = utils.RemoveNil(buildNodesRemoveCreateOpts(d))
+	createNodesRemoveResp, err := client.Request("PUT",
+		createNodesRemovePath, &createNodesRemoveOpt)
+	if err != nil {
+		return diag.Errorf("error removing nodes: %s", err)
+	}
+
+	createNodesRemoveRespBody, err := utils.FlattenResponse(createNodesRemoveResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobID := utils.PathSearch("status.jobID", createNodesRemoveRespBody, "")
+	if jobID == "" {
+		return diag.Errorf("error removing nodes: status.jobID is not found in API response")
+	}
+
+	stateJob := &resource.StateChangeConf{
+		Pending:      []string{"Initializing", "Running"},
+		Target:       []string{"Success"},
+		Refresh:      waitForJobStatus(client, jobID.(string)),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        90 * time.Second,
+		PollInterval: 15 * time.Second,
+	}
+
+	v, err := stateJob.WaitForStateContext(ctx)
+	if err != nil {
+		if job, ok := v.(*ccenodes.Job); ok {
+			return diag.Errorf("error waiting for job (%s) to become success: %s, reason: %s",
+				jobID, err, job.Status.Reason)
+		}
+
+		return diag.Errorf("error waiting for job (%s) to become success: %s", jobID, err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	return nil
+}
+
+func resourceNodesRemoveRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceNodesRemoveUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceNodesRemoveDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting nodes remove resource is not supported. The nodes add resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccNodesRemove_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccNodesRemove_basic -timeout 360m -parallel 4
=== RUN   TestAccNodesRemove_basic
=== PAUSE TestAccNodesRemove_basic
=== CONT  TestAccNodesRemove_basic
    testing_new.go:84: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: error deleting Subnet: timeout while waiting for state to become 'DELETED' (last state: 'ACTIVE', timeout: 10m0s)
        
--- FAIL: TestAccNodesRemove_basic (1702.39s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1702.445s
FAIL
make: *** [GNUmakefile:21: testacc] Error 1

The test faild because the ecs instances still exist when the nodes are removed from cluster
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
