### PR TITLE
feat(hss): support `hss_container_sync_cluster_information` resource

### DIFF
--- a/docs/resources/hss_container_sync_cluster_information.md
+++ b/docs/resources/hss_container_sync_cluster_information.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_container_sync_cluster_information"
+description: |-
+  Manages an HSS container synchronize cluster information resource within HuaweiCloud.
+---
+
+# huaweicloud_hss_container_sync_cluster_information
+
+Manages an HSS container synchronize cluster information resource within HuaweiCloud.
+
+-> This resource is a one-time action resource used to synchronize HSS cluster information. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_hss_container_sync_cluster_information" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the hosts under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2329,6 +2329,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_host_group":                             hss.ResourceHostGroup(),
 			"huaweicloud_hss_cce_protection":                         hss.ResourceCCEProtection(),
 			"huaweicloud_hss_container_export_task":                  hss.ResourceContainerExportTask(),
+			"huaweicloud_hss_container_sync_cluster_information":     hss.ResourceContainerSyncClusterInformation(),
 			"huaweicloud_hss_container_kubernetes_sync_mccs":         hss.ResourceContainerKubernetesSyncMccs(),
 			"huaweicloud_hss_container_kubernetes_cluster_daemonset": hss.ResourceContainerKubernetesClusterDaemonset(),
 			"huaweicloud_hss_host_protection":                        hss.ResourceHostProtection(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_container_sync_cluster_information_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_container_sync_cluster_information_test.go
@@ -1,0 +1,30 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccContainerSyncClusterInformation_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testContainerSyncClusterInformation_basic,
+			},
+		},
+	})
+}
+
+const testContainerSyncClusterInformation_basic = `
+resource "huaweicloud_hss_container_sync_cluster_information" "test" {
+  enterprise_project_id = "0"
+}
+`

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_container_sync_cluster_information.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_container_sync_cluster_information.go
@@ -1,0 +1,116 @@
+package hss
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var containerSyncClusterInformationNonUpdatableParams = []string{
+	"enterprise_project_id",
+}
+
+// @API HSS POST /v5/{project_id}/kubernetes/save-clusters
+func ResourceContainerSyncClusterInformation() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceContainerSyncClusterInformationCreate,
+		ReadContext:   resourceContainerSyncClusterInformationRead,
+		UpdateContext: resourceContainerSyncClusterInformationUpdate,
+		DeleteContext: resourceContainerSyncClusterInformationDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(3 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(containerSyncClusterInformationNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			// Query param.
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceContainerSyncClusterInformationCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v5/{project_id}/kubernetes/save-clusters"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	if epsId != "" {
+		requestPath += "?enterprise_project_id=" + epsId
+	}
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error synchronizing HSS cluster information: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return nil
+}
+
+func resourceContainerSyncClusterInformationRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceContainerSyncClusterInformationUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceContainerSyncClusterInformationDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to synchronize HSS cluster information. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information from the tf
+    state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_container_sync_cluster_information` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_container_sync_cluster_information` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccContainerSyncClusterInformation_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccContainerSyncClusterInformation_basic -timeout 360m -parallel 4
=== RUN   TestAccContainerSyncClusterInformation_basic
=== PAUSE TestAccContainerSyncClusterInformation_basic
=== CONT  TestAccContainerSyncClusterInformation_basic
--- PASS: TestAccContainerSyncClusterInformation_basic (11.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       11.846s

```
<img width="950" height="45" alt="image" src="https://github.com/user-attachments/assets/2fa73ef1-6b93-4dd0-b36e-2e4747b5f04b" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
