### PR TITLE
feat(workspace/app): add new data source to get execution recodes of the specified schedule task

### DIFF
--- a/docs/data-sources/workspace_app_schedule_task_executions.md
+++ b/docs/data-sources/workspace_app_schedule_task_executions.md
@@ -1,0 +1,72 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_schedule_task_executions"
+description: |-
+  Use this data source to get execution list under specified schedule task within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_schedule_task_executions
+
+Use this data source to get execution list under specified schedule task within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "task_id" {}
+
+data "huaweicloud_workspace_app_schedule_task_executions" "test" {
+  task_id = var.task_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the schedule task is located.  
+  If omitted, the provider-level region will be used.
+
+* `task_id` - (Required, String) Specifies the ID of the schedule task.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `executions` - The list of schedule task executions.
+  The [executions](#schedule_task_executions_attr) structure is documented below.
+
+<a name="schedule_task_executions_attr"></a>
+The `executions` block supports:
+
+* `id` - The ID of the schedule task execution record.
+
+* `task_id` - The ID of the schedule task.
+
+* `task_type` - The type of the schedule task.
+
+* `scheduled_type` - The execution cycle of the schedule task.
+  + **FIXED_TIME**
+  + **DAY**
+  + **WEEK**
+  + **MONTH**
+
+* `status` - The status of the schedule task execution.
+  + **SUCCESS**
+  + **FAILED**
+
+* `total_count` - The total number of subtasks.
+
+* `success_count` - The number of successful subtasks.
+
+* `failed_count` - The number of failed subtasks.
+
+* `time_zone` - The timezone of the schedule task.
+
+* `begin_time` - The begin time of the schedule task execution, in UTC format.
+
+* `create_time` - The creation time of the schedule task, in UTC format.
+
+* `end_time` - The end time of the schedule task execution, in UTC format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1629,6 +1629,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_nas_storages":                    workspace.DataSourceAppNasStorages(),
 			"huaweicloud_workspace_app_publishable_apps":                workspace.DataSourceWorkspaceAppPublishableApps(),
 			"huaweicloud_workspace_app_schedule_tasks":                  workspace.DataSourceAppScheduleTasks(),
+			"huaweicloud_workspace_app_schedule_task_executions":        workspace.DataSourceAppScheduleTaskExecutions(),
 			"huaweicloud_workspace_app_schedule_task_future_executions": workspace.DataSourceAppScheduleTaskFutureExecutions(),
 			"huaweicloud_workspace_app_servers":                         workspace.DataSourceAppServers(),
 			"huaweicloud_workspace_app_service":                         workspace.DataSourceAppService(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_schedule_task_executions_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_schedule_task_executions_test.go
@@ -1,0 +1,131 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAppScheduleTaskExecutions_basic(t *testing.T) {
+	var (
+		rName      = acceptance.RandomAccResourceName()
+		dataSource = "data.huaweicloud_workspace_app_schedule_task_executions.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"null": {
+				Source:            "hashicorp/null",
+				VersionConstraint: "3.2.1",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAppScheduleTaskExecutions_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "executions.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "executions.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "executions.0.task_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "executions.0.task_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "executions.0.scheduled_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "executions.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "executions.0.total_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "executions.0.time_zone"),
+					resource.TestCheckResourceAttrSet(dataSource, "executions.0.begin_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "executions.0.end_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "executions.0.create_time"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceAppScheduleTaskExecutions_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_service" "test" {}
+
+resource "huaweicloud_workspace_app_server_group" "test" {
+  name             = "%[1]s"
+  os_type          = "Windows"
+  flavor_id        = "%[2]s"
+  vpc_id           = data.huaweicloud_workspace_service.test.vpc_id
+  subnet_id        = data.huaweicloud_workspace_service.test.network_ids[0]
+  system_disk_type = "SAS"
+  system_disk_size = 80
+  is_vdi           = true
+  app_type         = "COMMON_APP"
+  image_id         = "%[3]s"
+  image_type       = "gold"
+  image_product_id = "%[4]s"
+}
+
+resource "huaweicloud_workspace_app_server" "test" {
+  name                = "%[1]s" 
+  server_group_id     = huaweicloud_workspace_app_server_group.test.id
+  type                = "createApps"
+  flavor_id           = huaweicloud_workspace_app_server_group.test.flavor_id
+  vpc_id              = huaweicloud_workspace_app_server_group.test.vpc_id
+  subnet_id           = huaweicloud_workspace_app_server_group.test.subnet_id
+  update_access_agent = false
+
+  root_volume {
+    type = huaweicloud_workspace_app_server_group.test.system_disk_type
+    size = huaweicloud_workspace_app_server_group.test.system_disk_size
+  }
+}
+
+resource "huaweicloud_workspace_app_schedule_task" "test" {
+  task_name      = "%[1]s"
+  task_type      = "STOP_SERVER"
+  scheduled_time = formatdate("HH:mm:ss", timeadd(timestamp(), "1m"))
+  scheduled_type = "DAY"
+  day_interval   = 1
+  time_zone      = "Coordinated Universal Time"
+
+  target_infos {
+    target_type = "SERVER_GROUP"
+    target_id   = huaweicloud_workspace_app_server.test.id
+  }
+
+  # The 'scheduled_time' field is generated using a timestamp, so its changes should be ignored.
+  lifecycle {
+    ignore_changes = [scheduled_time]
+  }
+}
+`, name,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID)
+}
+
+func testDataSourceAppScheduleTaskExecutions_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Wait for the scheduled task to be executed.
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "sleep 90"
+  }
+
+  depends_on = [huaweicloud_workspace_app_schedule_task.test]
+}
+
+data "huaweicloud_workspace_app_schedule_task_executions" "test" {
+  depends_on = [null_resource.test]
+
+  task_id = huaweicloud_workspace_app_schedule_task.test.id
+}
+`, testDataSourceAppScheduleTaskExecutions_base(name))
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_schedule_task_executions.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_schedule_task_executions.go
@@ -1,0 +1,202 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/schedule-task/{task_id}/execute-history
+func DataSourceAppScheduleTaskExecutions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppScheduleTaskExecutionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The region where the schedule task is located.",
+			},
+			"task_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the schedule task.",
+			},
+			"executions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the schedule task execution record.",
+						},
+						"task_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the schedule task.",
+						},
+						"task_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of the schedule task.",
+						},
+						"scheduled_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The execution cycle of the schedule task.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The status of the schedule task execution.",
+						},
+						"total_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The total number of subtasks.",
+						},
+						"success_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of successful subtasks.",
+						},
+						"failed_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of failed subtasks.",
+						},
+						"time_zone": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The timezone of the schedule task.",
+						},
+						"begin_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The begin time of the schedule task execution, in UTC format.",
+						},
+						"end_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The end time of the schedule task execution, in UTC format.",
+						},
+						"create_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The creation time of the schedule task, in UTC format.",
+						},
+					},
+				},
+				Description: "The list of schedule task executions.",
+			},
+		},
+	}
+}
+
+func queryScheduleTaskExecutions(client *golangsdk.ServiceClient, taskId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/schedule-task/{task_id}/execute-history"
+		result  = make([]interface{}, 0)
+		limit   = 100
+		offset  = 0
+		opt     = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+		}
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{task_id}", taskId)
+	listPath = fmt.Sprintf("%s?limit=%d", listPath, limit)
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		executeHistories := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, executeHistories...)
+		if len(executeHistories) < limit {
+			break
+		}
+		offset += len(executeHistories)
+	}
+
+	return result, nil
+}
+
+func dataSourceAppScheduleTaskExecutionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		taskId = d.Get("task_id").(string)
+	)
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	executions, err := queryScheduleTaskExecutions(client, taskId)
+	if err != nil {
+		return diag.Errorf("error querying schedule task(%s) executions: %s", taskId, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("executions", flattenScheduleTaskExecutions(executions)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenScheduleTaskExecutions(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"id":             utils.PathSearch("id", item, nil),
+			"task_id":        utils.PathSearch("task_id", item, nil),
+			"task_type":      utils.PathSearch("task_type", item, nil),
+			"scheduled_type": utils.PathSearch("scheduled_type", item, nil),
+			"status":         utils.PathSearch("status", item, nil),
+			"total_count":    utils.PathSearch("total_count", item, nil),
+			"success_count":  utils.PathSearch("success_count", item, nil),
+			"failed_count":   utils.PathSearch("failed_count", item, nil),
+			"time_zone":      utils.PathSearch("time_zone", item, nil),
+			"begin_time":     utils.PathSearch("begin_time", item, nil),
+			"end_time":       utils.PathSearch("end_time", item, nil),
+			"create_time":    utils.PathSearch("create_time", item, nil),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source (**huaweicloud_workspace_app_schedule_task_executions**) to query the execution records of specified schedule task.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source.
2. add related document and acceptance test.

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataSourceAppScheduleTaskExecutions_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataSourceAppScheduleTaskExecutions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAppScheduleTaskExecutions_basic
=== PAUSE TestAccDataSourceAppScheduleTaskExecutions_basic
=== CONT  TestAccDataSourceAppScheduleTaskExecutions_basic
--- PASS: TestAccDataSourceAppScheduleTaskExecutions_basic (606.14s)
PASS
coverage: 9.8% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 606.260s        coverage: 9.8% of statements in ./huaweicloud/services/workspace
```

<img width="1079" height="314" alt="image" src="https://github.com/user-attachments/assets/4e66f576-2662-4e1c-bf18-44b88fd92ca9" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
