### PR TITLE
feat(workspace/app): add new data source to query HDA latest versions

### DIFF
--- a/docs/data-sources/workspace_app_hda_latest_versions.md
+++ b/docs/data-sources/workspace_app_hda_latest_versions.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_hda_latest_versions"
+description: |-
+  Use this data source to get HDA latest versions under a specified region of the Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_hda_latest_versions
+
+Use this data source to get HDA latest versions under a specified region of the Workspace APP within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_workspace_app_hda_latest_versions" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the HDA latest versions are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `hda_latest_versions` - The list of HDA latest versions that matched filter parameters.  
+  The [hda_latest_versions](#workspace_app_hda_latest_versions) structure is documented below.
+
+<a name="workspace_app_hda_latest_versions"></a>
+The `hda_latest_versions` block supports:
+
+* `latest_version` - The latest version of the HDA.
+
+* `hda_type` - The type of the HDA.
+  + **SBC**: Non-VDI SBC type
+  + **OA_APP**: VDI non-GPU type
+  + **PT_APP**: VDI GPU type

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1623,6 +1623,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_group_authorizations":            workspace.DataSourceWorkspaceAppGroupAuthorizations(),
 			"huaweicloud_workspace_app_groups":                          workspace.DataSourceWorkspaceAppGroups(),
 			"huaweicloud_workspace_app_hda_configurations":              workspace.DataSourceAppHdaConfigurations(),
+			"huaweicloud_workspace_app_hda_latest_versions":             workspace.DataSourceAppHdaLatestVersions(),
 			"huaweicloud_workspace_app_ies_availability_zones":          workspace.DataSourceIesAvailabilityZones(),
 			"huaweicloud_workspace_app_image_servers":                   workspace.DataSourceWorkspaceAppImageServers(),
 			"huaweicloud_workspace_app_nas_storages":                    workspace.DataSourceAppNasStorages(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_hda_latest_versions_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_hda_latest_versions_test.go
@@ -1,0 +1,48 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataAppHdaLatestVersions_basic(t *testing.T) {
+	rName := "data.huaweicloud_workspace_app_hda_latest_versions.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataAppHdaLatestVersions_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_latest_version_set", "true"),
+					resource.TestCheckOutput("is_hda_type_set", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataAppHdaLatestVersions_basic string = `
+data "huaweicloud_workspace_app_hda_latest_versions" "test" {}
+
+locals {
+  hda_latest_versions      = data.huaweicloud_workspace_app_hda_latest_versions.test.hda_latest_versions
+  first_hda_latest_version = try(local.hda_latest_versions[0], {})
+}
+
+output "is_latest_version_set" {
+  value = length(local.hda_latest_versions) != 0 ? try(local.first_hda_latest_version.latest_version != "", false) : true 
+}
+
+output "is_hda_type_set" {
+  value = length(local.hda_latest_versions) != 0 ? try(local.first_hda_latest_version.hda_type != "", false) : true 
+}
+`

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_hda_latest_versions.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_hda_latest_versions.go
@@ -1,0 +1,120 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/app-servers/access-agent/actions/show-latest-version
+func DataSourceAppHdaLatestVersions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppHdaLatestVersionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the HDA latest versions are located.`,
+			},
+
+			// Attributes
+			"hda_latest_versions": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of HDA latest versions that matched filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"latest_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest version of the HDA.`,
+						},
+						"hda_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the HDA.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func listAppHdaLatestVersions(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	httpUrl := "v1/{project_id}/app-servers/access-agent/actions/show-latest-version"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenAppHdaLatestVersions(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"latest_version": utils.PathSearch("latest_version", item, nil),
+			"hda_type":       utils.PathSearch("hda_type", item, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceAppHdaLatestVersionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	hdaLatestVersions, err := listAppHdaLatestVersions(client)
+	if err != nil {
+		return diag.Errorf("error querying HDA latest versions: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("hda_latest_versions", flattenAppHdaLatestVersions(hdaLatestVersions)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports new data source to query HDA latest versions

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new data source to query HDA latest versions.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataAppHdaLatestVersions_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAppHdaLatestVersions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAppHdaLatestVersions_basic
=== PAUSE TestAccDataAppHdaLatestVersions_basic
=== CONT  TestAccDataAppHdaLatestVersions_basic
--- PASS: TestAccDataAppHdaLatestVersions_basic (8.82s)
PASS
coverage: 2.8% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 8.904s  coverage: 2.8% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
