### PR TITLE
feat(workspace): add new data source to query HDA configurations

### DIFF
--- a/docs/data-sources/workspace_app_hda_configurations.md
+++ b/docs/data-sources/workspace_app_hda_configurations.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_hda_configurations"
+description: |-
+  Use this data source to get the list of HDA configurations within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_hda_configurations
+
+Use this data source to get the list of HDA configurations within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "server_name" {}
+
+data "huaweicloud_workspace_app_hda_configurations" "test" {
+  server_name = var.server_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the HDA configurations are located.  
+  If omitted, the provider-level region will be used.
+
+* `server_group_id` - (Optional, String) Specifies the ID of the server group to be queried.
+
+* `server_name` - (Optional, String) Specifies the name of the server to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `configurations` - The list of HDA configurations that match the query parameters.  
+  The [configurations](#workspace_app_hda_configurations) structure is documented below.
+
+<a name="workspace_app_hda_configurations"></a>
+The `configurations` block supports:
+
+* `server_id` - The ID of the server.
+
+* `machine_name` - The machine name of the server.
+
+* `maintain_status` - Whether the server is in maintenance status.
+
+* `server_name` - The name of the server.
+
+* `server_group_id` - The ID of the server group.
+
+* `server_group_name` - The name of the server group.
+
+* `sid` - The SID of the server.
+
+* `session_count` - The number of sessions.
+
+* `status` - The status of the server.
+  + **UNREGISTER** - Not registered
+  + **REGISTERED** - Registered and ready
+  + **MAINTAINING** - Under maintenance
+  + **FREEZE** - Frozen
+  + **STOPPED** - Stopped
+  + **NONE** - Abnormal status
+
+* `current_version` - The current version of the access agent.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1620,6 +1620,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_flavors":                         workspace.DataSourceAppFlavors(),
 			"huaweicloud_workspace_app_group_authorizations":            workspace.DataSourceWorkspaceAppGroupAuthorizations(),
 			"huaweicloud_workspace_app_groups":                          workspace.DataSourceWorkspaceAppGroups(),
+			"huaweicloud_workspace_app_hda_configurations":              workspace.DataSourceAppHdaConfigurations(),
 			"huaweicloud_workspace_app_ies_availability_zones":          workspace.DataSourceIesAvailabilityZones(),
 			"huaweicloud_workspace_app_image_servers":                   workspace.DataSourceWorkspaceAppImageServers(),
 			"huaweicloud_workspace_app_nas_storages":                    workspace.DataSourceAppNasStorages(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -1982,7 +1982,7 @@ func TestAccPreCheckWorkspaceAppServerGroupId(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckWorkspaceAppServerID(t *testing.T) {
+func TestAccPreCheckWorkspaceAppServerId(t *testing.T) {
 	if HW_WORKSPACE_APP_SERVER_ID == "" {
 		t.Skip("HW_WORKSPACE_APP_SERVER_ID must be set for Workspace APP acceptance tests.")
 	}

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_hda_configurations_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_hda_configurations_test.go
@@ -1,0 +1,109 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataAppHdaConfigurations_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_workspace_app_hda_configurations.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byServerGroupId   = "data.huaweicloud_workspace_app_hda_configurations.filter_by_server_group_id"
+		dcByServerGroupId = acceptance.InitDataSourceCheck(byServerGroupId)
+
+		byServerName   = "data.huaweicloud_workspace_app_hda_configurations.filter_by_server_name"
+		dcByServerName = acceptance.InitDataSourceCheck(byServerName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataAppHdaConfigurations_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "configurations.#", regexp.MustCompile(`^[0-9]+$`)),
+
+					dcByServerGroupId.CheckResourceExists(),
+					resource.TestCheckOutput("is_server_group_id_filter_useful", "true"),
+					resource.TestCheckResourceAttrSet(byServerGroupId, "configurations.#"),
+
+					dcByServerName.CheckResourceExists(),
+					resource.TestCheckOutput("is_server_name_filter_useful", "true"),
+					resource.TestCheckResourceAttrSet(byServerName, "configurations.#"),
+
+					// Check item attributes if configurations exist
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.server_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.machine_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.maintain_status"),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.server_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.server_group_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.server_group_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.sid"),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.session_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.current_version"),
+				),
+			},
+		},
+	})
+}
+
+func testDataAppHdaConfigurations_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_app_servers" "test" {
+  server_id = "%[1]s"
+}
+
+locals {
+  server_name = try(data.huaweicloud_workspace_app_servers.test.servers[0].name, "NOT_FOUND")
+}
+
+# Get all HDA configurations
+data "huaweicloud_workspace_app_hda_configurations" "test" {}
+
+# Filter by server group ID (using a test server group ID)
+data "huaweicloud_workspace_app_hda_configurations" "filter_by_server_group_id" {
+  server_group_id = "%[2]s"
+}
+
+locals {
+  server_group_id_filter_result = [
+    for v in data.huaweicloud_workspace_app_hda_configurations.filter_by_server_group_id.configurations[*].server_group_id :
+      v == "%[2]s"
+  ]
+}
+
+output "is_server_group_id_filter_useful" {
+  value = length(local.server_group_id_filter_result) > 0 && alltrue(local.server_group_id_filter_result)
+}
+
+# Filter by server name (using a test server name)
+data "huaweicloud_workspace_app_hda_configurations" "filter_by_server_name" {
+  server_name = local.server_name
+}
+
+locals {
+  server_name_filter_result = [
+    for v in data.huaweicloud_workspace_app_hda_configurations.filter_by_server_name.configurations[*].server_name :
+      v == local.server_name
+  ]
+}
+
+output "is_server_name_filter_useful" {
+  value = length(local.server_name_filter_result) > 0 && alltrue(local.server_name_filter_result)
+}
+`, acceptance.HW_WORKSPACE_APP_SERVER_ID, acceptance.HW_WORKSPACE_APP_SERVER_GROUP_ID)
+}

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_vnc_remote_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_vnc_remote_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceAppVncRemote_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckWorkspaceAppServerID(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_hda_configurations.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_hda_configurations.go
@@ -1,0 +1,211 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/app-servers/access-agent/list
+func DataSourceAppHdaConfigurations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppHdaConfigurationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the HDA configurations are located.`,
+			},
+
+			// Optional parameters.
+			"server_group_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the server group to be queried.`,
+			},
+			"server_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the server to be queried.`,
+			},
+
+			// Attributes.
+			"configurations": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of HDA configurations that match the query parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"server_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the server.`,
+						},
+						"machine_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The machine name of the server.`,
+						},
+						"maintain_status": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the server is in maintenance status.`,
+						},
+						"server_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the server.`,
+						},
+						"server_group_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the server group.`,
+						},
+						"server_group_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the server group.`,
+						},
+						"sid": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The SID of the server.`,
+						},
+						"session_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The number of sessions.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the server.`,
+						},
+						"current_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The current version of the access agent.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAppHdaConfigurationsQueryParams(d *schema.ResourceData) string {
+	queryParams := ""
+
+	if v, ok := d.GetOk("server_group_id"); ok {
+		queryParams = fmt.Sprintf("%s&server_group_id=%v", queryParams, v.(string))
+	}
+	if v, ok := d.GetOk("server_name"); ok {
+		queryParams = fmt.Sprintf("%s&server_name=%v", queryParams, v.(string))
+	}
+
+	return queryParams
+}
+
+func listAppHdaConfigurations(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/app-servers/access-agent/list?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildAppHdaConfigurationsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithPagination := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithPagination, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		configurations := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, configurations...)
+		if len(configurations) < limit {
+			break
+		}
+		offset += len(configurations)
+	}
+
+	return result, nil
+}
+
+func flattenAppHdaConfigurations(configurations []interface{}) []map[string]interface{} {
+	if len(configurations) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(configurations))
+	for _, configuration := range configurations {
+		result = append(result, map[string]interface{}{
+			"server_id":         utils.PathSearch("server_id", configuration, nil),
+			"machine_name":      utils.PathSearch("machine_name", configuration, nil),
+			"maintain_status":   utils.PathSearch("maintain_status", configuration, nil),
+			"server_name":       utils.PathSearch("server_name", configuration, nil),
+			"server_group_id":   utils.PathSearch("server_group_id", configuration, nil),
+			"server_group_name": utils.PathSearch("server_group_name", configuration, nil),
+			"sid":               utils.PathSearch("sid", configuration, nil),
+			"session_count":     utils.PathSearch("session_count", configuration, nil),
+			"status":            utils.PathSearch("status", configuration, nil),
+			"current_version":   utils.PathSearch("current_version", configuration, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceAppHdaConfigurationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	configurations, err := listAppHdaConfigurations(client, d)
+	if err != nil {
+		return diag.Errorf("error retrieving HDA configurations: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("configurations", flattenAppHdaConfigurations(configurations)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports new data source to query HDA configurations.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query HDA configurations.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataAppHdaConfigurations_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAppHdaConfigurations_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAppHdaConfigurations_basic
=== PAUSE TestAccDataAppHdaConfigurations_basic
=== CONT  TestAccDataAppHdaConfigurations_basic
--- PASS: TestAccDataAppHdaConfigurations_basic (12.28s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 12.357s coverage: 4.5% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
