### PR TITLE
feat(DNS): support tags filter

### DIFF
--- a/docs/data-sources/dns_tags_filter.md
+++ b/docs/data-sources/dns_tags_filter.md
@@ -1,0 +1,85 @@
+---
+subcategory: "Domain Name Service (DNS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dns_tags_filter"
+description: |-
+  Use this data source to filter resources by tags.
+---
+
+# huaweicloud_dns_tags_filter
+
+Use this data source to filter resources by tags.
+
+## Example Usage
+
+```hcl
+variable "resource_type" {}
+
+data "huaweicloud_dns_tags_filter" "test" {
+  resource_type = var.resource_type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `resource_type` - (Required, String) Specifies the resource type.
+
+* `matches` - (Optional, List) Specifies the fields to be queried.
+  The [matches](#block--matches) structure is documented below.
+
+* `tags` - (Optional, List) Specifies the list of the tags to be queried.
+  The [tag_values](#block--tag_values) structure is documented below.
+
+* `tags_any` - (Optional, List) Specifies the list of the tags to be queried.
+  The [tag_values](#block--tag_values) structure is documented below.
+
+* `not_tags` - (Optional, List) Specifies the list of the tags to be queried.
+  The [tag_values](#block--tag_values) structure is documented below.
+
+* `not_tags_any` - (Optional, List) Specifies the list of the tags to be queried.
+  The [tag_values](#block--tag_values) structure is documented below.
+
+<a name="block--matches"></a>
+The `matches` block supports:
+
+* `key` - (Required, String) Specifies the key to be matched.
+
+* `value` - (Optional, String) Specifies the value of the matching field.
+
+<a name="block--tag_values"></a>
+The `tag_values` block supports:
+
+* `key` - (Optional, String) Specifies the key of tag.
+
+* `values` - (Optional, List) Specifies the list of values of the tag.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `resources` - Indicates all dedicated resources that match the filter parameters.
+  The [resources](#attrblock--resources) structure is documented below.
+
+<a name="attrblock--resources"></a>
+The `resources` block supports:
+
+* `resource_id` - Indicates the ID of the resource.
+
+* `resource_name` - Indicates the name of the resource.
+
+* `tags` - Indicates the tag list associated with the resource.
+  The [tags](#attrblock--resources--tags) structure is documented below.
+
+<a name="attrblock--resources--tags"></a>
+The `tags` block supports:
+
+* `key` - Indicates the key of the resource tag.
+
+* `value` - Indicates the value of the resource tag.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -940,6 +940,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_recordsets":          dns.DataSourceRecordsets(),
 			"huaweicloud_dns_zones":               dns.DataSourceZones(),
 			"huaweicloud_dns_tags":                dns.DataSourceDNSTags(),
+			"huaweicloud_dns_tags_filter":         dns.DataSourceDNSTagsFilter(),
 
 			"huaweicloud_drs_availability_zones": drs.DataSourceAvailabilityZones(),
 			"huaweicloud_drs_node_types":         drs.DataSourceNodeTypes(),

--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_tags_filter_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_tags_filter_test.go
@@ -1,0 +1,150 @@
+package dns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDnsTagsFilter_basic(t *testing.T) {
+	var (
+		name   = fmt.Sprintf("acpttest-zone-%s.com", acctest.RandString(5))
+		dcName = "data.huaweicloud_dns_tags_filter.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDnsTagsFilter_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dcName, "resources.#"),
+					resource.TestCheckResourceAttrSet(dcName, "resources.0.resource_id"),
+					resource.TestCheckResourceAttrSet(dcName, "resources.0.resource_name"),
+					resource.TestCheckResourceAttrSet(dcName, "resources.0.tags.#"),
+					resource.TestCheckResourceAttrSet(dcName, "resources.0.tags.0.key"),
+					resource.TestCheckResourceAttrSet(dcName, "resources.0.tags.0.value"),
+
+					resource.TestCheckOutput("is_all_tags_result_useful", "true"),
+					resource.TestCheckOutput("is_any_tags_result_useful", "true"),
+					resource.TestCheckOutput("is_without_all_tags_result_useful", "true"),
+					resource.TestCheckOutput("is_without_any_tags_result_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDnsTagsFilter_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+locals {
+  tag_key   = keys(huaweicloud_dns_zone.test.tags)[0]
+  tag_value = huaweicloud_dns_zone.test.tags[local.tag_key]
+}
+
+data "huaweicloud_dns_tags_filter" "test" {
+  depends_on = [huaweicloud_dns_zone.test]
+
+  resource_type = "DNS-public_zone"
+}
+
+# filter by all tags 
+data "huaweicloud_dns_tags_filter" "filter_by_all_tags" {
+  resource_type = "DNS-public_zone"
+
+  tags {
+    key    = local.tag_key
+    values = [local.tag_value]
+  }
+}
+
+locals {
+  all_tag_keys = flatten([
+    for v in data.huaweicloud_dns_tags_filter.filter_by_all_tags.resources : [
+      for tag in v.tags : tag.key
+    ]
+  ])
+}
+
+output "is_all_tags_result_useful" {
+  value = contains(local.all_tag_keys, local.tag_key)
+}
+
+# filter by any tags
+data "huaweicloud_dns_tags_filter" "filter_by_any_tags" {
+  resource_type = "DNS-public_zone"
+
+  tags_any {
+    key    = local.tag_key
+    values = [local.tag_value]
+  }
+}
+
+locals {
+  any_tag_keys = flatten([
+    for v in data.huaweicloud_dns_tags_filter.filter_by_any_tags.resources : [
+      for tag in v.tags : tag.key
+    ]
+  ])
+}
+
+output "is_any_tags_result_useful" {
+  value = contains(local.any_tag_keys, local.tag_key)
+}
+
+# filter by without all tags
+data "huaweicloud_dns_tags_filter" "filter_by_without_all_tags" {
+  resource_type = "DNS-public_zone"
+
+  not_tags {
+    key    = local.tag_key
+    values = [local.tag_value]
+  }
+}
+
+locals {
+  without_all_tag_keys = flatten([
+    for v in data.huaweicloud_dns_tags_filter.filter_by_without_all_tags.resources : [
+      for tag in v.tags : tag.key
+    ]
+  ])
+}
+
+output "is_without_all_tags_result_useful" {
+  value = !contains(local.without_all_tag_keys, local.tag_key)
+}
+
+# filter by without any tags
+data "huaweicloud_dns_tags_filter" "filter_by_without_any_tags" {
+  resource_type = "DNS-public_zone"
+
+  not_tags_any {
+    key    = local.tag_key
+    values = [local.tag_value]
+  }
+}
+
+locals {
+  without_any_tag_keys = flatten([
+    for v in data.huaweicloud_dns_tags_filter.filter_by_without_any_tags.resources : [
+      for tag in v.tags : tag.key
+    ]
+  ])
+}
+
+output "is_without_any_tags_result_useful" {
+  value = !contains(local.without_any_tag_keys, local.tag_key)
+}
+`, testAccDNSZone_basic(name))
+}

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_tags.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_tags.go
@@ -90,7 +90,7 @@ func dataSourceDNSTagsRead(_ context.Context, d *schema.ResourceData, meta inter
 
 // @API DNS GET /v2/{project_id}/{resource_type}/tags
 func (w *TagsDSWrapper) ListTags() (*gjson.Result, error) {
-	client, err := w.NewClient(w.Config, "dns")
+	client, err := w.NewClient(w.Config, "dns_region")
 	if err != nil {
 		return nil, err
 	}

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_tags_filter.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_tags_filter.go
@@ -1,0 +1,269 @@
+package dns
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG POST /v2/{project_id}/{resource_type}/resource_instances/action
+func DataSourceDNSTagsFilter() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDNSTagsFilterRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"resource_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the resource type.`,
+			},
+			"tags": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `Specifies the list of the tags to be queried.`,
+				Elem:        dnsQueriedTagsFilterSchema(),
+			},
+			"tags_any": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `Specifies the list of the tags to be queried.`,
+				Elem:        dnsQueriedTagsFilterSchema(),
+			},
+			"not_tags": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `Specifies the list of the tags to be queried.`,
+				Elem:        dnsQueriedTagsFilterSchema(),
+			},
+			"not_tags_any": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `Specifies the list of the tags to be queried.`,
+				Elem:        dnsQueriedTagsFilterSchema(),
+			},
+			"matches": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `Specifies the fields to be queried.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `Specifies the key to be matched.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the value of the matching field.`,
+						},
+					},
+				},
+			},
+			"resources": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Indicates all dedicated resources that match the filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the ID of the resource.`,
+						},
+						"resource_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the name of the resource.`,
+						},
+						"tags": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `Indicates the tag list associated with the resource.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `Indicates the key of the resource tag.`,
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `Indicates the value of the resource tag.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dnsQueriedTagsFilterSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the key of tag.",
+			},
+			"values": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Specifies the list of values of the tag.",
+			},
+		},
+	}
+}
+
+func dataSourceDNSTagsFilterRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dns_region", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	httpUrl := "v2/{project_id}/{resource_type}/resource_instances/action"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{resource_type}", d.Get("resource_type").(string))
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	offset := 0
+	result := make([]map[string]interface{}, 0)
+	for {
+		listOpt.JSONBody = utils.RemoveNil(buildGetDNSTagsBodyParams(d, offset))
+		requestResp, err := client.Request("POST", listPath, &listOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DNS resources: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		resources := utils.PathSearch("resources", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, flattenDNSTagsResp(resources)...)
+		if len(resources) == 0 {
+			break
+		}
+
+		offset += len(resources)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("resources", result),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildGetDNSTagsBodyParams(d *schema.ResourceData, offset int) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"limit":        100,
+		"offset":       offset,
+		"action":       "filter",
+		"tags":         buildGetResourceTagsBodyParams(d.Get("tags").([]interface{})),
+		"tags_any":     buildGetResourceTagsBodyParams(d.Get("tags_any").([]interface{})),
+		"not_tags":     buildGetResourceTagsBodyParams(d.Get("not_tags").([]interface{})),
+		"not_tags_any": buildGetResourceTagsBodyParams(d.Get("not_tags_any").([]interface{})),
+		"matches":      buildGetResourceMatchesBodyParams(d.Get("matches").([]interface{})),
+	}
+	return bodyParams
+}
+
+func buildGetResourceTagsBodyParams(tags []interface{}) []map[string]interface{} {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	res := make([]map[string]interface{}, len(tags))
+	for i, tagRaw := range tags {
+		if tag, ok := tagRaw.(map[string]interface{}); ok {
+			res[i] = map[string]interface{}{
+				// require empty value
+				"key":    tag["key"],
+				"values": tag["values"],
+			}
+		}
+	}
+	return res
+}
+
+func buildGetResourceMatchesBodyParams(matches []interface{}) []map[string]interface{} {
+	if len(matches) == 0 {
+		return nil
+	}
+
+	res := make([]map[string]interface{}, len(matches))
+	for i, matchRaw := range matches {
+		if match, ok := matchRaw.(map[string]interface{}); ok {
+			res[i] = map[string]interface{}{
+				// require empty value
+				"key":   match["key"],
+				"value": match["value"],
+			}
+		}
+	}
+	return res
+}
+
+func flattenDNSTagsResp(resources []interface{}) []map[string]interface{} {
+	if len(resources) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, len(resources))
+	for i, v := range resources {
+		rst[i] = map[string]interface{}{
+			"resource_id":   utils.PathSearch("resource_id", v, nil),
+			"resource_name": utils.PathSearch("resource_name", v, nil),
+			"tags":          flattenResourceResourceTagsResp(utils.PathSearch("tags", v, make([]interface{}, 0)).([]interface{})),
+		}
+	}
+	return rst
+}
+
+func flattenResourceResourceTagsResp(tags []interface{}) []interface{} {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(tags))
+	for i, tag := range tags {
+		rst[i] = map[string]interface{}{
+			"key":   utils.PathSearch("key", tag, nil),
+			"value": utils.PathSearch("value", tag, nil),
+		}
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dns TESTARGS='-run TestAccDataSourceDNSTags_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDataSourceDNSTags_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDNSTags_basic
=== PAUSE TestAccDataSourceDNSTags_basic
=== CONT  TestAccDataSourceDNSTags_basic
--- PASS: TestAccDataSourceDNSTags_basic (26.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       26.491s

make testacc TEST=./huaweicloud/services/acceptance/dns TESTARGS='-run TestAccDataSourceDnsTagsFilter_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDataSourceDnsTagsFilter_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDnsTagsFilter_basic
=== PAUSE TestAccDataSourceDnsTagsFilter_basic
=== CONT  TestAccDataSourceDnsTagsFilter_basic
--- PASS: TestAccDataSourceDnsTagsFilter_basic (27.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       27.182s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
