### PR TITLE
feat(hss): add new datasource to get the list of common login IPs

### DIFF
--- a/docs/data-sources/hss_setting_login_common_ips.md
+++ b/docs/data-sources/hss_setting_login_common_ips.md
@@ -1,0 +1,54 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_setting_login_common_ips"
+description: |-
+  Use this data source to get the list of common login IP addresses information.
+---
+
+# huaweicloud_hss_setting_login_common_ips
+
+Use this data source to get the list of common login IP addresses information.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_setting_login_common_ips" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `ip_addr` - (Optional, String) Specifies the login IP address.
+  The IP address can a specify IP or a network segment. e.g. **192.68.78.3** or **192.78.10.0/24**.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `total_num` - The total number of common login IPs that have been set.
+
+* `data_list` - The list of common login IP information.
+  The [data_list](#login_common_ips_data_list) structure is documented below.
+
+<a name="login_common_ips_data_list"></a>
+The `data_list` block supports:
+
+* `ip_addr` - The IP address.
+
+* `total_num` - The total number of hosts associated with the IP address.
+
+* `host_id_list` - The list of server IDs associated with the IP address.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1115,6 +1115,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_rasp_servers":                         hss.DataSourceRaspServers(),
 			"huaweicloud_hss_rasp_status":                          hss.DataSourceRaspStatus(),
 			"huaweicloud_hss_resource_quotas":                      hss.DataSourceResourceQuotas(),
+			"huaweicloud_hss_setting_login_common_ips":             hss.DataSourceSettingLoginCommonIps(),
 			"huaweicloud_hss_tags":                                 hss.DataSourceHssTags(),
 			"huaweicloud_hss_vulnerabilities":                      hss.DataSourceVulnerabilities(),
 			"huaweicloud_hss_vulnerability_handle_history":         hss.DataSourceVulnerabilityHandleHistory(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_setting_login_common_ips_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_setting_login_common_ips_test.go
@@ -1,0 +1,68 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSettingLoginCommonIps_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_setting_login_common_ips.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Before running the test, you need to prepare a host with host protection enabled.
+			// And setting login common ips on console for the host.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+
+			{
+				Config: testAccDataSourceSettingLoginCommonIps_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.ip_addr"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.host_id_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.total_num"),
+
+					resource.TestCheckOutput("is_ip_addr_filter_useful", "true"),
+					resource.TestCheckOutput("is_eps_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceSettingLoginCommonIps_basic = `
+data "huaweicloud_hss_setting_login_common_ips" "test" {}
+
+locals {
+  ip_addr = data.huaweicloud_hss_setting_login_common_ips.test.data_list[0].ip_addr
+}
+
+data "huaweicloud_hss_setting_login_common_ips" "ip_addr_filter" {
+  ip_addr  = local.ip_addr
+}
+
+output "is_ip_addr_filter_useful" {
+  value = length(data.huaweicloud_hss_setting_login_common_ips.ip_addr_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_setting_login_common_ips.ip_addr_filter.data_list[*].ip_addr : v == local.ip_addr]
+  )
+}
+
+data "huaweicloud_hss_setting_login_common_ips" "eps_filter" {
+  enterprise_project_id = "all_granted_eps"
+}
+
+output "is_eps_filter_useful" {
+  value = length(data.huaweicloud_hss_setting_login_common_ips.eps_filter.data_list) > 0
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_setting_login_common_ips.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_setting_login_common_ips.go
@@ -1,0 +1,144 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/setting/login-common-ip
+func DataSourceSettingLoginCommonIps() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSettingLoginCommonIpsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"ip_addr": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip_addr": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"total_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"host_id_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildSettingLoginCommonIpsQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := ""
+
+	if v, ok := d.GetOk("ip_addr"); ok {
+		queryParams = fmt.Sprintf("%s&ip_addr=%v", queryParams, v)
+	}
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+
+	if queryParams != "" {
+		queryParams = "?" + queryParams[1:]
+	}
+
+	return queryParams
+}
+
+func dataSourceSettingLoginCommonIpsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/setting/login-common-ip"
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildSettingLoginCommonIpsQueryParams(d, epsId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving common login IPs: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataList := utils.PathSearch("data_list", getRespBody, make([]interface{}, 0)).([]interface{})
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_num", utils.PathSearch("total_num", getRespBody, nil)),
+		d.Set("data_list", flattenSettingLoginCommonIps(dataList)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSettingLoginCommonIps(dataListResp []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(dataListResp))
+	for _, v := range dataListResp {
+		rst = append(rst, map[string]interface{}{
+			"ip_addr":      utils.PathSearch("ip_addr", v, nil),
+			"total_num":    utils.PathSearch("total_num", v, nil),
+			"host_id_list": utils.PathSearch("host_id_list", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new datasource to get the list of common login IPs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceSettingLoginCommonIps_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceSettingLoginCommonIps_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSettingLoginCommonIps_basic
=== PAUSE TestAccDataSourceSettingLoginCommonIps_basic
=== CONT  TestAccDataSourceSettingLoginCommonIps_basic
--- PASS: TestAccDataSourceSettingLoginCommonIps_basic (16.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       16.192s
```
<img width="1097" height="36" alt="image" src="https://github.com/user-attachments/assets/267f1910-41a0-4473-8a6d-5d446fcc7291" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
