### PR TITLE
feat(hss): add resource to close a server dynamic port honeypot policy

### DIFF
--- a/docs/resources/hss_close_honeypot_port_policy.md
+++ b/docs/resources/hss_close_honeypot_port_policy.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_close_honeypot_port_policy"
+description: |-
+  Manages a resource to close a server dynamic port honeypot policy within HuaweiCloud.
+---
+
+# huaweicloud_hss_close_honeypot_port_policy
+
+Manages a resource to close a server dynamic port honeypot policy within HuaweiCloud.
+
+-> This resource is a one-time action resource. Deleting this resource will not clear the corresponding request record,
+  but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "policy" {}
+variable "host_id" {}
+
+resource "huaweicloud_hss_close_honeypot_port_policy" "test" {
+  policy_id = var.policy_id
+  host_id   = var.host_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `policy_id` - (Required, String, NonUpdatable) Specifies the dynamic port honeypot policy ID.
+
+* `host_id` - (Required, String, NonUpdatable) Specifies the host ID.
+  Multiple host ID is supported, separated by commas (,).
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the hosts under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2328,6 +2328,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_asset_manual_collect":                   hss.ResourceAssetManualCollect(),
 			"huaweicloud_hss_host_group":                             hss.ResourceHostGroup(),
 			"huaweicloud_hss_cce_protection":                         hss.ResourceCCEProtection(),
+			"huaweicloud_hss_close_honeypot_port_policy":             hss.ResourceCloseHoneypotPortPolicy(),
 			"huaweicloud_hss_container_export_task":                  hss.ResourceContainerExportTask(),
 			"huaweicloud_hss_container_kubernetes_sync_mccs":         hss.ResourceContainerKubernetesSyncMccs(),
 			"huaweicloud_hss_container_kubernetes_cluster_daemonset": hss.ResourceContainerKubernetesClusterDaemonset(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_close_honeypot_port_policy_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_close_honeypot_port_policy_test.go
@@ -1,0 +1,39 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccCloseHoneypotPortPolicy_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting a host ID that has enabled premium edition host protection.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+			// The dynamic port honeypot policy ID is Required.
+			acceptance.TestAccPreCheckHSSPolicyId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testCloseHoneypotPortPolicy_basic(),
+			},
+		},
+	})
+}
+
+func testCloseHoneypotPortPolicy_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_hss_close_honeypot_port_policy" "test" {
+  policy_id             = "%[1]s"
+  host_id               = "%[2]s"
+  enterprise_project_id = "0"
+}
+`, acceptance.HW_HSS_POLICY_ID, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
+}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_close_honeypot_port_policy.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_close_honeypot_port_policy.go
@@ -1,0 +1,122 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var closeHoneypotPortPolicyNonUpdatableParams = []string{"policy_id", "host_id", "enterprise_project_id"}
+
+// @API HSS DELETE /v5/{project_id}/honeypot-port/host-policy/{policy_id}
+func ResourceCloseHoneypotPortPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCloseHoneypotPortPolicyCreate,
+		ReadContext:   resourceCloseHoneypotPortPolicyRead,
+		UpdateContext: resourceCloseHoneypotPortPolicyUpdate,
+		DeleteContext: resourceCloseHoneypotPortPolicyDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(closeHoneypotPortPolicyNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildCloseHoneypotPortPolicyBodyParams(d *schema.ResourceData, epsId string) string {
+	queryParams := fmt.Sprintf("?host_id=%v", d.Get("host_id"))
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%s", queryParams, epsId)
+	}
+
+	return queryParams
+}
+
+func resourceCloseHoneypotPortPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		httpUrl  = "v5/{project_id}/honeypot-port/host-policy/{policy_id}"
+		epsId    = cfg.GetEnterpriseProjectID(d)
+		policyId = d.Get("policy_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{policy_id}", policyId)
+	requestPath += buildCloseHoneypotPortPolicyBodyParams(d, epsId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error closing dynamic port honeypot port policy: %s", err)
+	}
+
+	d.SetId(policyId)
+
+	return resourceCloseHoneypotPortPolicyRead(ctx, d, meta)
+}
+
+func resourceCloseHoneypotPortPolicyRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceCloseHoneypotPortPolicyUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceCloseHoneypotPortPolicyDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to close honeypot port policy. Deleting
+	this resource will not clear the corresponding close records, but will only remove the resource information from
+	the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add resource to close a server dynamic port honeypot policy.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccCloseHoneypotPortPolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccCloseHoneypotPortPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccCloseHoneypotPortPolicy_basic
=== PAUSE TestAccCloseHoneypotPortPolicy_basic
=== CONT  TestAccCloseHoneypotPortPolicy_basic
--- PASS: TestAccCloseHoneypotPortPolicy_basic (11.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       11.667s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
