### PR TITLE
feat(secmaster): add datasource to get list of layout wizards under a specify layout

### DIFF
--- a/docs/data-sources/secmaster_layout_wizards.md
+++ b/docs/data-sources/secmaster_layout_wizards.md
@@ -1,0 +1,87 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_layout_wizards"
+description: |-
+  Use this data source to get the list of layout wizards under a specified layout.
+---
+
+# huaweicloud_secmaster_layout_wizards
+
+Use this data source to get the list of layout wizards under a specified layout.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "layout_id" {}
+
+data "huaweicloud_secmaster_layout_wizards" "test" {
+  workspace_id = var.workspace_id
+  layout_id    = var.layout_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID.
+
+* `layout_id` - (Required, String) Specifies the layout ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data` - The list of layout wizards.
+
+  The [data](#data_struct) structure is documented below.
+
+<a name="data_struct"></a>
+The `data` block supports:
+
+* `id` - The layout wizard ID.
+
+* `name` - The layout wizard name.
+
+* `en_name` - The layout wizard English name.
+
+* `description` - The layout wizard description.
+
+* `en_description` - The layout wizard English description.
+
+* `wizard_json` - The layout wizard related information.
+
+* `creator_id` - The creator ID.
+
+* `create_time` - The creation time.
+
+* `update_time` - The update time.
+
+* `project_id` - The project ID.
+
+* `workspace_id` - The workspace ID.
+
+* `is_binding` - Whether bound the button.
+
+* `binding_button` - The binding button information.
+  The [binding_button](#data_binding_button_struct) structure is documented below.
+
+* `is_built_in` - Whether the page is a system page.
+
+* `boa_version` - The BOA base version.
+
+* `version` - The Secmaster version.
+
+<a name="data_binding_button_struct"></a>
+The `binding_button` block supports:
+
+* `button_id` - The button ID.
+
+* `button_name` - The button name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1415,6 +1415,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_incidents":                 secmaster.DataSourceIncidents(),
 			"huaweicloud_secmaster_alerts":                    secmaster.DataSourceAlerts(),
 			"huaweicloud_secmaster_indicators":                secmaster.DataSourceIndicators(),
+			"huaweicloud_secmaster_layout_wizards":            secmaster.DataSourceLayoutWizards(),
 			"huaweicloud_secmaster_metric_results":            secmaster.DataSourceMetricResults(),
 			"huaweicloud_secmaster_baseline_check_results":    secmaster.DataSourceSecmasterBaselineCheckResults(),
 			"huaweicloud_secmaster_playbooks":                 secmaster.DataSourceSecmasterPlaybooks(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_layout_wizards_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_layout_wizards_test.go
@@ -1,0 +1,57 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceLayoutWizards_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_secmaster_layout_wizards.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+			acceptance.TestAccPreCheckSecMasterLayoutID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceLayoutWizards_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.wizard_json"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.creator_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.update_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.project_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.workspace_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.is_binding"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.binding_button.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.binding_button.0.button_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.binding_button.0.button_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.version"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceLayoutWizards_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_layout_wizards" "test" {
+  workspace_id = "%[1]s"
+  layout_id    = "%[2]s"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID, acceptance.HW_SECMASTER_LAYOUT_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_layout_wizards.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_layout_wizards.go
@@ -1,0 +1,217 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Secmaster GET /v1/{project_id}/workspaces/{workspace_id}/soc/layouts/{layout_id}/wizards
+func DataSourceLayoutWizards() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceLayoutWizardsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"layout_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"en_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"en_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"wizard_json": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creator_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"workspace_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_binding": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"binding_button": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"button_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"button_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"is_built_in": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"boa_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceLayoutWizardsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/workspaces/{workspace_id}/soc/layouts/{layout_id}/wizards"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{workspace_id}", d.Get("workspace_id").(string))
+	listPath = strings.ReplaceAll(listPath, "{layout_id}", d.Get("layout_id").(string))
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	listResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving layout wizards: %s", err)
+	}
+
+	listRespBody, err := utils.FlattenResponse(listResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataList := utils.PathSearch("data", listRespBody, make([]interface{}, 0)).([]interface{})
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data", flattenLayoutWizards(dataList)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenLayoutWizards(wizards []interface{}) []interface{} {
+	if len(wizards) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(wizards))
+	for _, v := range wizards {
+		result = append(result, map[string]interface{}{
+			"id":             utils.PathSearch("id", v, nil),
+			"name":           utils.PathSearch("name", v, nil),
+			"en_name":        utils.PathSearch("en_name", v, nil),
+			"description":    utils.PathSearch("description", v, nil),
+			"en_description": utils.PathSearch("en_description", v, nil),
+			"wizard_json":    utils.PathSearch("wizard_json", v, nil),
+			"creator_id":     utils.PathSearch("creator_id", v, nil),
+			"create_time":    utils.PathSearch("create_time", v, nil),
+			"update_time":    utils.PathSearch("update_time", v, nil),
+			"project_id":     utils.PathSearch("project_id", v, nil),
+			"workspace_id":   utils.PathSearch("workspace_id", v, nil),
+			"is_binding":     utils.PathSearch("is_binding", v, nil),
+			"binding_button": flattenBindingButtons(utils.PathSearch("binding_buttons", v, make([]interface{}, 0)).([]interface{})),
+			"is_built_in":    utils.PathSearch("is_built_in", v, nil),
+			"boa_version":    utils.PathSearch("boa_version", v, nil),
+			"version":        utils.PathSearch("version", v, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenBindingButtons(buttons []interface{}) []interface{} {
+	if len(buttons) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(buttons))
+	for _, v := range buttons {
+		result = append(result, map[string]interface{}{
+			"button_id":   utils.PathSearch("button_id", v, nil),
+			"button_name": utils.PathSearch("button_name", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add datasource to get list of layout wizards under a specify layout.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/secmaster" TESTARGS="-run TestAccDataSourceLayoutWizards_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/secmaster -v -run TestAccDataSourceLayoutWizards_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceLayoutWizards_basic
=== PAUSE TestAccDataSourceLayoutWizards_basic
=== CONT  TestAccDataSourceLayoutWizards_basic
--- PASS: TestAccDataSourceLayoutWizards_basic (19.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 19.361s
```
<img width="1108" height="41" alt="image" src="https://github.com/user-attachments/assets/92b12db4-ef74-4341-846a-b4db8ae7e140" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
