### PR TITLE
chore(workspace/app): rename warehouse application resource

### DIFF
--- a/docs/resources/workspace_app_warehouse_application.md
+++ b/docs/resources/workspace_app_warehouse_application.md
@@ -1,12 +1,12 @@
 ---
 subcategory: "Workspace"
 layout: "huaweicloud"
-page_title: "HuaweiCloud: huaweicloud_workspace_app_warehouse_app"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_warehouse_application"
 description: |-
   Manages an application resource of Workspace APP warehouse within HuaweiCloud.
 ---
 
-# huaweicloud_workspace_app_warehouse_app
+# huaweicloud_workspace_app_warehouse_application
 
 Manages an application resource of Workspace APP warehouse within HuaweiCloud.
 
@@ -18,7 +18,7 @@ var "version" {}
 var "version_name" {}
 var "file_store_obs_path" {}
 
-resource "huaweicloud_workspace_app_warehouse_app" "test" {
+resource "huaweicloud_workspace_app_warehouse_application" "test" {
   name            = var.application_name
   category        = "OTHER"
   os_type         = "Windows"
@@ -89,7 +89,7 @@ In addition to all arguments above, the following attributes are exported:
 The resource can be imported using `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_workspace_app_warehouse_app.test <id>
+$ terraform import huaweicloud_workspace_app_warehouse_application.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
@@ -100,7 +100,7 @@ You can then decide if changes should be applied to the instance, or the resourc
 align with the instance. Also you can ignore changes as below.
 
 ```hcl
-resource "huaweicloud_workspace_app_warehouse_app" "test" {
+resource "huaweicloud_workspace_app_warehouse_application" "test" {
   ...
 
   lifecycle {

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2934,7 +2934,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_server_batch_action":             workspace.ResourceAppServerBatchAction(),
 			"huaweicloud_workspace_app_shared_folder":                   workspace.ResourceAppSharedFolder(),
 			"huaweicloud_workspace_app_storage_policy":                  workspace.ResourceAppStoragePolicy(),
-			"huaweicloud_workspace_app_warehouse_app":                   workspace.ResourceWarehouseApplication(),
+			"huaweicloud_workspace_app_warehouse_application":           workspace.ResourceAppWarehouseApplication(),
 
 			"huaweicloud_cpts_project": cpts.ResourceProject(),
 			"huaweicloud_cpts_task":    cpts.ResourceTask(),
@@ -3184,6 +3184,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_batchtask_file": deprecated.ResourceBatchTaskFile(),
 
 			"huaweicloud_images_image": deprecated.ResourceImsImage(),
+
+			"huaweicloud_workspace_app_warehouse_app": workspace.ResourceAppWarehouseApplication(),
 		},
 	}
 

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_warehouse_applications_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_warehouse_applications_test.go
@@ -168,5 +168,5 @@ locals {
 output "is_verify_status_filter_useful" {
   value = length(local.verify_status_filter_result) > 0 && alltrue(local.verify_status_filter_result)
 }
-`, testAccWarehouseApp_basic_step1(name))
+`, testAccResourceWarehouseApplication_basic_step1(name))
 }

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_warehouse_application_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_warehouse_application_test.go
@@ -20,10 +20,10 @@ func getWarehouseApplicationFunc(conf *config.Config, state *terraform.ResourceS
 	return workspace.GetWarehouseApplicationById(client, state.Primary.ID)
 }
 
-func TestAccAppWarehouseApp_basic(t *testing.T) {
+func TestAccResourceAppWarehouseApplication_basic(t *testing.T) {
 	var (
 		application  interface{}
-		resourceName = "huaweicloud_workspace_app_warehouse_app.test"
+		resourceName = "huaweicloud_workspace_app_warehouse_application.test"
 		name         = acceptance.RandomAccResourceName()
 		updateName   = acceptance.RandomAccResourceName()
 		rc           = acceptance.InitResourceCheck(
@@ -48,7 +48,7 @@ func TestAccAppWarehouseApp_basic(t *testing.T) {
 		CheckDestroy: rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWarehouseApp_basic_step1(name),
+				Config: testAccResourceWarehouseApplication_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -62,7 +62,7 @@ func TestAccAppWarehouseApp_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccWarehouseApp_basic_step2(updateName),
+				Config: testAccResourceWarehouseApplication_basic_step2(updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
@@ -128,11 +128,11 @@ resource "huaweicloud_obs_bucket_object" "test" {
 }`, acceptance.HW_REGION_NAME, acceptance.HW_WORKSPACE_APP_FILE_NAME)
 }
 
-func testAccWarehouseApp_basic_step1(name string) string {
+func testAccResourceWarehouseApplication_basic_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_workspace_app_warehouse_app" "test" {
+resource "huaweicloud_workspace_app_warehouse_application" "test" {
   name            = "%[2]s"
   category        = "OTHER"
   os_type         = "Windows"
@@ -144,11 +144,11 @@ resource "huaweicloud_workspace_app_warehouse_app" "test" {
 `, executionFileUploadResourcesConfig(), name, acceptance.HW_WORKSPACE_APP_FILE_NAME)
 }
 
-func testAccWarehouseApp_basic_step2(name string) string {
+func testAccResourceWarehouseApplication_basic_step2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_workspace_app_warehouse_app" "test" {
+resource "huaweicloud_workspace_app_warehouse_application" "test" {
   name            = "%[2]s"
   category        = "PRODUCTIVITY_AND_COLLABORATION"
   os_type         = "Linux"

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_warehouse_application.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_warehouse_application.go
@@ -20,12 +20,12 @@ import (
 // @API Workspace GET /v1/{project_id}/app-warehouse/apps
 // @API Workspace PATCH /v1/{project_id}/app-warehouse/apps/{id}
 // @API Workspace DELETE /v1/{project_id}/app-warehouse/apps/{id}
-func ResourceWarehouseApplication() *schema.Resource {
+func ResourceAppWarehouseApplication() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceWarehouseApplicationCreate,
-		ReadContext:   resourceWarehouseApplicationRead,
-		UpdateContext: resourceWarehouseApplicationUpdate,
-		DeleteContext: resourceWarehouseApplicationDelete,
+		CreateContext: resourceAppWarehouseApplicationCreate,
+		ReadContext:   resourceAppWarehouseApplicationRead,
+		UpdateContext: resourceAppWarehouseApplicationUpdate,
+		DeleteContext: resourceAppWarehouseApplicationDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -88,7 +88,7 @@ func ResourceWarehouseApplication() *schema.Resource {
 	}
 }
 
-func resourceWarehouseApplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAppWarehouseApplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	httpUrl := "v1/{project_id}/app-warehouse/apps"
 	client, err := cfg.NewServiceClient("appstream", cfg.GetRegion(d))
@@ -100,7 +100,7 @@ func resourceWarehouseApplicationCreate(ctx context.Context, d *schema.ResourceD
 	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
 	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateWarehouseAppBodyParams(d)),
+		JSONBody:         utils.RemoveNil(buildCreateWarehouseApplicationBodyParams(d)),
 	}
 	requestResp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
@@ -117,10 +117,10 @@ func resourceWarehouseApplicationCreate(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("unable to find application ID from API response")
 	}
 	d.SetId(applicationId)
-	return resourceWarehouseApplicationRead(ctx, d, meta)
+	return resourceAppWarehouseApplicationRead(ctx, d, meta)
 }
 
-func buildCreateWarehouseAppBodyParams(d *schema.ResourceData) map[string]interface{} {
+func buildCreateWarehouseApplicationBodyParams(d *schema.ResourceData) map[string]interface{} {
 	return map[string]interface{}{
 		"app_name":           d.Get("name"),
 		"app_category":       d.Get("category"),
@@ -133,7 +133,7 @@ func buildCreateWarehouseAppBodyParams(d *schema.ResourceData) map[string]interf
 	}
 }
 
-func resourceWarehouseApplicationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAppWarehouseApplicationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg    = meta.(*config.Config)
 		region = cfg.GetRegion(d)
@@ -193,7 +193,7 @@ func GetWarehouseApplicationById(client *golangsdk.ServiceClient, applicationId 
 	return application, nil
 }
 
-func resourceWarehouseApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAppWarehouseApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := cfg.NewServiceClient("appstream", cfg.GetRegion(d))
 	if err != nil {
@@ -208,7 +208,7 @@ func resourceWarehouseApplicationUpdate(ctx context.Context, d *schema.ResourceD
 		updatePath = strings.ReplaceAll(updatePath, "{id}", applicationId)
 		updateOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			JSONBody:         utils.RemoveNil(buildUpdateWarehouseAppBodyParams(d)),
+			JSONBody:         utils.RemoveNil(buildUpdateWarehouseApplicationBodyParams(d)),
 		}
 
 		_, err := client.Request("PATCH", updatePath, &updateOpt)
@@ -217,10 +217,10 @@ func resourceWarehouseApplicationUpdate(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
-	return resourceWarehouseApplicationRead(ctx, d, meta)
+	return resourceAppWarehouseApplicationRead(ctx, d, meta)
 }
 
-func buildUpdateWarehouseAppBodyParams(d *schema.ResourceData) map[string]interface{} {
+func buildUpdateWarehouseApplicationBodyParams(d *schema.ResourceData) map[string]interface{} {
 	return map[string]interface{}{
 		"app_name":        utils.ValueIgnoreEmpty(d.Get("name")),
 		"app_category":    utils.ValueIgnoreEmpty(d.Get("category")),
@@ -232,7 +232,7 @@ func buildUpdateWarehouseAppBodyParams(d *schema.ResourceData) map[string]interf
 	}
 }
 
-func resourceWarehouseApplicationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAppWarehouseApplicationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	httpUrl := "v1/{project_id}/app-warehouse/apps/{id}"
 	client, err := cfg.NewServiceClient("appstream", cfg.GetRegion(d))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Rename warehouse application resource and related method.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Rename 'huaweicloud_workspace_app_warehouse_app' to 'huaweicloud_workspace_app_warehouse_application'.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o workspace -f TestAccResourceAppWarehouseApplication_basic 
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceAppWarehouseApplication_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceAppWarehouseApplication_basic
=== PAUSE TestAccResourceAppWarehouseApplication_basic
=== CONT  TestAccResourceAppWarehouseApplication_basic
--- PASS: TestAccResourceAppWarehouseApplication_basic (91.72s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 91.942s coverage: 3.7% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
