### PR TITLE
feat(aad): new resource to unblock IP address

### DIFF
--- a/docs/resources/aad_unblock_ip.md
+++ b/docs/resources/aad_unblock_ip.md
@@ -1,0 +1,38 @@
+---
+subcategory: "Advanced Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aad_unblock_ip"
+description: |-
+  Use this resource to unblock an IP address that has been blocked by the Advanced Anti-DDoS service.
+---
+
+# huaweicloud_aad_unblock_ip
+
+Use this resource to unblock an IP address that has been blocked by the Advanced Anti-DDoS service.
+
+-> This resource is a one-time action resource for unblocking IP addresses. Deleting this resource will not
+re-block the IP address, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "ip" {}
+
+resource "huaweicloud_aad_unblock_ip" "test" {
+  ip = var.ip
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ip` - (Required, String, NonUpdatable) Specifies the IP address to be unblocked.
+
+* `blocking_time` - (Optional, Int, NonUpdatable) Specifies the blocking timestamp in milliseconds.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1800,6 +1800,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aad_black_white_list":           aad.ResourceBlackWhiteList(),
 			"huaweicloud_aad_change_specification":       aad.ResourceChangeSpecification(),
 			"huaweicloud_aad_domain_security_protection": aad.ResourceDomainSecurityProtection(),
+			"huaweicloud_aad_unblock_ip":                 aad.ResourceUnblockIp(),
 
 			"huaweicloud_antiddos_basic":                     antiddos.ResourceCloudNativeAntiDdos(),
 			"huaweicloud_antiddos_default_protection_policy": antiddos.ResourceDefaultProtectionPolicy(),

--- a/huaweicloud/services/aad/resource_huaweicloud_aad_unblock_ip.go
+++ b/huaweicloud/services/aad/resource_huaweicloud_aad_unblock_ip.go
@@ -1,0 +1,114 @@
+package aad
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AAD POST /v1/unblockservice/{domain_id}/unblock
+func ResourceUnblockIp() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceUnblockIpCreate,
+		ReadContext:   resourceUnblockIpRead,
+		UpdateContext: resourceUnblockIpUpdate,
+		DeleteContext: resourceUnblockIpDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{"ip", "blocking_time"}),
+
+		Schema: map[string]*schema.Schema{
+			"ip": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the IP address to be unblocked.`,
+			},
+			"blocking_time": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies the blocking timestamp (in milliseconds).`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildUnblockIpBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"ip": d.Get("ip"),
+	}
+
+	if v, ok := d.GetOk("blocking_time"); ok {
+		bodyParams["blocking_time"] = v
+	}
+
+	return bodyParams
+}
+
+func resourceUnblockIpCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v1/unblockservice/{domain_id}/unblock"
+		product = "aad"
+	)
+
+	client, err := cfg.NewServiceClient(product, cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", cfg.DomainID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildUnblockIpBodyParams(d),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error unblocking AAD IP address: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	return resourceUnblockIpRead(ctx, d, meta)
+}
+
+func resourceUnblockIpRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceUnblockIpUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceUnblockIpDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to unblock IP address. Deleting this 
+resource will not change the current AAD IP unblock status, but will only remove the resource information from the 
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}

--- a/huaweicloud/services/acceptance/aad/resource_huaweicloud_aad_unblock_ip_test.go
+++ b/huaweicloud/services/acceptance/aad/resource_huaweicloud_aad_unblock_ip_test.go
@@ -1,0 +1,33 @@
+package antiddos
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Note: Due to the lack of a test environment, this test case only verifies the expected error message.
+func TestAccResourceUnblockIp_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testUnblockIp_basic,
+				ExpectError: regexp.MustCompile(`不允许解封,因为IP \{0\} 未被封堵`),
+			},
+		},
+	})
+}
+
+const testUnblockIp_basic = `
+resource "huaweicloud_aad_unblock_ip" "test" {
+  ip            = "*.*.*.*"
+  blocking_time = 1688105685078
+}`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to unblock IP address.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o aad -f TestAccResourceUnblockIp_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/aad" -v -coverprofile="./huaweicloud/services/acceptance/aad/aad_coverage.cov" -coverpkg="./huaweicloud/services/aad" -run TestAccResourceUnblockIp_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceUnblockIp_basic
=== PAUSE TestAccResourceUnblockIp_basic
=== CONT  TestAccResourceUnblockIp_basic
--- PASS: TestAccResourceUnblockIp_basic (6.25s)
PASS
coverage: 6.4% of statements in ./huaweicloud/services/aad
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aad       6.374s  coverage: 6.4% of statements in ./huaweicloud/services/aad
```
<img width="1346" height="81" alt="image" src="https://github.com/user-attachments/assets/33b13857-bea6-4e63-a927-ca0b12d421ab" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
