### PR TITLE
feat(workspace/app): supports new data source to query HDA upgrade records

### DIFF
--- a/docs/data-sources/workspace_app_hda_upgrade_records.md
+++ b/docs/data-sources/workspace_app_hda_upgrade_records.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_hda_upgrade_records"
+description: |-
+  Use this data source to get HDA upgrade records of the Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_hda_upgrade_records
+
+Use this data source to get HDA upgrade records of the Workspace APP within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_workspace_app_hda_upgrade_records" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the HDA upgrade records are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `records` - The list of HDA upgrade records that matched filter parameters.  
+  The [records](#workspace_app_hda_upgrade_records) structure is documented below.
+
+<a name="workspace_app_hda_upgrade_records"></a>
+The `records` block supports:
+
+* `server_id` - The ID of the server.
+
+* `machine_name` - The machine name of the server.
+
+* `server_name` - The name of the server.
+
+* `server_group_name` - The name of the server group.
+
+* `sid` - The SID of the server.
+
+* `current_version` - The current version of the access agent.
+
+* `target_version` - The target version of the access agent.
+
+* `upgrade_status` - The HDA upgrade status.
+  + **SUCCESS**: Upgrade completed successfully
+  + **FAILED**: Upgrade failed
+  + **PENDING**: Upgrade pending
+  + **RUNNING**: Upgrade in progress
+
+* `upgrade_time` - The upgrade time, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1657,6 +1657,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_groups":                          workspace.DataSourceWorkspaceAppGroups(),
 			"huaweicloud_workspace_app_hda_configurations":              workspace.DataSourceAppHdaConfigurations(),
 			"huaweicloud_workspace_app_hda_latest_versions":             workspace.DataSourceAppHdaLatestVersions(),
+			"huaweicloud_workspace_app_hda_upgrade_records":             workspace.DataSourceAppHdaUpgradeRecords(),
 			"huaweicloud_workspace_app_ies_availability_zones":          workspace.DataSourceIesAvailabilityZones(),
 			"huaweicloud_workspace_app_image_servers":                   workspace.DataSourceWorkspaceAppImageServers(),
 			"huaweicloud_workspace_app_nas_storages":                    workspace.DataSourceAppNasStorages(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_hda_upgrade_records_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_hda_upgrade_records_test.go
@@ -1,0 +1,44 @@
+package workspace
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataAppHdaUpgradeRecords_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_workspace_app_hda_upgrade_records.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataAppHdaUpgradeRecords_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					// The server_id, machine_name, server_name, server_group_name are empty, unknown these fields which
+					// scenarios will be returned currently.
+					resource.TestMatchResourceAttr(all, "records.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "records.0.sid"),
+					resource.TestCheckResourceAttrSet(all, "records.0.current_version"),
+					resource.TestCheckResourceAttrSet(all, "records.0.target_version"),
+					resource.TestCheckResourceAttrSet(all, "records.0.upgrade_status"),
+					resource.TestCheckResourceAttrSet(all, "records.0.upgrade_time"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataAppHdaUpgradeRecords_basic = `
+data "huaweicloud_workspace_app_hda_upgrade_records" "test" {}
+`

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_hda_upgrade_records.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_hda_upgrade_records.go
@@ -1,0 +1,185 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/app-servers/access-agent/upgrade-record
+func DataSourceAppHdaUpgradeRecords() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppHdaUpgradeRecordsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the HDA upgrade records are located.`,
+			},
+
+			// Attributes.
+			"records": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of HDA upgrade records that matched filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"server_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the server.`,
+						},
+						"machine_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The machine name of the server.`,
+						},
+						"server_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the server.`,
+						},
+						"server_group_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the server group.`,
+						},
+						"sid": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The SID of the server.`,
+						},
+						"current_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The current version of the access agent.`,
+						},
+						"target_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The target version of the access agent.`,
+						},
+						"upgrade_status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The HDA upgrade status.`,
+						},
+						"upgrade_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The upgrade time.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func listAppHdaUpgradeRecords(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/app-servers/access-agent/upgrade-record?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		items := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, items...)
+		if len(items) < limit {
+			break
+		}
+
+		offset += len(items)
+	}
+
+	return result, nil
+}
+
+func flattenAppHdaUpgradeRecords(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(items))
+	for i, item := range items {
+		result[i] = map[string]interface{}{
+			"server_id":         utils.PathSearch("server_id", item, nil),
+			"machine_name":      utils.PathSearch("machine_name", item, nil),
+			"server_name":       utils.PathSearch("server_name", item, nil),
+			"server_group_name": utils.PathSearch("server_group_name", item, nil),
+			"sid":               utils.PathSearch("sid", item, nil),
+			"current_version":   utils.PathSearch("current_version", item, nil),
+			"target_version":    utils.PathSearch("target_version", item, nil),
+			"upgrade_status":    utils.PathSearch("upgrade_status", item, nil),
+			"upgrade_time": utils.FormatTimeStampRFC3339(
+				utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("upgrade_time", item, "").(string))/1000,
+				false,
+			),
+		}
+	}
+
+	return result
+}
+
+func dataSourceAppHdaUpgradeRecordsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	records, err := listAppHdaUpgradeRecords(client)
+	if err != nil {
+		return diag.Errorf("error querying HDA upgrade records: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("records", flattenAppHdaUpgradeRecords(records)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source to query HDA upgrade records of the Workpsace APP service.
<img width="538" height="754" alt="image" src="https://github.com/user-attachments/assets/54b954fd-f2cb-4d27-9d89-fd1e3b7e347a" />

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new data source to query HDA upgrade records.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataAppHdaUpgradeRecords_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAppHdaUpgradeRecords_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAppHdaUpgradeRecords_basic
=== PAUSE TestAccDataAppHdaUpgradeRecords_basic
=== CONT  TestAccDataAppHdaUpgradeRecords_basic
--- PASS: TestAccDataAppHdaUpgradeRecords_basic (8.37s)
PASS
coverage: 3.1% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 8.445s  coverage: 3.1% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
