### PR TITLE
feat(workspace): add new resource to create or authorize bucket

### DIFF
--- a/docs/resources/workspace_app_bucket_authorize.md
+++ b/docs/resources/workspace_app_bucket_authorize.md
@@ -1,0 +1,37 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_bucket_authorize"
+description: |-
+  Use this resource to create or authorize a bucket for the Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_bucket_authorize
+
+Use this resource to create or authorize a bucket for the Workspace APP within HuaweiCloud.
+
+-> 1. If the bucket does not exist, using this resource automatically creates an OBS bucket in the specified region,
+   the bucket name consists of `wks-app` and the current project ID, separated by a hyphen (-).
+   e.g. `wks-app-0970dd7a1300f5672ff2c003c60ae115`.
+   <br>2. This resource is a one-time operation resource used to create or authorize an OBS bucket. Deleting this resource
+   will not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_workspace_app_bucket_authorize" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the OBS bucket and the application to be
+  authorized are located.  
+  If omitted, the provider-level region will be used. Changing this will create new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2914,6 +2914,7 @@ func Provider() *schema.Provider {
 
 			// Workspace APP
 			"huaweicloud_workspace_app_application_batch_attach":        workspace.ResourceAppApplicationBatchAttach(),
+			"huaweicloud_workspace_app_bucket_authorize":                workspace.ResourceAppBucketAuthorize(),
 			"huaweicloud_workspace_app_group_authorization":             workspace.ResourceAppGroupAuthorization(),
 			"huaweicloud_workspace_app_group":                           workspace.ResourceWorkspaceAppGroup(),
 			"huaweicloud_workspace_app_image_server":                    workspace.ResourceAppImageServer(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_bucket_authorize_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_bucket_authorize_test.go
@@ -1,0 +1,50 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceAppBucketAuthorize_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceAppBucketAuthorize_basic(),
+				Check:  resource.TestCheckOutput("is_success", "true"),
+			},
+		},
+	})
+}
+
+func testAccResourceAppBucketAuthorize_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_app_bucket_authorize" "test" {}
+
+data "huaweicloud_identity_projects" "test" {
+  name = "%[1]s"
+}
+
+locals {
+  bucket_name = format("wks-app-%%s", data.huaweicloud_identity_projects.test.projects[0].id)
+}
+
+# Exactly match the bucket name.
+data "huaweicloud_obs_buckets" "test" {
+  depends_on = [huaweicloud_workspace_app_bucket_authorize.test]
+  bucket     = local.bucket_name
+}
+
+output "is_success" {
+  value = try(data.huaweicloud_obs_buckets.test.buckets[0].bucket == local.bucket_name, false)
+}
+`, acceptance.HW_REGION_NAME)
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_bucket_authorize.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_bucket_authorize.go
@@ -1,0 +1,78 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API Workspace POST /v1/{project_id}/app-warehouse/bucket-and-acl/create
+func ResourceAppBucketAuthorize() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppBucketAuthorizeCreate,
+		ReadContext:   resourceAppBucketAuthorizeRead,
+		DeleteContext: resourceAppBucketAuthorizeDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the OBS bucket and the application to be authorized are located.`,
+			},
+		},
+	}
+}
+
+func resourceAppBucketAuthorizeCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v1/{project_id}/app-warehouse/bucket-and-acl/create"
+	)
+
+	client, err := cfg.NewServiceClient("appstream", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating OBS bucket or authorization: %s", err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomId)
+
+	return nil
+}
+
+func resourceAppBucketAuthorizeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppBucketAuthorizeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time operation resource used to create or authorize an OBS bucket. Deleting this resource
+will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new resource (`huaweicloud_workspace_app_bucket_authorize`) to create or authorize an OBS bucket.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new resource.
2. add corresponding documation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ../scripts/coverage.sh -o workspace -f TestAccResourceAppBucketAuthorize_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceAppBucketAuthorize_basic -timeout 360m -parallel 10

=== RUN   TestAccResourceAppBucketAuthorize_basic
=== PAUSE TestAccResourceAppBucketAuthorize_basic
=== CONT  TestAccResourceAppBucketAuthorize_basic
--- PASS: TestAccResourceAppBucketAuthorize_basic (31.63s)
PASS
coverage: 2.7% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 31.800s coverage: 2.7% of statements in ./huaweicloud/services/workspace
```
<img width="1075" height="505" alt="image" src="https://github.com/user-attachments/assets/743f752a-e08c-4427-93ee-719e00d8ce7a" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
