### PR TITLE
refactor(worksapce): use new API instead of batch delete API and add a new attribute

### DIFF
--- a/docs/resources/workspace_app_warehouse_app.md
+++ b/docs/resources/workspace_app_warehouse_app.md
@@ -82,6 +82,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID, also application ID.
 
+* `record_id` - The record ID of the application.
+
 ## Import
 
 The resource can be imported using `id`, e.g.

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_warehouse_app_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_warehouse_app_test.go
@@ -58,6 +58,7 @@ func TestAccAppWarehouseApp_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "version_name", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "file_store_path", acceptance.HW_WORKSPACE_APP_FILE_NAME),
 					resource.TestCheckResourceAttr(resourceName, "description", "Created by script"),
+					resource.TestCheckResourceAttrSet(resourceName, "record_id"),
 				),
 			},
 			{

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_warehouse_app.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_warehouse_app.go
@@ -16,10 +16,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API WORKSPACEAPP POST /v1/{project_id}/app-warehouse/apps
-// @API WORKSPACEAPP GET /v1/{project_id}/app-warehouse/apps
-// @API WORKSPACEAPP PATCH /v1/{project_id}/app-warehouse/apps/{id}
-// @API WORKSPACEAPP POST /v1/{project_id}/app-warehouse/actions/batch-delete
+// @API Workspace POST /v1/{project_id}/app-warehouse/apps
+// @API Workspace GET /v1/{project_id}/app-warehouse/apps
+// @API Workspace PATCH /v1/{project_id}/app-warehouse/apps/{id}
+// @API Workspace DELETE /v1/{project_id}/app-warehouse/apps/{id}
 func ResourceWarehouseApplication() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceWarehouseApplicationCreate,
@@ -228,7 +228,7 @@ func buildUpdateWarehouseAppBodyParams(d *schema.ResourceData) map[string]interf
 
 func resourceWarehouseApplicationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	httpUrl := "v1/{project_id}/app-warehouse/actions/batch-delete"
+	httpUrl := "v1/{project_id}/app-warehouse/apps/{id}"
 	client, err := cfg.NewServiceClient("appstream", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating Workspace APP client: %s", err)
@@ -236,16 +236,14 @@ func resourceWarehouseApplicationDelete(_ context.Context, d *schema.ResourceDat
 
 	deletePath := client.Endpoint + httpUrl
 	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{id}", d.Id())
 	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody: map[string]interface{}{
-			"ids": []string{d.Id()},
-		},
 	}
 	// Although the deletion result of the main region shows that the interface returns a 200 status code when
 	// deleting a non-existent warehouse application, in order to avoid the possible return of a 404 status code in the
 	// future, the CheckDeleted design is retained here.
-	_, err = client.Request("POST", deletePath, &deleteOpt)
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "application of Workspace APP warehouse")
 	}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_warehouse_app.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_warehouse_app.go
@@ -79,6 +79,11 @@ func ResourceWarehouseApplication() *schema.Resource {
 				Optional:    true,
 				Description: `The icon of the application.`,
 			},
+			"record_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The record ID of the application.`,
+			},
 		},
 	}
 }
@@ -153,6 +158,7 @@ func resourceWarehouseApplicationRead(_ context.Context, d *schema.ResourceData,
 		d.Set("version_name", utils.PathSearch("version_name", application, nil)),
 		d.Set("file_store_path", utils.PathSearch("appfile_store_path", application, nil)),
 		d.Set("description", utils.PathSearch("app_description", application, nil)),
+		d.Set("record_id", utils.PathSearch("id", application, nil)),
 	)
 
 	if err = mErr.ErrorOrNil(); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Use new API instead of batch delete API.
   + When deleting a non-existent warehouse application, the interface returns a 200 status code.
   <img width="1601" height="749" alt="image" src="https://github.com/user-attachments/assets/ba615c0d-e01d-4991-b9ed-7ad8c66eabb3" />

2. Add a new attribute.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccAppWarehouseApp_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppWarehouseApp_basic -timeout 360m -parallel 10
=== RUN   TestAccAppWarehouseApp_basic
=== PAUSE TestAccAppWarehouseApp_basic
=== CONT  TestAccAppWarehouseApp_basic
--- PASS: TestAccAppWarehouseApp_basic (75.50s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 75.621s coverage: 3.7% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
