### PR TITLE
feat(secmaster): new datasource to query catalogues

### DIFF
--- a/docs/data-sources/secmaster_catalogues.md
+++ b/docs/data-sources/secmaster_catalogues.md
@@ -1,0 +1,90 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_catalogues"
+description: |-
+  Use this data source to get the list of SecMaster catalogues.
+---
+
+# huaweicloud_secmaster_catalogues
+
+Use this data source to get the list of SecMaster catalogues.
+This data source provides detailed information about all catalogues in the specified workspace.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "catalogue_type" {}
+variable "catalogue_code" {}
+
+# Get all catalogues
+data "huaweicloud_secmaster_catalogues" "all" {
+  workspace_id = var.workspace_id
+}
+
+# Get specific catalogues by type and code
+data "huaweicloud_secmaster_catalogues" "filtered" {
+  workspace_id   = var.workspace_id
+  catalogue_type = var.catalogue_type
+  catalogue_code = var.catalogue_code
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID.
+
+* `catalogue_type` - (Optional, String) Specifies the type of catalogues to filter.
+
+* `catalogue_code` - (Optional, String) Specifies the code of catalogues to filter.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data` - The list of the catalogues.
+
+  The [data](#data_struct) structure is documented below.
+
+<a name="data_struct"></a>
+The `data` block supports:
+
+* `id` - The unique identifier of the catalogue.
+
+* `parent_catalogue` - The name of the parent (first-level) catalogue.
+
+* `second_catalogue` - The name of the second-level catalogue.
+
+* `catalogue_status` - Whether the catalogue is built-in.
+
+* `catalogue_address` - The address of the catalogue.
+
+* `layout_id` - The ID of the layout associated with the catalogue.
+
+* `layout_name` - The name of the layout associated with the catalogue.
+
+* `publisher_name` - The name of the publisher.
+
+* `is_card_area` - Whether to display the card area.
+
+* `is_display` - Whether to display the catalogue.
+
+* `is_landing_page` - Whether it is a landing page.
+
+* `is_navigation` - Whether to display the breadcrumb navigation.
+
+* `parent_alisa_en` - The English alias of the parent catalogue.
+
+* `parent_alisa_zh` - The Chinese alias of the parent catalogue.
+
+* `second_alias_en` - The English alias of the second-level catalogue.
+
+* `second_alias_zh` - The Chinese alias of the second-level catalogue.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1427,6 +1427,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_playbook_monitors":         secmaster.DataSourceSecmasterPlaybookMonitors(),
 			"huaweicloud_secmaster_playbook_approvals":        secmaster.DataSourcePlaybookApprovals(),
 			"huaweicloud_secmaster_alert_rule_metrics":        secmaster.DataSourceSecmasterAlertRuleMetrics(),
+			"huaweicloud_secmaster_catalogues":                secmaster.DataSourceSecmasterCatalogues(),
 
 			// Querying by Ver.2 APIs
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_catalogues_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_catalogues_test.go
@@ -1,0 +1,57 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSecmasterCatalogues_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_secmaster_catalogues.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSecmasterCatalogues_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.catalogue_status"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.is_card_area"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.is_display"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.is_landing_page"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.is_navigation"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.parent_catalogue"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.second_catalogue"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceSecmasterCatalogues_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_catalogues" "test" {
+  workspace_id = "%[1]s"
+}
+
+# Fields catalogue_type and catalogue_code are only used to perform the query param code.
+# In fact, the data returned by the values of these two fields is empty. 
+data "huaweicloud_secmaster_catalogues" "test-filter" {
+  workspace_id   = "%[1]s"
+  catalogue_type = "demo-type"
+  catalogue_code = "demo-code"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_catalogues.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_catalogues.go
@@ -1,0 +1,211 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Secmaster GET /v1/{project_id}/workspaces/{workspace_id}/soc/catalogues
+func DataSourceSecmasterCatalogues() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecmasterCataloguesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"catalogue_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"catalogue_code": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"parent_catalogue": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"second_catalogue": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"catalogue_status": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"catalogue_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"layout_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"layout_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"publisher_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_card_area": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_display": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_landing_page": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_navigation": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"parent_alisa_en": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"parent_alisa_zh": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"second_alias_en": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"second_alias_zh": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildSecmasterCataloguesQueryParams(d *schema.ResourceData) string {
+	rst := ""
+
+	if v, ok := d.GetOk("catalogue_type"); ok {
+		rst = fmt.Sprintf("%s&catalogue_type=%v", rst, v)
+	}
+	if v, ok := d.GetOk("catalogue_code"); ok {
+		rst = fmt.Sprintf("%s&catalogue_code=%v", rst, v)
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func dataSourceSecmasterCataloguesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/workspaces/{workspace_id}/soc/catalogues"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", d.Get("workspace_id").(string))
+	requestPath += buildSecmasterCataloguesQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving SecMaster catalogues: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("data", flattenCatalogues(utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCatalogues(catalogues []interface{}) []interface{} {
+	if len(catalogues) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(catalogues))
+	for _, v := range catalogues {
+		rst = append(rst, map[string]interface{}{
+			"id":                utils.PathSearch("id", v, nil),
+			"parent_catalogue":  utils.PathSearch("parent_catalogue", v, nil),
+			"second_catalogue":  utils.PathSearch("second_catalogue", v, nil),
+			"catalogue_status":  utils.PathSearch("catalogue_status", v, nil),
+			"catalogue_address": utils.PathSearch("catalogue_address", v, nil),
+			"layout_id":         utils.PathSearch("layout_id", v, nil),
+			"layout_name":       utils.PathSearch("layout_name", v, nil),
+			"publisher_name":    utils.PathSearch("publisher_name", v, nil),
+			"is_card_area":      utils.PathSearch("is_card_area", v, nil),
+			"is_display":        utils.PathSearch("is_display", v, nil),
+			"is_landing_page":   utils.PathSearch("is_landing_page", v, nil),
+			"is_navigation":     utils.PathSearch("is_navigation", v, nil),
+			"parent_alisa_en":   utils.PathSearch("parent_alisa_en", v, nil),
+			"parent_alisa_zh":   utils.PathSearch("parent_alisa_zh", v, nil),
+			"second_alias_en":   utils.PathSearch("second_alias_en", v, nil),
+			"second_alias_zh":   utils.PathSearch("second_alias_zh", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query catalogues.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccDataSourceSecmasterCatalogues_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourceSecmasterCatalogues_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceSecmasterCatalogues_basic
=== PAUSE TestAccDataSourceSecmasterCatalogues_basic
=== CONT  TestAccDataSourceSecmasterCatalogues_basic
--- PASS: TestAccDataSourceSecmasterCatalogues_basic (38.25s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 38.344s coverage: 4.5% of statements in ./huaweicloud/services/secmaster
```
<img width="1340" height="71" alt="image" src="https://github.com/user-attachments/assets/b3380c57-5300-48d6-a997-e3227f8ac4f4" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
