### PR TITLE
fix(DC): fix dc virtual interface vgw_id to optional

### DIFF
--- a/docs/resources/dc_virtual_interface.md
+++ b/docs/resources/dc_virtual_interface.md
@@ -42,13 +42,11 @@ resource "huaweicloud_dc_virtual_interface" "test" {
 
 ```hcl
 variable "direct_connect_id" {}
-variable "vgw_id" {}
 variable "interface_name" {}
 variable "gateway_id" {}
 
 resource "huaweicloud_dc_virtual_interface" "test" {
   direct_connect_id = var.direct_connect_id
-  vgw_id            = var.vgw_id
   name              = var.interface_name
   type              = "private"
   route_mode        = "static"
@@ -76,10 +74,6 @@ The following arguments are supported:
 
 * `direct_connect_id` - (Required, String, ForceNew) Specifies the ID of the direct connection associated with the
   virtual interface.
-  Changing this will create a new resource.
-
-* `vgw_id` - (Required, String, ForceNew) Specifies the ID of the virtual gateway to which the virtual interface is
-  connected.
   Changing this will create a new resource.
 
 * `name` - (Required, String) Specifies the name of the virtual interface.
@@ -117,6 +111,9 @@ The following arguments are supported:
 * `service_type` - (Optional, String, ForceNew) Specifies the service type of the virtual interface.
   The valid values are **VGW**, **GDGW** and **LGW**. The default value is **VGW**.
   Changing this will create a new resource.
+
+* `vgw_id` - (Optional, String, ForceNew) Specifies the ID of the virtual gateway to which the virtual interface is
+  connected.
 
 * `gateway_id` - (Optional, String, ForceNew) Specifies the ID of the gateway associated with the virtual
   interface (the ID of the global DC gateway).

--- a/huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_interface_test.go
+++ b/huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_interface_test.go
@@ -175,7 +175,6 @@ func TestAccVirtualInterface_gdgw(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "direct_connect_id", acceptance.HW_DC_DIRECT_CONNECT_ID),
-					resource.TestCheckResourceAttrPair(rName, "vgw_id", "huaweicloud_dc_virtual_gateway.test", "id"),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
 					resource.TestCheckResourceAttr(rName, "type", "private"),
@@ -225,7 +224,6 @@ func TestAccVirtualInterface_gdgw(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "direct_connect_id", acceptance.HW_DC_DIRECT_CONNECT_ID),
-					resource.TestCheckResourceAttrPair(rName, "vgw_id", "huaweicloud_dc_virtual_gateway.test", "id"),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
 					resource.TestCheckResourceAttr(rName, "description", ""),
 					resource.TestCheckResourceAttr(rName, "type", "private"),
@@ -275,16 +273,6 @@ resource "huaweicloud_vpc" "test" {
   cidr = "192.168.0.0/16"
 }
 
-resource "huaweicloud_dc_virtual_gateway" "test" {
-  vpc_id      = huaweicloud_vpc.test.id
-  name        = "%[1]s"
-  description = "Created by acc test"
-
-  local_ep_group = [
-    huaweicloud_vpc.test.cidr,
-  ]
-}
-
 resource "huaweicloud_dc_global_gateway" "test" {
   name           = "%[1]s"
   description    = "test description"
@@ -300,7 +288,6 @@ func testAccVirtualInterface_gdgw(name string) string {
 
 resource "huaweicloud_dc_virtual_interface" "test" {
   direct_connect_id = "%[2]s"
-  vgw_id            = huaweicloud_dc_virtual_gateway.test.id
   name              = "%[3]s"
   description       = "Created by acc test"
   type              = "private"
@@ -334,7 +321,6 @@ func testAccVirtualInterface_gdgw_update1(name string) string {
 
 resource "huaweicloud_dc_virtual_interface" "test" {
   direct_connect_id = "%[2]s"
-  vgw_id            = huaweicloud_dc_virtual_gateway.test.id
   name              = "%[3]s"
   type              = "private"
   route_mode        = "static"
@@ -368,7 +354,6 @@ func testAccVirtualInterface_gdgw_update2(name string) string {
 
 resource "huaweicloud_dc_virtual_interface" "test" {
   direct_connect_id = "%[2]s"
-  vgw_id            = huaweicloud_dc_virtual_gateway.test.id
   name              = "%[3]s"
   type              = "private"
   route_mode        = "static"

--- a/huaweicloud/services/dc/resource_huaweicloud_dc_virtual_interface.go
+++ b/huaweicloud/services/dc/resource_huaweicloud_dc_virtual_interface.go
@@ -51,12 +51,6 @@ func ResourceVirtualInterface() *schema.Resource {
 				ForceNew:    true,
 				Description: "The ID of the direct connection associated with the virtual interface.",
 			},
-			"vgw_id": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "The ID of the virtual gateway to which the virtual interface is connected.",
-			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -110,6 +104,13 @@ func ResourceVirtualInterface() *schema.Resource {
 				Computed:    true,
 				ForceNew:    true,
 				Description: "The service type of the virtual interface.",
+			},
+			"vgw_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The ID of the virtual gateway to which the virtual interface is connected.",
 			},
 			"gateway_id": {
 				Type:        schema.TypeString,
@@ -440,7 +441,6 @@ func buildCreateVirtualInterfaceEnableNqa(d *schema.ResourceData) interface{} {
 
 func buildCreateVirtualInterfaceBodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
 	bodyParams := map[string]interface{}{
-		"vgw_id":                d.Get("vgw_id"),
 		"type":                  d.Get("type"),
 		"route_mode":            d.Get("route_mode"),
 		"vlan":                  d.Get("vlan"),
@@ -451,6 +451,7 @@ func buildCreateVirtualInterfaceBodyParams(d *schema.ResourceData, cfg *config.C
 		"description":           utils.ValueIgnoreEmpty(d.Get("description")),
 		"direct_connect_id":     utils.ValueIgnoreEmpty(d.Get("direct_connect_id")),
 		"service_type":          utils.ValueIgnoreEmpty(d.Get("service_type")),
+		"vgw_id":                utils.ValueIgnoreEmpty(d.Get("vgw_id")),
 		"gateway_id":            utils.ValueIgnoreEmpty(d.Get("gateway_id")),
 		"local_gateway_v4_ip":   utils.ValueIgnoreEmpty(d.Get("local_gateway_v4_ip")),
 		"remote_gateway_v4_ip":  utils.ValueIgnoreEmpty(d.Get("remote_gateway_v4_ip")),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix dc virtual interface vgw_id to optional
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix dc virtual interface vgw_id to optional
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dc/ TESTARGS='-run TestAccVirtualInterface_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dc/ -v -run TestAccVirtualInterface_basic -timeout 360m -parallel 4
=== RUN   TestAccVirtualInterface_basic
=== PAUSE TestAccVirtualInterface_basic
=== CONT  TestAccVirtualInterface_basic
--- PASS: TestAccVirtualInterface_basic (175.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dc        175.311s

make testacc TEST=./huaweicloud/services/acceptance/dc/ TESTARGS='-run TestAccVirtualInterface_gdgw'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dc/ -v -run TestAccVirtualInterface_gdgw -timeout 360m -parallel 4
=== RUN   TestAccVirtualInterface_gdgw
=== PAUSE TestAccVirtualInterface_gdgw
=== CONT  TestAccVirtualInterface_gdgw
--- PASS: TestAccVirtualInterface_gdgw (128.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dc        128.575s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
