### PR TITLE
fix(fgs/function): LTS log switch parameter supports omit feature

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -456,7 +456,12 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the function.
 
-* `enable_lts_log` - (Optional, Bool) Specifies whether to enable the LTS log, defaults to **false**.
+* `enable_lts_log` - (Optional, Bool) Specifies whether to enable the LTS logging feature.  
+  The valid values are as follows:
+  + **null** or omit this parameter definition: Using the default value configured on the FunctionGraph service to
+    configure the LTS logging feature.
+  + **true**: Explicitly enable the LTS logging feature.
+  + **false**: Explicitly disable the LTS logging feature.
 
 * `log_group_id` - (Optional, String) Specifies the LTS group ID for collecting logs.
 
@@ -467,7 +472,7 @@ The following arguments are supported:
 * `log_stream_name` - (Optional, String) Specifies the LTS stream name for collecting logs.
 
 -> 1. The `log_group_id`, `log_group_name`, `log_stream_id`, and `log_stream_name` are available and used together
-   only when `enable_lts_log` is set to **true**.
+   only when `enable_lts_log` is set to **true** or the service default value is **true** (omit `enable_lts_log`).
    <br>2. When creating a function, if the `enable_lts_log` parameter is set to **true**, and the corresponding
    LTS log parameters are not specified, the FunctionGraph will automatically create a log group and log stream.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Omit `enable_lts_log` parameter setting in the request body means using default value configured on the FunctionGraph service.
And for most account, the default value is **true**.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. LTS log switch parameter supports omit feature
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

<img width="2436" height="1357" alt="image" src="https://github.com/user-attachments/assets/46c3896f-8919-4360-9217-1a51c94a47dc" />

No changes happen if the value of parameter enable_lts_log from null (omit and using default value true) to **true**
<img width="1248" height="998" alt="image" src="https://github.com/user-attachments/assets/aa4396a8-94d6-45c8-9ab5-fd57bd77fa73" />

Error report if we disable the LTS log (set the value of parameter `enable_lts_log` as false) but still configure the LTS group and LTS stream
<img width="2247" height="959" alt="image" src="https://github.com/user-attachments/assets/68c2d7f1-5884-44c6-97e5-f0480e3d0d46" />

Disable the LTS log feature (set the value of parameter `enable_lts_log` as false) and remove the LTS configurations (group and stream)
<img width="1394" height="1069" alt="image" src="https://github.com/user-attachments/assets/bc20de1b-fbd8-4073-9b20-15da6e73f798" />

What console show after LTS log feature has been disabled
```
resource "huaweicloud_fgs_function" "test" {
  ...

  enable_lts_log = false
  # log_group_id    = huaweicloud_lts_group.test.id
  # log_stream_id   = huaweicloud_lts_stream.test.id
  # log_group_name  = huaweicloud_lts_group.test.group_name
  # log_stream_name = huaweicloud_lts_stream.test.stream_name
}
```
<img width="909" height="1267" alt="image" src="https://github.com/user-attachments/assets/f20afe1e-1c77-463c-87ca-5d4d425ca5fa" />
<img width="533" height="435" alt="image" src="https://github.com/user-attachments/assets/6ae91fbe-8b59-4b81-99aa-dcd81bf11d98" />
<img width="1059" height="460" alt="image" src="https://github.com/user-attachments/assets/a38b5988-cadc-43ba-9d90-469b6549d911" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
