### PR TITLE
feat(sfsturbo): add one time resource to change charge mode

### DIFF
--- a/docs/resources/sfs_turbo_change_charge_mode.md
+++ b/docs/resources/sfs_turbo_change_charge_mode.md
@@ -1,0 +1,61 @@
+---
+subcategory: "SFS Turbo"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_sfs_turbo_change_charge_mode"
+description: |-
+  Use this resource to change the charge mode of the SFS turbo within HuaweiCloud.
+---
+
+# huaweicloud_sfs_turbo_change_charge_mode
+
+Use this resource to change the charge mode of the SFS turbo within HuaweiCloud.
+
+-> The current resource is a one-time action resource using to change SFS Turbo charge mode. Deleting this resource
+will not reset the charge mode, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "share_id" {}
+variable "period_num" {}
+variable "period_type" {}
+variable "is_auto_renew" {}
+
+resource "huaweicloud_sfs_turbo_change_charge_mode" "test" {
+  share_id    = var.share_id
+  period_num    = var.period_num
+  period_type   = var.period_type
+  is_auto_renew = var.is_auto_renew
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `share_id` - (Required, String, NonUpdatable) Specifies the ID of the SFS Turbo.
+
+* `period_num` - (Required, Int, NonUpdatable) Specifies the charging period of the SFS Turbo.
+
+* `period_type` - (Required, Int, NonUpdatable) Specifies the charging period unit of the SFS Turbo.
+  + **2**: paid monthly.
+  + **3**: paid annual.
+
+* `is_auto_renew` - (Optional, Int, NonUpdatable) Specifies whether auto renew is enabled. Defaults to **0**.
+  + **0**: no automatic renewal.
+  + **1**: automatic renewal.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2753,6 +2753,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_sfs_turbo_du_task":            sfsturbo.ResourceDuTask(),
 			"huaweicloud_sfs_turbo_obs_target":         sfsturbo.ResourceOBSTarget(),
 			"huaweicloud_sfs_turbo_perm_rule":          sfsturbo.ResourceSFSTurboPermRule(),
+			"huaweicloud_sfs_turbo_change_charge_mode": sfsturbo.ResourceSFSTurboChangeChargeMode(),
 
 			"huaweicloud_smn_topic":                      smn.ResourceTopic(),
 			"huaweicloud_smn_subscription":               smn.ResourceSubscription(),

--- a/huaweicloud/services/acceptance/sfsturbo/resource_huaweicloud_sfs_turbo_change_charge_mode_test.go
+++ b/huaweicloud/services/acceptance/sfsturbo/resource_huaweicloud_sfs_turbo_change_charge_mode_test.go
@@ -1,0 +1,39 @@
+package sfsturbo
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceSFSTurboChangeChargeMode_basic(t *testing.T) {
+	// Avoid CheckDestroy because this resource is a one-time action resource and there is nothing in the destroy method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Before running test, please prepare a SFS Turbo file system which is postpaid.
+			acceptance.TestAccPrecheckSFSTurboShareId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSFSTurboChangeChargeMode_basic(),
+			},
+		},
+	})
+}
+
+func testAccSFSTurboChangeChargeMode_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_sfs_turbo_change_charge_mode" "test" {
+  share_id      = "%s"
+  period_num    = 1
+  period_type   = 2
+  is_auto_renew = 0
+}
+`, acceptance.HW_SFS_TURBO_SHARE_ID)
+}

--- a/huaweicloud/services/sfsturbo/resource_huaweicloud_sfs_turbo_change_charge_mode.go
+++ b/huaweicloud/services/sfsturbo/resource_huaweicloud_sfs_turbo_change_charge_mode.go
@@ -1,0 +1,165 @@
+package sfsturbo
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var updatableChargeModeNonUpdatableParams = []string{
+	"share_id",
+	"period_num",
+	"period_type",
+	"is_auto_renew",
+}
+
+// @API SFSTurbo POST /v2/{project_id}/sfs-turbo/shares/{share_id}/change-charge-mode
+func ResourceSFSTurboChangeChargeMode() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSFSTurboChangeChargeModeCreate,
+		ReadContext:   resourceSFSTurboChangeChargeModeRead,
+		UpdateContext: resourceSFSTurboChangeChargeModeUpdate,
+		DeleteContext: resourceSFSTurboChangeChargeModeDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(updatableChargeModeNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+			},
+			"share_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"period_num": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"period_type": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"is_auto_renew": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildSFSTurboChangeChargeModeBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"bss_param": map[string]interface{}{
+			"period_num":    d.Get("period_num"),
+			"period_type":   d.Get("period_type"),
+			"is_auto_renew": d.Get("is_auto_renew"),
+			"is_auto_pay":   1,
+		},
+	}
+
+	return bodyParams
+}
+
+func resourceSFSTurboChangeChargeModeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		shareId = d.Get("share_id").(string)
+		httpUrl = "v2/{project_id}/sfs-turbo/shares/{share_id}/change-charge-mode"
+		product = "sfs-turbo"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating SFS Turbo client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{share_id}", shareId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildSFSTurboChangeChargeModeBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error changing SFS Turbo charge mode: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// The api only create one order in fact, so just wait for first order completed.
+	orderId := utils.PathSearch("order_ids|[0]", respBody, "").(string)
+	if orderId == "" {
+		return diag.Errorf("error changing SFS Turbo charge mode: Order ID is not found in API response")
+	}
+
+	bssClient, err := cfg.BssV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating BSS v2 client: %s", err)
+	}
+
+	if err := common.WaitOrderComplete(ctx, bssClient, orderId, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(uuid)
+
+	return nil
+}
+
+func resourceSFSTurboChangeChargeModeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceSFSTurboChangeChargeModeUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceSFSTurboChangeChargeModeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to change SFS Turbo charge mode. Deleting this 
+resource will not change the current charge mode result, but will only remove the resource information from the 
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add one time resource to change charge mode
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add one time resource to change charge mode
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
<img width="1485" height="321" alt="image" src="https://github.com/user-attachments/assets/b2aa7ee8-7503-4fcd-a957-032d8f03cdd9" />
<img width="1183" height="44" alt="image" src="https://github.com/user-attachments/assets/3066ac5e-c380-4dba-aeb2-c69cf9869e1d" />

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
