### PR TITLE
feat(workspace/app): add new data source to get warehouse applications

### DIFF
--- a/docs/data-sources/workspace_app_warehouse_applications.md
+++ b/docs/data-sources/workspace_app_warehouse_applications.md
@@ -1,0 +1,91 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_warehouse_applications"
+description: |-
+  Use this data source to get warehouse application list of the Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_warehouse_applications
+
+Use this data source to get warehouse application list of the Workspace APP within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "application_id" {}
+
+data "huaweicloud_workspace_app_warehouse_applications" "test" {
+  app_id = var.application_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the warehouse applications are located.  
+  If omitted, the provider-level region will be used.
+
+* `app_id` - (Optional, String) Specifies the ID of the application.
+
+* `name` - (Optional, String) Specifies the name of the application.  
+  Fuzzy matching is supported.
+
+* `category` - (Optional, String) Specifies the category of the application.  
+  The valid values are as follows:
+  + **GAME**
+  + **SECURE_STORAGE**
+  + **MULTIMEDIA_AND_CODING**
+  + **PROJECT_MANAGEMENT**
+  + **PRODUCTIVITY_AND_COLLABORATION**
+  + **GRAPHIC_DESIGN**
+  + **OTHER**
+
+* `verify_status` - (Optional, String) Specifies the verification status of the application.  
+  The valid values are as follows:
+  + **VERIFIED** - Verification passed.
+  + **VERIFY_FAILED** - Verification failed.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `applications` - All applications that match the filter parameters.  
+  The [applications](#data_app_warehouse_applications) structure is documented below.
+
+<a name="data_app_warehouse_applications"></a>
+The `applications` block supports:
+
+* `id` - The record ID of the application.
+
+* `app_id` - The ID of the application.
+
+* `name` - The name of the application.
+
+* `category` - The category of the application.
+
+* `os_type` - The operating system type of the application.
+  + **Windows**
+  + **Linux**
+  + **Other**
+
+* `version` - The version of the application.
+
+* `version_name` - The version name of the application.
+
+* `file_store_path` - The storage path of the application file.
+
+* `app_file_size` - The size of the application file.
+
+* `description` - The description of the application.
+
+* `verify_status` - The verification status of the application.
+
+* `icon` - The base64 encoded application icon.
+
+* `created_at` - The creation time of the application, in RFC3339 format.
+
+* `updated_at` - The latest update time of the application, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1669,6 +1669,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_session_types":                   workspace.DataSourceSessionTypes(),
 			"huaweicloud_workspace_app_storage_policies":                workspace.DataSourceAppStoragePolicies(),
 			"huaweicloud_workspace_app_vnc_remote":                      workspace.DataSourceAppVncRemote(),
+			"huaweicloud_workspace_app_warehouse_applications":          workspace.DataSourceAppWarehouseApplications(),
 
 			"huaweicloud_cpts_projects": cpts.DataSourceCptsProjects(),
 

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_warehouse_applications_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_warehouse_applications_test.go
@@ -1,0 +1,172 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAppWarehouseApplications_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		dataSource = "data.huaweicloud_workspace_app_warehouse_applications.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byAppId   = "data.huaweicloud_workspace_app_warehouse_applications.filter_by_app_id"
+		dcByAppId = acceptance.InitDataSourceCheck(byAppId)
+
+		exactByName   = "data.huaweicloud_workspace_app_warehouse_applications.exact_filter_by_name"
+		dcExactByName = acceptance.InitDataSourceCheck(exactByName)
+
+		byName   = "data.huaweicloud_workspace_app_warehouse_applications.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byCategory   = "data.huaweicloud_workspace_app_warehouse_applications.filter_by_category"
+		dcByCategory = acceptance.InitDataSourceCheck(byCategory)
+
+		byVerifyStatus   = "data.huaweicloud_workspace_app_warehouse_applications.filter_by_verify_status"
+		dcByVerifyStatus = acceptance.InitDataSourceCheck(byVerifyStatus)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppFileName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"null": {
+				Source:            "hashicorp/null",
+				VersionConstraint: "3.2.1",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAppWarehouseApplications_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "applications.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByAppId.CheckResourceExists(),
+					resource.TestCheckOutput("is_app_id_filter_useful", "true"),
+					resource.TestCheckResourceAttrSet(byAppId, "applications.0.id"),
+					resource.TestCheckResourceAttrSet(byAppId, "applications.0.app_id"),
+					resource.TestCheckResourceAttrSet(byAppId, "applications.0.name"),
+					resource.TestCheckResourceAttrSet(byAppId, "applications.0.category"),
+					resource.TestCheckResourceAttrSet(byAppId, "applications.0.os_type"),
+					resource.TestCheckResourceAttrSet(byAppId, "applications.0.version"),
+					resource.TestCheckResourceAttrSet(byAppId, "applications.0.version_name"),
+					resource.TestCheckResourceAttr(byAppId, "applications.0.file_store_path", acceptance.HW_WORKSPACE_APP_FILE_NAME),
+					resource.TestCheckResourceAttrSet(byAppId, "applications.0.app_file_size"),
+					resource.TestCheckResourceAttrSet(byAppId, "applications.0.description"),
+					resource.TestCheckResourceAttrSet(byAppId, "applications.0.verify_status"),
+					resource.TestMatchResourceAttr(byAppId, "applications.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(byAppId, "applications.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					dcExactByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_exact_filter_useful", "true"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcByCategory.CheckResourceExists(),
+					resource.TestCheckOutput("is_category_filter_useful", "true"),
+					dcByVerifyStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_verify_status_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAppWarehouseApplications_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_workspace_app_warehouse_applications" "test" {
+  depends_on = [huaweicloud_workspace_app_warehouse_app.test]
+}
+
+locals {
+  application_id = huaweicloud_workspace_app_warehouse_app.test.id
+  name           = huaweicloud_workspace_app_warehouse_app.test.name
+  category       = huaweicloud_workspace_app_warehouse_app.test.category
+  verify_status  = try(data.huaweicloud_workspace_app_warehouse_applications.test.applications[0].verify_status, null)
+}
+
+# Filter by application ID.
+data "huaweicloud_workspace_app_warehouse_applications" "filter_by_app_id" {
+  app_id = local.application_id
+}
+
+locals {
+  app_id_filter_result = [for v in data.huaweicloud_workspace_app_warehouse_applications.filter_by_app_id.applications :
+  v.app_id == local.application_id]
+}
+
+output "is_app_id_filter_useful" {
+  value = length(local.app_id_filter_result) > 0 && alltrue(local.app_id_filter_result)
+}
+
+# Filter by application name (Exact match).
+data "huaweicloud_workspace_app_warehouse_applications" "exact_filter_by_name" {
+  name       = local.name
+  depends_on = [huaweicloud_workspace_app_warehouse_app.test]
+}
+
+locals {
+  name_exact_filter_result = [for v in data.huaweicloud_workspace_app_warehouse_applications.exact_filter_by_name.applications : v.name == local.name]
+}
+
+output "is_name_exact_filter_useful" {
+  value = length(local.name_exact_filter_result) > 0 && alltrue(local.name_exact_filter_result)
+}
+
+# Filter by application name (Fuzzy search).
+data "huaweicloud_workspace_app_warehouse_applications" "filter_by_name" {
+  name       = "tf_test"
+  depends_on = [huaweicloud_workspace_app_warehouse_app.test]
+}
+
+locals {
+  name_filter_result = [for v in data.huaweicloud_workspace_app_warehouse_applications.filter_by_name.applications :
+  strcontains(v.name, "tf_test")]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by application category.
+data "huaweicloud_workspace_app_warehouse_applications" "filter_by_category" {
+  category   = local.category
+  depends_on = [huaweicloud_workspace_app_warehouse_app.test]
+}
+
+locals {
+  category_filter_result = [for v in data.huaweicloud_workspace_app_warehouse_applications.filter_by_category.applications :
+  v.category == local.category]
+}
+
+output "is_category_filter_useful" {
+  value = length(local.category_filter_result) > 0 && alltrue(local.category_filter_result)
+}
+
+# Filter by application verify status.
+data "huaweicloud_workspace_app_warehouse_applications" "filter_by_verify_status" {
+  verify_status = local.verify_status
+  depends_on    = [huaweicloud_workspace_app_warehouse_app.test]
+}
+
+locals {
+  verify_status_filter_result = [for v in data.huaweicloud_workspace_app_warehouse_applications.filter_by_verify_status.applications :
+  v.verify_status == local.verify_status]
+}
+
+output "is_verify_status_filter_useful" {
+  value = length(local.verify_status_filter_result) > 0 && alltrue(local.verify_status_filter_result)
+}
+`, testAccWarehouseApp_basic_step1(name))
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_warehouse_applications.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_warehouse_applications.go
@@ -1,0 +1,253 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/app-warehouse/apps
+func DataSourceAppWarehouseApplications() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppWarehouseApplicationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the warehouse applications are located.`,
+			},
+			"app_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the application.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the application.`,
+			},
+			"category": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The category of the application.`,
+			},
+			"verify_status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The verification status of the application.`,
+			},
+			"applications": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The record ID of the application.`,
+						},
+						"app_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the application.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the application.`,
+						},
+						"category": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The category of the application.`,
+						},
+						"os_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The operating system type of the application.`,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The version of the application.`,
+						},
+						"version_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The version name of the application.`,
+						},
+						"file_store_path": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The storage path of the application file.`,
+						},
+						"app_file_size": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The size of the application file.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the application.`,
+						},
+						"verify_status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The verification status of the application.`,
+						},
+						"icon": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The base64 encoded application icon.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the application, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the application, in RFC3339 format.`,
+						},
+					},
+				},
+				Description: `All applications that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func dataSourceAppWarehouseApplicationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	applications, err := listAppWarehouseApplications(client, d)
+	if err != nil {
+		return diag.Errorf("error getting Workspace APP warehouse applications: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("applications", flattenAppWarehouseApplications(applications)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func listAppWarehouseApplications(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/app-warehouse/apps"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = fmt.Sprintf("%s?limit=%d", listPath, limit)
+	listPath += buildAppWarehouseApplicationsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		applications := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, applications...)
+		if len(applications) < limit {
+			break
+		}
+
+		offset += len(applications)
+	}
+
+	return result, nil
+}
+
+func buildAppWarehouseApplicationsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("app_id"); ok {
+		res = fmt.Sprintf("%s&app_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&app_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("category"); ok {
+		res = fmt.Sprintf("%s&app_category=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("verify_status"); ok {
+		res = fmt.Sprintf("%s&verify_status=%v", res, v)
+	}
+
+	return res
+}
+
+func flattenAppWarehouseApplications(applications []interface{}) []map[string]interface{} {
+	if len(applications) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(applications))
+	for _, application := range applications {
+		result = append(result, map[string]interface{}{
+			"id":              utils.PathSearch("id", application, nil),
+			"app_id":          utils.PathSearch("app_id", application, nil),
+			"name":            utils.PathSearch("app_name", application, nil),
+			"category":        utils.PathSearch("app_category", application, nil),
+			"os_type":         utils.PathSearch("os_type", application, nil),
+			"version":         utils.PathSearch("version_id", application, nil),
+			"version_name":    utils.PathSearch("version_name", application, nil),
+			"file_store_path": utils.PathSearch("appfile_store_path", application, nil),
+			"app_file_size":   utils.PathSearch("app_file_size", application, nil),
+			"description":     utils.PathSearch("app_description", application, nil),
+			"verify_status":   utils.PathSearch("verify_status", application, nil),
+			"icon":            utils.PathSearch("app_icon", application, nil),
+			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("create_time",
+				application, "").(string))/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("modify_time",
+				application, "").(string))/1000, false),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source (`huaweicloud_workspace_app_warehouse_apps`) to get warehouse applications.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source.
2. add corresponding acceptance test and documation.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataSourceAppWarehouseApps_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataSourceAppWarehouseApps_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAppWarehouseApps_basic
=== PAUSE TestAccDataSourceAppWarehouseApps_basic
=== CONT  TestAccDataSourceAppWarehouseApps_basic
--- PASS: TestAccDataSourceAppWarehouseApps_basic (52.75s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 52.860s coverage: 4.2% of statements in ./huaweicloud/services/workspace
```
<img width="1088" height="508" alt="image" src="https://github.com/user-attachments/assets/c15b6b0c-4c97-494e-b6a8-09a177c2cffa" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
