### PR TITLE
feat(workspace/app): add new resource to batch upgrade HDA versions

### DIFF
--- a/docs/resources/workspace_app_hda_batch_upgrade.md
+++ b/docs/resources/workspace_app_hda_batch_upgrade.md
@@ -1,0 +1,44 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_hda_batch_upgrade"
+description: |-
+  Use this resource to batch upgrade HDA versions of APP servers within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_hda_batch_upgrade
+
+Use this resource to batch upgrade HDA versions of APP servers within HuaweiCloud.
+
+-> This resource is only a one-time action resource for batch upgrading HDA versions. Deleting this resource will not
+   clear the corresponding upgrade request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+### Upgrade Multiple Servers
+
+```hcl
+variable "server_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_workspace_app_hda_batch_upgrade" "test" {
+  server_ids = var.server_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the servers to be upgraded are located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `server_ids` - (Required, List, NonUpdatable) Specifies the list of server IDs to be upgraded HDA in batches.  
+  The server SIDs must exist and be valid. This parameter cannot be updated after creation.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2928,6 +2928,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_bucket_authorize":                workspace.ResourceAppBucketAuthorize(),
 			"huaweicloud_workspace_app_group_authorization":             workspace.ResourceAppGroupAuthorization(),
 			"huaweicloud_workspace_app_group":                           workspace.ResourceWorkspaceAppGroup(),
+			"huaweicloud_workspace_app_hda_batch_upgrade":               workspace.ResourceAppHdaBatchUpgrade(),
 			"huaweicloud_workspace_app_image_server":                    workspace.ResourceAppImageServer(),
 			"huaweicloud_workspace_app_image":                           workspace.ResourceAppImage(),
 			"huaweicloud_workspace_app_nas_storage":                     workspace.ResourceAppNasStorage(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_hda_batch_upgrade_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_hda_batch_upgrade_test.go
@@ -1,0 +1,119 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccAppHdaBatchUpgrade_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_workspace_app_hda_batch_upgrade.test"
+		name         = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				// The first step is to upgrade the first server.
+				Config: testAccAppHdaBatchUpgrade_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "server_sids.#", "1"),
+				),
+			},
+			{
+				// The second step is to upgrade the remaining two servers.
+				Config: testAccAppHdaBatchUpgrade_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "server_sids.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAppHdaBatchUpgrade_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_app_server_groups" "test" {
+  server_group_id = "%[1]s"
+}
+
+data "huaweicloud_vpc_subnets" "test" {
+  id = try(data.huaweicloud_workspace_app_server_groups.test.server_groups[0].subnet_id, null)
+}
+
+resource "huaweicloud_workspace_app_server" "test" {
+  count = 3
+
+  name                = format("%[2]s_%%d", count.index)
+  server_group_id     = try(data.huaweicloud_workspace_app_server_groups.test.server_groups[0].id, null)
+  type                = "createApps"
+  flavor_id           = try(data.huaweicloud_workspace_app_server_groups.test.server_groups[0].product_id, null)
+  vpc_id              = try(data.huaweicloud_vpc_subnets.test.subnets[0].vpc_id, null)
+  subnet_id           = try(data.huaweicloud_workspace_app_server_groups.test.server_groups[0].subnet_id, null)
+  update_access_agent = false
+  description         = "Created by terraform script for HDA upgrade test"
+  maintain_status     = true
+
+  root_volume {
+    type = try(data.huaweicloud_workspace_app_server_groups.test.server_groups[0].system_disk_type, null)
+    size = try(data.huaweicloud_workspace_app_server_groups.test.server_groups[0].system_disk_size, null)
+  }
+
+  lifecycle {
+    ignore_changes = [
+      maintain_status
+    ]
+  }
+}
+`, acceptance.HW_WORKSPACE_APP_SERVER_GROUP_ID, name)
+}
+
+func testAccAppHdaBatchUpgrade_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_hda_batch_upgrade" "test" {
+  depends_on = [
+    huaweicloud_workspace_app_server.test
+  ]
+
+  server_ids       = slice(huaweicloud_workspace_app_server.test[*].id, 0, 1)
+  enable_force_new = true
+
+  provisioner "local-exec" {
+    command = "sleep 300"
+  }
+}
+`, testAccAppHdaBatchUpgrade_base(name))
+}
+
+func testAccAppHdaBatchUpgrade_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_hda_batch_upgrade" "test" {
+  depends_on = [
+    huaweicloud_workspace_app_server.test
+  ]
+
+  server_ids       = slice(huaweicloud_workspace_app_server.test[*].id, 1, 3)
+  enable_force_new = true
+
+  provisioner "local-exec" {
+    command = "sleep 300"
+  }
+}
+`, testAccAppHdaBatchUpgrade_base(name))
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_hda_batch_upgrade.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_hda_batch_upgrade.go
@@ -1,0 +1,113 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var appHdaBatchUpgradeNonUpdatableParams = []string{"server_sids"}
+
+// @API Workspace PATCH /v1/{project_id}/app-servers/access-agent/actions/upgrade
+func ResourceAppHdaBatchUpgrade() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppHdaBatchUpgradeCreate,
+		ReadContext:   resourceAppHdaBatchUpgradeRead,
+		UpdateContext: resourceAppHdaBatchUpgradeUpdate,
+		DeleteContext: resourceAppHdaBatchUpgradeDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(appHdaBatchUpgradeNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the servers to be upgraded are located.`,
+			},
+
+			// Required parameters.
+			"server_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of server IDs to be upgraded HDA in batches.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildAppHdaBatchUpgradeBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"items": d.Get("server_ids").([]interface{}),
+	}
+}
+
+func resourceAppHdaBatchUpgradeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	httpUrl := "v1/{project_id}/app-servers/access-agent/actions/upgrade"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildAppHdaBatchUpgradeBodyParams(d),
+	}
+
+	_, err = client.Request("PATCH", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error executing HDA batch upgrade: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceAppHdaBatchUpgradeRead(ctx, d, meta)
+}
+
+func resourceAppHdaBatchUpgradeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppHdaBatchUpgradeUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppHdaBatchUpgradeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource for batch upgrading HDA versions of servers. Deleting this
+resource will not clear the corresponding upgrade request record, but will only remove the resource information from the
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new resource to batch upgrade HDA versions

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to batch upgrade HDA.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccAppHdaBatchUpgrade_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppHdaBatchUpgrade_basic -timeout 360m -parallel 10
=== RUN   TestAccAppHdaBatchUpgrade_basic
=== PAUSE TestAccAppHdaBatchUpgrade_basic
=== CONT  TestAccAppHdaBatchUpgrade_basic
--- PASS: TestAccAppHdaBatchUpgrade_basic (1263.99s)
PASS
coverage: 6.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 1264.105s       coverage: 6.0% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
