### PR TITLE
feat(workspace/app): add new data source to get server quotas

### DIFF
--- a/docs/data-sources/workspace_app_server_quotas.md
+++ b/docs/data-sources/workspace_app_server_quotas.md
@@ -1,0 +1,92 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_server_quotas"
+description: |-
+  Use this data source to get the quota list of Workspace APP server within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_server_quotas
+
+Use this data source to get the quota list of Workspace APP server within HuaweiCloud.
+
+## Example Usage
+
+### Query all quotas under specified product ID
+
+```hcl
+variable "product_id" {}
+
+data "huaweicloud_workspace_app_server_quotas" "test" {
+  product_id       = var.product_id
+  subscription_num =  1
+  disk_size        =  80
+  disk_num         =  2
+}
+```
+
+### Query quotas under specified product ID by flavor ID
+
+```hcl
+variable "product_id" {}
+variable "flavor_id" {}
+
+data "huaweicloud_workspace_app_server_quotas" "advanced" {
+  product_id       = var.product_id
+  subscription_num = 1
+  disk_size        = 80
+  disk_num         = 2
+  flavor_id        = var.flavor_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the Workspace APP server quotas are located.  
+  If omitted, the provider-level region will be used.
+
+* `product_id` - (Required, String) Specifies the ID of the product to be queried.
+
+* `subscription_num` - (Required, Int) Specifies the number of server instances to be queried.
+
+* `disk_size` - (Required, Int) Specifies the disk size of the single server instance to be queried.
+
+* `disk_num` - (Required, Int) Specifies the number of disks for the single server instance to be queried.  
+  The valid value ranges from `1` to `11`.
+
+* `flavor_id` - (Optional, String) Specifies the ID of the flavor to be queried.
+
+* `is_period` - (Optional, Bool) Specifies whether the instance is prepaid.  
+  Defaults to **false**.
+
+* `deh_id` - (Optional, String) Specifies the ID of the dedicated host.
+
+* `cluster_id` - (Optional, String) Specifies the ID of the cloud dedicated distributed storage pool.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `is_enough` - Whether the quota is sufficient.
+
+* `quotas` - The list of the quotas that match the filter parameters.  
+  The [quotas](#data_app_server_quotas) structure is documented below.
+
+<a name="data_app_server_quotas"></a>
+The `quotas` block supports:
+
+* `type` - The quota resource type.
+  + **GPU_INSTANCES**: Number of GPU resource instances.
+  + **INSTANCES**: Number of Normal instances.
+  + **VOLUME_GIGABYTES**: Total disk capacity, in GB.
+  + **VOLUMES**: Number of disks.
+  + **CORES**: Number of CPUs.
+  + **MEMORY**: Memory capacity, in MB.
+
+* `remainder` - The remaining quota.
+
+* `need` - The required quota.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1683,6 +1683,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_server_groups":                   workspace.DataSourceAppServerGroups(),
 			"huaweicloud_workspace_app_server_group_restrict":           workspace.DataSourceAppServerGroupRestrict(),
 			"huaweicloud_workspace_app_server_group_status":             workspace.DataSourceAppServerGroupStatus(),
+			"huaweicloud_workspace_app_server_quotas":                   workspace.DataSourceAppServerQuotas(),
 			"huaweicloud_workspace_app_session_types":                   workspace.DataSourceSessionTypes(),
 			"huaweicloud_workspace_app_storage_policies":                workspace.DataSourceAppStoragePolicies(),
 			"huaweicloud_workspace_app_vnc_remote":                      workspace.DataSourceAppVncRemote(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_server_quotas_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_server_quotas_test.go
@@ -1,0 +1,104 @@
+package workspace
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAppServerQuotas_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_workspace_app_server_quotas.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byFlavorId   = "data.huaweicloud_workspace_app_server_quotas.filter_by_flavor_id"
+		dcByFlavorId = acceptance.InitDataSourceCheck(byFlavorId)
+
+		byIsPeriod   = "data.huaweicloud_workspace_app_server_quotas.filter_by_is_period"
+		dcByIsPeriod = acceptance.InitDataSourceCheck(byIsPeriod)
+		// The deh_id and cluster_id parameters have no test scenarios.
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAppServerQuotas_notFound,
+				ExpectError: regexp.MustCompile("The product 'not_exist' not find"),
+			},
+			{
+				Config: testAccDataSourceAppServerQuotas_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "quotas.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(dataSourceName, "is_enough", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.type"),
+					dcByFlavorId.CheckResourceExists(),
+					resource.TestCheckOutput("is_flavor_id_filter_useful", "true"),
+					dcByIsPeriod.CheckResourceExists(),
+					resource.TestMatchResourceAttr(byIsPeriod, "quotas.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAppServerQuotas_notFound = `
+data "huaweicloud_workspace_app_server_quotas" "test" {
+  product_id       = "not_exist"
+  subscription_num = 1
+  disk_size        = 80
+  disk_num         = 1
+}
+`
+
+const testAccDataSourceAppServerQuotas_basic = `
+data "huaweicloud_workspace_app_flavors" "test" {}
+
+locals {
+  product_id = try(data.huaweicloud_workspace_app_flavors.test.flavors[0].product_id, null)
+  disk_size  = try(data.huaweicloud_workspace_app_flavors.test.flavors[0].system_disk_size, null)
+}
+
+data "huaweicloud_workspace_app_server_quotas" "test" {
+  product_id       = local.product_id
+  subscription_num = 1
+  disk_size        = local.disk_size
+  disk_num         = 1
+}
+
+data "huaweicloud_workspace_app_server_quotas" "filter_by_flavor_id" {
+  product_id       = local.product_id
+  subscription_num = 1
+  disk_size        = try(data.huaweicloud_workspace_app_flavors.test.flavors[0].system_disk_size, null)
+  disk_num         = 1
+  flavor_id        = try(data.huaweicloud_workspace_app_flavors.test.flavors[0].id, null)
+}
+
+locals {
+  is_flavor_id_filter_result = [for v in data.huaweicloud_workspace_app_server_quotas.filter_by_flavor_id.quotas :
+  v if v.type == "VOLUMES"]
+}
+
+output "is_flavor_id_filter_useful" {
+  value = alltrue(
+    [
+      length(local.is_flavor_id_filter_result) > 0,
+      local.is_flavor_id_filter_result[0].remainder > 0,
+      local.is_flavor_id_filter_result[0].need > 0
+    ]
+  )
+}
+
+data "huaweicloud_workspace_app_server_quotas" "filter_by_is_period" {
+  product_id       = local.product_id
+  subscription_num = 1
+  disk_size        = local.disk_size
+  disk_num         = 1
+  is_period        = true
+}
+`

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_server_quotas.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_server_quotas.go
@@ -1,0 +1,192 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/check/quota
+func DataSourceAppServerQuotas() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppServerQuotasRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the Workspace APP server quotas are located.`,
+			},
+			"product_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the product to be queried.`,
+			},
+			"subscription_num": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The number of server instances to be queried.`,
+			},
+			"disk_size": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The disk size of the single server instance to be queried.`,
+			},
+			"disk_num": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The number of disks for the single server instance to be queried.`,
+			},
+			"flavor_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the flavor to be queried.`,
+			},
+			"is_period": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether the instance is prepaid.`,
+			},
+			"deh_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the dedicated host.`,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The of the cloud dedicated distributed storage pool.`,
+			},
+			"is_enough": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the quota is sufficient.`,
+			},
+			"quotas": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The quota resource type.`,
+						},
+						"remainder": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The remaining quota.`,
+						},
+						"need": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The required quota.`,
+						},
+					},
+				},
+				Description: `The list of the quotas that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildAppServerQuotasQueryParams(d *schema.ResourceData) string {
+	res := fmt.Sprintf("?product_id=%v&subscription_num=%v&disk_size=%v&disk_num=%v",
+		d.Get("product_id"),
+		d.Get("subscription_num"),
+		d.Get("disk_size"),
+		d.Get("disk_num"),
+	)
+
+	if v, ok := d.GetOk("flavor_id"); ok {
+		res = fmt.Sprintf("%s&flavor_id=%v", res, v)
+	}
+
+	if v := utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "is_period"); v != nil {
+		res = fmt.Sprintf("%s&is_period=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("deh_id"); ok {
+		res = fmt.Sprintf("%s&deh_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("cluster_id"); ok {
+		res = fmt.Sprintf("%s&cluster_id=%v", res, v)
+	}
+
+	return res
+}
+
+func dataSourceAppServerQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/check/quota"
+		opt     = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+		}
+	)
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildAppServerQuotasQueryParams(d)
+
+	resp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	respBodoy, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.Errorf("error querying Workspace APP server quotas: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("is_enough", utils.PathSearch("is_enough", respBodoy, nil)),
+		d.Set("quotas", flattenAppServerQuotas(utils.PathSearch("quota_remainder",
+			respBodoy, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAppServerQuotas(quotas []interface{}) []map[string]interface{} {
+	if len(quotas) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(quotas))
+	for i, item := range quotas {
+		result[i] = map[string]interface{}{
+			"type":      utils.PathSearch("type", item, nil),
+			"remainder": utils.PathSearch("remainder", item, nil),
+			"need":      utils.PathSearch("need", item, nil),
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source (`huaweicloud_workspace_app_server_quotas`) to get server quotas.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source.
2. add corresponding documation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataSourceAppServerQuotas_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataSourceAppServerQuotas_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAppServerQuotas_basic
=== PAUSE TestAccDataSourceAppServerQuotas_basic
=== CONT  TestAccDataSourceAppServerQuotas_basic
--- PASS: TestAccDataSourceAppServerQuotas_basic (18.58s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 18.656s coverage: 3.7% of statements in ./huaweicloud/services/workspace
```
<img width="1084" height="504" alt="image" src="https://github.com/user-attachments/assets/0e1f92a0-b336-44e3-8d18-750f61dfcf9e" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
