### PR TITLE
fix(workspace/app): modify incorrect parameter naming

### DIFF
--- a/docs/resources/workspace_app_application_batch_attach.md
+++ b/docs/resources/workspace_app_application_batch_attach.md
@@ -17,13 +17,13 @@ Use this resource to attach applications to Workspace APP image instance in Huaw
 
 ```hcl
 variable "server_id" {}
-variable "applications_ids" {
+variable "record_ids" {
   type = list(string)
 }
 
 resource "huaweicloud_workspace_app_application_batch_attach" "test" {
-  server_id        = var.server_id
-  applications_ids = var.applications_ids
+  server_id  = var.server_id
+  record_ids = var.record_ids
 }
 ```
 
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `server_id` - (Required, String) Specifies the ID of the image server instance.
 
-* `applications_ids` - (Required, List) Specifies the list of application IDs to be attach.
+* `record_ids` - (Required, List) Specifies the list of application record IDs to be attach.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_application_batch_attach_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_application_batch_attach_test.go
@@ -42,7 +42,8 @@ func TestAccResourceAppApplicationBatchAttach_basic(t *testing.T) {
 			{
 				Config: testAccResourceAppApplicationBatchAttach_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceName, "applications_ids.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestMatchResourceAttr(resourceName, "record_ids.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(resourceName, "uri"),
 				),
 			},
 		},
@@ -52,8 +53,8 @@ func TestAccResourceAppApplicationBatchAttach_basic(t *testing.T) {
 func testAccResourceAppApplicationBatchAttach_expectError(randomId string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_workspace_app_application_batch_attach" "expectError" {
-  server_id        = "%[1]s"
-  applications_ids = ["%[1]s"]
+  server_id  = "%[1]s"
+  record_ids = ["%[1]s"]
 }
 `, randomId)
 }
@@ -166,8 +167,8 @@ func testAccResourceAppApplicationBatchAttach_basic(name string) string {
 %[1]s
 
 resource "huaweicloud_workspace_app_application_batch_attach" "test" {
-  server_id        = huaweicloud_workspace_app_image_server.test.id
-  applications_ids = [huaweicloud_workspace_app_warehouse_app.test.id]
+  server_id  = huaweicloud_workspace_app_image_server.test.id
+  record_ids = [huaweicloud_workspace_app_warehouse_app.test.record_id]
 }
 `, testAccResourceAppApplicationBatchAttach_base(name))
 }

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_application_batch_attach.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_application_batch_attach.go
@@ -15,7 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-var applicationBatchAttachNonUpdateParams = []string{"server_id", "applications_ids"}
+var applicationBatchAttachNonUpdateParams = []string{"server_id", "record_ids"}
 
 // @API Workspace POST /v1/{project_id}/image-servers/{server_id}/actions/attach-app
 func ResourceAppApplicationBatchAttach() *schema.Resource {
@@ -40,11 +40,11 @@ func ResourceAppApplicationBatchAttach() *schema.Resource {
 				Required:    true,
 				Description: `The ID of the image server instance.`,
 			},
-			"applications_ids": {
+			"record_ids": {
 				Type:        schema.TypeList,
 				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: `The list of application IDs to be attach.`,
+				Description: `The list of application record IDs to be attach.`,
 			},
 			"uri": {
 				Type:        schema.TypeString,
@@ -80,7 +80,7 @@ func resourceAppApplicationBatchAttachCreate(_ context.Context, d *schema.Resour
 	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		JSONBody: map[string]interface{}{
-			"items": utils.ExpandToStringList(d.Get("applications_ids").([]interface{})),
+			"items": utils.ExpandToStringList(d.Get("record_ids").([]interface{})),
 		},
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Modify incorrect parameter naming of the resource (`huaweicloud_workspace_app_application_batch_attach`).

The interface parameter corresponding to this resource should be the application record IDs instead of the application IDs.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o workspace -f TestAccResourceAppApplicationBatchAttach_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceAppApplicationBatchAttach_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceAppApplicationBatchAttach_basic
=== PAUSE TestAccResourceAppApplicationBatchAttach_basic
=== CONT  TestAccResourceAppApplicationBatchAttach_basic
--- PASS: TestAccResourceAppApplicationBatchAttach_basic (660.65s)
PASS
coverage: 7.4% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 660.835s        coverage: 7.4% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
