### PR TITLE
feat(eg): add new data source to query connections

### DIFF
--- a/docs/data-sources/eg_connections.md
+++ b/docs/data-sources/eg_connections.md
@@ -1,0 +1,121 @@
+---
+subcategory: "EventGrid (EG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_eg_connections"
+description: |-
+  Use this data source to get the list of EG connections within HuaweiCloud.
+---
+
+# huaweicloud_eg_connections
+
+Use this data source to get the list of EG connections within HuaweiCloud.
+
+## Example Usage
+
+### Query all connections
+
+```hcl
+data "huaweicloud_eg_connections" "test" {}
+```
+
+### Query connections by connection name
+
+```hcl
+variable "connection_name" {}
+
+data "huaweicloud_eg_connections" "test" {
+  name = var.connection_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the connections are located.  
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the exact name of the connection to be queried.
+
+* `fuzzy_name` - (Optional, String) Specifies the name of the connection to be queried for fuzzy matching.
+
+* `sort` - (Optional, String) Specifies the sorting method for query results.  
+  The format is `field:order`, where `field` is the field name and `order` is `ASC` or `DESC`. e.g. `name:ASC`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `connections` - All connections that match the filter parameters.  
+  The [connections](#data_attr_connections) structure is documented below.
+
+<a name="data_attr_connections"></a>
+The `connections` block supports:
+
+* `id` - The ID of the connection.
+
+* `name` - The name of the connection.
+
+* `description` - The description of the connection.
+
+* `vpc_id` - The ID of the VPC to which the connection belongs.
+
+* `subnet_id` - The ID of the subnet to which the connection belongs.
+
+* `type` - The type of the connection.
+  + **WEBHOOK**
+  + **KAFKA**
+
+* `status` - The status of the connection.
+
+* `kafka_detail` - The Kafka detail information for the connection.  
+  The [kafka_detail](#data_connections_kafka_detail) structure is documented below.
+
+* `agency` - The user delegation name used by the private network connection.
+
+* `flavor` - The flavor information of the connection.
+  The [flavor](#data_connections_flavor) structure is documented below.
+
+* `created_time` - The creation time of the connection, in UTC format.
+
+* `updated_time` - The latest update time of the connection, in UTC format.
+
+* `error_info` - The error information of the connection.  
+  The [error_info](#data_connections_error_info) structure is documented below.
+
+<a name="data_connections_kafka_detail"></a>
+The `kafka_detail` block supports:
+
+* `instance_id` - The ID of the Kafka instance.
+
+* `connect_address` - The connection address of the Kafka instance.
+
+* `security_protocol` - The security protocol used for the connection.
+
+* `enable_sasl_ssl` - Whether SASL_SSL is enabled for the Kafka instance.
+
+* `user_name` - The username of the Kafka instance.
+
+* `acks` - The number of confirmation signals the producer‌ needs to receive to consider the message sent successfully.
+
+<a name="data_connections_flavor"></a>
+The `flavor` block supports:
+
+* `name` - The name of the flavor.
+
+* `concurrency_type` - The concurrency type of the flavor.
+
+* `concurrency` - The concurrency value of the flavor.
+
+* `bandwidth_type` - The bandwidth type of the flavor.
+
+<a name="data_connections_error_info"></a>
+The `error_info` block supports:
+
+* `error_code` - The error code.
+
+* `error_detail` - The detailed error information.
+
+* `error_msg` - The error message.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -952,6 +952,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_availability_zones": drs.DataSourceAvailabilityZones(),
 			"huaweicloud_drs_node_types":         drs.DataSourceNodeTypes(),
 
+			"huaweicloud_eg_connections":           eg.DataSourceConnections(),
 			"huaweicloud_eg_custom_event_channels": eg.DataSourceCustomEventChannels(),
 			"huaweicloud_eg_custom_event_sources":  eg.DataSourceCustomEventSources(),
 			"huaweicloud_eg_event_channels":        eg.DataSourceEventChannels(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -495,6 +495,10 @@ var (
 	HW_EG_TEST_ON     = os.Getenv("HW_EG_TEST_ON") // Whether to run the EG related tests.
 	HW_EG_CHANNEL_ID  = os.Getenv("HW_EG_CHANNEL_ID")
 	HW_EG_AGENCY_NAME = os.Getenv("HW_EG_AGENCY_NAME")
+	// Currently, only up to 3 target connections are allowed to be created, so this variable is provided.
+	// The IDs of the EG connections. Using commas (,) to separate multiple IDs, the first ID is the webhook connection,
+	// the second is the Kafka connection, and the connections cannot be the default.
+	HW_EG_CONNECTION_IDS = os.Getenv("HW_EG_CONNECTION_IDS")
 
 	HW_KOOGALLERY_ASSET = os.Getenv("HW_KOOGALLERY_ASSET")
 
@@ -2538,6 +2542,13 @@ func TestAccPreCheckEgChannelId(t *testing.T) {
 func TestAccPreCheckEgAgencyName(t *testing.T) {
 	if HW_EG_AGENCY_NAME == "" {
 		t.Skip("HW_EG_AGENCY_NAME must be set for resource creation of the EG connection")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckEgConnectionIds(t *testing.T) {
+	if HW_EG_CONNECTION_IDS == "" || len(strings.Split(HW_EG_CONNECTION_IDS, ",")) != 2 {
+		t.Skip("The number of HW_EG_CONNECTION_IDS must be 2 for the acceptance test, separated by a comma (,)")
 	}
 }
 

--- a/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_connections_test.go
+++ b/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_connections_test.go
@@ -1,0 +1,141 @@
+package eg
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataConnections_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_eg_connections.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byName   = "data.huaweicloud_eg_connections.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byFuzzyName   = "data.huaweicloud_eg_connections.filter_by_fuzzy_name"
+		dcByFuzzyName = acceptance.InitDataSourceCheck(byFuzzyName)
+
+		bySortDesc   = "data.huaweicloud_eg_connections.filter_by_sort_desc"
+		dcBySortDesc = acceptance.InitDataSourceCheck(bySortDesc)
+
+		bySortAsc   = "data.huaweicloud_eg_connections.filter_by_sort_asc"
+		dcBySortAsc = acceptance.InitDataSourceCheck(bySortAsc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEgConnectionIds(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataConnections_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "connections.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckResourceAttrSet(byName, "connections.0.id"),
+					resource.TestCheckResourceAttrSet(byName, "connections.0.name"),
+					resource.TestCheckResourceAttrSet(byName, "connections.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(byName, "connections.0.subnet_id"),
+					resource.TestCheckResourceAttrSet(byName, "connections.0.type"),
+					resource.TestCheckResourceAttrSet(byName, "connections.0.status"),
+					resource.TestCheckResourceAttrSet(byName, "connections.0.created_time"),
+					resource.TestCheckResourceAttrSet(byName, "connections.0.updated_time"),
+					resource.TestCheckResourceAttr(byName, "connections.0.flavor.#", "1"),
+					resource.TestCheckResourceAttrSet(byName, "connections.0.flavor.0.name"),
+					resource.TestCheckResourceAttrSet(byName, "connections.0.flavor.0.concurrency_type"),
+					resource.TestCheckResourceAttrSet(byName, "connections.0.flavor.0.concurrency"),
+					resource.TestCheckResourceAttrSet(byName, "connections.0.flavor.0.bandwidth_type"),
+					dcByFuzzyName.CheckResourceExists(),
+					resource.TestCheckOutput("is_fuzzy_name_filter_useful", "true"),
+					dcBySortDesc.CheckResourceExists(),
+					dcBySortAsc.CheckResourceExists(),
+					resource.TestCheckOutput("is_sort_filter_useful", "true"),
+					resource.TestCheckOutput("is_kafka_detail_and_valid", "true"),
+					// `description` and `error_info` may be empty, so we don't check them.
+				),
+			},
+		},
+	})
+}
+
+func testAccDataConnections_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_eg_connections" "test" {}
+
+locals {
+  connection_ids = "%[1]s"
+  filter_result  = try([for v in data.huaweicloud_eg_connections.test.connections : v if v.id == split(",", local.connection_ids)[0]][0], {})
+  name           = lookup(local.filter_result, "name", "")
+  kafka_connection_filter_result = try(
+    [for v in data.huaweicloud_eg_connections.test.connections : v if v.id == split(",", local.connection_ids)[1]][0].kafka_detail[0],
+    {}
+  )
+}
+
+data "huaweicloud_eg_connections" "filter_by_name" {
+  name = local.name
+}
+
+locals {
+  name_filter_result = [for v in data.huaweicloud_eg_connections.filter_by_name.connections[*].name : v == local.name]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+data "huaweicloud_eg_connections" "filter_by_fuzzy_name" {
+  fuzzy_name = local.name
+}
+
+locals {
+  fuzzy_name_filter_result = [for v in data.huaweicloud_eg_connections.filter_by_fuzzy_name.connections[*].name :
+  strcontains(v, local.name)]
+}
+
+output "is_fuzzy_name_filter_useful" {
+  value = length(local.fuzzy_name_filter_result) > 0 && alltrue(local.fuzzy_name_filter_result)
+}
+
+data "huaweicloud_eg_connections" "filter_by_sort_desc" {
+  sort = "name:DESC"
+}
+
+data "huaweicloud_eg_connections" "filter_by_sort_asc" {
+  sort = "name:ASC"
+}
+
+locals {
+  sort_desc_filter_result = data.huaweicloud_eg_connections.filter_by_sort_desc.connections[*].name
+  sort_asc_filter_result  = data.huaweicloud_eg_connections.filter_by_sort_asc.connections[*].name
+}
+
+output "is_sort_filter_useful" {
+  value = (
+    length(local.sort_desc_filter_result) == length(local.sort_asc_filter_result) &&
+    local.sort_desc_filter_result == reverse(local.sort_asc_filter_result)
+  )
+}
+
+output "is_kafka_detail_and_valid" {
+  value = alltrue([
+    lookup(local.kafka_connection_filter_result, "instance_id", "") != "",
+    lookup(local.kafka_connection_filter_result, "connect_address", "") != "",
+    lookup(local.kafka_connection_filter_result, "security_protocol", "") != "",
+    lookup(local.kafka_connection_filter_result, "enable_sasl_ssl", "") == true,
+    lookup(local.kafka_connection_filter_result, "user_name", "") != "",
+    lookup(local.kafka_connection_filter_result, "acks", "") != "",
+  ])
+}
+`, acceptance.HW_EG_CONNECTION_IDS)
+}

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_connections.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_connections.go
@@ -1,0 +1,361 @@
+package eg
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EG GET /v1/{project_id}/connections
+func DataSourceConnections() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceConnectionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the connections are located.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The exact name of the connection to be queried.`,
+			},
+			"fuzzy_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the connection to be queried for fuzzy matching.`,
+			},
+			"sort": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The sorting method for query results.`,
+			},
+			"connections": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the connection.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the connection.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the connection.`,
+						},
+						"vpc_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the VPC to which the connection belongs.`,
+						},
+						"subnet_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the subnet to which the connection belongs.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the connection.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the connection.`,
+						},
+						"kafka_detail": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"instance_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the Kafka instance.`,
+									},
+									"connect_address": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The connection address of the Kafka instance.`,
+									},
+									"security_protocol": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The security protocol used for the connection.`,
+									},
+									"enable_sasl_ssl": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: `Whether SASL_SSL is enabled for the Kafka instance.`,
+									},
+									"user_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The username of the Kafka instance.`,
+									},
+									"acks": {
+										Type:     schema.TypeString,
+										Computed: true,
+										Description: `The number of confirmation signals the producer
+											needs to receive to consider the message sent successfully.`,
+									},
+								},
+							},
+							Description: `The Kafka detail information for the connection.`,
+						},
+						"agency": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The user delegation name used by the private network connection.`,
+						},
+						"flavor": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the flavor.`,
+									},
+									"concurrency_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The concurrency type of the flavor.`,
+									},
+									"concurrency": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The concurrency value of the flavor.`,
+									},
+									"bandwidth_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The bandwidth type of the flavor.`,
+									},
+								},
+							},
+							Description: `The flavor information of the connection.`,
+						},
+						"created_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the connection, in UTC format.`,
+						},
+						"updated_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the connection, in UTC format.`,
+						},
+						"error_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"error_code": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The error code.`,
+									},
+									"error_detail": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The detailed error information.`,
+									},
+									"error_msg": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The error message.`,
+									},
+								},
+							},
+							Description: `The error information of the connection.`,
+						},
+					},
+				},
+				Description: `All connections that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func dataSourceConnectionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("eg", region)
+	if err != nil {
+		return diag.Errorf("error creating EG client: %s", err)
+	}
+
+	connections, err := listConnections(client, d)
+	if err != nil {
+		return diag.Errorf("error getting EG connections: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("connections", flattenConnections(connections)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func listConnections(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/connections"
+		limit   = 500
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = fmt.Sprintf("%s?limit=%d", listPath, limit)
+	listPath += buildConnectionsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		connections := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, connections...)
+		if len(connections) < limit {
+			break
+		}
+
+		offset += len(connections)
+	}
+
+	return result, nil
+}
+
+func buildConnectionsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("fuzzy_name"); ok {
+		res = fmt.Sprintf("%s&fuzzy_name=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("sort"); ok {
+		res = fmt.Sprintf("%s&sort=%v", res, v)
+	}
+
+	return res
+}
+
+func flattenConnectionKafkaDetail(kafkaDetail interface{}) []interface{} {
+	if kafkaDetail == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"instance_id":       utils.PathSearch("instance_id", kafkaDetail, nil),
+			"connect_address":   utils.PathSearch("addr", kafkaDetail, nil),
+			"security_protocol": utils.PathSearch("security_protocol", kafkaDetail, nil),
+			"enable_sasl_ssl":   utils.PathSearch("enable_sasl_ssl", kafkaDetail, nil),
+			"user_name":         utils.PathSearch("user_name", kafkaDetail, nil),
+			"acks":              utils.PathSearch("acks", kafkaDetail, nil),
+		},
+	}
+}
+
+func flattenConnectionFlavor(flavor interface{}) []interface{} {
+	if flavor == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"name":             utils.PathSearch("name", flavor, nil),
+			"concurrency_type": utils.PathSearch("concurrency_type", flavor, nil),
+			"concurrency":      utils.PathSearch("concurrency", flavor, nil),
+			"bandwidth_type":   utils.PathSearch("bandwidth_type", flavor, nil),
+		},
+	}
+}
+
+func flattenConnectionErrorInfo(errorInfo interface{}) []interface{} {
+	if errorInfo == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"error_code":   utils.PathSearch("error_code", errorInfo, nil),
+			"error_detail": utils.PathSearch("error_detail", errorInfo, nil),
+			"error_msg":    utils.PathSearch("error_msg", errorInfo, nil),
+		},
+	}
+}
+
+func flattenConnections(connections []interface{}) []map[string]interface{} {
+	if len(connections) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(connections))
+	for _, connection := range connections {
+		result = append(result, map[string]interface{}{
+			"id":           utils.PathSearch("id", connection, nil),
+			"name":         utils.PathSearch("name", connection, nil),
+			"description":  utils.PathSearch("description", connection, nil),
+			"vpc_id":       utils.PathSearch("vpc_id", connection, nil),
+			"subnet_id":    utils.PathSearch("subnet_id", connection, nil),
+			"type":         utils.PathSearch("type", connection, nil),
+			"status":       utils.PathSearch("status", connection, nil),
+			"kafka_detail": flattenConnectionKafkaDetail(utils.PathSearch("kafka_detail", connection, nil)),
+			"agency":       utils.PathSearch("agency", connection, nil),
+			"flavor":       flattenConnectionFlavor(utils.PathSearch("flavor", connection, nil)),
+			"created_time": utils.PathSearch("created_time", connection, nil),
+			"updated_time": utils.PathSearch("updated_time", connection, nil),
+			"error_info":   flattenConnectionErrorInfo(utils.PathSearch("error_info", connection, nil)),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source (`huaweicloud_eg_connections`) to query connections.

+ The `instance_id` parameter is not effective. The service side responded that the tenant account does not support this field. They will be removed later.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
2. add corresponding documation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o eg -f TestAccDataConnections_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eg" -v -coverprofile="./huaweicloud/services/acceptance/eg/eg_coverage.cov" -coverpkg="./huaweicloud/services/eg" -run TestAccDataConnections_basic -timeout 360m -parallel 10
=== RUN   TestAccDataConnections_basic
=== PAUSE TestAccDataConnections_basic
=== CONT  TestAccDataConnections_basic
--- PASS: TestAccDataConnections_basic (13.54s)
PASS
coverage: 8.2% of statements in ./huaweicloud/services/eg
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        13.605s coverage: 8.2% of statements in ./huaweicloud/services/eg
```
<img width="1091" height="346" alt="image" src="https://github.com/user-attachments/assets/e1bf10a4-3a50-43ba-ba4c-7351782347ff" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
