### PR TITLE
feat(cnad): new resource to set tag to protected IP

### DIFF
--- a/docs/resources/cnad_advanced_protected_ip_tag.md
+++ b/docs/resources/cnad_advanced_protected_ip_tag.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Cloud Native Anti-DDoS Advanced"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cnad_advanced_protected_ip_tag"
+description: |-
+  Manages a CNAD advanced protected IP tag resource within HuaweiCloud.
+---
+
+# huaweicloud_cnad_advanced_protected_ip_tag
+
+Manages a CNAD advanced protected IP tag resource within HuaweiCloud.
+
+-> This resource is a one-time action resource for setting tag on protected IP. Deleting this resource will not
+remove the tag from the protected IP, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "protected_ip_id" {}
+variable "ip_tag" {}
+
+resource "huaweicloud_cnad_advanced_protected_ip_tag" "test" {
+  protected_ip_id = var.protected_ip_id
+  tag             = var.ip_tag
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `protected_ip_id` - (Required, String, NonUpdatable) Specifies the ID of the protected IP.
+
+* `tag` - (Required, String, NonUpdatable) Specifies the tag to be set on the protected IP.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2031,6 +2031,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cnad_advanced_policy":             cnad.ResourceCNADAdvancedPolicy(),
 			"huaweicloud_cnad_advanced_policy_associate":   cnad.ResourcePolicyAssociate(),
 			"huaweicloud_cnad_advanced_protected_object":   cnad.ResourceProtectedObject(),
+			"huaweicloud_cnad_advanced_protected_ip_tag":   cnad.ResourceProtectedIpTag(),
 
 			"huaweicloud_compute_instance":          ecs.ResourceComputeInstance(),
 			"huaweicloud_compute_interface_attach":  ecs.ResourceComputeInterfaceAttach(),

--- a/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_protected_ip_tag_test.go
+++ b/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_protected_ip_tag_test.go
@@ -1,0 +1,34 @@
+package cnad
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Note: Due to limited test conditions, this test case only verifies the expected error scenario.
+func TestAccResourceProtectedIpTag_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testProtectedIpTag_basic,
+				ExpectError: regexp.MustCompile(`Resource Not Found.|资源不存在。`),
+			},
+		},
+	})
+}
+
+// The value of field `protected_ip_id` is mock data.
+const testProtectedIpTag_basic = `
+resource "huaweicloud_cnad_advanced_protected_ip_tag" "test" {
+  protected_ip_id = "79189f77-bc57-46ff-a69d-17168d95c970"
+  tag             = "test"
+}`

--- a/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_protected_ip_tag.go
+++ b/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_protected_ip_tag.go
@@ -1,0 +1,108 @@
+package cnad
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AAD PUT /v1/cnad/protected-ips/tags
+func ResourceProtectedIpTag() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceProtectedIpTagCreate,
+		ReadContext:   resourceProtectedIpTagRead,
+		UpdateContext: resourceProtectedIpTagUpdate,
+		DeleteContext: resourceProtectedIpTagDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{"protected_ip_id", "tag"}),
+
+		Schema: map[string]*schema.Schema{
+			"protected_ip_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the protected IP ID.`,
+			},
+			"tag": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the tag to be set on the protected IP.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildProtectedIpTagBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"id":  d.Get("protected_ip_id"),
+		"tag": d.Get("tag"),
+	}
+}
+
+func resourceProtectedIpTagCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/cnad/protected-ips/tags"
+		product = "aad"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CNAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildProtectedIpTagBodyParams(d),
+	}
+
+	_, err = client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error setting CNAD protected IP tag: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	return resourceProtectedIpTagRead(ctx, d, meta)
+}
+
+func resourceProtectedIpTagRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceProtectedIpTagUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceProtectedIpTagDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to set tag on protected IP. Deleting this 
+resource will not change the current CNAD protected IP tag, but will only remove the resource information from the 
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to set tag to protected IP.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cnad -f TestAccResourceProtectedIpTag_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cnad" -v -coverprofile="./huaweicloud/services/acceptance/cnad/cnad_coverage.cov" -coverpkg="./huaweicloud/services/cnad" -run TestAccResourceProtectedIpTag_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceProtectedIpTag_basic
=== PAUSE TestAccResourceProtectedIpTag_basic
=== CONT  TestAccResourceProtectedIpTag_basic
--- PASS: TestAccResourceProtectedIpTag_basic (4.07s)
PASS
coverage: 5.2% of statements in ./huaweicloud/services/cnad
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cnad      4.137s  coverage: 5.2% of statements in ./huaweicloud/services/cnad
```
<img width="1296" height="81" alt="image" src="https://github.com/user-attachments/assets/8c1a7ece-e221-41f2-9a7d-8276cb9c39df" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
