### PR TITLE
fix(iam): fix response_type and response_mode in identity provider

### DIFF
--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_provider_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_provider_test.go
@@ -206,10 +206,10 @@ resource "huaweicloud_identity_provider" "provider_1" {
   description = "unit test"
 
   access_config {
-    access_type            = "program"
-    provider_url           = "https://accounts.example.com"
-    client_id              = "client_id_example3"
-    signing_key            = jsonencode(
+    access_type  = "program"
+    provider_url = "https://accounts.example.com"
+    client_id    = "client_id_example3"
+    signing_key  = jsonencode(
     {
       keys = [
         {

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_provider.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_provider.go
@@ -127,12 +127,12 @@ func ResourceIdentityProvider() *schema.Resource {
 						"response_type": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "id_token",
+							Computed: true,
 						},
 						"response_mode": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Default:      "form_post",
+							Computed:     true,
 							ValidateFunc: validation.StringInSlice([]string{"fragment", "form_post"}, false),
 						},
 					},
@@ -243,8 +243,18 @@ func resourceIdentityProviderCreate(ctx context.Context, d *schema.ResourceData,
 			scopes := utils.ExpandToStringList(accessConfig["scopes"].([]interface{}))
 			createAccessTypeOpts.Scope = strings.Join(scopes, scopeSpilt)
 			createAccessTypeOpts.AuthorizationEndpoint = accessConfig["authorization_endpoint"].(string)
-			createAccessTypeOpts.ResponseType = accessConfig["response_type"].(string)
-			createAccessTypeOpts.ResponseMode = accessConfig["response_mode"].(string)
+
+			responseType := accessConfig["response_type"].(string)
+			if responseType == "" {
+				responseType = "id_token"
+			}
+			createAccessTypeOpts.ResponseType = responseType
+
+			responseMode := accessConfig["response_mode"].(string)
+			if responseMode == "" {
+				responseMode = "form_post"
+			}
+			createAccessTypeOpts.ResponseMode = responseMode
 		}
 
 		log.Printf("[DEBUG] Create access type of provider: %#v", opts)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/iam' TESTARGS='-run TestAccIdentityProvider'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityProvider -timeout 360m -parallel 4
=== RUN   TestAccIdentityProviderConversion_basic
=== PAUSE TestAccIdentityProviderConversion_basic
=== RUN   TestAccIdentityProvider_basic
=== PAUSE TestAccIdentityProvider_basic
=== RUN   TestAccIdentityProvider_oidc
=== PAUSE TestAccIdentityProvider_oidc
=== CONT  TestAccIdentityProviderConversion_basic
=== CONT  TestAccIdentityProvider_basic
=== CONT  TestAccIdentityProvider_oidc
--- PASS: TestAccIdentityProvider_basic (26.64s)
--- PASS: TestAccIdentityProviderConversion_basic (28.18s)
--- PASS: TestAccIdentityProvider_oidc (33.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       34.002s
```

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
