### PR TITLE
feat(waf): add a new datasource to query geolocation options detail

### DIFF
--- a/docs/data-sources/waf_geolocation_detail.md
+++ b/docs/data-sources/waf_geolocation_detail.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_geolocation_detail"
+description: |-
+  Use this data source to query geolocation options detail.
+---
+
+# huaweicloud_waf_geolocation_detail
+
+Use this data source to query geolocation options detail.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_waf_geolocation_detail" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `lang` - (Optional, String) Specifies the language type.
+  The value can be **cn** or **en**. Defaults to **cn**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `continent` - The distribution information of country names on each continent, in JSON format.
+
+* `geomap` - The key value represents the abbreviations of each country (except for AB and AB2, where AB indicates
+  overseas and Hong Kong, Macao and Taiwan, and AB2 indicates overseas). When the key is CN, the array content inside
+  is the abbreviation of each province.
+  The `geomap` value in JSON format.
+
+* `locale` - The display names of the corresponding languages for the values in `geomap`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1604,6 +1604,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_dedicated_domains":                    waf.DataSourceWafDedicatedDomains(),
 			"huaweicloud_waf_dedicated_instances":                  waf.DataSourceWafDedicatedInstances(),
 			"huaweicloud_waf_domains":                              waf.DataSourceWafDomains(),
+			"huaweicloud_waf_geolocation_detail":                   waf.DataSourceGeolocationDetail(),
 			"huaweicloud_waf_instance_groups":                      waf.DataSourceWafInstanceGroups(),
 			"huaweicloud_waf_overviews_bandwidth_timeline":         waf.DataSourceWafOverviewsBandwidthTimeline(),
 			"huaweicloud_waf_overviews_classification":             waf.DataSourceWafOverviewsClassification(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_geolocation_detail_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_geolocation_detail_test.go
@@ -1,0 +1,40 @@
+package waf
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGeolocationDetail_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_waf_geolocation_detail.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGeolocationDetail_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "continent"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "geomap"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.CN"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceGeolocationDetail_basic = `
+data "huaweicloud_waf_geolocation_detail" "test" {
+  lang = "en"
+}
+`

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_geolocation_detail.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_geolocation_detail.go
@@ -1,0 +1,102 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/waf/tag/geoip/map
+func DataSourceGeolocationDetail() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGeolocationDetailRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"lang": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"continent": {
+				Type:     schema.TypeString, // JSON format
+				Computed: true,
+			},
+			"geomap": {
+				Type:     schema.TypeString, // JSON format
+				Computed: true,
+			},
+			"locale": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceGeolocationDetailRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v1/{project_id}/waf/tag/geoip/map"
+		geoLanguage = d.Get("lang").(string)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	if geoLanguage != "" {
+		getPath = fmt.Sprintf("%s?lang=%s", getPath, geoLanguage)
+	}
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving geolocation detail: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("continent", utils.JsonToString(utils.PathSearch("continent", respBody, nil))),
+		d.Set("geomap", utils.JsonToString(utils.PathSearch("geomap", respBody, nil))),
+		d.Set("locale", utils.PathSearch("locale", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new datasource to query geolocation options detail.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccDataSourceGeolocationDetail_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceGeolocationDetail_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceGeolocationDetail_basic
=== PAUSE TestAccDataSourceGeolocationDetail_basic
=== CONT  TestAccDataSourceGeolocationDetail_basic
--- PASS: TestAccDataSourceGeolocationDetail_basic (16.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       16.478s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
