### PR TITLE
feat(workspace/app): add new resource to attach application to image instance

### DIFF
--- a/docs/resources/workspace_app_application_batch_attach.md
+++ b/docs/resources/workspace_app_application_batch_attach.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_application_batch_attach"
+description: |-
+  Use this resource to attach applications to Workspace APP image instance in HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_application_batch_attach
+
+Use this resource to attach applications to Workspace APP image instance in HuaweiCloud.
+
+-> This resource is a one-time action resource used to attach applications to specified image instance. Deleting resource
+   will not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "server_id" {}
+variable "applications_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_workspace_app_application_batch_attach" "test" {
+  server_id        = var.server_id
+  applications_ids = var.applications_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the Workspace APP is located.  
+  Changing this creates a new resource.
+
+* `server_id` - (Required, String) Specifies the ID of the image server instance.
+
+* `applications_ids` - (Required, List) Specifies the list of application IDs to be attach.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `uri` - The URI of the application attachment.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2874,6 +2874,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_eip_associate":                workspace.ResourceEipAssociate(),
 
 			// Workspace APP
+			"huaweicloud_workspace_app_application_batch_attach":    workspace.ResourceAppApplicationBatchAttach(),
 			"huaweicloud_workspace_app_group_authorization":         workspace.ResourceAppGroupAuthorization(),
 			"huaweicloud_workspace_app_group":                       workspace.ResourceWorkspaceAppGroup(),
 			"huaweicloud_workspace_app_image_server":                workspace.ResourceAppImageServer(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_application_batch_attach_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_application_batch_attach_test.go
@@ -1,0 +1,173 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceAppApplicationBatchAttach_basic(t *testing.T) {
+	var (
+		randUUID, _  = uuid.GenerateUUID()
+		name         = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_workspace_app_application_batch_attach.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+			acceptance.TestAccPreCheckWorkspaceAppImageSpecCode(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"null": {
+				Source:            "hashicorp/null",
+				VersionConstraint: "3.2.1",
+			},
+		},
+		// This resource is a one-time action resource with no deletion logic.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceAppApplicationBatchAttach_expectError(randUUID),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("'%s' is a non-existing cloud application server", randUUID)),
+			},
+			{
+				Config: testAccResourceAppApplicationBatchAttach_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceName, "applications_ids.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceAppApplicationBatchAttach_expectError(randomId string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_app_application_batch_attach" "expectError" {
+  server_id        = "%[1]s"
+  applications_ids = ["%[1]s"]
+}
+`, randomId)
+}
+
+func testAccResourceAppApplicationBatchAttach_base(name string) string {
+	return fmt.Sprintf(`
+variable "script_content" {
+  type    = string
+  default = <<EOT
+def main():  
+    print("Hello, World!")  
+
+if __name__ == "__main__":  
+    main()
+EOT
+}
+
+variable "application_file_name" {
+  type    = string
+  default = "%[1]s.exe"
+}
+
+data "huaweicloud_identity_projects" "test" {
+  name = "%[2]s"
+}
+
+data "huaweicloud_obs_buckets" "test" {
+  bucket = format("wks-app-%%s", data.huaweicloud_identity_projects.test.projects[0].id)
+}
+
+resource "null_resource" "test" {
+  depends_on = [data.huaweicloud_obs_buckets.test]
+
+  triggers = {
+    file_name = var.application_file_name
+  }
+
+  provisioner "local-exec" {
+    command = "echo '${var.script_content}' >> ${var.application_file_name}"
+  }
+  provisioner "local-exec" {
+    command = "rm ${self.triggers.file_name}"
+    when    = destroy
+  }
+}
+
+resource "huaweicloud_obs_bucket_object" "test" {
+  depends_on = [null_resource.test]
+
+  bucket       = data.huaweicloud_obs_buckets.test.buckets[0].bucket
+  key          = var.application_file_name
+  source       = abspath(var.application_file_name)
+  content_type = "application/x-msdownload"
+}
+
+resource "huaweicloud_workspace_app_warehouse_app" "test" {
+  name            = "%[1]s"
+  category        = "OTHER"
+  os_type         = "Windows"
+  version         = "1.0"
+  version_name    = "terraform"
+  file_store_path = var.application_file_name
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_workspace_service" "test" {}
+
+resource "huaweicloud_workspace_user" "test" {
+  name                   = "%[1]s"
+  email                  = "%[1]s@example.com"
+  password_never_expires = false
+  disabled               = false
+}
+
+resource "huaweicloud_workspace_app_image_server" "test" {
+  name                           = "%[1]s"
+  flavor_id                      = "%[3]s"
+  vpc_id                         = try(data.huaweicloud_workspace_service.test.vpc_id, null)
+  subnet_id                      = try(data.huaweicloud_workspace_service.test.network_ids[0], null)
+  image_id                       = "%[4]s"
+  image_type                     = "gold"
+  image_source_product_id        = "%[5]s"
+  spec_code                      = "%[6]s"
+  is_vdi                         = true
+  is_delete_associated_resources = true
+
+  authorize_accounts {
+    account = huaweicloud_workspace_user.test.name
+    type    = "USER"
+  }
+
+  root_volume {
+    type = "SAS"
+    size = 80
+  }
+}
+`,
+		name,
+		acceptance.HW_REGION_NAME,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_SPEC_CODE,
+	)
+}
+
+func testAccResourceAppApplicationBatchAttach_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_application_batch_attach" "test" {
+  server_id        = huaweicloud_workspace_app_image_server.test.id
+  applications_ids = [huaweicloud_workspace_app_warehouse_app.test.id]
+}
+`, testAccResourceAppApplicationBatchAttach_base(name))
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_application_batch_attach.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_application_batch_attach.go
@@ -1,0 +1,124 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var applicationBatchAttachNonUpdateParams = []string{"server_id", "applications_ids"}
+
+// @API Workspace POST /v1/{project_id}/image-servers/{server_id}/actions/attach-app
+func ResourceAppApplicationBatchAttach() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppApplicationBatchAttachCreate,
+		ReadContext:   resourceAppApplicationBatchAttachRead,
+		UpdateContext: resourceAppApplicationBatchAttachUpdate,
+		DeleteContext: resourceAppApplicationBatchAttachDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(applicationBatchAttachNonUpdateParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the Workspace APP is located.`,
+			},
+			"server_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the image server instance.`,
+			},
+			"applications_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of application IDs to be attach.`,
+			},
+			"uri": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The URI of the application attachment.`,
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceAppApplicationBatchAttachCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		httpUrl  = "v1/{project_id}/image-servers/{server_id}/actions/attach-app"
+		serverId = d.Get("server_id").(string)
+	)
+	client, err := cfg.NewServiceClient("appstream", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{server_id}", serverId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"items": utils.ExpandToStringList(d.Get("applications_ids").([]interface{})),
+		},
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("unable to attach applications to the server (%s): %s", serverId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID)
+
+	return diag.FromErr(d.Set("uri", utils.PathSearch("uri", respBody, nil)))
+}
+
+func resourceAppApplicationBatchAttachRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppApplicationBatchAttachUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppApplicationBatchAttachDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to attach applications to specified image instance. Deleting this
+resource will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource (`huaweicloud_workspace_app_application_attach`) to attach applications for specified image instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource.
2. add corresponding documation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccResourceAppApplicationBatchAttach_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceAppApplicationBatchAttach_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceAppApplicationBatchAttach_basic
=== PAUSE TestAccResourceAppApplicationBatchAttach_basic
=== CONT  TestAccResourceAppApplicationBatchAttach_basic
--- PASS: TestAccResourceAppApplicationBatchAttach_basic (579.57s)
PASS
coverage: 7.5% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 579.697s        coverage: 7.5% of statements in ./huaweicloud/services/workspace
```

<img width="1091" height="514" alt="image" src="https://github.com/user-attachments/assets/6d11bcb1-788e-4ba4-90cd-dfc27a33f31f" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
