### PR TITLE
refactor(workspace): replace some history APIs and adjust corresponding tests

### DIFF
--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_group_authorization_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_group_authorization_test.go
@@ -10,12 +10,13 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
+// Before running this test, please create a workspace APP server group with SESSION_DESKTOP_APP type.
 func TestAccResourceAppGroupAuthorization_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      nil,
@@ -29,44 +30,20 @@ func TestAccResourceAppGroupAuthorization_basic(t *testing.T) {
 
 func testAccAppGroupAuthorization_base(name string) string {
 	return fmt.Sprintf(`
-data "huaweicloud_workspace_service" "test" {}
-
-resource "huaweicloud_workspace_app_server_group" "test" {
-  name             = "%[1]s"
-  os_type          = "Windows"
-  flavor_id        = "%[2]s"
-  vpc_id           = data.huaweicloud_workspace_service.test.vpc_id
-  subnet_id        = data.huaweicloud_workspace_service.test.network_ids[0]
-  system_disk_type = "SAS"
-  system_disk_size = 80
-  is_vdi           = true
-  app_type         = "SESSION_DESKTOP_APP"
-  image_id         = "%[3]s"
-  image_type       = "gold"
-  image_product_id = "%[4]s"
-}
-
-resource "huaweicloud_workspace_app_group" "test" {
-  server_group_id = huaweicloud_workspace_app_server_group.test.id
-  name            = "%[1]s"
-  type            = "SESSION_DESKTOP_APP"
-  description     = "Created APP group by script"
-}
+%[1]s
 
 resource "huaweicloud_workspace_user" "test" {
-  name  = "%[1]s"
+  name  = "%[2]s"
   email = "tf@example.com"
 }
 
 resource "huaweicloud_workspace_user_group" "test" {
   count = 2
 
-  name  = "%[1]s${count.index}"
+  name  = "%[2]s${count.index}"
   type  = "LOCAL"
 }
-`, name, acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
-		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
-		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID)
+`, testDataSourceAppGroups_base(name), name)
 }
 
 func testAccAppGroupAuthorization_basic(name string) string {
@@ -99,7 +76,7 @@ func TestAccResourceAppGroupAuthorization_expectErr(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      nil,
@@ -139,5 +116,5 @@ resource "huaweicloud_workspace_app_group_authorization" "test" {
     type    = "USER"
   }
 }
-`, testResourceWorkspaceAppGroup_basic_step1(testResourceWorkspaceAppGroup_base(name), name), name)
+`, testDataSourceAppGroups_base(name), name)
 }

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_group_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_group_test.go
@@ -3,17 +3,15 @@ package workspace
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/httphelper"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 func getResourceWorkspaceAppGroupFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -22,23 +20,13 @@ func getResourceWorkspaceAppGroupFunc(cfg *config.Config, state *terraform.Resou
 		return nil, fmt.Errorf("error creating Workspace APP client: %s", err)
 	}
 
-	uri := "/v1/{project_id}/app-groups"
-	queryParam := map[string]any{
-		"app_group_id": state.Primary.ID,
-	}
-	resp, err := httphelper.New(client).
+	uri := "/v1/{project_id}/app-groups/{app_group_id}"
+	uri = strings.ReplaceAll(uri, "{app_group_id}", state.Primary.ID)
+	return httphelper.New(client).
 		Method("GET").
 		URI(uri).
-		Query(queryParam).
 		Request().
-		Data()
-
-	groups := utils.PathSearch("items", resp, make([]interface{}, 0))
-	if len(groups.([]interface{})) == 0 {
-		return nil, golangsdk.ErrDefault404{}
-	}
-
-	return resp, err
+		Result()
 }
 
 func TestAccResourceAppGroup_basic(t *testing.T) {

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_group_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_group_test.go
@@ -29,12 +29,12 @@ func getResourceWorkspaceAppGroupFunc(cfg *config.Config, state *terraform.Resou
 		Result()
 }
 
+// Before running this test, please create a workspace APP server group with SESSION_DESKTOP_APP type.
 func TestAccResourceAppGroup_basic(t *testing.T) {
 	var (
 		resourceName = "huaweicloud_workspace_app_group.test"
 		name         = acceptance.RandomAccResourceName()
 		updateName   = acceptance.RandomAccResourceName()
-		baseConfig   = testResourceWorkspaceAppGroup_base(name)
 
 		appGroup interface{}
 		rc       = acceptance.InitResourceCheck(
@@ -46,29 +46,29 @@ func TestAccResourceAppGroup_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testResourceWorkspaceAppGroup_basic_step1(baseConfig, name),
+				Config: testResourceWorkspaceAppGroup_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "type", "SESSION_DESKTOP_APP"),
-					resource.TestCheckResourceAttrPair(resourceName, "server_group_id", "huaweicloud_workspace_app_server_group.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "server_group_id", acceptance.HW_WORKSPACE_APP_SERVER_GROUP_ID),
 					resource.TestCheckResourceAttr(resourceName, "description", "Created APP group by script"),
 					resource.TestMatchResourceAttr(resourceName, "created_at",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
 			{
-				Config: testResourceWorkspaceAppGroup_basic_step2(baseConfig, updateName),
+				Config: testResourceWorkspaceAppGroup_basic_step2(updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
-					resource.TestCheckResourceAttr(resourceName, "server_group_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "server_group_id", acceptance.HW_WORKSPACE_APP_SERVER_GROUP_ID),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 				),
 			},
@@ -81,59 +81,27 @@ func TestAccResourceAppGroup_basic(t *testing.T) {
 	})
 }
 
-func testResourceWorkspaceAppGroup_base(name string, appType ...string) string {
+func testResourceWorkspaceAppGroup_basic_step1(name string, appType ...string) string {
 	actAppType := "SESSION_DESKTOP_APP"
 	if len(appType) > 0 {
 		actAppType = appType[0]
 	}
 
 	return fmt.Sprintf(`
-data "huaweicloud_workspace_service" "test" {}
-
-resource "huaweicloud_workspace_app_server_group" "test" {
-  name             = "%[1]s"
-  app_type         = "%[2]s"
-  os_type          = "Windows"
-  flavor_id        = "%[3]s"
-  vpc_id           = data.huaweicloud_workspace_service.test.vpc_id
-  subnet_id        = data.huaweicloud_workspace_service.test.network_ids[0]
-  system_disk_type = "SAS"
-  system_disk_size = 80
-  is_vdi           = true
-  image_id         = "%[4]s"
-  image_type       = "gold"
-  image_product_id = "%[5]s"
-}
-`, name, actAppType,
-		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
-		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
-		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID)
-}
-
-func testResourceWorkspaceAppGroup_basic_step1(baseConfig, name string, appType ...string) string {
-	actAppType := "SESSION_DESKTOP_APP"
-	if len(appType) > 0 {
-		actAppType = appType[0]
-	}
-
-	return fmt.Sprintf(`
-%[1]s
-
 resource "huaweicloud_workspace_app_group" "test" {
-  server_group_id = huaweicloud_workspace_app_server_group.test.id
+  server_group_id = "%[1]s"
   name            = "%[2]s"
   type            = "%[3]s"
   description     = "Created APP group by script"
 }
-`, baseConfig, name, actAppType)
+`, acceptance.HW_WORKSPACE_APP_SERVER_GROUP_ID, name, actAppType)
 }
 
