### PR TITLE
refactor(examples/ecs): adjust attach network best practice

### DIFF
--- a/examples/ecs/attached-interface/README.md
+++ b/examples/ecs/attached-interface/README.md
@@ -1,3 +1,156 @@
-# ECS Instance With Attached Network Interface
+# Create an ECS Instance with attached network interface
 
-This example provisions an ecs instance with network interface attached.
+This example provides best practice code for using Terraform to create an ECS instance with an attached
+network interface in HuaweiCloud.
+
+## Prerequisites
+
+* A HuaweiCloud account
+* Terraform installed
+* HuaweiCloud access key and secret key (AK/SK)
+
+## Variable Introduction
+
+The following variables need to be configured:
+
+### Authentication Variables
+
+* `region_name` - The region where the ECS instance is located
+* `access_key`  - The access key of the IAM user
+* `secret_key`  - The secret key of the IAM user
+
+### Resource Variables
+
+#### Required Variables
+
+* `vpc_name` - The name of the VPC
+* `subnet_configurations` - The list of subnet configurations for ECS instance
+* `security_group_name` - The name of the security group
+* `instance_name` - The name of the ECS instance
+* `instance_admin_password` - The login password of the ECS instance
+
+#### Optional Variables
+
+* `availability_zone` - The availability zone to which the ECS instance belongs (default: "")
+* `instance_flavor_id` - The flavor ID of the ECS instance (default: "")
+* `instance_performance_type` - The performance type of the ECS instance flavor (default: "normal")
+* `instance_cpu_core_count` - The number of CPU cores of the ECS instance (default: 2)
+* `instance_memory_size` - The memory size in GB of the ECS instance (default: 4)
+* `instance_image_id` - The image ID of the ECS instance (default: "")
+* `instance_image_visibility` - The visibility of the ECS instance image (default: "public")
+* `instance_image_os` - The operating system of the ECS instance image (default: "Ubuntu")
+* `vpc_cidr` - The CIDR block of the VPC (default: "192.168.0.0/16")
+* `attached_network_id` - The ID of the network to which the ECS instance to be attached (default: "")
+* `attached_interface_fixed_ip` - The fixed IP address of the ECS instance to be attached (default: null)
+* `attached_security_group_ids` - The list of security group IDs of the ECS instance to be attached (default: null)
+
+## Subnet Configuration
+
+The `subnet_configurations` parameter defines the subnets that will be created for the ECS instance.
+Each subnet configuration object contains the following fields:
+
+```hcl
+{
+  subnet_name       = string          # Required: Name of the subnet
+  subnet_cidr       = optional(string) # Optional: CIDR block for the subnet
+  subnet_gateway_ip = optional(string) # Optional: Gateway IP address for the subnet
+}
+```
+
+## Network Interface Attachment Methods
+
+This example supports two methods for attaching network interfaces to ECS instances:
+
+### Optional 1: Attach to existing network
+
+When you have an existing network that you want to attach to the ECS instance:
+
+Example configuration:
+
+```hcl
+subnet_configurations = [
+  {
+    subnet_name = "tf_test_main_subnet"
+  }
+]
+attached_network_id = "existing-network-id"
+```
+
+### Optional 2: Create new subnets and attach to ECS instance
+
+When you want to create new subnets and attach one of them to the ECS instance:
+
+* Configure `subnet_configurations` with exactly `2` subnets:
+  - First subnet: Used for the ECS instance's primary network
+  - Second subnet: Used for the attached network interface
+
+Example configuration:
+
+```hcl
+subnet_configurations = [
+  {
+    subnet_name = "main-subnet"
+  },
+  {
+    subnet_name = "attached-subnet"
+  },
+]
+```
+
+## Usage
+
+* Copy this example script to your `main.tf`.
+
+* Create a `terraform.tfvars` file and fill in the required variables:
+
+  ```hcl
+  vpc_name = "your_vpc_name"
+  subnet_configurations = [
+    {
+      subnet_name       = "your_main_subnet_name"
+      subnet_cidr       = "your_main_subnet_cidr"
+      subnet_gateway_ip = "your_main_subnet_gateway_ip"
+    }
+  ]
+  security_group_name     = "your_security_group_name"
+  instance_name           = "your_instance_name"
+  instance_admin_password = "your_instance_password"
+  ```
+
+* Initialize Terraform:
+
+  ```bash
+  $ terraform init
+  ```
+
+* Review the Terraform plan:
+
+  ```bash
+  $ terraform plan
+  ```
+
+* Apply the configuration:
+
+  ```bash
+  $ terraform apply
+  ```
+
+* To clean up the resources:
+
+  ```bash
+  $ terraform destroy
+  ```
+
+## Note
+
+* Make sure to keep your credentials secure and never commit them to version control
+* The creation of the ECS instance and network interface may take several minutes
+* All resources will be created in the specified region
+* If no security groups are specified for the attached interface, the default security group will be automatically added
+
+## Requirements
+
+| Name         | Version     |
+| ------------ | ----------- |
+| terraform | >= 1.9.0   |
+| huaweicloud | >= 1.61.0   |

