### PR TITLE
feat(workspace): add new resource to batch operate servers

### DIFF
--- a/docs/resources/workspace_app_server_batch_action.md
+++ b/docs/resources/workspace_app_server_batch_action.md
@@ -1,0 +1,114 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_server_batch_action"
+description: |-
+  Use this resource to batch operate APP servers within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_server_batch_action
+
+Use this resource to batch operate APP servers within HuaweiCloud.
+
+-> This resource is only a one-time action resource for batch operate APP servers. Deleting this resource will not clear
+   the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+### Modify Server Image
+
+```hcl
+variable "operate_server_ids" {
+  type = list(string)
+}
+variable "new_image_id" {}
+
+resource "huaweicloud_workspace_app_server_batch_action" "test" {
+  type    = "batch-change-image"
+  content = jsonencode({
+    server_ids          = var.operate_server_ids
+    image_id            = var.new_image_id
+    image_type          = "private"
+    os_type             = "Windows"
+    update_access_agent = true
+  })
+}
+```
+
+### Reinstall Server
+
+```hcl
+variable "operate_server_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_workspace_app_server_batch_action" "test" {
+  type    = "batch-reinstall"
+  content = jsonencode({
+    server_ids          = var.operate_server_ids
+    update_access_agent = false
+  })
+}
+```
+
+### Rejoin Domain
+
+```hcl
+variable "operate_server_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_workspace_app_server_batch_action" "rejoin_domain" {
+  type    = "batch-rejoin-domain"
+  content = jsonencode({
+    items = var.operate_server_ids
+  })
+}
+```
+
+### Update Virtual Session IP Configuration
+
+```hcl
+variable "operate_server_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_workspace_app_server_batch_action" "update_tsvi" {
+  type    = "batch-update-tsvi"
+  content = jsonencode({
+    items = [
+      for o in var.operate_server_ids : {
+        id     = o
+        enable = true
+      }
+    ]
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the APP servers to be batch operated are located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `type` - (Required, String, NonUpdatable) Specifies the batch operation (action) type for the APP servers.  
+  The valid values are as follows:
+  + **batch-change-image**: Modify server image.
+  + **batch-reinstall**: Reinstall server.
+  + **batch-rejoin-domain**: Rejoin AD domain.
+  + **batch-update-tsvi**: Update virtual session IP configuration.
+
+* `content` - (Required, String, NonUpdatable) Specifies the JSON string content for the batch operation (action)
+  request.
+
+* `max_retries` - (Optional, Int) Specifies the maximum number of retries for the batch operation (action) when
+  encountering 409 conflict errors.  
+  The default value is **0**, which means no retry will be performed.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20250812112343-62efdf749af3
+	github.com/chnsz/golangsdk v0.0.0-20250813031404-b29976bf6c00
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20250812112343-62efdf749af3 h1:wrhBn84ZYYc/bewfUWchVBrTvrxyDCy1RUEZYanFXnw=
-github.com/chnsz/golangsdk v0.0.0-20250812112343-62efdf749af3/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
+github.com/chnsz/golangsdk v0.0.0-20250813031404-b29976bf6c00 h1:IjLGdiSyPLz4R/GqQOezfKOToX1iWHo2zeEcZcZ5hco=
+github.com/chnsz/golangsdk v0.0.0-20250813031404-b29976bf6c00/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2906,6 +2906,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_server_group_scaling_policy": workspace.ResourceAppServerGroupScalingPolicy(),
 			"huaweicloud_workspace_app_server_group":                workspace.ResourceAppServerGroup(),
 			"huaweicloud_workspace_app_server":                      workspace.ResourceAppServer(),
+			"huaweicloud_workspace_app_server_batch_action":         workspace.ResourceAppServerBatchAction(),
 			"huaweicloud_workspace_app_shared_folder":               workspace.ResourceAppSharedFolder(),
 			"huaweicloud_workspace_app_storage_policy":              workspace.ResourceAppStoragePolicy(),
 			"huaweicloud_workspace_app_warehouse_app":               workspace.ResourceWarehouseApplication(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_server_batch_action_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_server_batch_action_test.go
@@ -1,0 +1,247 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccAppServerBatchAction_batchChangeImage(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_workspace_app_server_batch_action.test"
+		name         = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time batch action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppServerBatchAction_batchChangeImage(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "batch-change-image"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAppServerBatchAction_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_app_server_groups" "test" {
+  server_group_id = "%[1]s"
+}
+
+data "huaweicloud_vpc_subnets" "test" {
+  id = try(data.huaweicloud_workspace_app_server_groups.test.server_groups[0].subnet_id, null)
+}
+
+resource "huaweicloud_workspace_app_server" "test" {
+  name                = "%[2]s" 
+  server_group_id     = try(data.huaweicloud_workspace_app_server_groups.test.server_groups[0].id, null)
+  type                = "createApps"
+  flavor_id           = try(data.huaweicloud_workspace_app_server_groups.test.server_groups[0].product_id, null)
+  vpc_id              = try(data.huaweicloud_vpc_subnets.test.subnets[0].vpc_id, null)
+  subnet_id           = try(data.huaweicloud_workspace_app_server_groups.test.server_groups[0].subnet_id, null)
+  update_access_agent = false
+  description         = "Created by terraform script"
+  maintain_status     = true
+
+  root_volume {
+    type = try(data.huaweicloud_workspace_app_server_groups.test.server_groups[0].system_disk_type, null)
+    size = try(data.huaweicloud_workspace_app_server_groups.test.server_groups[0].system_disk_size, null)
+  }
+
+  lifecycle {
+    ignore_changes = [
+      maintain_status
+    ]
+  }
+}
+`, acceptance.HW_WORKSPACE_APP_SERVER_GROUP_ID, name)
+}
+
+func testAccAppServerBatchAction_batchChangeImage(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_images_images" "test" {
+  visibility = "market"
+  os         = "Windows"
+}
+
+locals {
+  available_images = try([
+    for o in data.huaweicloud_images_images.test.images : o if 
+      strcontains(lower(o.name), "appstream") && o.id != try(data.huaweicloud_workspace_app_server_groups.test.server_groups[0].image_id, "")
+    ], [])
+}
+
+resource "huaweicloud_workspace_app_server_batch_action" "test" {
+  type    = "batch-change-image"
+  content = jsonencode({
+    server_ids          = [huaweicloud_workspace_app_server.test.id]
+    image_id            = try(local.available_images[0].id, "NOT_FOUND")
+    image_type          = "gold"
+    os_type             = "Windows"
+    update_access_agent = true
+  })
+
+  max_retries = 3
+
+  provisioner "local-exec" {
+    command = "sleep 600"
+  }
+}
+`, testAccAppServerBatchAction_base(name))
+}
+
+func TestAccAppServerBatchAction_batchReinstall(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_workspace_app_server_batch_action.test"
+		name         = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time batch action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppServerBatchAction_batchReinstall(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "batch-reinstall"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAppServerBatchAction_batchReinstall(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_server_batch_action" "test" {
+  type    = "batch-reinstall"
+  content = jsonencode({
+    server_ids          = [huaweicloud_workspace_app_server.test.id]
+    update_access_agent = false
+  })
+
+  max_retries = 3
+
+  provisioner "local-exec" {
+    command = "sleep 1200"
+  }
+}
+`, testAccAppServerBatchAction_base(name))
+}
+
+func TestAccAppServerBatchAction_batchRejoinDomain(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_workspace_app_server_batch_action.test"
+		name         = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time batch action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppServerBatchAction_batchRejoinDomain(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "batch-rejoin-domain"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAppServerBatchAction_batchRejoinDomain(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_server_batch_action" "test" {
+  type    = "batch-rejoin-domain"
+  content = jsonencode({
+    items = [huaweicloud_workspace_app_server.test.id]
+  })
+
+  max_retries = 3
+
+  provisioner "local-exec" {
+    command = "sleep 300"
+  }
+}
+`, testAccAppServerBatchAction_base(name))
+}
+
+func TestAccAppServerBatchAction_batchUpdateTsvi(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_workspace_app_server_batch_action.test"
+		name         = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time batch action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppServerBatchAction_batchUpdateTsvi(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "batch-update-tsvi"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAppServerBatchAction_batchUpdateTsvi(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_server_batch_action" "test" {
+  type    = "batch-update-tsvi"
+  content = jsonencode({
+    items = [
+      {
+        id     = huaweicloud_workspace_app_server.test.id
+        enable = true
+      }
+    ]
+  })
+
+  max_retries = 3
+
+  provisioner "local-exec" {
+    command = "sleep 600"
+  }
+}
+`, testAccAppServerBatchAction_base(name))
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_server_batch_action.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_server_batch_action.go
@@ -1,0 +1,162 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var batchActionHTTPMethodMap = map[string]string{
+	"batch-change-image":  "POST",
+	"batch-reinstall":     "POST",
+	"batch-rejoin-domain": "PATCH",
+	"batch-update-tsvi":   "PATCH",
+}
+
+var appServerBatchActionNonUpdatableParams = []string{"type", "content"}
+
+// @API Workspace POST /v1/{project_id}/app-servers/actions/batch-change-image
+// @API Workspace POST /v1/{project_id}/app-servers/actions/batch-reinstall
+// @API Workspace PATCH /v1/{project_id}/app-servers/actions/batch-rejoin-domain
+// @API Workspace PATCH /v1/{project_id}/app-servers/actions/batch-update-tsvi
+func ResourceAppServerBatchAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppServerBatchActionCreate,
+		ReadContext:   resourceAppServerBatchActionRead,
+		UpdateContext: resourceAppServerBatchActionUpdate,
+		DeleteContext: resourceAppServerBatchActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(appServerBatchActionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the APP servers to be batch operated are located.`,
+			},
+
+			// Required parameter(s).
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The batch operation (action) type for the APP servers.`,
+				ValidateFunc: validation.StringInSlice([]string{
+					"batch-change-image",
+					"batch-reinstall",
+					"batch-rejoin-domain",
+					"batch-update-tsvi",
+				}, false),
+			},
+			"content": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The JSON string content for the batch operation (action) request.`,
+			},
+
+			// Optional parameter(s).
+			"max_retries": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The maximum number of retries for the batch operation (action) when encountering 409 conflict errors.`,
+			},
+
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceAppServerBatchActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v1/{project_id}/app-servers/actions/{type}"
+		actionType = d.Get("type").(string)
+		content    = d.Get("content").(string)
+		maxRetries = d.Get("max_retries").(int)
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	httpMethod, exists := batchActionHTTPMethodMap[actionType]
+	if !exists {
+		return diag.Errorf("unsupported operation (action) type: %s", actionType)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{type}", actionType)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.StringToJson(content),
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate resource ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	for i := 0; i < maxRetries+1; i++ {
+		_, err = client.Request(httpMethod, createPath, &opt)
+		if err == nil {
+			break
+		}
+
+		if _, ok := err.(golangsdk.ErrDefault409); ok {
+			// lintignore:R018
+			time.Sleep(30 * time.Second)
+			continue
+		}
+		if i < 1 {
+			return diag.Errorf("error executing APP server batch operation (action: %s): %s", actionType, err)
+		}
+		return diag.Errorf("after %d retries, the APP server batch operation (action: %s) still reports an error: %s",
+			i, actionType, err)
+	}
+
+	return resourceAppServerBatchActionRead(ctx, d, meta)
+}
+
+func resourceAppServerBatchActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppServerBatchActionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppServerBatchActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to batch operate APP servers. Deleting this resource
+will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}

