### PR TITLE
feat(secmaster): new datasource to query catalogues search

### DIFF
--- a/docs/data-sources/secmaster_catalogues_search.md
+++ b/docs/data-sources/secmaster_catalogues_search.md
@@ -1,0 +1,87 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_catalogues_search"
+description: |-
+  Use this data source to query the SecMaster catalogues within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_catalogues_search
+
+Use this data source to query the SecMaster catalogues within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_secmaster_catalogues_search" "example" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the catalogues.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to query catalogues.
+
+* `parent_catalogue` - (Optional, String) Specifies the parent catalogue name.
+
+* `second_catalogue` - (Optional, String) Specifies the second-level catalogue name.
+
+* `catalogue_status` - (Optional, Bool) Specifies the status of the catalogue. Defaults to **false**.
+
+* `layout_name` - (Optional, String) Specifies the layout name.
+
+* `publisher_name` - (Optional, String) Specifies the publisher name.
+
+* `analysis_version` - (Optional, String) Specifies the analysis version.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data` - The list of catalogues that match the query criteria.
+
+  The [data](#data_struct) structure is documented below.
+
+<a name="data_struct"></a>
+The `data` block supports:
+
+* `id` - The ID of the catalogue.
+
+* `parent_catalogue` - The name of the parent catalogue.
+
+* `second_catalogue` - The name of the second-level catalogue.
+
+* `catalogue_status` - The status of the catalogue (builtin/custom).
+
+* `catalogue_address` - The address of the catalogue.
+
+* `layout_id` - The ID of the layout.
+
+* `layout_name` - The name of the layout.
+
+* `publisher_name` - The name of the publisher.
+
+* `is_card_area` - Whether to display the card area.
+
+* `is_display` - Whether to display the catalogue.
+
+* `is_landing_page` - Whether it is a landing page.
+
+* `is_navigation` - Whether to display navigation.
+
+* `parent_alias_en` - The English alias of the parent catalogue.
+
+* `parent_alias_zh` - The Chinese alias of the parent catalogue.
+
+* `second_alias_en` - The English alias of the second-level catalogue.
+
+* `second_alias_zh` - The Chinese alias of the second-level catalogue.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1431,6 +1431,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_catalogues":                secmaster.DataSourceSecmasterCatalogues(),
 			"huaweicloud_secmaster_component_templates":       secmaster.DataSourceComponentTemplates(),
 			"huaweicloud_secmaster_vpc_endpoint_services":     secmaster.DataSourceSecmasterVpcEndpointServices(),
+			"huaweicloud_secmaster_catalogues_search":         secmaster.DataSourceSecmasterCataloguesSearch(),
 
 			// Querying by Ver.2 APIs
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_catalogues_search_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_catalogues_search_test.go
@@ -1,0 +1,97 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSecmasterCataloguesSearch_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_secmaster_catalogues_search.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSecmasterCataloguesSearch_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.catalogue_address"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.catalogue_status"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.is_card_area"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.is_display"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.is_landing_page"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.is_navigation"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.parent_catalogue"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.publisher_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.parent_alias_en"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.parent_alias_zh"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.second_alias_en"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.second_alias_zh"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.second_catalogue"),
+
+					resource.TestCheckOutput("is_second_catalogue_filter_useful", "true"),
+					resource.TestCheckOutput("is_publisher_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceSecmasterCataloguesSearch_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_catalogues_search" "test" {
+  workspace_id = "%[1]s"
+}
+
+# Filter by second_catalogue
+locals {
+  second_catalogue = data.huaweicloud_secmaster_catalogues_search.test.data[0].second_catalogue
+}
+
+data "huaweicloud_secmaster_catalogues_search" "filter_by_second_catalogue" {
+  workspace_id     = "%[1]s"
+  second_catalogue = local.second_catalogue
+}
+
+locals {
+  list_by_second_catalogue = data.huaweicloud_secmaster_catalogues_search.filter_by_second_catalogue.data
+}
+
+output "is_second_catalogue_filter_useful" {
+  value = length(local.list_by_second_catalogue) > 0 && alltrue(
+    [for v in local.list_by_second_catalogue[*].second_catalogue : v == local.second_catalogue]
+  )
+}
+
+# Filter by publisher_name
+locals {
+  publisher_name = data.huaweicloud_secmaster_catalogues_search.test.data[0].publisher_name
+}
+
+data "huaweicloud_secmaster_catalogues_search" "filter_by_publisher_name" {
+  workspace_id   = "%[1]s"
+  publisher_name = local.publisher_name
+}
+
+locals {
+  list_by_publisher_name = data.huaweicloud_secmaster_catalogues_search.filter_by_publisher_name.data
+}
+
+output "is_publisher_name_filter_useful" {
+  value = length(local.list_by_publisher_name) > 0 && alltrue(
+    [for v in local.list_by_publisher_name[*].publisher_name : v == local.publisher_name]
+  )
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_catalogues_search.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_catalogues_search.go
@@ -1,0 +1,244 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Secmaster POST /v1/{project_id}/workspaces/{workspace_id}/soc/catalogues/search
+func DataSourceSecmasterCataloguesSearch() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecmasterCataloguesSearchRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"parent_catalogue": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"second_catalogue": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"catalogue_status": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"layout_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"publisher_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"analysis_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"parent_catalogue": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"second_catalogue": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"catalogue_status": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"catalogue_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"layout_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"layout_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"publisher_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_card_area": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_display": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_landing_page": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_navigation": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						// Fields `parent_alias_en` and `parent_alias_zh` are misspelled in the API documentation.
+						// The actual names defined in the current schema are valid.
+						"parent_alias_en": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"parent_alias_zh": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"second_alias_en": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"second_alias_zh": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildSecmasterCataloguesSearchParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"parent_catalogue": utils.ValueIgnoreEmpty(d.Get("parent_catalogue")),
+		"second_catalogue": utils.ValueIgnoreEmpty(d.Get("second_catalogue")),
+		"catalogue_status": d.Get("catalogue_status"),
+		"layout_name":      utils.ValueIgnoreEmpty(d.Get("layout_name")),
+		"publisher_name":   utils.ValueIgnoreEmpty(d.Get("publisher_name")),
+		"analysis_version": utils.ValueIgnoreEmpty(d.Get("analysis_version")),
+	}
+}
+
+func dataSourceSecmasterCataloguesSearchRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/workspaces/{workspace_id}/soc/catalogues/search"
+		offset  = 0
+		allData = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", d.Get("workspace_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildSecmasterCataloguesSearchParams(d)),
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s?offset=%d", requestPath, offset)
+
+		resp, err := client.Request("POST", requestPathWithOffset, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving SecMaster catalogues search: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		data := utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{})
+		if len(data) == 0 {
+			break
+		}
+
+		// There is a problem with the API's paging logic. The offset can always be queried for data.
+		// It is necessary to compare the `total` value to safely jump out of the loop logic.
+		allData = append(allData, data...)
+		totalCount := int(utils.PathSearch("total", respBody, float64(0)).(float64))
+		if len(allData) >= totalCount {
+			break
+		}
+
+		offset += len(data)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data", flattenCataloguesSearch(allData)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCataloguesSearch(catalogues []interface{}) []interface{} {
+	if len(catalogues) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(catalogues))
+	for _, v := range catalogues {
+		rst = append(rst, map[string]interface{}{
+			"id":                utils.PathSearch("id", v, nil),
+			"parent_catalogue":  utils.PathSearch("parent_catalogue", v, nil),
+			"second_catalogue":  utils.PathSearch("second_catalogue", v, nil),
+			"catalogue_status":  utils.PathSearch("catalogue_status", v, nil),
+			"catalogue_address": utils.PathSearch("catalogue_address", v, nil),
+			"layout_id":         utils.PathSearch("layout_id", v, nil),
+			"layout_name":       utils.PathSearch("layout_name", v, nil),
+			"publisher_name":    utils.PathSearch("publisher_name", v, nil),
+			"is_card_area":      utils.PathSearch("is_card_area", v, nil),
+			"is_display":        utils.PathSearch("is_display", v, nil),
+			"is_landing_page":   utils.PathSearch("is_landing_page", v, nil),
+			"is_navigation":     utils.PathSearch("is_navigation", v, nil),
+			"parent_alias_en":   utils.PathSearch("parent_alias_en", v, nil),
+			"parent_alias_zh":   utils.PathSearch("parent_alias_zh", v, nil),
+			"second_alias_en":   utils.PathSearch("second_alias_en", v, nil),
+			"second_alias_zh":   utils.PathSearch("second_alias_zh", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query catalogues search.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccDataSourceSecmasterCataloguesSearch_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourceSecmasterCataloguesSearch_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceSecmasterCataloguesSearch_basic
=== PAUSE TestAccDataSourceSecmasterCataloguesSearch_basic
=== CONT  TestAccDataSourceSecmasterCataloguesSearch_basic
--- PASS: TestAccDataSourceSecmasterCataloguesSearch_basic (12.20s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 12.309s coverage: 4.5% of statements in ./huaweicloud/services/secmaster
```
<img width="1358" height="89" alt="image" src="https://github.com/user-attachments/assets/40551c77-f387-4ca6-8219-df6e6ae0b971" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
