### PR TITLE
feat(secmaster): new datasource to query installation scripts

### DIFF
--- a/docs/data-sources/secmaster_installation_scripts.md
+++ b/docs/data-sources/secmaster_installation_scripts.md
@@ -1,0 +1,46 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_installation_scripts"
+description: |-
+  Use this data source to get the installation scripts of SecMaster nodes.
+---
+
+# huaweicloud_secmaster_installation_scripts
+
+Use this data source to get the installation scripts of SecMaster nodes.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_secmaster_installation_scripts" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `records` - The list of installation scripts.
+  The [records](#secmaster_installation_scripts) structure is documented below.
+
+<a name="secmaster_installation_scripts"></a>
+The `records` block supports:
+
+* `os_type` - The operating system type.
+
+* `commands` - The installation commands for the specified operating system.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1447,6 +1447,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_upgradation_version":         secmaster.DataSourceUpgradationVersion(),
 			"huaweicloud_secmaster_vpc_endpoint_services":       secmaster.DataSourceSecmasterVpcEndpointServices(),
 			"huaweicloud_secmaster_catalogues_search":           secmaster.DataSourceSecmasterCataloguesSearch(),
+			"huaweicloud_secmaster_installation_scripts":        secmaster.DataSourceSecmasterInstallationScripts(),
 			"huaweicloud_secmasterv2_alert_rule_templates":      secmaster.DataSourceAlertRuleTemplatesV2(),
 			// In the API documentation, there are two API groups: Plugin Management and Component Management,
 			// and their API URLs are both named with "components". To differentiate them, all resources under the

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_installation_scripts_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_installation_scripts_test.go
@@ -1,0 +1,44 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSecmasterInstallationScripts_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_secmaster_installation_scripts.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSecmasterInstallationScripts_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "id"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.os_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.commands"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceSecmasterInstallationScripts_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_installation_scripts" "test" {
+  workspace_id = "%s"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_installation_scripts.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_installation_scripts.go
@@ -1,0 +1,116 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Secmaster GET /v1/{project_id}/workspaces/{workspace_id}/nodes/installation-scripts
+func DataSourceSecmasterInstallationScripts() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecmasterInstallationScriptsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"records": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"os_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"commands": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceSecmasterInstallationScriptsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v1/{project_id}/workspaces/{workspace_id}/nodes/installation-scripts"
+		workspaceID = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", workspaceID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving SecMaster installation scripts: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("records", flattenRecordsAttribute(respBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRecordsAttribute(respBody interface{}) []map[string]interface{} {
+	records := utils.PathSearch("records", respBody, make([]interface{}, 0)).([]interface{})
+	if len(records) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(records))
+	for _, v := range records {
+		rst = append(rst, map[string]interface{}{
+			"os_type":  utils.PathSearch("os_type", v, nil),
+			"commands": utils.PathSearch("commands", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query installation scripts

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccDataSourceSecmasterInstallationScripts_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourceSecmasterInstallationScripts_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceSecmasterInstallationScripts_basic
=== PAUSE TestAccDataSourceSecmasterInstallationScripts_basic
=== CONT  TestAccDataSourceSecmasterInstallationScripts_basic
--- PASS: TestAccDataSourceSecmasterInstallationScripts_basic (9.77s)
PASS
coverage: 3.9% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 9.872s  coverage: 3.9% of statements in ./huaweicloud/services/secmaster
```
<img width="1390" height="85" alt="image" src="https://github.com/user-attachments/assets/d98c3dd2-019c-4b92-9ddc-ed64cdf038df" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
