### PR TITLE
feat(workspace/app): add new data source to get schedule task execution details

### DIFF
--- a/docs/data-sources/workspace_app_schedule_task_execute_details.md
+++ b/docs/data-sources/workspace_app_schedule_task_execute_details.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_schedule_task_execute_details"
+description: |-
+  Use this data source to get the details of Workspace APP schedule task executions within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_schedule_task_execute_details
+
+Use this data source to get the details of Workspace APP schedule task executions within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "execute_history_id" {}
+
+data "huaweicloud_workspace_app_schedule_task_execute_details" "test" {
+  execute_history_id = var.execute_history_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the schedule task execution details are located.  
+  If omitted, the provider-level region will be used.
+
+* `execute_history_id` - (Required, String) Specifies the ID of the schedule task execution record.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `execute_details` - The list of the sub-task execution details.
+  The [execute_details](#app_schedule_task_execute_details) structure is documented below.
+
+<a name="app_schedule_task_execute_details"></a>
+The `execute_details` block supports:
+
+* `id` - The ID of the sub-task to be executed.
+
+* `execute_id` - The ID of the schedule task execution record.
+
+* `server_id` - The ID of the server being operated.
+
+* `server_name` - The name of the server being operated.
+
+* `status` - The status of schedule task execution.
+  + **SUCCESS**
+  + **FAILED**
+
+* `task_type` - The type of the schedule task.
+  + **RESTART_SERVER**
+  + **START_SERVER**
+  + **STOP_SERVER**
+  + **REINSTALL_OS**
+
+* `time_zone` - The timezone of the schedule task.
+
+* `begin_time` - The start time of the sub-task, in UTC format.
+
+* `end_time` - The end time of the sub-task, in UTC format.
+
+* `result_code` - The error code when the task execution fails.
+
+* `result_message` - The reason of task failure.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1647,6 +1647,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_publishable_apps":                workspace.DataSourceWorkspaceAppPublishableApps(),
 			"huaweicloud_workspace_app_schedule_tasks":                  workspace.DataSourceAppScheduleTasks(),
 			"huaweicloud_workspace_app_schedule_task_executions":        workspace.DataSourceAppScheduleTaskExecutions(),
+			"huaweicloud_workspace_app_schedule_task_execute_details":   workspace.DataSourceAppScheduleTaskExecuteDetails(),
 			"huaweicloud_workspace_app_schedule_task_future_executions": workspace.DataSourceAppScheduleTaskFutureExecutions(),
 			"huaweicloud_workspace_app_servers":                         workspace.DataSourceAppServers(),
 			"huaweicloud_workspace_app_service":                         workspace.DataSourceAppService(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_schedule_task_execute_details_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_schedule_task_execute_details_test.go
@@ -1,0 +1,141 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataAppScheduleTaskExecuteDetails_basic(t *testing.T) {
+	var (
+		rName      = acceptance.RandomAccResourceName()
+		dataSource = "data.huaweicloud_workspace_app_schedule_task_execute_details.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"null": {
+				Source:            "hashicorp/null",
+				VersionConstraint: "3.2.1",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataAppScheduleTaskExecuteDetails_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "execute_details.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "execute_details.0.id"),
+					resource.TestCheckResourceAttrPair(dataSource, "execute_details.0.execute_id",
+						"data.huaweicloud_workspace_app_schedule_task_executions.test", "executions.0.id"),
+					resource.TestCheckResourceAttrPair(dataSource, "execute_details.0.server_id",
+						"huaweicloud_workspace_app_server.test", "id"),
+					resource.TestCheckResourceAttrPair(dataSource, "execute_details.0.server_name",
+						"huaweicloud_workspace_app_server.test", "name"),
+					resource.TestCheckResourceAttrPair(dataSource, "execute_details.0.task_type",
+						"huaweicloud_workspace_app_schedule_task.test", "task_type"),
+					resource.TestCheckResourceAttrPair(dataSource, "execute_details.0.time_zone",
+						"huaweicloud_workspace_app_schedule_task.test", "time_zone"),
+					resource.TestCheckResourceAttrSet(dataSource, "execute_details.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "execute_details.0.begin_time"),
+					// The task may not be completed yet, `end_time` is not checked.
+				),
+			},
+		},
+	})
+}
+
+func testAccDataAppScheduleTaskExecuteDetails_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_service" "test" {}
+
+resource "huaweicloud_workspace_app_server_group" "test" {
+  name             = "%[1]s"
+  os_type          = "Windows"
+  flavor_id        = "%[2]s"
+  vpc_id           = data.huaweicloud_workspace_service.test.vpc_id
+  subnet_id        = try(data.huaweicloud_workspace_service.test.network_ids[0], null)
+  system_disk_type = "SAS"
+  system_disk_size = 80
+  is_vdi           = true
+  app_type         = "COMMON_APP"
+  image_id         = "%[3]s"
+  image_type       = "gold"
+  image_product_id = "%[4]s"
+}
+
+resource "huaweicloud_workspace_app_server" "test" {
+  name                = "%[1]s" 
+  server_group_id     = huaweicloud_workspace_app_server_group.test.id
+  type                = "createApps"
+  flavor_id           = huaweicloud_workspace_app_server_group.test.flavor_id
+  vpc_id              = huaweicloud_workspace_app_server_group.test.vpc_id
+  subnet_id           = huaweicloud_workspace_app_server_group.test.subnet_id
+  update_access_agent = false
+
+  root_volume {
+    type = huaweicloud_workspace_app_server_group.test.system_disk_type
+    size = huaweicloud_workspace_app_server_group.test.system_disk_size
+  }
+}
+
+resource "huaweicloud_workspace_app_schedule_task" "test" {
+  task_name      = "%[1]s"
+  task_type      = "STOP_SERVER"
+  scheduled_time = formatdate("HH:mm:ss", timeadd(timestamp(), "1m"))
+  scheduled_type = "DAY"
+  day_interval   = 1
+  time_zone      = "Coordinated Universal Time"
+
+  target_infos {
+    target_type = "SERVER"
+    target_id   = huaweicloud_workspace_app_server.test.id
+  }
+
+  # The 'scheduled_time' field is generated using a timestamp, so its changes should be ignored.
+  lifecycle {
+    ignore_changes = [scheduled_time]
+  }
+}
+
+# Wait for the scheduled task to be executed.
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "sleep 90"
+  }
+
+  depends_on = [huaweicloud_workspace_app_schedule_task.test]
+}
+
+data "huaweicloud_workspace_app_schedule_task_executions" "test" {
+  depends_on = [null_resource.test]
+
+  task_id = huaweicloud_workspace_app_schedule_task.test.id
+}
+`, name,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID)
+}
+
+func testAccDataAppScheduleTaskExecuteDetails_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_workspace_app_schedule_task_execute_details" "test" {
+  depends_on = [null_resource.test]
+
+  execute_history_id = try(data.huaweicloud_workspace_app_schedule_task_executions.test.executions[0].id, "")
+}
+`, testAccDataAppScheduleTaskExecuteDetails_base(name))
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_schedule_task_execute_details.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_schedule_task_execute_details.go
@@ -1,0 +1,196 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/schedule-task/{execute_history_id}/execute-detail
+func DataSourceAppScheduleTaskExecuteDetails() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppScheduleTaskExecuteDetailsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The region where the schedule task execution details are located.",
+			},
+			"execute_history_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the schedule task execution record.",
+			},
+			"execute_details": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the sub-task to be executed.",
+						},
+						"execute_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the schedule task execution record.",
+						},
+						"server_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the server being operated.",
+						},
+						"server_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the server being operated.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The status of schedule task execution.",
+						},
+						"task_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of the schedule task.",
+						},
+						"time_zone": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The timezone of the schedule task.",
+						},
+						"begin_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The start time of the sub-task, in UTC format.",
+						},
+						"end_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The end time of the sub-task, in UTC format.",
+						},
+						"result_code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The error code when the task execution fails.",
+						},
+						"result_message": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The reason of task failure.",
+						},
+					},
+				},
+				Description: "The list of the sub-task execution details.",
+			},
+		},
+	}
+}
+
+func queryScheduleTaskExecuteDetails(client *golangsdk.ServiceClient, executeHistoryId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/schedule-task/{execute_history_id}/execute-detail"
+		result  = make([]interface{}, 0)
+		limit   = 100
+		offset  = 0
+		opt     = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+		}
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{execute_history_id}", executeHistoryId)
+	listPath = fmt.Sprintf("%s?limit=%d", listPath, limit)
+	for {
+		listPathWithOfset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOfset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		executeDetails := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, executeDetails...)
+		if len(executeDetails) < limit {
+			break
+		}
+
+		offset += len(executeDetails)
+	}
+
+	return result, nil
+}
+
+func dataSourceAppScheduleTaskExecuteDetailsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		executeHistoryId = d.Get("execute_history_id").(string)
+	)
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	executeDetails, err := queryScheduleTaskExecuteDetails(client, executeHistoryId)
+	if err != nil {
+		return diag.Errorf("error querying sub-task execution details under specified task (%s): %s", executeHistoryId, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("execute_details", flattenScheduleTaskExecuteDetails(executeDetails)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenScheduleTaskExecuteDetails(executeDetails []interface{}) []map[string]interface{} {
+	if len(executeDetails) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(executeDetails))
+	for _, item := range executeDetails {
+		result = append(result, map[string]interface{}{
+			"id":             utils.PathSearch("id", item, nil),
+			"execute_id":     utils.PathSearch("execute_id", item, nil),
+			"server_id":      utils.PathSearch("server_id", item, nil),
+			"server_name":    utils.PathSearch("server_name", item, nil),
+			"status":         utils.PathSearch("status", item, nil),
+			"task_type":      utils.PathSearch("task_type", item, nil),
+			"time_zone":      utils.PathSearch("time_zone", item, nil),
+			"begin_time":     utils.PathSearch("begin_time", item, nil),
+			"end_time":       utils.PathSearch("end_time", item, nil),
+			"result_code":    utils.PathSearch("result_code", item, nil),
+			"result_message": utils.PathSearch("result_message", item, nil),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source (`huaweicloud_workspace_app_schedule_task_execute_details`) to get schedule task execution details.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source.
2. add corresponding documation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataAppScheduleTaskExecuteDetails_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAppScheduleTaskExecuteDetails_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAppScheduleTaskExecuteDetails_basic
=== PAUSE TestAccDataAppScheduleTaskExecuteDetails_basic
=== CONT  TestAccDataAppScheduleTaskExecuteDetails_basic
--- PASS: TestAccDataAppScheduleTaskExecuteDetails_basic (606.86s)
PASS
coverage: 9.9% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 606.959s        coverage: 9.9% of statements in ./huaweicloud/services/workspace
```
<img width="1099" height="366" alt="image" src="https://github.com/user-attachments/assets/51e8783e-2c82-4518-9f62-855c07db6913" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
