### PR TITLE
feat(secmaster): new datasource to query vpc endpoint services

### DIFF
--- a/docs/data-sources/secmaster_vpc_endpoint_services.md
+++ b/docs/data-sources/secmaster_vpc_endpoint_services.md
@@ -1,0 +1,53 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_vpc_endpoint_services"
+description: |-
+  Use this data source to get the list of SecMaster VPC endpoint services within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_vpc_endpoint_services
+
+Use this data source to get the list of SecMaster VPC endpoint services within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_secmaster_vpc_endpoint_services" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `records` - The list of VPC endpoint services.
+
+  The [records](#records_struct) structure is documented below.
+
+<a name="records_struct"></a>
+The `records` block supports:
+
+* `id` - The unique identifier of the service (UUID).
+
+* `name` - The name of the tenant to which the service belongs.
+
+* `type` - The type of VPC service. Valid values are:
+  + **MANAGE**: Management channel.
+  + **DATA**: Data channel.
+
+* `deprecated` - Whether the service is deprecated.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1430,6 +1430,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_alert_rule_metrics":        secmaster.DataSourceSecmasterAlertRuleMetrics(),
 			"huaweicloud_secmaster_catalogues":                secmaster.DataSourceSecmasterCatalogues(),
 			"huaweicloud_secmaster_component_templates":       secmaster.DataSourceComponentTemplates(),
+			"huaweicloud_secmaster_vpc_endpoint_services":     secmaster.DataSourceSecmasterVpcEndpointServices(),
 
 			// Querying by Ver.2 APIs
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_vpc_endpoint_services_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_vpc_endpoint_services_test.go
@@ -1,0 +1,47 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Each workspace has default endpoint service data, so you can run test cases directly.
+func TestAccDataSourceSecmasterVpcEndpointServices_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_secmaster_vpc_endpoint_services.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSecmasterVpcEndpointServices_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "records.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.deprecated"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceSecmasterVpcEndpointServices_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_vpc_endpoint_services" "test" {
+  workspace_id = "%[1]s"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_vpc_endpoint_services.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_vpc_endpoint_services.go
@@ -1,0 +1,124 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Secmaster GET /v1/{project_id}/workspaces/{workspace_id}/nodes/vpc-endpoint-services
+func DataSourceSecmasterVpcEndpointServices() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecmasterVpcEndpointServicesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"records": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"deprecated": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceSecmasterVpcEndpointServicesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/workspaces/{workspace_id}/nodes/vpc-endpoint-services"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", d.Get("workspace_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving SecMaster VPC endpoint services: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("records", flattenVpcEndpointServices(utils.PathSearch("records", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenVpcEndpointServices(services []interface{}) []interface{} {
+	if len(services) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(services))
+	for _, v := range services {
+		rst = append(rst, map[string]interface{}{
+			"id":         utils.PathSearch("id", v, nil),
+			"name":       utils.PathSearch("name", v, nil),
+			"type":       utils.PathSearch("type", v, nil),
+			"deprecated": utils.PathSearch("deprecated", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query vpc endpoint services.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccDataSourceSecmasterVpcEndpointServices_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourceSecmasterVpcEndpointServices_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceSecmasterVpcEndpointServices_basic
=== PAUSE TestAccDataSourceSecmasterVpcEndpointServices_basic
=== CONT  TestAccDataSourceSecmasterVpcEndpointServices_basic
--- PASS: TestAccDataSourceSecmasterVpcEndpointServices_basic (10.33s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 10.450s coverage: 4.2% of statements in ./huaweicloud/services/secmaster
```
<img width="1354" height="104" alt="image" src="https://github.com/user-attachments/assets/618ffcbc-fd9a-4038-b33e-872581bcb501" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