-func testResourceWorkspaceAppGroup_basic_step2(baseConfig, name string) string {
+func testResourceWorkspaceAppGroup_basic_step2(name string) string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "huaweicloud_workspace_app_group" "test" {
-  name = "%[2]s"
+  server_group_id = "%[1]s"
+  name            = "%[2]s"
 }
-`, baseConfig, name)
+`, acceptance.HW_WORKSPACE_APP_SERVER_GROUP_ID, name)
 }

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_policy_group_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_policy_group_test.go
@@ -20,6 +20,7 @@ func getAppPolicyGroupFunc(conf *config.Config, state *terraform.ResourceState) 
 	return workspace.GetAppGroupPolicy(client, state.Primary.Attributes["name"], state.Primary.ID)
 }
 
+// Before running this test, please create a workspace APP server group with SESSION_DESKTOP_APP type.
 func TestAccAppPolicyGroup_basic(t *testing.T) {
 	var (
 		policyGroup  interface{}
@@ -37,7 +38,7 @@ func TestAccAppPolicyGroup_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -48,7 +49,7 @@ func TestAccAppPolicyGroup_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "priority", "1"),
-					resource.TestCheckResourceAttr(resourceName, "description", "Created APP policy group by script"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
 					resource.TestCheckResourceAttr(resourceName, "targets.0.type", "APPGROUP"),
 					resource.TestCheckResourceAttrPair(resourceName, "targets.0.id", "huaweicloud_workspace_app_group.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "targets.0.name", "huaweicloud_workspace_app_group.test", "name"),
@@ -60,7 +61,7 @@ func TestAccAppPolicyGroup_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
 					resource.TestCheckResourceAttr(resourceName, "priority", "1"),
-					resource.TestCheckResourceAttr(resourceName, "description", "Updated APP policy group by script"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by terraform script"),
 					resource.TestCheckResourceAttr(resourceName, "targets.0.type", "ALL"),
 					resource.TestCheckResourceAttr(resourceName, "targets.0.id", "default-apply-all-targets"),
 					resource.TestCheckResourceAttr(resourceName, "targets.0.name", "All-Targets"),
@@ -94,7 +95,7 @@ func testAccAppPolicyGroup_basic_step1(name string) string {
 resource "huaweicloud_workspace_app_policy_group" "test" {
   name        = "%[2]s"
   priority    = 1
-  description = "Created APP policy group by script"
+  description = "Created by terraform script"
 
   targets {
     id   = huaweicloud_workspace_app_group.test.id
@@ -110,17 +111,15 @@ resource "huaweicloud_workspace_app_policy_group" "test" {
     }
   })
 }
-`, testResourceWorkspaceAppGroup_basic_step1(testResourceWorkspaceAppGroup_base(name), name), name)
+`, testDataSourceAppGroups_base(name), name)
 }
 
 func testAccAppPolicyGroup_basic_step2(name string) string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "huaweicloud_workspace_app_policy_group" "test" {
-  name        = "%[2]s"
+  name        = "%[1]s"
   priority    = 1
-  description = "Updated APP policy group by script"
+  description = "Updated by terraform script"
 
   targets {
     id   = "default-apply-all-targets"
@@ -136,15 +135,13 @@ resource "huaweicloud_workspace_app_policy_group" "test" {
     }
   })
 }
-`, testResourceWorkspaceAppGroup_basic_step1(testResourceWorkspaceAppGroup_base(name), name), name)
+`, name)
 }
 
 func testAccAppPolicyGroup_basic_step3(name string) string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "huaweicloud_workspace_app_policy_group" "test" {
-  name     = "%[2]s"
+  name     = "%[1]s"
   priority = 1
 
   policies = jsonencode({
@@ -155,5 +152,5 @@ resource "huaweicloud_workspace_app_policy_group" "test" {
     }
   })
 }
