### PR TITLE
feat(evs): add one time resource to expand evs volumes

### DIFF
--- a/docs/resources/evs_volumes_batch_expand.md
+++ b/docs/resources/evs_volumes_batch_expand.md
@@ -1,0 +1,74 @@
+---
+subcategory: "Elastic Volume Service (EVS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_evs_volumes_batch_expand"
+description: |-
+  Manages an EVS volumes expand resource within HuaweiCloud.
+---
+
+# huaweicloud_evs_volumes_batch_expand
+
+Manages an EVS volumes expand resource within HuaweiCloud.
+
+-> The current resource is a one-time action resource using to expand volumes. Deleting this resource will not reset
+the expanded volumes, but will only remove the resource information from the tfstate file.  
+Using this resource may cause incompatible changes to other resources that contain volume size fields. Please use
+`lifecycle.ignore_changes` properly to handle unexpected changes.  
+If the status of the to-be-expanded disk is available, there are no restrictions. If the status of the to-be-expanded
+disk is in-use, the restrictions are as follows:
+<br/>1. A shared disk cannot be expanded, which means that the value of multiattach must be false.
+<br/>2. The status of the server to which the disk attached must be **ACTIVE**, **PAUSED**, **SUSPENDED**, or **SHUTOFF**.
+
+## Example Usage
+
+```hcl
+variable "id" {}
+variable "new_size" {}
+variable "is_auto_pay" {
+  type = bool
+}
+
+resource "huaweicloud_evs_volumes_batch_expand" "test" {
+  volumes    {
+    id       = var.id
+    new_size = var.new_size
+  }
+
+  is_auto_pay = var.is_auto_pay
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+
+* `volumes` - (Required, List, NonUpdatable) Specifies the to-be-expanded volume list.
+  The [volumes](#volumes_struct) structure is documented below.
+
+* `is_auto_pay` - (Optional, Bool, NonUpdatable) Specifies whether to pay immediately. This parameter is valid only
+  when the disk in prepaid mode. Defaults to **false**. Possible values are:
+  + **true**: An order is immediately paid from the account balance.
+  + **false**: An order is not paid immediately after being created.
+
+<a name="volumes_struct"></a>
+The `volumes` block supports:
+
+* `id` - (Required, String, NonUpdatable) Specifies the volume ID.
+
+* `new_size` - (Required, Int, NonUpdatable) Specifies the new size of the to-be-expanded volume, in GiB.
+  Must be greater than the current size. The maximum disk size: Data disk: `32,768` GiB, System disk: `1,024` GiB
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2262,6 +2262,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_evs_volume_transfer_accepter":   evs.ResourceVolumeTransferAccepter(),
 			"huaweicloud_evsv3_volume_transfer_accepter": evs.ResourceV3VolumeTransferAccepter(),
 			"huaweicloud_evs_unsubscribe_prepaid_volume": evs.ResourceUnsubscribePrepaidVolume(),
+			"huaweicloud_evs_volumes_batch_expand":       evs.ResourceVolumesBatchExpand(),
 
 			"huaweicloud_fgs_application":                    fgs.ResourceApplication(),
 			"huaweicloud_fgs_async_invoke_configuration":     fgs.ResourceAsyncInvokeConfiguration(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -558,6 +558,9 @@ var (
 	HW_EVS_ENABLE_FLAG              = os.Getenv("HW_EVS_ENABLE_FLAG")
 	HW_EVS_VOLUME_ID                = os.Getenv("HW_EVS_VOLUME_ID")
 	HW_EVS_SERVER_ID                = os.Getenv("HW_EVS_SERVER_ID")
+	HW_EVS_VOLUME_NEW_SIZE          = os.Getenv("HW_EVS_VOLUME_NEW_SIZE")
+	HW_EVS_PREPAID_VOLUME_ID        = os.Getenv("HW_EVS_PREPAID_VOLUME_ID")
+	HW_EVS_PREPAID_VOLUME_NEW_SIZE  = os.Getenv("HW_EVS_PREPAID_VOLUME_NEW_SIZE")
 
 	HW_ECS_LAUNCH_TEMPLATE_ID = os.Getenv("HW_ECS_LAUNCH_TEMPLATE_ID")
 	HW_ECS_ID                 = os.Getenv("HW_ECS_ID")
@@ -1327,6 +1330,27 @@ func TestAccPreCheckEVSServerID(t *testing.T) {
 func TestAccPreCheckEVSVolumeID(t *testing.T) {
 	if HW_EVS_VOLUME_ID == "" {
 		t.Skip("HW_EVS_VOLUME_ID must be set for acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckEVSVolumeNewSize(t *testing.T) {
+	if HW_EVS_VOLUME_NEW_SIZE == "" {
+		t.Skip("HW_EVS_VOLUME_NEW_SIZE must be set for acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckEVSPrepaidVolumeID(t *testing.T) {
+	if HW_EVS_PREPAID_VOLUME_ID == "" {
+		t.Skip("HW_EVS_PREPAID_VOLUME_ID must be set for acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckEVSPrepaidVolumeNewSize(t *testing.T) {
+	if HW_EVS_PREPAID_VOLUME_NEW_SIZE == "" {
+		t.Skip("HW_EVS_PREPAID_VOLUME_NEW_SIZE must be set for acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volumes_batch_expand_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volumes_batch_expand_test.go
@@ -1,0 +1,62 @@
+package evs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccEvsVolumesBatchExpand_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test needs to create an EVS prepaid volume and an EVS postpaid volume before running.
+			// The HW_EVS_VOLUME_NEW_SIZE and HW_EVS_PREPAID_VOLUME_NEW_SIZE needs bigger than now.
+			acceptance.TestAccPreCheckEVSVolumeID(t)
+			acceptance.TestAccPreCheckEVSVolumeNewSize(t)
+			acceptance.TestAccPreCheckEVSPrepaidVolumeID(t)
+			acceptance.TestAccPreCheckEVSPrepaidVolumeNewSize(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEvsVolumesBatchExpand_postpaid(),
+			},
+			{
+				Config: testAccEvsVolumesBatchExpand_prepaid(),
+			},
+		},
+	})
+}
+
+func testAccEvsVolumesBatchExpand_postpaid() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_evs_volumes_batch_expand" "postpaid_test" {
+  volumes  {
+    id       = "%[1]s"
+    new_size = "%[2]s"
+  }
+
+  is_auto_pay = true
+}
+`, acceptance.HW_EVS_VOLUME_ID, acceptance.HW_EVS_VOLUME_NEW_SIZE)
+}
+
+func testAccEvsVolumesBatchExpand_prepaid() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_evs_volumes_batch_expand" "prepaid_test" {
+  volumes  {
+    id       = "%[1]s"
+    new_size = "%[2]s"
+  }
+
+  is_auto_pay = true
+}
+`, acceptance.HW_EVS_PREPAID_VOLUME_ID, acceptance.HW_EVS_PREPAID_VOLUME_NEW_SIZE)
+}

--- a/huaweicloud/services/evs/resource_huaweicloud_evs_volumes_batch_expand.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_volumes_batch_expand.go
@@ -1,0 +1,235 @@
+package evs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var volumesBatchExpandNonUpdatableParams = []string{
+	"volumes",
+	"volumes.*.id",
+	"volumes.*.new_size",
+	"is_auto_pay",
+}
+
+// @API EVS POST /v5/{project_id}/volumes/batch-extend
+// @API EVS GET /v1/{project_id}/jobs/{job_id}
+// @API BSS GET /v2/orders/customer-orders/details/{order_id}
+// @API BSS POST /v2/orders/suscriptions/resources/query
+func ResourceVolumesBatchExpand() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVolumesBatchExpandCreate,
+		ReadContext:   resourceVolumesBatchExpandRead,
+		UpdateContext: resourceVolumesBatchExpandUpdate,
+		DeleteContext: resourceVolumesBatchExpandDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(volumesBatchExpandNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"volumes": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"new_size": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+			},
+			"is_auto_pay": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildVolumesBatchExpandBodyParams(d *schema.ResourceData) map[string]interface{} {
+	volumes := d.Get("volumes").([]interface{})
+	volumesList := make([]map[string]interface{}, 0, len(volumes))
+
+	for _, v := range volumes {
+		volume, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		volumesList = append(volumesList, map[string]interface{}{
+			"id":       volume["id"],
+			"new_size": volume["new_size"],
+		})
+	}
+
+	bodyParams := map[string]interface{}{
+		"bss_param": map[string]interface{}{
+			"is_auto_pay": d.Get("is_auto_pay"),
+		},
+		"volumes": volumesList,
+	}
+
+	return bodyParams
+}
+
+func getExpandJobDetail(client *golangsdk.ServiceClient, jobID string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/jobs/{job_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", jobID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error querying EVS job detail: %s", err)
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func waitingForExpandVolumeJobSuccess(ctx context.Context, client *golangsdk.ServiceClient, jobID string,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			respBody, err := getExpandJobDetail(client, jobID)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			status := utils.PathSearch("status", respBody, "").(string)
+			if status == "" {
+				return respBody, "ERROR", fmt.Errorf("status is not found in EVS job (%s) detail API response", jobID)
+			}
+
+			if status == "SUCCESS" {
+				return respBody, "COMPLETED", nil
+			}
+
+			if status == "FAIL" {
+				return respBody, status, fmt.Errorf("the EVS job (%s) status is FAIL, the fail reason is: %s",
+					jobID, utils.PathSearch("fail_reason", respBody, "").(string))
+			}
+
+			return respBody, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceVolumesBatchExpandCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v5/{project_id}/volumes/batch-extend"
+		product = "evs"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildVolumesBatchExpandBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error batch expanding EVS volumes: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.Errorf("error flattening response: %s", err)
+	}
+
+	if jobID := utils.PathSearch("job_id", respBody, "").(string); jobID != "" {
+		if err := waitingForExpandVolumeJobSuccess(ctx, client, jobID, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return diag.Errorf("error waiting for the job (%s) to succeed: %s", jobID, err)
+		}
+	}
+
+	if orderID := utils.PathSearch("order_id", respBody, "").(string); orderID != "" {
+		bssClient, err := cfg.BssV2Client(cfg.GetRegion(d))
+		if err != nil {
+			return diag.Errorf("error creating BSS v2 client: %s", err)
+		}
+		if err = common.WaitOrderComplete(ctx, bssClient, orderID, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return diag.Errorf("the order (%s) is not completed while expanding EVS volume: %v", orderID, err)
+		}
+		if _, err = common.WaitOrderAllResourceComplete(ctx, bssClient, orderID, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	return nil
+}
+
+func resourceVolumesBatchExpandRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceVolumesBatchExpandUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceVolumesBatchExpandDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to expand volumes.
+Deleting this resource will not reset the expanded volumes, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add one time resource to expand evs volumes
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add one time resource to expand evs volumes
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
<img width="1620" height="294" alt="image" src="https://github.com/user-attachments/assets/e037b2dc-9f40-4e58-990d-75c56550e9b8" />
<img width="1298" height="51" alt="image" src="https://github.com/user-attachments/assets/166d5a22-e1e9-47ba-bccb-12fcb498f05c" />


* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
