### PR TITLE
feat(eg): add new data source to query availability zones for the EventRouter cluster

### DIFF
--- a/docs/data-sources/eg_eventrouter_availability_zones.md
+++ b/docs/data-sources/eg_eventrouter_availability_zones.md
@@ -1,0 +1,32 @@
+---
+subcategory: "EventGrid (EG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_eg_eventrouter_availability_zones"
+description: |-
+  Use this data source to query EG event router availability zones within HuaweiCloud.
+---
+
+# huaweicloud_eg_eventrouter_availability_zones
+
+Use this data source to query EG event router availability zones within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_eg_eventrouter_availability_zones" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the event router availability zones are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `names` - The list of availability zone names.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -964,12 +964,16 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_availability_zones": drs.DataSourceAvailabilityZones(),
 			"huaweicloud_drs_node_types":         drs.DataSourceNodeTypes(),
 
+			// EventGrid
 			"huaweicloud_eg_connections":           eg.DataSourceConnections(),
 			"huaweicloud_eg_custom_event_channels": eg.DataSourceCustomEventChannels(),
 			"huaweicloud_eg_custom_event_sources":  eg.DataSourceCustomEventSources(),
 			"huaweicloud_eg_event_channels":        eg.DataSourceEventChannels(),
 			"huaweicloud_eg_event_sources":         eg.DataSourceEventSources(),
 			"huaweicloud_eg_event_streams":         eg.DataSourceEventStreams(),
+
+			// Professional EventRouter
+			"huaweicloud_eg_eventrouter_availability_zones": eg.DataSourceEventRouterAvailabilityZones(),
 
 			"huaweicloud_enterprise_project":        eps.DataSourceEnterpriseProject(),
 			"huaweicloud_enterprise_projects":       eps.DataSourceEnterpriseProjects(),

--- a/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_eventrouter_availability_zones_test.go
+++ b/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_eventrouter_availability_zones_test.go
@@ -1,0 +1,36 @@
+package eg
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataEventRouterAvailabilityZones_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_eg_eventrouter_availability_zones.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataEventRouterAvailabilityZones_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(all, "region"),
+					resource.TestMatchResourceAttr(all, "names.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataEventRouterAvailabilityZones_basic = `
+data "huaweicloud_eg_eventrouter_availability_zones" "test" {}
+`

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_eventrouter_availability_zones.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_eventrouter_availability_zones.go
@@ -1,0 +1,91 @@
+package eg
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EG GET /v1/{project_id}/eventrouter/clusters/availability-zone
+func DataSourceEventRouterAvailabilityZones() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEventRouterAvailabilityZonesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The region where the event router availability zones are located.",
+			},
+
+			// Attribute(s).
+			"names": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The list of availability zone names.",
+			},
+		},
+	}
+}
+
+func dataSourceEventRouterAvailabilityZonesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("eg", region)
+	if err != nil {
+		return diag.Errorf("error creating EG client: %s", err)
+	}
+
+	resp, err := listEventRouterAvailabilityZones(client)
+	if err != nil {
+		return diag.Errorf("error querying availability zones for the professional Event Router cluster: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("names", resp),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func listEventRouterAvailabilityZones(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	httpUrl := "v1/{project_id}/eventrouter/clusters/availability-zone"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("zone_names", respBody, make([]interface{}, 0)).([]interface{}), nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source to query the list of availability zones for perfessional EG.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new data source to query the list of availability zones for perfessional EG.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

<img width="1236" height="916" alt="image" src="https://github.com/user-attachments/assets/3c351928-b2e5-40d8-af30-03423860c9aa" />

```
./scripts/coverage.sh -o eg -f TestAccDataEventRouterAvailabilityZones_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eg" -v -coverprofile="./huaweicloud/services/acceptance/eg/eg_coverage.cov" -coverpkg="./huaweicloud/services/eg" -run TestAccDataEventRouterAvailabilityZones_basic -timeout 360m -parallel 10
=== RUN   TestAccDataEventRouterAvailabilityZones_basic
=== PAUSE TestAccDataEventRouterAvailabilityZones_basic
=== CONT  TestAccDataEventRouterAvailabilityZones_basic
--- PASS: TestAccDataEventRouterAvailabilityZones_basic (11.18s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/eg
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        11.243s coverage: 5.1% of statements in ./huaweicloud/services/eg
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
