### PR TITLE
feat(fgs): add new data source to query function tags

### DIFF
--- a/docs/data-sources/fgs_function_tags.md
+++ b/docs/data-sources/fgs_function_tags.md
@@ -1,0 +1,48 @@
+---
+subcategory: "FunctionGraph"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_fgs_function_tags"
+description: |-
+  Use this data source to query function tags within HuaweiCloud.
+---
+
+# huaweicloud_fgs_function_tags
+
+Use this data source to query function tags within HuaweiCloud.
+
+## Example Usage
+
+### Query function tags by function ID
+
+```hcl
+variable "function_id" {}
+
+data "huaweicloud_fgs_function_tags" "test" {
+  function_id = var.function_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the function is located and tags to be queried.  
+  If omitted, the provider-level region will be used.
+
+* `function_id` - (Required, String) Specifies the ID of the function to which the tags belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tags` - The list of the function tags.  
+  The [tags](#fgs_function_tags_attr) structure is documented below.
+
+<a name="fgs_function_tags_attr"></a>
+The `tags` block supports:
+
+* `key` - The key of the tag.
+
+* `value` - The value of the tag.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1008,6 +1008,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_dependencies":          fgs.DataSourceDependencies(),
 			"huaweicloud_fgs_dependency_versions":   fgs.DataSourceDependencieVersions(),
 			"huaweicloud_fgs_function_events":       fgs.DataSourceFunctionEvents(),
+			"huaweicloud_fgs_function_tags":         fgs.DataSourceFunctionTags(),
 			"huaweicloud_fgs_function_triggers":     fgs.DataSourceFunctionTriggers(),
 			"huaweicloud_fgs_functions":             fgs.DataSourceFunctions(),
 			"huaweicloud_fgs_quotas":                fgs.DataSourceQuotas(),

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_function_tags_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_function_tags_test.go
@@ -1,0 +1,105 @@
+package fgs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataFunctionTags_basic(t *testing.T) {
+	var (
+		base = "huaweicloud_fgs_function.test"
+
+		all          = "data.huaweicloud_fgs_function_tags.all"
+		dcForAllTags = acceptance.InitDataSourceCheck(all)
+
+		byFunctionId   = "data.huaweicloud_fgs_function_tags.filter_by_function_id"
+		dcByFunctionId = acceptance.InitDataSourceCheck(byFunctionId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataFunctionTags_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// Without filter parameters.
+					dcForAllTags.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(all, "function_id"),
+					// Filter by function ID.
+					dcByFunctionId.CheckResourceExists(),
+					resource.TestCheckOutput("is_function_id_filter_useful", "true"),
+					// Check the attributes.
+					resource.TestCheckResourceAttrPair(byFunctionId, "function_id", base, "urn"),
+					resource.TestCheckResourceAttr(byFunctionId, "tags.#", "2"),
+					resource.TestCheckResourceAttr(byFunctionId, "tags.0.key", "foo"),
+					resource.TestCheckResourceAttr(byFunctionId, "tags.0.value", "bar"),
+					resource.TestCheckResourceAttr(byFunctionId, "tags.1.key", "key"),
+					resource.TestCheckResourceAttr(byFunctionId, "tags.1.value", "value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataFunctionTags_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+variable "function_code_content" {
+  type    = string
+  default = <<EOT
+def main():  
+    print("Hello, World!")  
+
+if __name__ == "__main__":  
+    main()
+EOT
+}
+
+resource "huaweicloud_fgs_function" "test" {
+  name        = "%[1]s"
+  memory_size = 128
+  runtime     = "Python2.7"
+  timeout     = 3
+  app         = "default"
+  handler     = "index.handler"
+  code_type   = "inline"
+  func_code   = base64encode(var.function_code_content)
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+# Without any filter parameter.
+data "huaweicloud_fgs_function_tags" "all" {
+  function_id = huaweicloud_fgs_function.test.id
+}
+
+# Filter by function ID.
+locals {
+  function_id = huaweicloud_fgs_function.test.id
+}
+
+data "huaweicloud_fgs_function_tags" "filter_by_function_id" {
+  function_id = local.function_id
+}
+
+locals {
+  function_id_filter_result = [for v in data.huaweicloud_fgs_function_tags.filter_by_function_id.tags[*].key :
+    v == "foo" || v == "key"]
+}
+
+output "is_function_id_filter_useful" {
+  value = length(local.function_id_filter_result) == 2 && alltrue(local.function_id_filter_result)
+}
+`, name)
+}

--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_function_tags.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_function_tags.go
@@ -1,0 +1,150 @@
+package fgs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API FunctionGraph GET /v2/{project_id}/{resource_type}/{resource_id}/tags
+func DataSourceFunctionTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceFunctionTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the function is located and tags to be queried.`,
+			},
+
+			// Required parameter(s).
+			"function_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the function to which the tags belong.`,
+			},
+
+			// Attribute(s).
+			"tags": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The key of the tag.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The value of the tag.`,
+						},
+					},
+				},
+				Description: `The list of the function tags.`,
+			},
+
+			// Internal attribute(s).
+			"sys_tags": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The key of the system tag.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The value of the system tag.`,
+						},
+					},
+				},
+				Description: utils.SchemaDesc(
+					`The list of the system tags.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func getFunctionTags(client *golangsdk.ServiceClient, functionId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/functions/{function_id}/tags"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{function_id}", functionId)
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func flattenFunctionTags(tags []interface{}) []map[string]interface{} {
+	if len(tags) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(tags))
+	for _, tag := range tags {
+		result = append(result, map[string]interface{}{
+			"key":   utils.PathSearch("key", tag, nil),
+			"value": utils.PathSearch("value", tag, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceFunctionTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	functionId := d.Get("function_id").(string)
+	resp, err := getFunctionTags(client, functionId)
+	if err != nil {
+		return diag.Errorf("error querying FunctionGraph function tags: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("tags", flattenFunctionTags(utils.PathSearch("tags", resp, make([]interface{}, 0)).([]interface{}))),
+		d.Set("sys_tags", flattenFunctionTags(utils.PathSearch("sys_tags", resp, make([]interface{}, 0)).([]interface{}))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source that used to query tags under a specified function.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new data source that used to query tags under a specified function.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccDataFunctionTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataFunctionTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataFunctionTags_basic
=== PAUSE TestAccDataFunctionTags_basic
=== CONT  TestAccDataFunctionTags_basic
--- PASS: TestAccDataFunctionTags_basic (13.97s)
PASS
coverage: 14.6% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       14.062s coverage: 14.6% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
