### PR TITLE
feat(secmaster): add new datasource to get list of alert rule templates

### DIFF
--- a/docs/data-sources/secmasterv2_alert_rule_templates.md
+++ b/docs/data-sources/secmasterv2_alert_rule_templates.md
@@ -1,0 +1,144 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmasterv2_alert_rule_templates"
+description: |-
+  Use this data source to get the list of alert rule templates (V2).
+---
+
+# huaweicloud_secmasterv2_alert_rule_templates
+
+Use this data source to get the list of alert rule templates (V2).
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_secmasterv2_alert_rule_templates" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID.
+
+* `template_name` - (Optional, String) Specifies the alert rule template name.
+
+* `severity` - (Optional, String) Specifies the alert level.
+  The value can be **TIPS**, **LOW**, **MEDIUM**, **HIGH** or **FATAL**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `records` - The list of alert rule templates.
+
+  The [records](#records_struct) structure is documented below.
+
+<a name="records_struct"></a>
+The `records` block supports:
+
+* `template_id` - The alert rule template ID.
+
+* `template_name` - The alert rule template name.
+
+* `accumulated_times` - The cumulative number of times.
+
+* `alert_description` - The alert description.
+
+* `alert_name` - The query type of the alert rule template.
+
+* `alert_remediation` - The custom extension information.
+
+* `alert_type` - The alert type.
+
+* `create_by` - The user ID.
+
+* `create_time` - The creation time.
+
+* `custom_properties` - The custom properties.
+
+* `description` - The alert rule template description.
+
+* `event_grouping` - Whether to put events in a group.
+
+* `job_mode` - The mode corresponding to alert rule template.
+
+* `process_status` - The process status.
+  The value can be **COMPLETED**, **CREATING**, **UPDATING**, **ENABLING**, **DISABLING**, **DELETING**,
+  **CREATE_FAILED**, **UPDATE_FAILED**, **ENABLE_FAILED**, **DISABLE_FAILED**, **DELETE_FAILED** or **RECOVERING**.
+
+* `query` - The query statement.
+
+* `query_type` - The query type.
+  The value can be **SQL** or **CBSL**.
+
+* `schedule` - The alert rule schedule.
+
+  The [schedule](#templates_schedule_struct) structure is documented below.
+
+* `severity` - The alert level.
+
+* `simulation` - Whether simulation alert.
+
+* `status` - The alert rule template status.
+
+* `suppression` - Whether alert suppression.
+
+* `table_name` - The table name.
+
+* `triggers` - The alert trigger rules information.
+
+  The [triggers](#templates_triggers_struct) structure is documented below.
+
+* `update_by` - The user ID which update the alert rule template.
+
+* `update_time` - The update time.
+
+* `update_time_by_user` - The update time which the user update the alert rule template.
+
+<a name="templates_schedule_struct"></a>
+The `schedule` block supports:
+
+* `delay_interval` - The delay interval.
+
+* `frequency_interval` - The scheduling interval.
+
+* `frequency_unit` - The scheduling interval unit.
+  The value can be **MINUTE**, **HOUR** or **DAY**.
+
+* `overtime_interval` - The overtime interval.
+
+* `period_interval` - The time window interval.
+
+* `period_unit` - The time window unit.
+  The value can be **MINUTE**, **HOUR** or **DAY**.
+
+<a name="templates_triggers_struct"></a>
+The `triggers` block supports:
+
+* `accumulated_times` - The cumulative number of times.
+
+* `expression` - The expression.
+
+* `job_id` - The  job ID.
+
+* `mode` - The mode.
+
+* `operator` - The operator type.
+  The valid values are as follows:
+  + **EQ**: equal,
+  + **NE**: not equal,
+  + **GT**: greater than,
+  + **LT**: less than.
+
+* `severity` - The alert level.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1440,8 +1440,9 @@ func Provider() *schema.Provider {
 			// and their API URLs are both named with "components". To differentiate them, all resources under the
 			// Plugin Management group are prefixed with "soc", since the API URLs in the Plugin Management group
 			// also contain "soc".
-			"huaweicloud_secmaster_soc_components":       secmaster.DataSourceSocComponents(),
-			"huaweicloud_secmaster_soc_component_detail": secmaster.DataSourceSocComponentDetail(),
+			"huaweicloud_secmaster_soc_components":         secmaster.DataSourceSocComponents(),
+			"huaweicloud_secmaster_soc_component_detail":   secmaster.DataSourceSocComponentDetail(),
+			"huaweicloud_secmasterv2_alert_rule_templates": secmaster.DataSourceAlertRuleTemplatesV2(),
 
 			// Querying by Ver.2 APIs
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmasterv2_alert_rule_templates_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmasterv2_alert_rule_templates_test.go
@@ -1,0 +1,94 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAlertRuleTemplatesV2_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_secmasterv2_alert_rule_templates.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAlertRuleTemplatesV2_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "records.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.template_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.template_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.accumulated_times"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.alert_description"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.alert_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.alert_remediation"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.create_by"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.description"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.event_grouping"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.job_mode"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.process_status"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.query"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.query_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.severity"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.simulation"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.suppression"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.table_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.update_by"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.update_time"),
+
+					resource.TestCheckOutput("is_template_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_severity_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAlertRuleTemplatesV2_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmasterv2_alert_rule_templates" "test" {
+  workspace_id = "%[1]s"
+}
+
+locals {
+  template_name = data.huaweicloud_secmasterv2_alert_rule_templates.test.records[0].template_name
+}
+
+data "huaweicloud_secmasterv2_alert_rule_templates" "filter_by_template_name" {
+  workspace_id  = "%[1]s"
+  template_name = local.template_name
+}
+
+output "is_template_name_filter_useful" {
+  value = length(data.huaweicloud_secmasterv2_alert_rule_templates.filter_by_template_name.records) > 0 && alltrue(
+    [for v in data.huaweicloud_secmasterv2_alert_rule_templates.filter_by_template_name.records[*].template_name : v == local.template_name]
+  )
+}
+
+locals {
+  severity = data.huaweicloud_secmasterv2_alert_rule_templates.test.records[0].severity
+}
+
+data "huaweicloud_secmasterv2_alert_rule_templates" "filter_by_severity" {
+  workspace_id = "%[1]s"
+  severity     = local.severity
+}
+
+output "is_severity_filter_useful" {
+  value = length(data.huaweicloud_secmasterv2_alert_rule_templates.filter_by_severity.records) > 0 && alltrue(
+    [for v in data.huaweicloud_secmasterv2_alert_rule_templates.filter_by_severity.records[*].severity : v == local.severity]
+  )
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmasterv2_alert_rule_templates.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmasterv2_alert_rule_templates.go
@@ -1,0 +1,367 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SecMaster GET /v2/{project_id}/workspaces/{workspace_id}/siem/alert-rules/templates
+func DataSourceAlertRuleTemplatesV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAlertRuleTemplatesV2Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"template_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"severity": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"records": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"template_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"template_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"accumulated_times": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"alert_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"alert_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"alert_remediation": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"alert_type": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"create_by": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"custom_properties": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"event_grouping": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"job_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"process_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"query": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"query_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"schedule": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"delay_interval": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"frequency_interval": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"frequency_unit": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"overtime_interval": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"period_interval": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"period_unit": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"severity": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"simulation": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						// The field `suppression` is misspelled in the API documentation.
+						// The actual names defined in the current schema are valid.
+						"suppression": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"table_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"triggers": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"accumulated_times": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"expression": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"job_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"mode": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"operator": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"severity": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"update_by": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"update_time_by_user": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAlertRuleTemplatesv2QueryParams(d *schema.ResourceData) string {
+	queryParams := "?limit=1000"
+
+	if v, ok := d.GetOk("template_name"); ok {
+		queryParams = fmt.Sprintf("%s&template_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		queryParams = fmt.Sprintf("%s&status=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("severity"); ok {
+		queryParams = fmt.Sprintf("%s&severity=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("sort_key"); ok {
+		queryParams = fmt.Sprintf("%s&sort_key=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("sort_dir"); ok {
+		queryParams = fmt.Sprintf("%s&sort_dir=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceAlertRuleTemplatesV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		httpUrl     = "v2/{project_id}/workspaces/{workspace_id}/siem/alert-rules/templates"
+		result      = make([]interface{}, 0)
+		offset      = 0
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{workspace_id}", workspaceId)
+	getPath += buildAlertRuleTemplatesv2QueryParams(d)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", getPath, offset)
+		getResp, err := client.Request("GET", currentPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving alert rule templates (v2): %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		records := utils.PathSearch("records", getRespBody, make([]interface{}, 0)).([]interface{})
+		if len(records) == 0 {
+			break
+		}
+
+		result = append(result, records...)
+		offset += len(records)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("records", flattenAlertRuleTemplatesV2(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAlertRuleTemplatesV2(instancesResp []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(instancesResp))
+	for _, v := range instancesResp {
+		rst = append(rst, map[string]interface{}{
+			"template_id":         utils.PathSearch("template_id", v, nil),
+			"template_name":       utils.PathSearch("template_name", v, nil),
+			"accumulated_times":   utils.PathSearch("accumulated_times", v, nil),
+			"alert_description":   utils.PathSearch("alert_description", v, nil),
+			"alert_name":          utils.PathSearch("alert_name", v, nil),
+			"alert_remediation":   utils.PathSearch("alert_remediation", v, nil),
+			"alert_type":          utils.PathSearch("alert_type", v, nil),
+			"create_by":           utils.PathSearch("create_by", v, nil),
+			"create_time":         utils.PathSearch("create_time", v, nil),
+			"custom_properties":   utils.PathSearch("custom_properties", v, nil),
+			"description":         utils.PathSearch("description", v, nil),
+			"event_grouping":      utils.PathSearch("event_grouping", v, nil),
+			"job_mode":            utils.PathSearch("job_mode", v, nil),
+			"process_status":      utils.PathSearch("process_status", v, nil),
+			"query":               utils.PathSearch("query", v, nil),
+			"query_type":          utils.PathSearch("query_type", v, nil),
+			"schedule":            flattenAlertRuleTemplatesV2Schedule(utils.PathSearch("schedule", v, nil)),
+			"severity":            utils.PathSearch("severity", v, nil),
+			"simulation":          utils.PathSearch("simulation", v, nil),
+			"status":              utils.PathSearch("status", v, nil),
+			"suppression":         utils.PathSearch("suppression", v, nil),
+			"table_name":          utils.PathSearch("table_name", v, nil),
+			"triggers":            flattenAlertRuleTemplatesV2Triggers(utils.PathSearch("triggers", v, make([]interface{}, 0)).([]interface{})),
+			"update_by":           utils.PathSearch("update_by", v, nil),
+			"update_time":         utils.PathSearch("update_time", v, nil),
+			"update_time_by_user": utils.PathSearch("update_time_by_user", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenAlertRuleTemplatesV2Schedule(rawSchedule interface{}) []interface{} {
+	if rawSchedule == nil {
+		return nil
+	}
+
+	result := map[string]interface{}{
+		"delay_interval":     utils.PathSearch("delay_interval", rawSchedule, nil),
+		"frequency_interval": utils.PathSearch("frequency_interval", rawSchedule, nil),
+		"frequency_unit":     utils.PathSearch("frequency_unit", rawSchedule, nil),
+		"overtime_interval":  utils.PathSearch("overtime_interval", rawSchedule, nil),
+		"period_interval":    utils.PathSearch("period_interval", rawSchedule, nil),
+		"period_unit":        utils.PathSearch("period_unit", rawSchedule, nil),
+	}
+
+	return []interface{}{result}
+}
+
+func flattenAlertRuleTemplatesV2Triggers(rawTriggers []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(rawTriggers))
+	for _, v := range rawTriggers {
+		rst = append(rst, map[string]interface{}{
+			"accumulated_times": utils.PathSearch("accumulated_times", v, nil),
+			"expression":        utils.PathSearch("expression", v, nil),
+			"job_id":            utils.PathSearch("job_id", v, nil),
+			"mode":              utils.PathSearch("mode", v, nil),
+			"operator":          utils.PathSearch("operator", v, nil),
+			"severity":          utils.PathSearch("severity", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new datasource to get list of alert rule templates (V2).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/secmaster" TESTARGS="-run TestAccDataSourceAlertRuleTemplatesV2_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/secmaster -v -run TestAccDataSourceAlertRuleTemplatesV2_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAlertRuleTemplatesV2_basic
=== PAUSE TestAccDataSourceAlertRuleTemplatesV2_basic
=== CONT  TestAccDataSourceAlertRuleTemplatesV2_basic
--- PASS: TestAccDataSourceAlertRuleTemplatesV2_basic (43.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 44.226s
```
<img width="1088" height="28" alt="image" src="https://github.com/user-attachments/assets/083ecec2-2632-43ce-b896-b4101f815207" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
