### PR TITLE
feat(workspace): add new data source for query application catalogs

### DIFF
--- a/docs/data-sources/workspace_application_catalogs.md
+++ b/docs/data-sources/workspace_application_catalogs.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_application_catalogs"
+description: |-
+  Use this data source to query application catalogs under a specified region within HuaweiCloud.
+---
+
+# huaweicloud_workspace_application_catalogs
+
+Use this data source to query application catalogs under a specified region within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_workspace_application_catalogs" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies The region where the application catalogs are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `catalogs` - The list of application catalogs.  
+  The [catalogs](#workspace_application_catalogs) structure is documented below.
+
+<a name="workspace_application_catalogs"></a>
+The `catalogs` block supports:
+
+* `id` - The ID of the application catalog.
+
+* `zh` - The catalog description in Chinese.
+
+* `en` - The catalog description in English.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1617,6 +1617,7 @@ func Provider() *schema.Provider {
 
 			// Workspace
 			"huaweicloud_workspace_application_rules":      workspace.DataSourceApplicationRules(),
+			"huaweicloud_workspace_application_catalogs":   workspace.DataSourceApplicationCatalogs(),
 			"huaweicloud_workspace_available_ip_number":    workspace.DataSourceAvailableIpNumber(),
 			"huaweicloud_workspace_desktops":               workspace.DataSourceDesktops(),
 			"huaweicloud_workspace_desktop_connections":    workspace.DataSourceDesktopConnections(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_application_catalogs_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_application_catalogs_test.go
@@ -1,0 +1,38 @@
+package workspace
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataApplicationCatalogs_basic(t *testing.T) {
+	var (
+		dcName = "data.huaweicloud_workspace_application_catalogs.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataApplicationCatalogs_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dcName, "catalogs.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dcName, "catalogs.0.id"),
+					resource.TestCheckResourceAttrSet(dcName, "catalogs.0.zh"),
+					resource.TestCheckResourceAttrSet(dcName, "catalogs.0.en"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataApplicationCatalogs_basic = `
+data "huaweicloud_workspace_application_catalogs" "test" {}
+`

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_application_catalogs.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_application_catalogs.go
@@ -1,0 +1,128 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/app-center/app-catalogs
+func DataSourceApplicationCatalogs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceApplicationCatalogsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the application catalogs are located.`,
+			},
+			"catalogs": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        catalogSchema(),
+				Description: `The list of application catalogs.`,
+			},
+		},
+	}
+}
+
+func catalogSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the application catalog.`,
+			},
+			"zh": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The catalog description in Chinese.`,
+			},
+			"en": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The catalog description in English.`,
+			},
+		},
+	}
+}
+
+func listApplicationCatalogs(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	httpUrl := "v1/{project_id}/app-center/app-catalogs"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenApplicationCatalogs(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"id": utils.PathSearch("id", item, nil),
+			"zh": utils.PathSearch("catalog_zh", item, nil),
+			"en": utils.PathSearch("catalog_en", item, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceApplicationCatalogsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	resp, err := listApplicationCatalogs(client)
+	if err != nil {
+		return diag.Errorf("error querying Workspace application catalogs: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("catalogs", flattenApplicationCatalogs(resp)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(workspace): add new data source for query application catalogs

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataSourceAppCatalogs_basic -timeout 360m -parallel 10
# github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam
runtime: failed to create new OS thread (have 7 already; errno=12)
fatal error: newosproc
=== RUN   TestAccDataSourceAppCatalogs_basic
=== PAUSE TestAccDataSourceAppCatalogs_basic
=== CONT  TestAccDataSourceAppCatalogs_basic
--- PASS: TestAccDataSourceAppCatalogs_basic (18.65s)
PASS
coverage: 3.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 18.746s coverage: 3.0% of statements in ./huaweicloud/services/workspace
```

<img width="1607" height="1026" alt="image" src="https://github.com/user-attachments/assets/56766053-7ddb-474a-ba97-265125354e17" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.