-`, testResourceWorkspaceAppGroup_basic_step1(testResourceWorkspaceAppGroup_base(name), name), name)
+`, name)
 }

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_publishment_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_publishment_test.go
@@ -21,15 +21,14 @@ func getApplicationFunc(cfg *config.Config, state *terraform.ResourceState) (int
 	return workspace.GetApplicationByName(client, state.Primary.Attributes["app_group_id"], state.Primary.Attributes["name"])
 }
 
+// Before running this test, please create a workspace APP server group with COMMON_APP type.
 func TestAccAppPublishment_basic(t *testing.T) {
 	var (
 		application  interface{}
 		resourceName = "huaweicloud_workspace_app_publishment.test"
 		name         = acceptance.RandomAccResourceName()
 		updateName   = acceptance.RandomAccResourceName()
-		baseConfig   = testResourceWorkspaceAppGroup_basic_step1(
-			testResourceWorkspaceAppGroup_base(name, "COMMON_APP"),
-			name, "COMMON_APP")
+		baseConfig   = testDataSourceAppGroups_base(name, "COMMON_APP")
 	)
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -40,7 +39,7 @@ func TestAccAppPublishment_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Two history APIs are deprecated:
- GET /v1/{project_id}/app-groups
- POST /v1/{project_id}/app-groups/batch-delete

And supports two newest APIs:
- GET /v1/{project_id}/app-groups/{app_group_id}
- DELETE /v1/{project_id}/app-groups/{app_group_id}

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. replace some history APIs and adjust corresponding tests
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccResourceAppGroup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceAppGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceAppGroup_basic
=== PAUSE TestAccResourceAppGroup_basic
=== CONT  TestAccResourceAppGroup_basic
--- PASS: TestAccResourceAppGroup_basic (17.71s)
PASS
coverage: 3.4% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 17.785s coverage: 3.4% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataSourceAppGroups_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataSourceAppGroups_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAppGroups_basic
=== PAUSE TestAccDataSourceAppGroups_basic
=== CONT  TestAccDataSourceAppGroups_basic
--- PASS: TestAccDataSourceAppGroups_basic (10.01s)
PASS
coverage: 3.6% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 10.080s coverage: 3.6% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccAppPolicyGroup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppPolicyGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccAppPolicyGroup_basic
=== PAUSE TestAccAppPolicyGroup_basic
=== CONT  TestAccAppPolicyGroup_basic
--- PASS: TestAccAppPolicyGroup_basic (25.33s)
PASS
coverage: 4.8% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 25.404s coverage: 4.8% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccResourceAppGroupAuthorization -n 1
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceAppGroupAuthorization -timeout 360m -parallel 1
=== RUN   TestAccResourceAppGroupAuthorization_basic
=== PAUSE TestAccResourceAppGroupAuthorization_basic
=== RUN   TestAccResourceAppGroupAuthorization_expectErr
=== PAUSE TestAccResourceAppGroupAuthorization_expectErr
=== CONT  TestAccResourceAppGroupAuthorization_basic
--- PASS: TestAccResourceAppGroupAuthorization_basic (12.80s)
=== CONT  TestAccResourceAppGroupAuthorization_expectErr
--- PASS: TestAccResourceAppGroupAuthorization_expectErr (7.21s)
PASS
coverage: 6.3% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 20.096s coverage: 6.3% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccAppPublishment_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppPublishment_basic -timeout 360m -parallel 10
=== RUN   TestAccAppPublishment_basic
=== PAUSE TestAccAppPublishment_basic
=== CONT  TestAccAppPublishment_basic
--- PASS: TestAccAppPublishment_basic (17.60s)
PASS
coverage: 5.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 17.670s coverage: 5.0% of statements in ./huaweicloud/services/workspace
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