--- a/examples/ecs/attached-interface/main.tf
+++ b/examples/ecs/attached-interface/main.tf
@@ -1,50 +1,66 @@
-data "huaweicloud_availability_zones" "myaz" {}
-
-data "huaweicloud_compute_flavors" "myflavor" {
-  availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
-  performance_type  = "normal"
-  cpu_core_count    = 2
-  memory_size       = 4
+data "huaweicloud_availability_zones" "test" {
+  count = var.availability_zone == "" ? 1 : 0
 }
 
-data "huaweicloud_vpc_subnet" "mynet" {
-  name = "subnet-default"
+data "huaweicloud_compute_flavors" "test" {
+  count = var.instance_flavor_id == "" ? 1 : 0
+
+  availability_zone = var.availability_zone != "" ? var.availability_zone : try(data.huaweicloud_availability_zones.test[0].names[0], null)
+  performance_type  = var.instance_performance_type
+  cpu_core_count    = var.instance_cpu_core_count
+  memory_size       = var.instance_memory_size
 }
 
-data "huaweicloud_images_image" "myimage" {
-  name        = "Ubuntu 18.04 server 64bit"
-  most_recent = true
+data "huaweicloud_images_images" "test" {
+  count = var.instance_image_id == "" ? 1 : 0
+
+  flavor_id  = var.instance_flavor_id != "" ? var.instance_flavor_id : try(data.huaweicloud_compute_flavors.test[0].flavors[0].id, null)
+  visibility = var.instance_image_visibility
+  os         = var.instance_image_os
 }
 
-resource "huaweicloud_compute_instance" "myinstance" {
-  name              = "basic"
-  image_id          = data.huaweicloud_images_image.myimage.id
-  flavor_id         = data.huaweicloud_compute_flavors.myflavor.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
+resource "huaweicloud_vpc" "test" {
+  name = var.vpc_name
+  cidr = var.vpc_cidr
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  count = length(var.subnet_configurations)
+
+  vpc_id     = huaweicloud_vpc.test.id
+  name       = lookup(var.subnet_configurations[count.index], "subnet_name", null)
+  cidr       = try(coalesce(lookup(var.subnet_configurations[count.index], "subnet_cidr", null), cidrsubnet(huaweicloud_vpc.test.cidr, 8, count.index)), null)
+  gateway_ip = try(coalesce(lookup(var.subnet_configurations[count.index], "subnet_gateway_ip", null), cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 8, count.index), 1)), null)
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name                 = var.security_group_name
+  delete_default_rules = true
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = var.instance_name
+  image_id           = var.instance_image_id != "" ? var.instance_image_id : try(data.huaweicloud_images_images.test[0].images[0].id, null)
+  flavor_id          = var.instance_flavor_id != "" ? var.instance_flavor_id : try(data.huaweicloud_compute_flavors.test[0].flavors[0].id, null)
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = var.availability_zone != "" ? var.availability_zone : try(data.huaweicloud_availability_zones.test[0].names[0], null)
+  admin_pass         = var.instance_admin_password
 
   network {
-    uuid = data.huaweicloud_vpc_subnet.mynet.id
+    uuid = try(huaweicloud_vpc_subnet.test[0].id, null)
+  }
+
+  # When using `huaweicloud_compute_interface_attach`, if the security group is not specified, the default security group will be automatically added to the ECS instance.
+  lifecycle {
+    ignore_changes = [
+      security_group_ids
+    ]
   }
 }
 
-data "huaweicloud_vpc" "myvpc" {
-  name = "vpc-default"
-}
-
-resource "huaweicloud_vpc_subnet" "attach" {
-  name       = "subnet-attach"
-  cidr       = "192.168.1.0/24"
-  gateway_ip = "192.168.1.1"
-  vpc_id     = data.huaweicloud_vpc.myvpc.id
-
-  availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
-}
-
-resource "huaweicloud_compute_interface_attach" "attached" {
-  instance_id = huaweicloud_compute_instance.myinstance.id
-  network_id  = huaweicloud_vpc_subnet.attach.id
-
-  # This is optional
-  fixed_ip = "192.168.1.100"
+resource "huaweicloud_compute_interface_attach" "test" {
+  instance_id        = huaweicloud_compute_instance.test.id
+  network_id         = var.attached_network_id != "" ? var.attached_network_id : try(huaweicloud_vpc_subnet.test[1].id, null)
+  fixed_ip           = var.attached_interface_fixed_ip
+  security_group_ids = var.attached_security_group_ids
 }

--- a/examples/ecs/attached-interface/providers.tf
+++ b/examples/ecs/attached-interface/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.61.0"
+    }
+  }
+}
+
+provider "huaweicloud" {
+  region     = var.region_name
+  access_key = var.access_key
+  secret_key = var.secret_key
+}

