### PR TITLE
feat(workspace/app): add new data source to get latest applications attached to image server

### DIFF
--- a/docs/data-sources/workspace_app_latest_attached_applications.md
+++ b/docs/data-sources/workspace_app_latest_attached_applications.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_latest_attached_applications"
+description: |-
+  Use this data source to get the latest application list attached to the Workspace APP image server within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_latest_attached_applications
+
+Use this data source to get the latest application list attached to the Workspace APP image server within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "server_id" {}
+
+data "huaweicloud_workspace_app_latest_attached_applications" "test" {
+  server_id = var.server_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.  
+  If omitted, the provider-level region will be used.
+
+* `server_id` - (Required, String) Specifies the ID of the image server instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `applications` - The list of latest attached applications.
+  The [applications](#app_latest_attached_applications) structure is documented below.
+
+<a name="app_latest_attached_applications"></a>
+The `applications` block supports:
+
+* `app_id` - The ID of the attached application.
+
+* `record_id` - The record ID of the attached application.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1659,6 +1659,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_hda_latest_versions":             workspace.DataSourceAppHdaLatestVersions(),
 			"huaweicloud_workspace_app_ies_availability_zones":          workspace.DataSourceIesAvailabilityZones(),
 			"huaweicloud_workspace_app_image_servers":                   workspace.DataSourceWorkspaceAppImageServers(),
+			"huaweicloud_workspace_app_latest_attached_applications":    workspace.DataSourceLatestAttachedApplications(),
 			"huaweicloud_workspace_app_nas_storages":                    workspace.DataSourceAppNasStorages(),
 			"huaweicloud_workspace_app_publishable_apps":                workspace.DataSourceWorkspaceAppPublishableApps(),
 			"huaweicloud_workspace_app_schedule_tasks":                  workspace.DataSourceAppScheduleTasks(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_latest_attached_applications_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_latest_attached_applications_test.go
@@ -1,0 +1,71 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceLatestAttachedApplications_basic(t *testing.T) {
+	var (
+		name        = acceptance.RandomAccResourceName()
+		dataSource  = "data.huaweicloud_workspace_app_latest_attached_applications.test"
+		dc          = acceptance.InitDataSourceCheck(dataSource)
+		randUUID, _ = uuid.GenerateUUID()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+			acceptance.TestAccPreCheckWorkspaceAppImageSpecCode(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"null": {
+				Source:            "hashicorp/null",
+				VersionConstraint: "3.2.1",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceLatestAttachedApplications_notFound(randUUID),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("'%s' is a non-existing cloud application server", randUUID)),
+			},
+			{
+				Config: testAccDataSourceLatestAttachedApplications_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "applications.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "applications.0.app_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "applications.0.record_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceLatestAttachedApplications_notFound(randUUID string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_app_latest_attached_applications" "test" {
+  server_id = "%s"
+}
+`, randUUID)
+}
+
+func testAccDataSourceLatestAttachedApplications_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_workspace_app_latest_attached_applications" "test" {
+  depends_on = [huaweicloud_workspace_app_application_batch_attach.test]
+
+  server_id = huaweicloud_workspace_app_image_server.test.id
+}
+`, testAccResourceAppApplicationBatchAttach_basic(name))
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_latest_attached_applications.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_latest_attached_applications.go
@@ -1,0 +1,112 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/image-servers/{server_id}/actions/latest-attached-app
+func DataSourceLatestAttachedApplications() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceLatestAttachedApplicationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The region where the Workspace APP attached applications are located.`,
+			},
+			"server_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the image server instance.`,
+			},
+			"applications": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"app_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the attached application.`,
+						},
+						"record_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The record ID of the attached application.`,
+						},
+					},
+				},
+				Description: `The list of latest attached applications.`,
+			},
+		},
+	}
+}
+
+func dataSourceLatestAttachedApplicationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		httpUrl  = "v1/{project_id}/image-servers/{server_id}/actions/latest-attached-app"
+		serverId = d.Get("server_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{server_id}", serverId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving Workspace APP attached applications: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(serverId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("applications", flattenAppLatestAttachedApplications(utils.PathSearch("items",
+			respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAppLatestAttachedApplications(applications []interface{}) []interface{} {
+	if len(applications) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, len(applications))
+	for i, v := range applications {
+		result[i] = map[string]interface{}{
+			"app_id":    utils.PathSearch("app_id", v, nil),
+			"record_id": utils.PathSearch("id", v, nil),
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source (`huaweicloud_workspace_app_latest_attached_applications`) to get latest applications attached to image server.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source.
2. add corresponding documation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o workspace -f TestAccDataSourceLatestAttachedApplications_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataSourceLatestAttachedApplications_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceLatestAttachedApplications_basic
=== PAUSE TestAccDataSourceLatestAttachedApplications_basic
=== CONT  TestAccDataSourceLatestAttachedApplications_basic
--- PASS: TestAccDataSourceLatestAttachedApplications_basic (767.23s)
PASS
coverage: 7.6% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 767.392s        coverage: 7.6% of statements in ./huaweicloud/services/workspace
```

<img width="1120" height="316" alt="image" src="https://github.com/user-attachments/assets/cea4cd6f-56c2-4b60-9581-c064a2ab1bf3" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
