### PR TITLE
docs(obs/bucket): supports new best practice for encryption bucket

### DIFF
--- a/examples/obs/bucket-with-encryption/README.md
+++ b/examples/obs/bucket-with-encryption/README.md
@@ -1,0 +1,145 @@
+# Create an OBS bucket with KMS encryption
+
+This example provides best practice code for using Terraform to create an Object Storage Service (OBS) bucket in
+HuaweiCloud and encrypt with a DEW encryption key.
+
+## Prerequisites
+
+* A HuaweiCloud account
+* Terraform installed
+* HuaweiCloud access key and secret key (AK/SK)
+
+## Variable Introduction
+
+The following variables need to be configured:
+
+### Authentication Variables
+
+* `region_name` - The region where the OBS bucket is located
+* `access_key` - The access key of the IAM user
+* `secret_key` - The secret key of the IAM user
+
+### Resource Variables
+
+#### Required Variables
+
+* `bucket_name` - The name of the OBS bucket
+
+#### Optional Variables
+
+* `key_alias` - The alias of the KMS key (default: "")
+  The alias of the KMS key (required when `bucket_encryption` is true and `bucket_encryption_key_id` is empty)
+* `key_usage` - The usage of the KMS key (default: "ENCRYPT_DECRYPT")
+* `bucket_storage_class` - The storage class of the OBS bucket (default: "STANDARD")
+* `bucket_acl` - The ACL of the OBS bucket (default: "private")
+* `bucket_encryption` - Whether to enable encryption for the OBS bucket (default: true)
+* `bucket_sse_algorithm` - The SSE algorithm of the OBS bucket (default: "kms")
+* `bucket_encryption_key_id` - The encryption key ID of the OBS bucket (default: "")
+* `bucket_force_destroy` - Whether to force destroy the OBS bucket (default: true)
+* `bucket_tags` - The tags of the OBS bucket (default: {})
+
+## Usage
+
+* Copy this example script to your `main.tf`.
+
+* Create a `terraform.tfvars` file and fill in the required variables:
+
+  ```hcl
+  bucket_name = "your_obs_bucket_name"
+  key_alias   = "your_kms_key_alias"
+  ```
+
+* Initialize Terraform:
+
+  ```bash
+  $ terraform init
+  ```
+
+* Import the existing resources (optional):
+
+  ```bash
+  $ terraform import huaweicloud_kms_key.test[0] xxxxxxxx-xxx-xxx-xxx-xxxxxxxxxxxx
+  ```
+
+* Review the Terraform plan:
+
+  ```bash
+  $ terraform plan
+  ```
+
+* Apply the configuration:
+
+  ```bash
+  $ terraform apply
+  ```
+
+* To clean up the resources:
+
+  ```bash
+  $ terraform destroy
+  ```
+
+## Features
+
+This example demonstrates the following features:
+
+1. **OBS Bucket Creation**: Creates a complete OBS bucket with all necessary components
+2. **KMS Encryption**: Enables KMS encryption for enhanced data security
+3. **Flexible KMS Key Configuration**: Supports both creating new KMS key and using existing KMS key
+4. **Storage Class Configuration**: Configurable storage class for cost optimization
+5. **Access Control**: Configurable ACL for bucket access management
+6. **Tagging Support**: Supports custom tags for resource management
+
+## Encryption Options
+
+### Option 1: Create New KMS Key
+
+If you don't provide an existing KMS key ID, the example will create a new KMS key with the specified alias:
+
+```hcl
+bucket_encryption = true
+key_alias         = "your_kms_key_alias"
+```
+
+### Option 2: Use Existing KMS Key
+
+If you have an existing KMS key, you can use it directly:
+
+```hcl
+bucket_encryption        = true
+bucket_encryption_key_id = "your_existing_kms_key_id"
+```
+
+### Option 3: Disable Encryption
+
+If you don't need encryption, you can disable it:
+
+```hcl
+bucket_encryption = false
+```
+
+## Storage Classes
+
+The example supports different storage classes for cost optimization:
+
+* `STANDARD` - Standard storage for frequently accessed data (default)
+* `WARM` - Infrequent access storage for data accessed less than once per month
+* `COLD` - Archive storage for data accessed less than once per year
+
+## Note
+
+* Make sure to keep your credentials secure and never commit them to version control
+* The creation of the OBS bucket is usually instantaneous
+* This example creates the OBS bucket and optionally a KMS key for encryption
+* KMS encryption provides server-side encryption for enhanced data security
+* All resources will be created in the specified region
+* Bucket names must be globally unique across all HuaweiCloud accounts
+* When `bucket_force_destroy` is set to true, the bucket can be destroyed even if it contains objects
+
+## Requirements
+
+| Name | Version |
+| ---- | ---- |
+| terraform | >= 0.12.0 |
+| huaweicloud | >= 1.64.3 |
+| random | >= 3.0.0 |