--- a/examples/ecs/attached-interface/terraform.tfvars
+++ b/examples/ecs/attached-interface/terraform.tfvars
@@ -1,0 +1,12 @@
+vpc_name = "tf_test_ecs_instace"
+subnet_configurations = [
+  {
+    subnet_name = "tf_test_main"
+  },
+  {
+    subnet_name = "tf_test_standby"
+  },
+]
+security_group_name     = "tf_test_ecs_instace"
+instance_name           = "tf_test_ecs_instace"
+instance_admin_password = "YourPassword!"

--- a/examples/ecs/attached-interface/variables.tf
+++ b/examples/ecs/attached-interface/variables.tf
@@ -1,0 +1,129 @@
+# Variable definitions for authentication
+variable "region_name" {
+  description = "The region where the ECS instance is located"
+  type        = string
+}
+
+variable "access_key" {
+  description = "The access key of the IAM user"
+  type        = string
+  sensitive   = true
+}
+
+variable "secret_key" {
+  description = "The secret key of the IAM user"
+  type        = string
+  sensitive   = true
+}
+
+# Variable definitions for resources/data sources
+variable "availability_zone" {
+  description = "The availability zone to which the ECS instance belongs"
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "instance_flavor_id" {
+  description = "The flavor ID of the ECS instance"
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "instance_performance_type" {
+  description = "The performance type of the ECS instance flavor"
+  type        = string
+  default     = "normal"
+}
+
+variable "instance_cpu_core_count" {
+  description = "The number of CPU cores of the ECS instance"
+  type        = number
+  default     = 2
+}
+
+variable "instance_memory_size" {
+  description = "The memory size in GB of the ECS instance"
+  type        = number
+  default     = 4
+}
+
+variable "instance_image_id" {
+  description = "The image ID of the ECS instance"
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "instance_image_visibility" {
+  description = "The visibility of the ECS instance image"
+  type        = string
+  default     = "public"
+}
+
+variable "instance_image_os" {
+  description = "The operating system of the ECS instance image"
+  type        = string
+  default     = "Ubuntu"
+}
+
+variable "vpc_name" {
+  description = "The name of the VPC"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "The CIDR block of the VPC"
+  type        = string
+  default     = "192.168.0.0/16"
+}
+
+variable "subnet_configurations" {
+  description = "The list of subnet configurations for ECS instance."
+  type = list(object({
+    subnet_name       = string
+    subnet_cidr       = optional(string)
+    subnet_gateway_ip = optional(string)
+  }))
+}
+
+variable "security_group_name" {
+  description = "The name of the security group"
+  type        = string
+}
+
+variable "instance_name" {
+  description = "The name of the ECS instance"
+  type        = string
+}
+
+variable "instance_admin_password" {
+  description = "The login password of the ECS instance"
+  type        = string
+  sensitive   = true
+}
+
+variable "attached_network_id" {
+  description = "The ID of the network to which the ECS instance to be attached"
+  type        = string
+  default     = ""
+  nullable    = false
+
+  validation {
+    condition     = var.attached_network_id != "" || length(var.subnet_configurations) == 2
+    error_message = "When attached_network_id is not provided, subnet_configurations must have exactly 2 elements."
+  }
+}
+
+variable "attached_interface_fixed_ip" {
+  description = "The fixed IP address of the ECS instance to be attached"
+  type        = string
+  default     = null
+}
+
+variable "attached_security_group_ids" {
+  description = "The list of security group IDs of the ECS instance to be attached"
+  type        = list(string)
+  default     = null
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Refactor best practice for attaching network to ECS instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

<img width="852" height="454" alt="image" src="https://github.com/user-attachments/assets/2074d614-9962-434d-a65e-65f5e7432fd9" />
<img width="825" height="573" alt="image" src="https://github.com/user-attachments/assets/f0d2b66f-76c9-4fc3-ae40-bc94b61930bd" />


* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
