### PR TITLE
feat(worksapce/app): batch action resource supports new feature

### DIFF
--- a/docs/resources/workspace_app_server_batch_action.md
+++ b/docs/resources/workspace_app_server_batch_action.md
@@ -86,6 +86,22 @@ resource "huaweicloud_workspace_app_server_batch_action" "update_tsvi" {
 }
 ```
 
+### Mark Server Maintenance Status
+
+```hcl
+variable "operate_server_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_workspace_app_server_batch_action" "maintain_status" {
+  type    = "batch-maint"
+  content = jsonencode({
+    items           = var.operate_server_ids
+    maintain_status = true
+  })
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -99,6 +115,7 @@ The following arguments are supported:
   + **batch-reinstall**: Reinstall server.
   + **batch-rejoin-domain**: Rejoin AD domain.
   + **batch-update-tsvi**: Update virtual session IP configuration.
+  + **batch-maint**: Mark server maintenance status.
 
 * `content` - (Required, String, NonUpdatable) Specifies the JSON string content for the batch operation (action)
   request.

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_server_batch_action_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_server_batch_action_test.go
@@ -245,3 +245,49 @@ resource "huaweicloud_workspace_app_server_batch_action" "test" {
 }
 `, testAccAppServerBatchAction_base(name))
 }
+
+func TestAccAppServerBatchAction_batchMaint(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_workspace_app_server_batch_action.test"
+		name         = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time batch action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppServerBatchAction_batchMaint(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "batch-maint"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAppServerBatchAction_batchMaint(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_server_batch_action" "test" {
+  type    = "batch-maint"
+  content = jsonencode({
+    items           = [huaweicloud_workspace_app_server.test.id]
+    maintain_status = true
+  })
+
+  max_retries = 3
+
+  provisioner "local-exec" {
+    command = "sleep 120"
+  }
+}
+`, testAccAppServerBatchAction_base(name))
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_server_batch_action.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_server_batch_action.go
@@ -21,6 +21,7 @@ var batchActionHTTPMethodMap = map[string]string{
 	"batch-reinstall":     "POST",
 	"batch-rejoin-domain": "PATCH",
 	"batch-update-tsvi":   "PATCH",
+	"batch-maint":         "PATCH",
 }
 
 var appServerBatchActionNonUpdatableParams = []string{"type", "content"}
@@ -29,6 +30,7 @@ var appServerBatchActionNonUpdatableParams = []string{"type", "content"}
 // @API Workspace POST /v1/{project_id}/app-servers/actions/batch-reinstall
 // @API Workspace PATCH /v1/{project_id}/app-servers/actions/batch-rejoin-domain
 // @API Workspace PATCH /v1/{project_id}/app-servers/actions/batch-update-tsvi
+// @API Workspace PATCH /v1/{project_id}/app-servers/actions/batch-maint
 func ResourceAppServerBatchAction() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceAppServerBatchActionCreate,
@@ -57,6 +59,7 @@ func ResourceAppServerBatchAction() *schema.Resource {
 					"batch-reinstall",
 					"batch-rejoin-domain",
 					"batch-update-tsvi",
+					"batch-maint",
 				}, false),
 			},
 			"content": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New feature is supported for the resource `huaweicloud_workspace_app_server_batch_action`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. batch action resource supports new feature
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccAppServerBatchAction_batchMaint
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppServerBatchAction_batchMaint -timeout 360m -parallel 10
=== RUN   TestAccAppServerBatchAction_batchMaint
=== PAUSE TestAccAppServerBatchAction_batchMaint
=== CONT  TestAccAppServerBatchAction_batchMaint
--- PASS: TestAccAppServerBatchAction_batchMaint (801.71s)
PASS
coverage: 6.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 801.782s        coverage: 6.0% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