--- a/vendor/github.com/chnsz/golangsdk/errors.go
+++ b/vendor/github.com/chnsz/golangsdk/errors.go
@@ -96,6 +96,11 @@ type ErrDefault408 struct {
 	ErrUnexpectedResponseCode
 }
 
+// ErrDefault409 is the default error type returned on a 409 HTTP response code.
+type ErrDefault409 struct {
+	ErrUnexpectedResponseCode
+}
+
 // ErrDefault429 is the default error type returned on a 429 HTTP response code.
 type ErrDefault429 struct {
 	ErrUnexpectedResponseCode
@@ -157,6 +162,9 @@ func (e ErrDefault405) Error() string {
 }
 func (e ErrDefault408) Error() string {
 	return "The server timed out waiting for the request"
+}
+func (e ErrDefault409) Error() string {
+	return "The request could not be processed due to conflict in the request"
 }
 func (e ErrDefault429) Error() string {
 	e.DefaultErrString = fmt.Sprintf(
@@ -220,6 +228,12 @@ type Err405er interface {
 // from a 408 error.
 type Err408er interface {
 	Error408(ErrUnexpectedResponseCode) error
+}
+
+// Err409er is the interface resource error types implement to override the error message
+// from a 409 error.
+type Err409er interface {
+	Error409(ErrUnexpectedResponseCode) error
 }
 
 // Err429er is the interface resource error types implement to override the error message

--- a/vendor/github.com/chnsz/golangsdk/provider_client.go
+++ b/vendor/github.com/chnsz/golangsdk/provider_client.go
@@ -429,6 +429,11 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 			if error404er, ok := errType.(Err404er); ok {
 				err = error404er.Error404(respErr)
 			}
+		case http.StatusConflict:
+			err = ErrDefault409{respErr}
+			if error409er, ok := errType.(Err409er); ok {
+				err = error409er.Error409(respErr)
+			}
 		case http.StatusMethodNotAllowed:
 			err = ErrDefault405{respErr}
 			if error405er, ok := errType.(Err405er); ok {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20250812112343-62efdf749af3
+# github.com/chnsz/golangsdk v0.0.0-20250813031404-b29976bf6c00
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add new resource to batch operate servers
it is a one time action resource 
<img width="1243" height="926" alt="image" src="https://github.com/user-attachments/assets/a9fd5b4b-2736-4496-a7cc-b4c94059d3c5" />

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new resource to batch operate servers
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccAppServerBatchAction_batchChangeImage
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppServerBatchAction_batchChangeImage -timeout 360m -parallel 10
=== RUN   TestAccAppServerBatchAction_batchChangeImage
=== PAUSE TestAccAppServerBatchAction_batchChangeImage
=== CONT  TestAccAppServerBatchAction_batchChangeImage
--- PASS: TestAccAppServerBatchAction_batchChangeImage (577.90s)
PASS
coverage: 6.2% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 577.969s        coverage: 6.2% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccAppServerBatchAction_batchReinstall
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppServerBatchAction_batchReinstall -timeout 360m -parallel 10
=== RUN   TestAccAppServerBatchAction_batchReinstall
=== PAUSE TestAccAppServerBatchAction_batchReinstall
=== CONT  TestAccAppServerBatchAction_batchReinstall
--- PASS: TestAccAppServerBatchAction_batchReinstall (1730.48s)
PASS
coverage: 6.1% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 1730.593s       coverage: 6.1% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccAppServerBatchAction_batchUpdateTsvi
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppServerBatchAction_batchUpdateTsvi -timeout 360m -parallel 10
=== RUN   TestAccAppServerBatchAction_batchUpdateTsvi
=== PAUSE TestAccAppServerBatchAction_batchUpdateTsvi
=== CONT  TestAccAppServerBatchAction_batchUpdateTsvi
--- PASS: TestAccAppServerBatchAction_batchUpdateTsvi (1343.27s)
PASS
coverage: 6.2% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 1343.341s       coverage: 6.2% of statements in ./huaweicloud/services/workspace
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