--- a/examples/obs/bucket-with-encryption/main.tf
+++ b/examples/obs/bucket-with-encryption/main.tf
@@ -1,0 +1,23 @@
+resource "huaweicloud_kms_key" "test" {
+  count = var.bucket_encryption && var.bucket_encryption_key_id == "" ? 1 : 0
+
+  key_alias = var.key_alias
+  key_usage = var.key_usage
+}
+
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = var.bucket_name
+  storage_class = var.bucket_storage_class
+  acl           = var.bucket_acl
+  encryption    = var.bucket_encryption
+  sse_algorithm = var.bucket_encryption ? var.bucket_sse_algorithm : null
+  kms_key_id    = var.bucket_encryption ? var.bucket_encryption_key_id != "" ? var.bucket_encryption_key_id : huaweicloud_kms_key.test[0].id : null
+  force_destroy = var.bucket_force_destroy
+  tags          = var.bucket_tags
+
+  lifecycle {
+    ignore_changes = [
+      sse_algorithm
+    ]
+  }
+}

--- a/examples/obs/bucket-with-encryption/providers.tf
+++ b/examples/obs/bucket-with-encryption/providers.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 0.12.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.64.3"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+provider "huaweicloud" {
+  region     = var.region_name
+  access_key = var.access_key
+  secret_key = var.secret_key
+}

--- a/examples/obs/bucket-with-encryption/terraform.tfvars
+++ b/examples/obs/bucket-with-encryption/terraform.tfvars
@@ -1,0 +1,2 @@
+key_alias   = "tf-test-obs-key"
+bucket_name = "tf-test-obs-bucket"

--- a/examples/obs/bucket-with-encryption/variables.tf
+++ b/examples/obs/bucket-with-encryption/variables.tf
@@ -1,0 +1,82 @@
+# Variable definitions for authentication
+variable "region_name" {
+  description = "The region where the OBS bucket is located"
+  type        = string
+}
+
+variable "access_key" {
+  description = "The access key of the IAM user"
+  type        = string
+}
+
+variable "secret_key" {
+  description = "The secret key of the IAM user"
+  type        = string
+}
+
+# Variable definitions for resources/data sources
+variable "bucket_encryption" {
+  description = "The encryption of the OBS bucket"
+  type        = bool
+  default     = true
+}
+
+variable "bucket_encryption_key_id" {
+  description = "The encryption key ID of the OBS bucket"
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "key_alias" {
+  description = "The alias of the KMS key"
+  type        = string
+  default     = ""
+  nullable    = false
+
+  validation {
+    condition     = var.key_alias != "" && var.bucket_encryption && var.bucket_encryption_key_id == ""
+    error_message = "The key_alias must be set when bucket_encryption is true and bucket_encryption_key_id is not set."
+  }
+}
+
+variable "key_usage" {
+  description = "The usage of the KMS key"
+  type        = string
+  default     = "ENCRYPT_DECRYPT"
+}
+
+variable "bucket_name" {
+  description = "The name of the OBS bucket"
+  type        = string
+}
+
+variable "bucket_storage_class" {
+  description = "The storage class of the OBS bucket"
+  type        = string
+  default     = "STANDARD"
+}
+
+variable "bucket_acl" {
+  description = "The ACL of the OBS bucket"
+  type        = string
+  default     = "private"
+}
+
+variable "bucket_sse_algorithm" {
+  description = "The SSE algorithm of the OBS bucket"
+  type        = string
+  default     = "kms"
+}
+
+variable "bucket_force_destroy" {
+  description = "The force destroy of the OBS bucket"
+  type        = bool
+  default     = true
+}
+
+variable "bucket_tags" {
+  description = "The tags of the OBS bucket"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports new best practice that supports creating bucket and encrypt it with a DEW encryption key.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new best practice that supports creating bucket and encrypt it with a DEW encryption key.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

<img width="1321" height="1315" alt="image" src="https://github.com/user-attachments/assets/cf0cabe7-fbd3-4624-ae7a-9e145973f2cd" />
<img width="1336" height="938" alt="image" src="https://github.com/user-attachments/assets/d0a61ae8-cb9c-4758-a76a-7f7c03414486" />
the sse_algorithm parameter should be ignore changes because of the response value is different with the user input:
<img width="1036" height="318" alt="image" src="https://github.com/user-attachments/assets/7ae9dcca-7389-45ef-b9ed-7fbe1541d5fb" />
<img width="1474" height="1017" alt="image" src="https://github.com/user-attachments/assets/ed14b596-5ebb-4fa0-8771-f9e6a00e27b7" />

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
