### PR TITLE
feat(antiddos): new datasource to query daily protection traffic

### DIFF
--- a/docs/data-sources/antiddos_eip_protection_traffic.md
+++ b/docs/data-sources/antiddos_eip_protection_traffic.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_antiddos_eip_protection_traffic"
+description: |-
+  Use this data source to query the EIP protection traffic of a specified EIP within HuaweiCloud.
+---
+
+# huaweicloud_antiddos_eip_protection_traffic
+
+Use this data source to query the EIP protection traffic of a specified EIP within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "floating_ip_id" {}
+variable "eip_address" {}
+
+data "huaweicloud_antiddos_eip_protection_traffic" "test" {
+  floating_ip_id = var.floating_ip_id
+  ip             = var.eip_address
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `floating_ip_id` - (Required, String) Specifies the ID of the EIP.
+
+* `ip` - (Optional, String) Specifies the EIP address.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `data` - The list of EIP protection traffic. The [data](#data_block) structure is documented below.
+
+<a name="data_block"></a>
+The `data` block supports:
+
+* `period_start` - The start time of the statistics period.
+
+* `bps_in` - The inbound traffic rate, in bit/s.
+
+* `bps_attack` - The attack traffic rate, in bit/s.
+
+* `total_bps` - The total traffic rate, in bit/s.
+
+* `pps_in` - The inbound packet rate, in packets per second (pps).
+
+* `pps_attack` - The attack packet rate, in packets per second (pps).
+
+* `total_pps` - The total packet rate, in packets per second (pps).

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -473,6 +473,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_antiddos_config_ranges":                antiddos.DataSourceConfigRanges(),
 			"huaweicloud_antiddos_weekly_protection_statistics": antiddos.DataSourceWeeklyProtectionStatistics(),
 			"huaweicloud_antiddos_eip_defense_statuses":         antiddos.DataSourceEipDefenseStatuses(),
+			"huaweicloud_antiddos_eip_protection_traffic":       antiddos.DataSourceEipProtectionTraffic(),
 
 			"huaweicloud_aom_access_codes":                    aom.DataSourceAomAccessCodes(),
 			"huaweicloud_aom_cloud_service_authorizations":    aom.DataSourceCloudServiceAuthorizations(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -353,6 +353,9 @@ var (
 	HW_DSC_INSTANCE_ID    = os.Getenv("HW_DSC_INSTANCE_ID")
 	HW_DSC_ALARM_TOPIC_ID = os.Getenv("HW_DSC_ALARM_TOPIC_ID")
 
+	HW_EIP_ID      = os.Getenv("HW_EIP_ID")
+	HW_EIP_ADDRESS = os.Getenv("HW_EIP_ADDRESS")
+
 	HW_CES_ALARM_TEMPLATE_ID = os.Getenv("HW_CES_ALARM_TEMPLATE_ID")
 	HW_CES_START_TIME        = os.Getenv("HW_CES_START_TIME")
 	HW_CES_END_TIME          = os.Getenv("HW_CES_END_TIME")
@@ -3646,6 +3649,13 @@ func TestAccPrecheckDscInstance(t *testing.T) {
 func TestAccPrecheckDscAlarmTopicID(t *testing.T) {
 	if HW_DSC_ALARM_TOPIC_ID == "" {
 		t.Skip("HW_DSC_ALARM_TOPIC_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPrecheckEipIDAndIP(t *testing.T) {
+	if HW_EIP_ID == "" || HW_EIP_ADDRESS == "" {
+		t.Skip("HW_EIP_ID and HW_EIP_ADDRESS must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/antiddos/data_source_huaweicloud_antiddos_eip_protection_traffic_test.go
+++ b/huaweicloud/services/acceptance/antiddos/data_source_huaweicloud_antiddos_eip_protection_traffic_test.go
@@ -1,0 +1,51 @@
+package antiddos
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Please prepare the EIP ID and IP address in advance and ensure that the EIP has access traffic.
+func TestAccDataSourceEipProtectionTraffic_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_antiddos_eip_protection_traffic.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckEipIDAndIP(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceEipProtectionTraffic_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.period_start"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.bps_in"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.bps_attack"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.total_bps"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.pps_in"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.pps_attack"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.total_pps"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceEipProtectionTraffic_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_antiddos_eip_protection_traffic" "test" {
+  floating_ip_id = "%s"
+  ip             = "%s"
+}
+`, acceptance.HW_EIP_ID, acceptance.HW_EIP_ADDRESS)
+}

--- a/huaweicloud/services/antiddos/data_source_huaweicloud_antiddos_eip_protection_traffic.go
+++ b/huaweicloud/services/antiddos/data_source_huaweicloud_antiddos_eip_protection_traffic.go
@@ -1,0 +1,163 @@
+package antiddos
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ANTI-DDOS GET /v1/{project_id}/antiddos/{floating_ip_id}/daily
+func DataSourceEipProtectionTraffic() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEipProtectionTrafficRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"floating_ip_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the EIP.`,
+			},
+			"ip": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the EIP address.`,
+			},
+			"data": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of daily protection statistics.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"period_start": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The start time of the statistics period.`,
+						},
+						"bps_in": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The inbound traffic rate in bit/s.`,
+						},
+						"bps_attack": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The attack traffic rate in bit/s.`,
+						},
+						"total_bps": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The total traffic rate in bit/s.`,
+						},
+						"pps_in": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The inbound packet rate in pps.`,
+						},
+						"pps_attack": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The attack packet rate in pps.`,
+						},
+						"total_pps": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The total packet rate in pps.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildEipProtectionTrafficQueryParams(d *schema.ResourceData) string {
+	if v, ok := d.GetOk("ip"); ok {
+		return fmt.Sprintf("?ip=%s", v.(string))
+	}
+
+	return ""
+}
+
+func dataSourceEipProtectionTrafficRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/antiddos/{floating_ip_id}/daily"
+		product = "anti-ddos"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Anti-DDoS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{floating_ip_id}", d.Get("floating_ip_id").(string))
+	requestPath += buildEipProtectionTrafficQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving Anti-DDoS daily protection traffic: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("data", flattenEipProtectionTraffic(utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenEipProtectionTraffic(dataArray []interface{}) []map[string]interface{} {
+	if len(dataArray) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(dataArray))
+	for _, v := range dataArray {
+		result = append(result, map[string]interface{}{
+			"period_start": utils.PathSearch("period_start", v, nil),
+			"bps_in":       utils.PathSearch("bps_in", v, 0),
+			"bps_attack":   utils.PathSearch("bps_attack", v, 0),
+			"total_bps":    utils.PathSearch("total_bps", v, 0),
+			"pps_in":       utils.PathSearch("pps_in", v, 0),
+			"pps_attack":   utils.PathSearch("pps_attack", v, 0),
+			"total_pps":    utils.PathSearch("total_pps", v, 0),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query daily protection traffic.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o antiddos -f TestAccDataSourceEipProtectionTraffic_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/antiddos" -v -coverprofile="./huaweicloud/services/acceptance/antiddos/antiddos_coverage.cov" -coverpkg="./huaweicloud/services/antiddos" -run TestAccDataSourceEipProtectionTraffic_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceEipProtectionTraffic_basic
=== PAUSE TestAccDataSourceEipProtectionTraffic_basic
=== CONT  TestAccDataSourceEipProtectionTraffic_basic
--- PASS: TestAccDataSourceEipProtectionTraffic_basic (10.29s)
PASS
coverage: 10.3% of statements in ./huaweicloud/services/antiddos
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/antiddos  10.365s coverage: 10.3% of statements in ./huaweicloud/services/antiddos
```
<img width="1334" height="83" alt="image" src="https://github.com/user-attachments/assets/4b0bea13-da25-455d-9b90-5920103dc14b" />



* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
