### PR TITLE
chore: fix(workspace/app): change read api and fix unable to ignore tags using ignore_changes

### DIFF
--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_image_servers_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_image_servers_test.go
@@ -126,5 +126,5 @@ locals {
 output "is_eps_id_filter_useful" {
   value = length(local.eps_id_filter_result) > 0 && alltrue(local.eps_id_filter_result)
 }
-`, testResourceAppImageServer_basic(name, "Data source test"))
+`, testResourceAppImageServer_withAD(name, "Data source test"))
 }

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_image_server_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_image_server_test.go
@@ -28,8 +28,146 @@ func getAcceptanceEpsId() string {
 	return acceptance.HW_ENTERPRISE_PROJECT_ID_TEST
 }
 
-// Before running this test, please enable a service that connects to LocalAD and the corresponding OU is created.
 func TestAccResourceAppImageServer_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		resourceName = "huaweicloud_workspace_app_image_server.test"
+		serverGroup  interface{}
+		rc           = acceptance.InitResourceCheck(
+			resourceName,
+			&serverGroup,
+			getResourceAppImageServerFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+			acceptance.TestAccPreCheckWorkspaceAppImageSpecCode(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceAppImageServer_basic(name, name, "Created by script"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "flavor_id", acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id",
+						"data.huaweicloud_workspace_service.test", "vpc_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_id",
+						"data.huaweicloud_workspace_service.test", "network_ids.0"),
+					resource.TestCheckResourceAttr(resourceName, "image_id", acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID),
+					resource.TestCheckResourceAttr(resourceName, "image_type", "gold"),
+					resource.TestCheckResourceAttr(resourceName, "image_source_product_id",
+						acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID),
+					resource.TestCheckResourceAttr(resourceName, "spec_code",
+						acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_SPEC_CODE),
+					resource.TestCheckResourceAttr(resourceName, "authorize_accounts.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "authorize_accounts.0.account",
+						"huaweicloud_workspace_user.test", "name"),
+					resource.TestCheckResourceAttr(resourceName, "authorize_accounts.0.type", "USER"),
+					resource.TestCheckResourceAttr(resourceName, "root_volume.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_volume.0.type", "SAS"),
+					resource.TestCheckResourceAttr(resourceName, "root_volume.0.size", "80"),
+					resource.TestCheckResourceAttr(resourceName, "is_vdi", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by script"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", getAcceptanceEpsId()),
+					resource.TestCheckResourceAttr(resourceName, "is_delete_associated_resources", "true"),
+				),
+			},
+			{
+				Config: testResourceAppImageServer_basic(name, updateName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"flavor_id",
+					"vpc_id",
+					"subnet_id",
+					"root_volume",
+					"image_source_product_id",
+					"is_vdi",
+					"availability_zone",
+					"scheduler_hints",
+					"tags",
+					"is_delete_associated_resources",
+				},
+			},
+		},
+	})
+}
+
+func testResourceAppImageServer_basic(name, updateName string, description string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_workspace_service" "test" {}
+
+resource "huaweicloud_workspace_user" "test" {
+  name                   = "%[1]s"
+  email                  = "%[1]s@example.com"
+  password_never_expires = false
+  disabled               = false
+}
+
+resource "huaweicloud_workspace_app_image_server" "test" {
+  name                           = "%[2]s"
+  flavor_id                      = "%[3]s"
+  vpc_id                         = try(data.huaweicloud_workspace_service.test.vpc_id, "")
+  subnet_id                      = try(data.huaweicloud_workspace_service.test.network_ids[0], "")
+  image_id                       = "%[4]s"
+  image_type                     = "gold"
+  image_source_product_id        = "%[5]s"
+  spec_code                      = "%[6]s"
+  is_vdi                         = true
+  availability_zone              = data.huaweicloud_availability_zones.test.names[0]
+  description                    = "%[7]s"
+  enterprise_project_id          = "%[8]s"
+  is_delete_associated_resources = true
+
+  # Currently only one user can be set.
+  authorize_accounts {
+    account = huaweicloud_workspace_user.test.name
+    type    = "USER"
+  }
+
+  root_volume {
+    type = "SAS"
+    size = 80
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, name,
+		updateName,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_SPEC_CODE,
+		description,
+		acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+// Before running this test, please enable a service that connects to LocalAD and the corresponding OU is created.
+func TestAccResourceAppImageServer_withAD(t *testing.T) {
 	var (
 		resourceName = "huaweicloud_workspace_app_image_server.test"
 		name         = acceptance.RandomAccResourceName()
@@ -55,7 +193,7 @@ func TestAccResourceAppImageServer_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testResourceAppImageServer_basic(name, "Created by script"),
+				Config: testResourceAppImageServer_withAD(name, "Created by script"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -97,7 +235,7 @@ func TestAccResourceAppImageServer_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testResourceAppImageServer_basic(updateName, ""),
+				Config: testResourceAppImageServer_withAD(updateName, ""),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
@@ -130,7 +268,7 @@ func TestAccResourceAppImageServer_basic(t *testing.T) {
 	})
 }
 
-func testResourceAppImageServer_basic(name, description string) string {
+func testResourceAppImageServer_withAD(name, description string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
 

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_image_server.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_image_server.go
@@ -418,6 +418,9 @@ func resourceAppImageServerRead(_ context.Context, d *schema.ResourceData, meta 
 		d.Set("image_type", utils.PathSearch("image_ref.image_type", imageServer, nil)),
 		d.Set("spec_code", utils.PathSearch("image_ref.spce_code", imageServer, nil)),
 		d.Set("description", utils.PathSearch("description", imageServer, nil)),
+		// The `tags` is a Computed behavior, but the API doesn't return this field, using `ignore_changes` in a script won't work,
+		// so we need to set this value to ensure `ignore_changes` takes effect during import.
+		d.Set("tags", d.Get("tags")),
 		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", imageServer, nil)),
 		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("create_time",
 			imageServer, "").(string))/1000, false)),

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_image_server.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_image_server.go
@@ -19,7 +19,7 @@ import (
 )
 
 // @API Workspace POST /v1/{project_id}/image-servers
-// @API Workspace GET /v1/{project_id}/image-servers
+// @API Workspace GET /v1/{project_id}/image-servers/{server_id}
 // @API Workspace PATCH /v1/{project_id}/image-servers/{server_id}
 // @API Workspace PATCH /v1/{project_id}/image-servers/actions/batch-delete
 func ResourceAppImageServer() *schema.Resource {
@@ -446,29 +446,19 @@ func flattenAuthorizAccounts(accounts []interface{}) []map[string]interface{} {
 }
 
 func GetAppImageServerById(client *golangsdk.ServiceClient, imageServerId string) (interface{}, error) {
-	httpUrl := "v1/{project_id}/image-servers"
+	httpUrl := "v1/{project_id}/image-servers/{server_id}"
 	getPath := client.Endpoint + httpUrl
 	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
-	getPath = fmt.Sprintf("%s?server_id=%s", getPath, imageServerId)
+	getPath = strings.ReplaceAll(getPath, "{server_id}", imageServerId)
 	getOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 	}
-	// In any case, the response status code is 200.
 	requestResp, err := client.Request("GET", getPath, &getOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving image server (%s): %s", imageServerId, err)
-	}
-
-	respBody, err := utils.FlattenResponse(requestResp)
 	if err != nil {
 		return nil, err
 	}
 
-	imageServer := utils.PathSearch("items|[0]", respBody, nil)
-	if imageServer == nil {
-		return nil, golangsdk.ErrDefault404{}
-	}
-	return imageServer, nil
+	return utils.FlattenResponse(requestResp)
 }
 
 func resourceAppImageServerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Use query details interface instead of list interface in ReadContext.
2. Fix unable to ignore tags using ignore_changes in script.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
. ./scripts/coverage.sh -o workspace -f TestAccResourceAppImageServer_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceAppImageServer_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceAppImageServer_basic
=== PAUSE TestAccResourceAppImageServer_basic
=== CONT  TestAccResourceAppImageServer_basic
--- PASS: TestAccResourceAppImageServer_basic (598.97s)
PASS
coverage: 6.5% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 599.061s        coverage: 6.5% of statements in ./huaweicloud/services/workspace
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
   <img width="1352" height="852" alt="image" src="https://github.com/user-attachments/assets/5403628f-4d40-4931-bd85-1ebe2a7cb493" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
