### PR TITLE
feat(hss): add new resource to manage dynamic port honeypot policy

### DIFF
--- a/docs/resources/hss_honeypot_port_policy.md
+++ b/docs/resources/hss_honeypot_port_policy.md
@@ -1,0 +1,136 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_honeypot_port_policy"
+description: |-
+  Manages a dynamic port honeypot policy resource within HuaweiCloud.
+---
+
+# huaweicloud_hss_honeypot_port_policy
+
+Manages a dynamic port honeypot policy resource within HuaweiCloud.
+
+-> Create the dynamic port honeypot policy resource need to meet the following conditions:
+  <br/>1. The server that not bound the EIP.
+  <br/>2. The HSS premium edition or higher has been enabled on the server.
+  <br/>3. The server agent is online. The Windows agent version is 4.0.22 or later, and the Linux agent version
+  is 3.2.10 or later.
+  <br/>4. For more details, please refer to [document](https://support.huaweicloud.com/intl/en-us/usermanual-hss2.0/hss_01_0600.html).
+
+## Example Usage
+
+```hcl
+variable "policy_name" {}
+variable "os_type" {}
+variable "white_ip" {
+  type = list(string)
+}
+variable "host_id" {
+  type = list(string)
+}
+
+resource "huaweicloud_hss_honeypot_port_policy" "test" {
+  policy_name = var.policy_name
+  os_type     = var.os_type
+
+  ports_list {
+    port     = 8006
+    protocol = "tcp"
+  }
+
+  ports_list {
+    port     = 8008
+    protocol = "tcp"
+  }
+
+  white_ip = var.white_ip
+  host_id  = var.host_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `policy_name` - (Required, String) Specifies the honeypot policy name.
+  The name must be unique.
+
+* `os_type` - (Required, String) Specifies the OS type.
+  The valid values are as follows:
+  + **Linux**
+  + **Windows**
+
+* `ports_list` - (Required, List) Specifies the port and protocol list.
+  The [ports_list](#honeypot_policy_ports_struct) structure is documented below.
+
+* `white_ip` - (Required, List) Specifies the IP addresses whitelist.
+
+* `host_id` - (Optional, List) Specifies the ID list of the hosts.
+
+* `group_list` - (Optional, List) Specifies the server group ID list.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the hosts under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+<a name="honeypot_policy_ports_struct"></a>
+The `ports_list` block supports:
+
+* `port` - (Required, Int) Specifies the port number.
+
+* `protocol` - (Required, String) Specifies the protocol type.
+  The valid values are as follows:
+  + **tcp**
+  + **tcp6**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `host_list` - The host ID list.
+
+* `port_list` - The port and protocol list.
+  The [port_list](#honeypot_policy_port_struct_attr) structure is documented below.
+
+<a name="honeypot_policy_port_struct_attr"></a>
+The `port_list` block supports:
+
+* `port` - The port number.
+
+* `protocol` - The protocol type.
+
+## Import
+
+The resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_hss_honeypot_port_policy.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes include: `ports_list`, `host_id`, `group_list`, `enterprise_project_id`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition
+should be updated to align with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_hss_honeypot_port_policy" "test" { 
+  ...
+  
+  lifecycle {
+    ignore_changes = [
+      "ports_list", host_id, group_list, enterprise_project_id,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2331,6 +2331,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_container_export_task":                  hss.ResourceContainerExportTask(),
 			"huaweicloud_hss_container_kubernetes_sync_mccs":         hss.ResourceContainerKubernetesSyncMccs(),
 			"huaweicloud_hss_container_kubernetes_cluster_daemonset": hss.ResourceContainerKubernetesClusterDaemonset(),
+			"huaweicloud_hss_honeypot_port_policy":                   hss.ResourceHoneypotPortPolicy(),
 			"huaweicloud_hss_host_protection":                        hss.ResourceHostProtection(),
 			"huaweicloud_hss_webtamper_protection":                   hss.ResourceWebTamperProtection(),
 			"huaweicloud_hss_quota":                                  hss.ResourceQuota(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_honeypot_port_policy_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_honeypot_port_policy_test.go
@@ -1,0 +1,142 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/hss"
+)
+
+func getResourceHoneypotPortPolicyFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("hss", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating HSS client: %s", err)
+	}
+
+	return hss.GetHoneypotPortPolicy(client, state.Primary.ID, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func TestAccResourceHoneypotPortPolicy_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_hss_honeypot_port_policy.test"
+		name         = acceptance.RandomAccResourceName()
+
+		object interface{}
+		rc     = acceptance.InitResourceCheck(
+			resourceName,
+			&object,
+			getResourceHoneypotPortPolicyFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHoneypotPortPolicy_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "policy_name", name),
+					resource.TestCheckResourceAttr(resourceName, "os_type", "Linux"),
+					resource.TestCheckResourceAttr(resourceName, "ports_list.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ports_list.0.port", "8002"),
+					resource.TestCheckResourceAttr(resourceName, "ports_list.0.protocol", "tcp"),
+					resource.TestCheckResourceAttr(resourceName, "host_id.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "white_ip.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "group_list.#", "1"),
+				),
+			},
+			{
+				Config: testAccHoneypotPortPolicy_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "policy_name", name+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "os_type", "Linux"),
+					resource.TestCheckResourceAttr(resourceName, "ports_list.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ports_list.0.port", "8008"),
+					resource.TestCheckResourceAttr(resourceName, "ports_list.0.protocol", "tcp"),
+					resource.TestCheckResourceAttr(resourceName, "host_id.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "white_ip.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "group_list.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"ports_list",
+					"host_id",
+					"group_list",
+					"enterprise_project_id",
+				},
+			},
+		},
+	})
+}
+
+func testAccHoneypotPortPolicy_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_hss_host_group" "test" {
+  name                  = "%[1]s"
+  host_ids              = ["%[2]s"]
+  enterprise_project_id = "%[3]s"
+}
+
+resource "huaweicloud_hss_honeypot_port_policy" "test" {
+  policy_name = "%[1]s" 
+  os_type     = "Linux"
+
+  ports_list {
+    port     = 8002
+    protocol = "tcp"
+  }
+
+  ports_list {
+    port     = 8006
+    protocol = "tcp"
+  }
+
+  host_id               = ["%[2]s"]
+  white_ip              = ["192.168.1.24","192.168.1.26"]
+  group_list            = [huaweicloud_hss_host_group.test.id]
+  enterprise_project_id = "%[3]s"
+}
+`, name, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccHoneypotPortPolicy_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_hss_host_group" "test" {
+  name                  = "%[1]s"
+  host_ids              = ["%[2]s"]
+  enterprise_project_id = "%[3]s"
+}
+
+resource "huaweicloud_hss_honeypot_port_policy" "test" {
+  policy_name = "%[1]s_update" 
+  os_type     = "Linux"
+
+  ports_list {
+    port     = 8008
+    protocol = "tcp"
+  }
+
+  host_id               = ["%[2]s"]
+  white_ip              = ["192.168.1.28"]
+  group_list            = [huaweicloud_hss_host_group.test.id]
+  enterprise_project_id = "%[3]s"
+}
+`, name, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_honeypot_port_policy.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_honeypot_port_policy.go
@@ -1,0 +1,372 @@
+package hss
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var honeypotPortPolicyNonUpdatableParams = []string{"enterprise_project_id"}
+
+// @API HSS POST /v5/{project_id}/honeypot-port/policy
+// @API HSS GET /v5/{project_id}/honeypot-port/policy-list
+// @API HSS GET /v5/{project_id}/honeypot-port/policy/{policy_id}
+// @API HSS PUT /v5/{project_id}/honeypot-port/policy/{policy_id}
+// @API HSS DELETE /v5/{project_id}/honeypot-port/policy/{policy_id}
+func ResourceHoneypotPortPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHoneypotPortPolicyCreate,
+		ReadContext:   resourceHoneypotPortPolicyRead,
+		UpdateContext: resourceHoneypotPortPolicyUpdate,
+		DeleteContext: resourceHoneypotPortPolicyDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(honeypotPortPolicyNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"policy_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"os_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ports_list": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"port": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"white_ip": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"host_id": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"group_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"host_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"port_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildHoneypotPortPolicyQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+	}
+
+	return ""
+}
+
+func buildHoneypotPortPolicyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"policy_name": d.Get("policy_name"),
+		"os_type":     d.Get("os_type"),
+		"ports_list":  buildPortsListBodyParams(d.Get("ports_list").(*schema.Set).List()),
+		"white_ip":    utils.ExpandToStringList(d.Get("white_ip").([]interface{})),
+		"host_id":     utils.ValueIgnoreEmpty(utils.ExpandToStringList(d.Get("host_id").([]interface{}))),
+		"group_list":  utils.ValueIgnoreEmpty(utils.ExpandToStringList(d.Get("group_list").([]interface{}))),
+	}
+
+	return bodyParams
+}
+
+func buildPortsListBodyParams(portsList []interface{}) []map[string]interface{} {
+	if len(portsList) == 0 {
+		return nil
+	}
+
+	ports := make([]map[string]interface{}, 0, len(portsList))
+	for _, v := range portsList {
+		raw, ok := v.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+
+		params := map[string]interface{}{
+			"port":     raw["port"],
+			"protocol": raw["protocol"],
+		}
+		ports = append(ports, params)
+	}
+
+	return ports
+}
+
+func resourceHoneypotPortPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		epsId      = cfg.GetEnterpriseProjectID(d)
+		policyName = d.Get("policy_name").(string)
+		httpUrl    = "v5/{project_id}/honeypot-port/policy"
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath += buildHoneypotPortPolicyQueryParams(epsId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildHoneypotPortPolicyBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating dynamic port honeypot policy: %s", err)
+	}
+
+	policy, err := getHoneypotPortPolicyId(client, policyName, epsId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	policyId := utils.PathSearch("policy_id", policy, "").(string)
+	if policyId == "" {
+		return diag.Errorf("error creating dynamic port honeypot policy: unable to find policy ID")
+	}
+
+	d.SetId(policyId)
+
+	return resourceHoneypotPortPolicyRead(ctx, d, meta)
+}
+
+func getHoneypotPortPolicyId(client *golangsdk.ServiceClient, policyName, epsId string) (interface{}, error) {
+	var (
+		httpUrl = "v5/{project_id}/honeypot-port/policy-list?limit=200"
+		offset  = 0
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	if epsId != "" {
+		listPath = fmt.Sprintf("%s&enterprise_project_id=%s", listPath, epsId)
+	}
+
+	listOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &listOpts)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving dynamic port honeypot policy list: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		policies := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(policies) < 1 {
+			break
+		}
+
+		policy := utils.PathSearch(fmt.Sprintf("[?policy_name=='%s']|[0]", policyName), policies, nil)
+		if policy != nil {
+			return policy, nil
+		}
+
+		offset += len(policies)
+	}
+
+	return nil, errors.New("error creating dynamic port honeypot policy: unable to find policy in list API")
+}
+
+func GetHoneypotPortPolicy(client *golangsdk.ServiceClient, policyId, epsId string) (interface{}, error) {
+	httpUrl := "v5/{project_id}/honeypot-port/policy/{policy_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{policy_id}", policyId)
+	getPath += buildHoneypotPortPolicyQueryParams(epsId)
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceHoneypotPortPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		epsId  = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	policy, err := GetHoneypotPortPolicy(client, d.Id(), epsId)
+	if err != nil {
+		// When the policy does not exist, the response body example of the details interface is as follows:
+		// error message: { "error_code": "HSS.1005","error_description": "无效的策略信息","error_msg": "无效的策略信息"}
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", "HSS.1005"),
+			"error retrieving dynamic port honeypot policy")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("policy_name", utils.PathSearch("policy_name", policy, nil)),
+		d.Set("os_type", utils.PathSearch("os_type", policy, nil)),
+		d.Set("port_list", flattenHoneypotPortPolicyPortList(utils.PathSearch("port_list", policy, make([]interface{}, 0)).([]interface{}))),
+		d.Set("white_ip", utils.PathSearch("white_ip", policy, nil)),
+		d.Set("host_list", utils.PathSearch("host_list", policy, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenHoneypotPortPolicyPortList(rawPortList []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(rawPortList))
+	for _, v := range rawPortList {
+		result = append(result, map[string]interface{}{
+			"port":     utils.PathSearch("port", v, nil),
+			"protocol": utils.PathSearch("protocol", v, nil),
+		})
+	}
+
+	return result
+}
+
+func resourceHoneypotPortPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/honeypot-port/policy/{policy_id}"
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{policy_id}", d.Id())
+	updatePath += buildHoneypotPortPolicyQueryParams(epsId)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildHoneypotPortPolicyBodyParams(d)),
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating dynamic port honeypot policy: %s", err)
+	}
+
+	return resourceHoneypotPortPolicyRead(ctx, d, meta)
+}
+
+func resourceHoneypotPortPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/honeypot-port/policy/{policy_id}"
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{policy_id}", d.Id())
+	deletePath += buildHoneypotPortPolicyQueryParams(epsId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		// If the policy does not exist, the response HTTP status code of the deletion API is 400.
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", "HSS.1005"),
+			fmt.Sprintf("error deleting dynamic port honeypot policy, the error message: %s", err))
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to manage dynamic port honeypot policy.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccResourceHoneypotPortPolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccResourceHoneypotPortPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceHoneypotPortPolicy_basic
=== PAUSE TestAccResourceHoneypotPortPolicy_basic
=== CONT  TestAccResourceHoneypotPortPolicy_basic
--- PASS: TestAccResourceHoneypotPortPolicy_basic (62.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       62.784s
```
<img width="1038" height="22" alt="image" src="https://github.com/user-attachments/assets/81c896f7-3885-41e3-be3c-fecbe3645454" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
<img width="744" height="187" alt="image" src="https://github.com/user-attachments/assets/628612f5-be64-4d09-a7a9-c8f31a9d73b4" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
<img width="754" height="274" alt="image" src="https://github.com/user-attachments/assets/df72d68d-82bd-47db-9e83-116ec5dd3c12" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
