### PR TITLE
feat(secmaster): new datasource to query subscription resource

### DIFF
--- a/docs/data-sources/secmaster_subscription_resource.md
+++ b/docs/data-sources/secmaster_subscription_resource.md
@@ -1,0 +1,69 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_subscription_resource"
+description: |-
+  Use this data source to get the subscription resource of SecMaster.
+---
+
+# huaweicloud_secmaster_subscription_resource
+
+Use this data source to get the subscription resource of SecMaster.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_secmaster_subscription_resource" "test" {
+  workspace_id = var.workspace_id
+  sku          = "FLOW_DATA_BANDWIDTH"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID.
+
+* `sku` - (Optional, String) Specifies the SKU type of the subscription resource.
+  The valid values are **FLOW_DATA_BANDWIDTH**, **CSS_CAPACITY**, **PAIMON_CAPACITY**, **OBS_CAPACITY**,
+  **JOB_CAPACITY**, **AD_HOC_COUNT**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `sku_attribute` - The SKU attribute of the subscription resource.
+
+* `upper_limit` - The upper limit of the resource.
+
+* `unit` - The unit of the resource quota (e.g., GB, count, shard, etc.).
+
+* `step` - The step of the quota.
+
+* `used_amount` - The amount of used resource.
+
+* `unused_amount` - The amount of unused resource.
+
+* `version` - The version number.
+
+* `index_storage_upper_limit` - The upper limit of index storage.
+
+* `index_shards_upper_limit` - The upper limit of index shards.
+
+* `index_shards_unused` - The number of unused index shards.
+
+* `partitions_unused` - The number of unused partitions.
+
+* `partition_upper_limit` - The upper limit of partitions.
+
+* `create_time` - The creation time in milliseconds timestamp.
+
+* `update_time` - The update time in milliseconds timestamp.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1439,6 +1439,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_playbook_audit_logs":         secmaster.DataSourceSecmasterPlaybookAuditLogs(),
 			"huaweicloud_secmaster_playbook_monitors":           secmaster.DataSourceSecmasterPlaybookMonitors(),
 			"huaweicloud_secmaster_playbook_approvals":          secmaster.DataSourcePlaybookApprovals(),
+			"huaweicloud_secmaster_subscription_resource":       secmaster.DataSourceSecmasterSubscriptionResource(),
 			"huaweicloud_secmaster_alert_rule_metrics":          secmaster.DataSourceSecmasterAlertRuleMetrics(),
 			"huaweicloud_secmaster_alert_rule_template_metrics": secmaster.DataSourceAlertRuleTemplateMetrics(),
 			"huaweicloud_secmaster_catalogues":                  secmaster.DataSourceSecmasterCatalogues(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_subscription_resource_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_subscription_resource_test.go
@@ -1,0 +1,57 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSecmasterSubscriptionResource_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_secmaster_subscription_resource.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSecmasterSubscriptionResource_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "id"),
+					resource.TestCheckResourceAttrSet(dataSource, "sku_attribute"),
+					resource.TestCheckResourceAttrSet(dataSource, "upper_limit"),
+					resource.TestCheckResourceAttrSet(dataSource, "unit"),
+					resource.TestCheckResourceAttrSet(dataSource, "step"),
+					resource.TestCheckResourceAttrSet(dataSource, "used_amount"),
+					resource.TestCheckResourceAttrSet(dataSource, "unused_amount"),
+					resource.TestCheckResourceAttrSet(dataSource, "version"),
+					resource.TestCheckResourceAttrSet(dataSource, "index_storage_upper_limit"),
+					resource.TestCheckResourceAttrSet(dataSource, "index_shards_upper_limit"),
+					resource.TestCheckResourceAttrSet(dataSource, "index_shards_unused"),
+					resource.TestCheckResourceAttrSet(dataSource, "partitions_unused"),
+					resource.TestCheckResourceAttrSet(dataSource, "partition_upper_limit"),
+					resource.TestCheckResourceAttrSet(dataSource, "create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "update_time"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceSecmasterSubscriptionResource_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_subscription_resource" "test" {
+  workspace_id = "%s"
+  sku          = "FLOW_DATA_BANDWIDTH"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_subscription_resource.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_subscription_resource.go
@@ -1,0 +1,163 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Secmaster GET /v2/{project_id}/workspaces/{workspace_id}/siem/subscription/resource
+func DataSourceSecmasterSubscriptionResource() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecmasterSubscriptionResourceRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"sku": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sku_attribute": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"upper_limit": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"unit": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"step": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"used_amount": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"unused_amount": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"index_storage_upper_limit": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"index_shards_upper_limit": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"index_shards_unused": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"partitions_unused": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"partition_upper_limit": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildSubscriptionResourceQueryParams(d *schema.ResourceData) string {
+	if sku, ok := d.GetOk("sku"); ok {
+		return "?sku=" + sku.(string)
+	}
+	return ""
+}
+
+func dataSourceSecmasterSubscriptionResourceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/workspaces/{workspace_id}/siem/subscription/resource"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", d.Get("workspace_id").(string))
+	requestPath += buildSubscriptionResourceQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving SecMaster subscription resource: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("sku_attribute", utils.PathSearch("sku", respBody, nil)),
+		d.Set("upper_limit", utils.PathSearch("upper_limit", respBody, nil)),
+		d.Set("unit", utils.PathSearch("unit", respBody, nil)),
+		d.Set("step", utils.PathSearch("step", respBody, nil)),
+		d.Set("used_amount", utils.PathSearch("used_amount", respBody, nil)),
+		d.Set("unused_amount", utils.PathSearch("unused_amount", respBody, nil)),
+		d.Set("version", utils.PathSearch("version", respBody, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", respBody, nil)),
+		d.Set("update_time", utils.PathSearch("update_time", respBody, nil)),
+		d.Set("index_storage_upper_limit", utils.PathSearch("index_storage_upper_limit", respBody, nil)),
+		d.Set("index_shards_upper_limit", utils.PathSearch("index_shards_upper_limit", respBody, nil)),
+		d.Set("index_shards_unused", utils.PathSearch("index_shards_unused", respBody, nil)),
+		d.Set("partitions_unused", utils.PathSearch("partitions_unused", respBody, nil)),
+		d.Set("partition_upper_limit", utils.PathSearch("partition_upper_limit", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query subscription resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccDataSourceSecmasterSubscriptionResource_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourceSecmasterSubscriptionResource_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceSecmasterSubscriptionResource_basic
=== PAUSE TestAccDataSourceSecmasterSubscriptionResource_basic
=== CONT  TestAccDataSourceSecmasterSubscriptionResource_basic
--- PASS: TestAccDataSourceSecmasterSubscriptionResource_basic (9.39s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 9.469s  coverage: 3.8% of statements in ./huaweicloud/services/secmaster
```
<img width="1353" height="78" alt="image" src="https://github.com/user-attachments/assets/40d9df2d-06b6-4d31-aa59-fc111c6f1844" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
