### PR TITLE
feat(dew): add a datasource to query the list of KMS key tags

### DIFF
--- a/docs/data-sources/kms_key_tags.md
+++ b/docs/data-sources/kms_key_tags.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_kms_key_tags"
+description: |-
+  Use this data source to query the list of KMS key tags within HuaweiCloud.
+---
+
+# huaweicloud_kms_key_tags
+
+Use this data source to query the list of KMS key tags within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_kms_key_tags" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tags` - the list of key tags.  
+  The [tags](#kms_project_tags) structure is documented below.
+
+<a name="kms_project_tags"></a>
+The `tags` block supports:
+
+* `key` - The tag key.
+
+* `values` - The list of tag values.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1175,6 +1175,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_public_key":            dew.DataSourceKmsPublicKey(),
 			"huaweicloud_kms_custom_keys_by_tags":   dew.DataSourceKmsCustomKeysByTags(),
 			"huaweicloud_kms_parameters_for_import": dew.DataSourceKmsParametersForImport(),
+			"huaweicloud_kms_key_tags":              dew.DataSourceKmsKeyTags(),
 			"huaweicloud_kps_failed_tasks":          dew.DataSourceDewKpsFailedTasks(),
 			"huaweicloud_kps_running_tasks":         dew.DataSourceDewKpsRunningTasks(),
 			"huaweicloud_kps_keypairs":              dew.DataSourceKeypairs(),

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_kms_key_tags_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_kms_key_tags_test.go
@@ -1,0 +1,38 @@
+package dew
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceKmsKeyTags_basic(t *testing.T) {
+	var (
+		dataSourcename = "data.huaweicloud_kms_key_tags.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourcename)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare a import KMS key ID with tag and config it to the environment variable.
+			acceptance.TestAccPreCheckKmsKeyID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceKmsKeyTags_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourcename, "tags.#"),
+					resource.TestCheckResourceAttrSet(dataSourcename, "tags.0.key"),
+					resource.TestCheckResourceAttrSet(dataSourcename, "tags.0.values.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceKmsKeyTags_basic = `data "huaweicloud_kms_key_tags" "test" {}`

--- a/huaweicloud/services/dew/data_source_huaweicloud_kms_key_tags.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_kms_key_tags.go
@@ -1,0 +1,119 @@
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW GET /v1.0/{project_id}/kms/tags
+func DataSourceKmsKeyTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceKmsKeyTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource.`,
+			},
+			"tags": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the key tags.`,
+				Elem:        tagSchema(),
+			},
+		},
+	}
+}
+
+func tagSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The tag key.",
+			},
+			"values": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The list of tag values.",
+			},
+		},
+	}
+}
+
+func dataSourceKmsKeyTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		mErr       *multierror.Error
+		getHttpUrl = "v1.0/{project_id}/kms/tags"
+		product    = "kms"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving KMS key tags: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	tagsList := utils.PathSearch("tags", getRespBody, make([]interface{}, 0)).([]interface{})
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("tags", flattenProjectTags(tagsList)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenProjectTags(tags []interface{}) []map[string]interface{} {
+	if len(tags) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(tags))
+	for _, tag := range tags {
+		result = append(result, map[string]interface{}{
+			"key":    utils.PathSearch("key", tag, nil),
+			"values": utils.PathSearch("values", tag, make([]interface{}, 0)),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports new data source to get kms key tags and names huaweicloud_kms_key_tags.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccDataSourceKmsKeyTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceKmsKeyTags_basic
=== PAUSE TestAccDataSourceKmsKeyTags_basic
=== CONT  TestAccDataSourceKmsKeyTags_basic
--- PASS: TestAccDataSourceKmsKeyTags_basic (10.44s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       10.467s coverage: 3.7% of statements in ./huaweicloud/services/dew
```
<img width="1217" height="43" alt="image" src="https://github.com/user-attachments/assets/9a23a961-71e1-47dd-84de-aca9caa63d08" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
