### PR TITLE
feat(secmaster): support `secmaster_soc_components` and `secmaster_soc_component_detail` data sources

### DIFF
--- a/docs/data-sources/secmaster_soc_component_detail.md
+++ b/docs/data-sources/secmaster_soc_component_detail.md
@@ -1,0 +1,132 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_soc_component_detail"
+description: |-
+  Use this data source to get the SecMaster soc component detail within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_soc_component_detail
+
+Use this data source to get the SecMaster soc component detail within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "component_id" {}
+
+data "huaweicloud_secmaster_soc_component_detail" "test" {
+  workspace_id = var.workspace_id
+  component_id = var.component_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID.
+
+* `component_id` - (Required, String) Specifies the component ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `data` - The soc component detail.
+
+  The [data](#data_struct) structure is documented below.
+
+<a name="data_struct"></a>
+The `data` block supports:
+
+* `id` - The ID.
+
+* `name` - The name.
+
+* `dev_language` - The dev language.
+
+* `dev_language_version` - The dev language version.
+
+* `alliance_id` - The alliance ID.
+
+* `alliance_name` - The alliance name.
+
+* `description` - The description.
+
+* `logo` - The market head icon.
+
+* `label` - The label.
+
+* `create_time` - The creation time.
+
+* `update_time` - The update time.
+
+* `creator_name` - The creator name.
+
+* `operate_history` - The plugin operation history.
+
+  The [operate_history](#operate_history_struct) structure is documented below.
+
+* `component_versions` - The plugin version information, compatible with previous Java versions with plugin granularity.
+
+  The [component_versions](#component_versions_struct) structure is documented below.
+
+* `component_type` - The plugin type.  
+  The valid values are as follows:
+  + **subscribe**: Subscription.
+  + **custom**: Custom development.
+  + **system**: System built-in.
+
+<a name="operate_history_struct"></a>
+The `operate_history` block supports:
+
+* `operate_name` - The operation name.
+
+* `operate_time` - The operating time.
+
+<a name="component_versions_struct"></a>
+The `component_versions` block supports:
+
+* `id` - The ID.
+
+* `version_num` - The version.
+
+* `version_desc` - The version description.
+
+* `status` - The status.
+
+* `package_name` - The package name.
+
+* `component_attachment_id` - The component attachment ID.
+
+* `sub_version_id` - The sub-version ID.
+
+* `connection_config` - The operational connection configuration list.
+
+  The [connection_config](#connection_config_struct) structure is documented below.
+
+<a name="connection_config_struct"></a>
+The `connection_config` block supports:
+
+* `default_value` - The default value.
+
+* `description` - The description.
+
+* `key` - The key.
+
+* `name` - The connection config name.
+
+* `readonly` - The readonly.
+
+* `required` - Is it required.
+
+* `type` - The type.
+
+* `value` - The value.

--- a/docs/data-sources/secmaster_soc_components.md
+++ b/docs/data-sources/secmaster_soc_components.md
@@ -1,0 +1,128 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_soc_components"
+description: |-
+  Use this data source to get the list of SecMaster soc components within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_soc_components
+
+Use this data source to get the list of SecMaster soc components within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_secmaster_soc_components" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `data` - The soc components list.
+
+  The [data](#data_struct) structure is documented below.
+
+<a name="data_struct"></a>
+The `data` block supports:
+
+* `id` - The ID.
+
+* `name` - The name.
+
+* `dev_language` - The dev language.
+
+* `dev_language_version` - The dev language version.
+
+* `alliance_id` - The alliance ID.
+
+* `alliance_name` - The alliance name.
+
+* `description` - The description.
+
+* `logo` - The market head icon.
+
+* `label` - The label.
+
+* `create_time` - The creation time.
+
+* `update_time` - The update time.
+
+* `creator_name` - The creator name.
+
+* `operate_history` - The plugin operation history.
+
+  The [operate_history](#operate_history_struct) structure is documented below.
+
+* `component_versions` - The plugin version information, compatible with previous Java versions with plugin granularity.
+
+  The [component_versions](#component_versions_struct) structure is documented below.
+
+* `component_type` - The plugin type.  
+  The valid values are as follows:
+  + **subscribe**: Subscription.
+  + **custom**: Custom development.
+  + **system**: System built-in.
+
+<a name="operate_history_struct"></a>
+The `operate_history` block supports:
+
+* `operate_name` - The operation name.
+
+* `operate_time` - The operating time.
+
+<a name="component_versions_struct"></a>
+The `component_versions` block supports:
+
+* `id` - The ID.
+
+* `version_num` - The version.
+
+* `version_desc` - The version description.
+
+* `status` - The status.
+
+* `package_name` - The package name.
+
+* `component_attachment_id` - The component attachment ID.
+
+* `sub_version_id` - The sub-version ID.
+
+* `connection_config` - The operational connection configuration list.
+
+  The [connection_config](#connection_config_struct) structure is documented below.
+
+<a name="connection_config_struct"></a>
+The `connection_config` block supports:
+
+* `default_value` - The default value.
+
+* `description` - The description.
+
+* `key` - The key.
+
+* `name` - The connection config name.
+
+* `readonly` - The readonly.
+
+* `required` - Is it required.
+
+* `type` - The type.
+
+* `value` - The value.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1433,6 +1433,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_component_templates":       secmaster.DataSourceComponentTemplates(),
 			"huaweicloud_secmaster_vpc_endpoint_services":     secmaster.DataSourceSecmasterVpcEndpointServices(),
 			"huaweicloud_secmaster_catalogues_search":         secmaster.DataSourceSecmasterCataloguesSearch(),
+			// In the API documentation, there are two API groups: Plugin Management and Component Management,
+			// and their API URLs are both named with "components". To differentiate them, all resources under the
+			// Plugin Management group are prefixed with "soc", since the API URLs in the Plugin Management group
+			// also contain "soc".
+			"huaweicloud_secmaster_soc_components": secmaster.DataSourceSocComponents(),
 
 			// Querying by Ver.2 APIs
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1437,7 +1437,8 @@ func Provider() *schema.Provider {
 			// and their API URLs are both named with "components". To differentiate them, all resources under the
 			// Plugin Management group are prefixed with "soc", since the API URLs in the Plugin Management group
 			// also contain "soc".
-			"huaweicloud_secmaster_soc_components": secmaster.DataSourceSocComponents(),
+			"huaweicloud_secmaster_soc_components":       secmaster.DataSourceSocComponents(),
+			"huaweicloud_secmaster_soc_component_detail": secmaster.DataSourceSocComponentDetail(),
 
 			// Querying by Ver.2 APIs
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_soc_component_detail_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_soc_component_detail_test.go
@@ -1,0 +1,61 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSocComponentDetail_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_secmaster_soc_component_detail.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSocComponentDetail_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.dev_language"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.dev_language_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.alliance_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.description"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.logo"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.label"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.update_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.creator_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.operate_history.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.component_versions.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.component_type"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceSocComponentDetail_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_soc_components" "test" {
+  workspace_id = "%[1]s"
+}
+
+data "huaweicloud_secmaster_soc_component_detail" "test" {
+  workspace_id = "%[1]s"
+  component_id = data.huaweicloud_secmaster_soc_components.test.data[0].id
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_soc_components_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_soc_components_test.go
@@ -1,0 +1,57 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSocComponents_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_secmaster_soc_components.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSocComponents_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.dev_language"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.dev_language_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.alliance_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.alliance_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.description"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.logo"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.label"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.update_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.creator_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.operate_history.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.component_versions.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.component_type"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceSocComponents_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_soc_components" "test" {
+  workspace_id = "%[1]s"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_soc_component_detail.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_soc_component_detail.go
@@ -1,0 +1,122 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Secmaster GET /v1/{project_id}/workspaces/{workspace_id}/soc/components/{component_id}
+func DataSourceSocComponentDetail() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSocComponentDetailRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"component_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: schemaSocComponentData(),
+				},
+			},
+		},
+	}
+}
+
+func dataSourceSocComponentDetailRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "secmaster"
+		httpUrl = "v1/{project_id}/workspaces/{workspace_id}/soc/components/{component_id}"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", d.Get("workspace_id").(string))
+	requestPath = strings.ReplaceAll(requestPath, "{component_id}", d.Get("component_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving SecMaster soc component detail: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataResp := utils.PathSearch("data", respBody, nil)
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data", flattenSocComponentDetailData(dataResp)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSocComponentDetailData(dataResp interface{}) []interface{} {
+	if dataResp == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"id":                   utils.PathSearch("id", dataResp, nil),
+			"name":                 utils.PathSearch("name", dataResp, nil),
+			"dev_language":         utils.PathSearch("dev_language", dataResp, nil),
+			"dev_language_version": utils.PathSearch("dev_language_version", dataResp, nil),
+			"alliance_id":          utils.PathSearch("alliance_id", dataResp, nil),
+			"alliance_name":        utils.PathSearch("alliance_name", dataResp, nil),
+			"description":          utils.PathSearch("description", dataResp, nil),
+			"logo":                 utils.PathSearch("logo", dataResp, nil),
+			"label":                utils.PathSearch("label", dataResp, nil),
+			"create_time":          utils.PathSearch("create_time", dataResp, nil),
+			"update_time":          utils.PathSearch("update_time", dataResp, nil),
+			"creator_name":         utils.PathSearch("creator_name", dataResp, nil),
+			"operate_history": flattenSocComponentsOperateHistory(
+				utils.PathSearch("operate_history", dataResp, make([]interface{}, 0)).([]interface{})),
+			"component_versions": flattenSocComponentsComponentVersions(
+				utils.PathSearch("component_versions", dataResp, make([]interface{}, 0)).([]interface{})),
+			"component_type": utils.PathSearch("component_type", dataResp, nil),
+		},
+	}
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_soc_components.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_soc_components.go
@@ -1,0 +1,342 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Secmaster GET /v1/{project_id}/workspaces/{workspace_id}/soc/components
+func DataSourceSocComponents() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSocComponentsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: schemaSocComponentData(),
+				},
+			},
+		},
+	}
+}
+
+func schemaSocComponentData() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"name": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"dev_language": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"dev_language_version": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"alliance_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"alliance_name": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"description": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"logo": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"label": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"create_time": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"update_time": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"creator_name": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"operate_history": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"operate_name": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"operate_time": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+		"component_versions": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"version_num": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"version_desc": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"status": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"package_name": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"component_attachment_id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"sub_version_id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"connection_config": {
+						Type:     schema.TypeList,
+						Computed: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"default_value": {
+									Type:     schema.TypeString,
+									Computed: true,
+								},
+								"description": {
+									Type:     schema.TypeString,
+									Computed: true,
+								},
+								"key": {
+									Type:     schema.TypeString,
+									Computed: true,
+								},
+								"name": {
+									Type:     schema.TypeString,
+									Computed: true,
+								},
+								"readonly": {
+									Type:     schema.TypeBool,
+									Computed: true,
+								},
+								"required": {
+									Type:     schema.TypeBool,
+									Computed: true,
+								},
+								"type": {
+									Type:     schema.TypeString,
+									Computed: true,
+								},
+								"value": {
+									Type:     schema.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"component_type": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func dataSourceSocComponentsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "secmaster"
+		httpUrl = "v1/{project_id}/workspaces/{workspace_id}/soc/components"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", d.Get("workspace_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s?limit=200&offset=%v", requestPath, offset)
+		requestResp, err := client.Request("GET", currentPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving SecMaster soc components: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataResp := utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataResp) == 0 {
+			break
+		}
+
+		result = append(result, dataResp...)
+		offset += len(dataResp)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data", flattenSocComponentsData(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSocComponentsData(dataResp []interface{}) []interface{} {
+	if len(dataResp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(dataResp))
+	for _, v := range dataResp {
+		rst = append(rst, map[string]interface{}{
+			"id":                   utils.PathSearch("id", v, nil),
+			"name":                 utils.PathSearch("name", v, nil),
+			"dev_language":         utils.PathSearch("dev_language", v, nil),
+			"dev_language_version": utils.PathSearch("dev_language_version", v, nil),
+			"alliance_id":          utils.PathSearch("alliance_id", v, nil),
+			"alliance_name":        utils.PathSearch("alliance_name", v, nil),
+			"description":          utils.PathSearch("description", v, nil),
+			"logo":                 utils.PathSearch("logo", v, nil),
+			"label":                utils.PathSearch("label", v, nil),
+			"create_time":          utils.PathSearch("create_time", v, nil),
+			"update_time":          utils.PathSearch("update_time", v, nil),
+			"creator_name":         utils.PathSearch("creator_name", v, nil),
+			"operate_history": flattenSocComponentsOperateHistory(
+				utils.PathSearch("operate_history", v, make([]interface{}, 0)).([]interface{})),
+			"component_versions": flattenSocComponentsComponentVersions(
+				utils.PathSearch("component_versions", v, make([]interface{}, 0)).([]interface{})),
+			"component_type": utils.PathSearch("component_type", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenSocComponentsOperateHistory(operateHistoryResp []interface{}) []interface{} {
+	if len(operateHistoryResp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(operateHistoryResp))
+	for _, v := range operateHistoryResp {
+		rst = append(rst, map[string]interface{}{
+			"operator_name": utils.PathSearch("operator_name", v, nil),
+			"operate_time":  utils.PathSearch("operate_time", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenSocComponentsComponentVersions(componentVersionsResp []interface{}) []interface{} {
+	if len(componentVersionsResp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(componentVersionsResp))
+	for _, v := range componentVersionsResp {
+		rst = append(rst, map[string]interface{}{
+			"id":                      utils.PathSearch("id", v, nil),
+			"version_num":             utils.PathSearch("version_num", v, nil),
+			"version_desc":            utils.PathSearch("version_desc", v, nil),
+			"status":                  utils.PathSearch("status", v, nil),
+			"package_name":            utils.PathSearch("package_name", v, nil),
+			"component_attachment_id": utils.PathSearch("component_attachment_id", v, nil),
+			"sub_version_id":          utils.PathSearch("sub_version_id", v, nil),
+			"connection_config": flattenConnectionConfig(
+				utils.PathSearch("connection_config", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return rst
+}
+
+func flattenConnectionConfig(connectionConfigResp []interface{}) []interface{} {
+	if len(connectionConfigResp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(connectionConfigResp))
+	for _, v := range connectionConfigResp {
+		rst = append(rst, map[string]interface{}{
+			"default_value": utils.PathSearch("default_value", v, nil),
+			"description":   utils.PathSearch("description", v, nil),
+			"key":           utils.PathSearch("key", v, nil),
+			"name":          utils.PathSearch("name", v, nil),
+			"readonly":      utils.PathSearch("readonly", v, nil),
+			"required":      utils.PathSearch("required", v, nil),
+			"type":          utils.PathSearch("type", v, nil),
+			"value":         utils.PathSearch("value", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

commit1: support `secmaster_soc_components` data source
commit2: support `secmaster_soc_component_detail` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `secmaster_soc_components` and `secmaster_soc_component_detail` data sources

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/secmaster" TESTARGS="-run TestAccDataSourceSocComponents_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/secmaster -v -run TestAccDataSourceSocComponents_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSocComponents_basic
=== PAUSE TestAccDataSourceSocComponents_basic
=== CONT  TestAccDataSourceSocComponents_basic
--- PASS: TestAccDataSourceSocComponents_basic (9.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 9.951s


make testacc TEST="./huaweicloud/services/acceptance/secmaster" TESTARGS="-run TestAccDataSourceSocComponentDetail_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/secmaster -v -run TestAccDataSourceSocComponentDetail_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSocComponentDetail_basic
=== PAUSE TestAccDataSourceSocComponentDetail_basic
=== CONT  TestAccDataSourceSocComponentDetail_basic
--- PASS: TestAccDataSourceSocComponentDetail_basic (11.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 11.770s

```
<img width="965" height="43" alt="image" src="https://github.com/user-attachments/assets/e0b7d14e-a692-440e-bcfe-a3b7e6588580" />
Because the `operate_history` and `component_versions` attributes have no values, the test case coverage is relatively low.


<img width="997" height="52" alt="image" src="https://github.com/user-attachments/assets/cc3278f4-4a91-42de-8837-c00588481d65" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
