### PR TITLE
feat(vpc): add new resource subnet_cidr_reservation

### DIFF
--- a/docs/resources/vpc_subnet_cidr_reservation.md
+++ b/docs/resources/vpc_subnet_cidr_reservation.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_vpc_subnet_cidr_reservation"
+description: |-
+  Manages a VPC subnet CIDR reservation resource within HuaweiCloud.
+---
+
+# huaweicloud_vpc_subnet_cidr_reservation
+
+Manages a VPC subnet CIDR reservation resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "subnet_id" {}
+
+resource "huaweicloud_vpc_subnet_cidr_reservation" "test" {
+  subnet_id   = var.subnet_id
+  ip_version  = 4
+  mask        = 24
+  name        = "test-reservation"
+  description = "test subnet CIDR reservation"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `subnet_id` - (Required, String, NonUpdatable) Specifies the ID of the virtual subnet to which the
+  CIDR reservation belongs.
+
+* `ip_version` - (Required, Int, NonUpdatable) Specifies the IP version of the subnet CIDR reservation (4 or 6).
+
+* `cidr` - (Optional, String, NonUpdatable) Specifies the reserved CIDR block in CIDR notation.
+  Conflicts with `mask`.
+
+* `mask` - (Optional, Int, NonUpdatable) Specifies the subnet mask length.
+  Conflicts with `cidr`.
+
+* `name` - (Optional, String) Specifies the name of the subnet CIDR reservation (1-64 characters).
+
+* `description` - (Optional, String) Specifies the description of the subnet CIDR reservation (max 255 characters).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `vpc_id` - The ID of the VPC to which the subnet belongs.
+
+* `project_id` - The project ID of the subnet CIDR reservation.
+
+* `created_at` - The creation time of the subnet CIDR reservation.
+
+* `updated_at` - The last update time of the subnet CIDR reservation.
+
+## Import
+
+Subnet CIDR reservations can be imported using their `id`:
+
+```bash
+terraform import huaweicloud_vpc_subnet_cidr_reservation.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2865,6 +2865,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_traffic_mirror_filter":       vpc.ResourceTrafficMirrorFilter(),
 			"huaweicloud_vpc_traffic_mirror_filter_rule":  vpc.ResourceTrafficMirrorFilterRule(),
 			"huaweicloud_vpc_traffic_mirror_session":      vpc.ResourceTrafficMirrorSession(),
+			"huaweicloud_vpc_subnet_cidr_reservation":     vpc.ResourceVpcSubnetCidrReservation(),
 
 			"huaweicloud_vpcep_approval": vpcep.ResourceVPCEndpointApproval(),
 			"huaweicloud_vpcep_endpoint": vpcep.ResourceVPCEndpoint(),

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_subnet_cidr_reservation_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_subnet_cidr_reservation_test.go
@@ -1,0 +1,187 @@
+package vpc_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getReservationResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("vpcv3", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating VPC v3 client: %s", err)
+	}
+
+	httpUrl := fmt.Sprintf("vpc/virsubnet-cidr-reservations/%s", state.Primary.ID)
+	getPath := client.ResourceBaseURL() + httpUrl
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func TestAccVpcSubnetCidrReservation_basic(t *testing.T) {
+	var reservation interface{}
+
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_vpc_subnet_cidr_reservation.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&reservation,
+		getReservationResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcSubnetCidrReservation_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "ip_version", "4"),
+					resource.TestCheckResourceAttr(resourceName, "mask", "26"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "cidr"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+				),
+			},
+			{
+				Config: testAccVpcSubnetCidrReservation_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "description", "updated by terraform"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccVpcSubnetCidrReservation_withCidr(t *testing.T) {
+	var reservation interface{}
+
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_vpc_subnet_cidr_reservation.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&reservation,
+		getReservationResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcSubnetCidrReservation_withCidr(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "ip_version", "4"),
+					resource.TestCheckResourceAttr(resourceName, "cidr", "192.168.0.64/26"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "mask"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccVpcSubnetCidrReservation_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name       = "%[1]s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = huaweicloud_vpc.test.id
+}
+`, name)
+}
+
+func testAccVpcSubnetCidrReservation_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_vpc_subnet_cidr_reservation" "test" {
+  subnet_id   = huaweicloud_vpc_subnet.test.id
+  ip_version  = 4
+  mask        = 26
+  name        = "%[2]s"
+  description = "created by terraform"
+}
+`, testAccVpcSubnetCidrReservation_base(name), name)
+}
+
+func testAccVpcSubnetCidrReservation_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_vpc_subnet_cidr_reservation" "test" {
+  subnet_id   = huaweicloud_vpc_subnet.test.id
+  ip_version  = 4
+  mask        = 26
+  name        = "%[2]s-update"
+  description = "updated by terraform"
+}
+`, testAccVpcSubnetCidrReservation_base(name), name)
+}
+
+func testAccVpcSubnetCidrReservation_withCidr(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_vpc_subnet_cidr_reservation" "test" {
+  subnet_id   = huaweicloud_vpc_subnet.test.id
+  ip_version  = 4
+  cidr        = "192.168.0.64/26"
+  name        = "%[2]s"
+  description = "created by terraform"
+}
+`, testAccVpcSubnetCidrReservation_base(name), name)
+}

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet_cidr_reservation.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet_cidr_reservation.go
@@ -1,0 +1,274 @@
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var reservationNonUpdatableParams = []string{
+	"subnet_id", "ip_version", "cidr", "mask",
+}
+
+// @API VPC POST /v3/{project_id}/vpc/virsubnet-cidr-reservations
+// @API VPC GET /v3/{project_id}/vpc/virsubnet-cidr-reservations/{reservation_id}
+// @API VPC PUT /v3/{project_id}/vpc/virsubnet-cidr-reservations/{reservation_id}
+// @API VPC DELETE /v3/{project_id}/vpc/virsubnet-cidr-reservations/{reservation_id}
+
+func ResourceVpcSubnetCidrReservation() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSubnetCidrReservationCreate,
+		ReadContext:   resourceSubnetCidrReservationRead,
+		UpdateContext: resourceSubnetCidrReservationUpdate,
+		DeleteContext: resourceSubnetCidrReservationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(reservationNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the subnet CIDR reservation is located.`,
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the virtual subnet to which the CIDR reservation belongs.`,
+			},
+			"ip_version": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `IP version of the subnet CIDR reservation.`,
+			},
+			"cidr": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Reserved CIDR block in CIDR notation.`,
+			},
+			"mask": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `Subnet mask length.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the subnet CIDR reservation.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the subnet CIDR reservation.`,
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the VPC to which the subnet belongs.`,
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The project ID of the subnet CIDR reservation.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the subnet CIDR reservation.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The last update time of the subnet CIDR reservation.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildCreateSubnetCidrReservationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"virsubnet_cidr_reservation": map[string]interface{}{
+			"virsubnet_id": d.Get("subnet_id").(string),
+			"ip_version":   d.Get("ip_version").(int),
+			"cidr":         utils.ValueIgnoreEmpty(d.Get("cidr")),
+			"mask":         utils.ValueIgnoreEmpty(d.Get("mask")),
+			"name":         utils.ValueIgnoreEmpty(d.Get("name")),
+			"description":  utils.ValueIgnoreEmpty(d.Get("description")),
+		},
+	}
+	return bodyParams
+}
+
+func resourceSubnetCidrReservationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vpcv3", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC v3 client: %s", err)
+	}
+
+	httpUrl := "vpc/virsubnet-cidr-reservations"
+	createPath := client.ResourceBaseURL() + httpUrl
+
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			201,
+		},
+	}
+
+	createOpts.JSONBody = utils.RemoveNil(buildCreateSubnetCidrReservationBodyParams(d))
+	resp, err := client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return diag.Errorf("error creating subnet CIDR reservation: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("virsubnet_cidr_reservation.id", respBody, "").(string)
+	if id == "" {
+		return diag.Errorf("error creating subnet CIDR reservation: ID is not found in API response")
+	}
+
+	d.SetId(id)
+	return resourceSubnetCidrReservationRead(ctx, d, meta)
+}
+
+func resourceSubnetCidrReservationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vpcv3", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC v3 client: %s", err)
+	}
+
+	httpUrl := fmt.Sprintf("vpc/virsubnet-cidr-reservations/%s", d.Id())
+	getPath := client.ResourceBaseURL() + httpUrl
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "subnet CIDR reservation")
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	reservation := utils.PathSearch("virsubnet_cidr_reservation", respBody, nil)
+
+	cidr := utils.PathSearch("cidr", reservation, "").(string)
+	mask := strings.Split(cidr, "/")[1]
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("subnet_id", utils.PathSearch("virsubnet_id", reservation, nil)),
+		d.Set("ip_version", utils.PathSearch("ip_version", reservation, nil)),
+		d.Set("cidr", cidr),
+		d.Set("mask", utils.StringToInt(&mask)),
+		d.Set("name", utils.PathSearch("name", reservation, nil)),
+		d.Set("description", utils.PathSearch("description", reservation, nil)),
+		d.Set("vpc_id", utils.PathSearch("vpc_id", reservation, nil)),
+		d.Set("project_id", utils.PathSearch("project_id", reservation, nil)),
+		d.Set("created_at", utils.PathSearch("created_at", reservation, nil)),
+		d.Set("updated_at", utils.PathSearch("updated_at", reservation, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdateSubnetCidrReservationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"virsubnet_cidr_reservation": map[string]interface{}{
+			"name":        d.Get("name"),
+			"description": d.Get("description"),
+		},
+	}
+	return bodyParams
+}
+
+func resourceSubnetCidrReservationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vpcv3", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC v3 client: %s", err)
+	}
+
+	if d.HasChanges("name", "description") {
+		httpUrl := fmt.Sprintf("vpc/virsubnet-cidr-reservations/%s", d.Id())
+		updatePath := client.ResourceBaseURL() + httpUrl
+
+		updateOpts := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				200,
+			},
+		}
+		updateOpts.JSONBody = utils.RemoveNil(buildUpdateSubnetCidrReservationBodyParams(d))
+		_, err = client.Request("PUT", updatePath, &updateOpts)
+		if err != nil {
+			return diag.Errorf("error updating subnet CIDR reservation: %s", err)
+		}
+	}
+
+	return resourceSubnetCidrReservationRead(ctx, d, meta)
+}
+
+func resourceSubnetCidrReservationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vpcv3", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC v3 client: %s", err)
+	}
+
+	httpUrl := fmt.Sprintf("vpc/virsubnet-cidr-reservations/%s", d.Id())
+	deletePath := client.ResourceBaseURL() + httpUrl
+
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+	_, err = client.Request("DELETE", deletePath, &deleteOpts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting subnet CIDR reservation")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcSubnetCidrReservation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcSubnetCidrReservation -timeout 360m -parallel 4
=== RUN   TestAccVpcSubnetCidrReservation_basic
=== PAUSE TestAccVpcSubnetCidrReservation_basic
=== RUN   TestAccVpcSubnetCidrReservation_withCidr
=== PAUSE TestAccVpcSubnetCidrReservation_withCidr
=== CONT  TestAccVpcSubnetCidrReservation_basic
=== CONT  TestAccVpcSubnetCidrReservation_withCidr
--- PASS: TestAccVpcSubnetCidrReservation_withCidr (51.26s)
--- PASS: TestAccVpcSubnetCidrReservation_basic (64.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       64.830s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1012" height="269" alt="image" src="https://github.com/user-attachments/assets/a870b28c-f0d9-4030-86a8-b3d16b07479d" />
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1276" height="788" alt="image" src="https://github.com/user-attachments/assets/b843f92f-16cf-41e0-8756-6f4c669d5873" />
