### PR TITLE
feat(sfsturbo): add resource to manage ad domain

### DIFF
--- a/docs/resources/sfs_turbo_ad_domain.md
+++ b/docs/resources/sfs_turbo_ad_domain.md
@@ -1,0 +1,116 @@
+---
+subcategory: "SFS Turbo"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_sfs_turbo_ad_domain"
+description: |-
+  Use this resource to manage the AD domain of the SFS turbo within HuaweiCloud.
+---
+
+# huaweicloud_sfs_turbo_ad_domain
+
+Use this resource to manage the AD domain of the SFS turbo within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "share_id" {}
+variable "service_account" {}
+variable "password" {}
+variable "domain_name" {}
+variable "system_name" {}
+variable "dns_server" {
+  type = list(string)
+}
+variable "organization_unit" {}
+variable "vpc_id" {}
+
+resource "huaweicloud_sfs_turbo_ad_domain" "test" {
+  share_id               = var.share_id
+  service_account        = var.service_account
+  password               = var.password
+  domain_name            = var.domain_name
+  system_name            = var.system_name
+  dns_server             = var.dns_server
+  overwrite_same_account = false
+  organization_unit      = var.organization_unit
+  vpc_id                 = var.vpc_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `share_id` - (Required, String, NonUpdatable) Specifies the ID of the SFS Turbo.
+
+* `service_account` - (Required, String) Specifies the service account, which is specified when the domain
+  server is created, **administrator** is used normally.
+
+* `password` - (Required, String) Specifies the password of the service account.
+
+* `domain_name` - (Required, String) Specifies the domain name of the domain controller. It is specified when the
+  domain server is created.
+
+* `system_name` - (Required, String) Specifies the name of the file storage system in the AD domain.
+
+* `dns_server` - (Required, List) Specifies the IP address of the DNS server. It is used to resolve the AD domain
+  name.
+
+* `overwrite_same_account` - (Optional, Bool) Whether overwrite the existing information in the domain controller.
+  If the option is enabled and the domain controller already has the file system name you specified, the information
+  you specified will be overwrited.
+
+* `organization_unit` - (Optional, String) Specifies the  group of domain objects, such as users, computers,
+  and printers. If you add the file system to an organizational unit (OU), it will become a member of that OU.
+  If this parameter is left blank, the file system will be added to the computers OU.
+
+* `vpc_id` - (Optional, String) Specifies the VPC ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - The current status of the AD domain. Possible values are: **JOINING**, **AVAILABLE**, **EXITING**
+  and **FAILED**.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The SFS Turbo AD domain can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_sfs_turbo_ad_domain.test <id>
+```
+
+```
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `share_id`, `service_account`, `password`,
+`overwrite_same_account`. It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the snapshot group. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_sfs_turbo_ad_domain" "test" {
+    ...
+  lifecycle {
+    ignore_changes = [
+      share_id,
+      service_account,
+      password,
+      overwrite_same_account,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2746,6 +2746,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_servicestagev3_runtime_stack_batch_release": servicestage.ResourceV3RuntimeStackBatchRelease(),
 
 			"huaweicloud_sfs_turbo":                    sfsturbo.ResourceSFSTurbo(),
+			"huaweicloud_sfs_turbo_ad_domain":          sfsturbo.ResourceSFSTurboAdDomain(),
 			"huaweicloud_sfs_turbo_cold_data_eviction": sfsturbo.ResourceColdDataEviction(),
 			"huaweicloud_sfs_turbo_dir":                sfsturbo.ResourceSfsTurboDir(),
 			"huaweicloud_sfs_turbo_dir_quota":          sfsturbo.ResourceSfsTurboDirQuota(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -673,10 +673,13 @@ var (
 	HW_DMS_ROCKETMQ_TOPIC_NAME  = os.Getenv("HW_DMS_ROCKETMQ_TOPIC_NAME")
 	HW_DMS_ROCKETMQ_GROUP_NAME  = os.Getenv("HW_DMS_ROCKETMQ_GROUP_NAME")
 
-	HW_SFS_TURBO_SHARE_ID           = os.Getenv("HW_SFS_TURBO_SHARE_ID")
-	HW_SFS_TURBO_BACKUP_ID          = os.Getenv("HW_SFS_TURBO_BACKUP_ID")
-	HW_SFS_TURBO_ECS_MOUNT_SHARE_IP = os.Getenv("HW_SFS_TURBO_ECS_MOUNT_SHARE_IP")
-	HW_SFS_FILE_SYSTEM_NAMES        = os.Getenv("HW_SFS_FILE_SYSTEM_NAMES")
+	HW_SFS_TURBO_SHARE_ID                = os.Getenv("HW_SFS_TURBO_SHARE_ID")
+	HW_SFS_TURBO_BACKUP_ID               = os.Getenv("HW_SFS_TURBO_BACKUP_ID")
+	HW_SFS_TURBO_ECS_MOUNT_SHARE_IP      = os.Getenv("HW_SFS_TURBO_ECS_MOUNT_SHARE_IP")
+	HW_SFS_FILE_SYSTEM_NAMES             = os.Getenv("HW_SFS_FILE_SYSTEM_NAMES")
+	HW_SFS_TURBO_AD_DOMAIN_NAME          = os.Getenv("HW_SFS_TURBO_AD_DOMAIN_NAME")
+	HW_SFS_TURBO_AD_DOMAIN_PW            = os.Getenv("HW_SFS_TURBO_AD_DOMAIN_PW")
+	HW_SFS_TURBO_AD_DOMAIN_DNS_SERVER_IP = os.Getenv("HW_SFS_TURBO_AD_DOMAIN_DNS_SERVER_IP")
 
 	HW_SMN_SUBSCRIBED_TOPIC_URN = os.Getenv("HW_SMN_SUBSCRIBED_TOPIC_URN")
 
@@ -3647,6 +3650,13 @@ func TestAccPrecheckSFSTurboShareId(t *testing.T) {
 func TestAccPrecheckSFSTurboBackupId(t *testing.T) {
 	if HW_SFS_TURBO_BACKUP_ID == "" {
 		t.Skip("HW_SFS_TURBO_BACKUP_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPrecheckSFSTurboADDomin(t *testing.T) {
+	if HW_SFS_TURBO_AD_DOMAIN_PW == "" || HW_SFS_TURBO_AD_DOMAIN_NAME == "" || HW_SFS_TURBO_AD_DOMAIN_DNS_SERVER_IP == "" {
+		t.Skip("HW_SFS_TURBO_AD_DOMAIN_PW, HW_SFS_TURBO_AD_DOMAIN_NAME and HW_SFS_TURBO_AD_DOMAIN_DNS_SERVER_IP must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/sfsturbo/resource_huaweicloud_sfs_turbo_ad_domain_test.go
+++ b/huaweicloud/services/acceptance/sfsturbo/resource_huaweicloud_sfs_turbo_ad_domain_test.go
@@ -1,0 +1,137 @@
+package sfsturbo
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getSFSTurboAdDomainResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		product = "sfs-turbo"
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/active-directory-domain"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SFS Turbo client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{share_id}", state.Primary.ID)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error getting SFS Turbo AD domain: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing response: %s", err)
+	}
+	return respBody, nil
+}
+
+func TestAccSFSTurboAdDomain_basic(t *testing.T) {
+	var obj interface{}
+	organizationUnit := "cn=Computers,dc=" + acceptance.HW_SFS_TURBO_AD_DOMAIN_NAME + ",dc=com"
+	resourceName := "huaweicloud_sfs_turbo_ad_domain.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getSFSTurboAdDomainResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckSFSTurboShareId(t)
+			acceptance.TestAccPrecheckSFSTurboADDomin(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSFSTurboAdDomain_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", fmt.Sprintf("%s.com", acceptance.HW_SFS_TURBO_AD_DOMAIN_NAME)),
+					resource.TestCheckResourceAttr(resourceName, "system_name", "sfs"),
+					resource.TestCheckResourceAttr(resourceName, "service_account", "administrator"),
+					resource.TestCheckResourceAttr(resourceName, "dns_server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dns_server.0", acceptance.HW_SFS_TURBO_AD_DOMAIN_DNS_SERVER_IP),
+					resource.TestCheckResourceAttr(resourceName, "organization_unit", organizationUnit),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+				),
+			},
+			{
+				Config: testAccSFSTurboAdDomain_update(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", fmt.Sprintf("%s.com", acceptance.HW_SFS_TURBO_AD_DOMAIN_NAME)),
+					resource.TestCheckResourceAttr(resourceName, "system_name", "sfs-update"),
+					resource.TestCheckResourceAttr(resourceName, "service_account", "administrator"),
+					resource.TestCheckResourceAttr(resourceName, "dns_server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dns_server.0", acceptance.HW_SFS_TURBO_AD_DOMAIN_DNS_SERVER_IP),
+					resource.TestCheckResourceAttr(resourceName, "organization_unit", organizationUnit),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"share_id", "service_account", "password", "overwrite_same_account",
+				},
+			},
+		},
+	})
+}
+
+func testAccSFSTurboAdDomain_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_sfs_turbo_ad_domain" "test" {
+  share_id               = "%[1]s"
+  service_account        = "administrator"
+  password               = "%[2]s"
+  domain_name            = "%[3]s.com"
+  system_name            = "sfs"
+  dns_server             = ["%[4]s"]
+  overwrite_same_account = false
+  organization_unit      = "cn=Computers,dc=%[5]s,dc=com"
+}
+`, acceptance.HW_SFS_TURBO_SHARE_ID, acceptance.HW_SFS_TURBO_AD_DOMAIN_PW, acceptance.HW_SFS_TURBO_AD_DOMAIN_NAME,
+		acceptance.HW_SFS_TURBO_AD_DOMAIN_DNS_SERVER_IP, acceptance.HW_SFS_TURBO_AD_DOMAIN_NAME)
+}
+
+func testAccSFSTurboAdDomain_update() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_sfs_turbo_ad_domain" "test" {
+  share_id          = "%[1]s"
+  service_account   = "administrator"
+  password          = "%[2]s"
+  domain_name       = "%[3]s.com"
+  system_name       = "sfs-update"
+  dns_server        = ["%[4]s"]
+  organization_unit = "cn=Computers,dc=%[5]s,dc=com"
+}
+`, acceptance.HW_SFS_TURBO_SHARE_ID, acceptance.HW_SFS_TURBO_AD_DOMAIN_PW, acceptance.HW_SFS_TURBO_AD_DOMAIN_NAME,
+		acceptance.HW_SFS_TURBO_AD_DOMAIN_DNS_SERVER_IP, acceptance.HW_SFS_TURBO_AD_DOMAIN_NAME)
+}

--- a/huaweicloud/services/sfsturbo/resource_huaweicloud_sfs_turbo_ad_domain.go
+++ b/huaweicloud/services/sfsturbo/resource_huaweicloud_sfs_turbo_ad_domain.go
@@ -1,0 +1,373 @@
+package sfsturbo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var adDomainNonUpdatableParams = []string{"share_id"}
+
+// @API SFSTurbo POST /v1/{project_id}/sfs-turbo/shares/{share_id}/fs/active-directory-domain
+// @API SFSTurbo GET /v1/{project_id}/sfs-turbo/shares/{share_id}/fs/active-directory-domain
+// @API SFSTurbo PUT /v1/{project_id}/sfs-turbo/shares/{share_id}/fs/active-directory-domain
+// @API SFSTurbo DELETE /v1/{project_id}/sfs-turbo/shares/{share_id}/fs/active-directory-domain
+// @API SFSTurbo GET /v1/{project_id}/sfs-turbo/jobs/{job_id}
+func ResourceSFSTurboAdDomain() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSFSTurboAdDomainCreate,
+		ReadContext:   resourceSFSTurboAdDomainRead,
+		UpdateContext: resourceSFSTurboAdDomainUpdate,
+		DeleteContext: resourceSFSTurboAdDomainDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(adDomainNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"share_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"service_account": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"system_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"dns_server": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"overwrite_same_account": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"organization_unit": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCreateOrUpdateSFSTurboAdDomainBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"service_account":        d.Get("service_account"),
+		"password":               d.Get("password"),
+		"domain_name":            d.Get("domain_name"),
+		"system_name":            d.Get("system_name"),
+		"dns_server":             d.Get("dns_server"),
+		"overwrite_same_account": d.Get("overwrite_same_account"),
+		"organization_unit":      utils.ValueIgnoreEmpty(d.Get("organization_unit")),
+		"vpc_id":                 utils.ValueIgnoreEmpty(d.Get("vpc_id")),
+	}
+
+	return bodyParams
+}
+
+func buildDeleteSFSTurboAdDomainBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"service_account": d.Get("service_account"),
+		"password":        d.Get("password"),
+	}
+
+	return bodyParams
+}
+
+func resourceSFSTurboAdDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		shareId = d.Get("share_id").(string)
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/active-directory-domain"
+		product = "sfs-turbo"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating SFS Turbo client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{share_id}", shareId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateOrUpdateSFSTurboAdDomainBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating SFS Turbo AD domain: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// The jobId field is inconsistent with the API doc cause there is a problem with the API doc.
+	jobID := utils.PathSearch("jobId", respBody, "").(string)
+	if jobID == "" {
+		return diag.Errorf("error creating SFS Turbo AD domain: jobId is not found in API response")
+	}
+
+	if err := waitForSFSTurboAdDomainJobSuccess(ctx, client, jobID, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("error waiting for SFS Turbo AD domain job creation to succeed: %s", err)
+	}
+
+	d.SetId(shareId)
+
+	return resourceSFSTurboAdDomainRead(ctx, d, meta)
+}
+
+func resourceSFSTurboAdDomainRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		shareId = d.Id()
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/active-directory-domain"
+		product = "sfs-turbo"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating SFS Turbo client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{share_id}", shareId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		// When the resource does not exist, the API returns 403 and errCode is SFS.TURBO.9000, which needs to be
+		// handled as 404 to be handled by CheckDeletedDiag.
+		convertedErr := common.ConvertExpected403ErrInto404Err(err, "errCode", "SFS.TURBO.9000")
+		return common.CheckDeletedDiag(d, convertedErr, "error retrieving SFS Turbo AD domain")
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("domain_name", utils.PathSearch("domain_name", respBody, nil)),
+		d.Set("system_name", utils.PathSearch("system_name", respBody, nil)),
+		d.Set("dns_server", utils.PathSearch("dns_server", respBody, nil)),
+		d.Set("organization_unit", utils.PathSearch("organization_unit", respBody, nil)),
+		d.Set("vpc_id", utils.PathSearch("vpc_id", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceSFSTurboAdDomainUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		shareId = d.Id()
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/active-directory-domain"
+		product = "sfs-turbo"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating SFS Turbo client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{share_id}", shareId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateOrUpdateSFSTurboAdDomainBodyParams(d)),
+	}
+
+	resp, err := client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error updating SFS Turbo AD domain: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// The jobId field is inconsistent with the API doc cause there is a problem with the API doc.
+	jobID := utils.PathSearch("jobId", respBody, "").(string)
+	if jobID == "" {
+		return diag.Errorf("error updating SFS Turbo AD domain: jobId is not found in API response")
+	}
+
+	if err := waitForSFSTurboAdDomainJobSuccess(ctx, client, jobID, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return diag.Errorf("error waiting for SFS Turbo AD domain job update to succeed: %s", err)
+	}
+
+	return resourceSFSTurboAdDomainRead(ctx, d, meta)
+}
+
+func resourceSFSTurboAdDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		shareId = d.Id()
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/active-directory-domain"
+		product = "sfs-turbo"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating SFS Turbo client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{share_id}", shareId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildDeleteSFSTurboAdDomainBodyParams(d),
+	}
+
+	resp, err := client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		// When the resource does not exist, delete the resource and the API returns 404.
+		return common.CheckDeletedDiag(d, err, "error deleting SFS Turbo AD domain")
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// The jobId field is inconsistent with the API doc cause there is a problem with the API doc.
+	jobID := utils.PathSearch("jobId", respBody, "").(string)
+	if jobID == "" {
+		return diag.Errorf("error deleting SFS Turbo AD domain: jobId is not found in API response")
+	}
+
+	if err := waitForSFSTurboAdDomainJobSuccess(ctx, client, jobID, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.Errorf("error waiting for SFS Turbo AD domain job deletion to succeed: %s", err)
+	}
+
+	return nil
+}
+
+func waitForSFSTurboAdDomainJobSuccess(ctx context.Context, client *golangsdk.ServiceClient, jobID string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"SUCCESS"},
+		Refresh: func() (interface{}, string, error) {
+			respBody, err := getSFSTurboJobDetail(client, jobID)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			status := utils.PathSearch("status", respBody, "").(string)
+			if status == "" {
+				return respBody, "ERROR", fmt.Errorf("status is not found in SFS Turbo job (%s) detail API response", jobID)
+			}
+
+			if status == "success" {
+				return respBody, "SUCCESS", nil
+			}
+
+			if status == "failed" {
+				return respBody, status, fmt.Errorf("the SFS Turbo job (%s) status is FAIL, the fail reason is: %s",
+					jobID, utils.PathSearch("fail_reason", respBody, "").(string))
+			}
+
+			return respBody, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func getSFSTurboJobDetail(client *golangsdk.ServiceClient, jobID string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/sfs-turbo/jobs/{job_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", jobID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error querying SFS Turbo job detail: %s", err)
+	}
+
+	return utils.FlattenResponse(resp)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add resource to manage ad domain
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add resource to manage ad domain
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
<img width="1479" height="299" alt="image" src="https://github.com/user-attachments/assets/29e4842a-e362-45a1-974e-2bf44f34a6c8" />
<img width="1092" height="33" alt="image" src="https://github.com/user-attachments/assets/4833ab40-2fce-4a4a-858e-629f49d7e01c" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
<img width="1215" height="258" alt="image" src="https://github.com/user-attachments/assets/b935fcf2-1d8e-4b9d-990c-fd2a7140413c" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
<img width="1117" height="167" alt="image" src="https://github.com/user-attachments/assets/f6b50b4e-bff6-4597-814f-4122a64c7815" />

