### PR TITLE
feat(fgs): add new data source to query resource tags

### DIFF
--- a/docs/data-sources/fgs_resource_tags.md
+++ b/docs/data-sources/fgs_resource_tags.md
@@ -1,0 +1,41 @@
+---
+subcategory: "FunctionGraph"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_fgs_resource_tags"
+description: |-
+  Use this data source to query all resource tags within HuaweiCloud.
+---
+
+# huaweicloud_fgs_resource_tags
+
+Use this data source to query all resource tags within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_fgs_resource_tags" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the resource tags are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tags` - The list of resource tags.
+
+  The [tags](#fgs_resource_tags_attr) structure is documented below.
+
+<a name="fgs_resource_tags_attr"></a>
+The `tags` block supports:
+
+* `key` - The key of the tag.
+
+* `values` - The values of the tag.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1011,6 +1011,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_function_triggers":     fgs.DataSourceFunctionTriggers(),
 			"huaweicloud_fgs_functions":             fgs.DataSourceFunctions(),
 			"huaweicloud_fgs_quotas":                fgs.DataSourceQuotas(),
+			"huaweicloud_fgs_resource_tags":         fgs.DataSourceResourceTags(),
 
 			"huaweicloud_ga_accelerators":       ga.DataSourceAccelerators(),
 			"huaweicloud_ga_access_logs":        ga.DataSourceGaAccessLogs(),

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_resource_tags_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_resource_tags_test.go
@@ -1,0 +1,74 @@
+package fgs
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataResourceTags_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_fgs_resource_tags.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataResourceTags_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "tags.#", regexp.MustCompile(`[1-9][0-9]*`)),
+					resource.TestMatchResourceAttr(all, "sys_tags.#", regexp.MustCompile(`[0-9]*`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataResourceTags_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+variable "function_code_content" {
+  type    = string
+  default = <<EOT
+def main():
+  print("Hello, World!")
+
+if __name__ == "__main__":
+  main()
+EOT
+}
+
+resource "huaweicloud_fgs_function" "test" {
+  name        = "%[1]s"
+  memory_size = 128
+  runtime     = "Python2.7"
+  timeout     = 3
+  app         = "default"
+  handler     = "index.handler"
+  code_type   = "inline"
+  func_code   = base64encode(var.function_code_content)
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+  
+data "huaweicloud_fgs_resource_tags" "all" {
+  depends_on = [
+    huaweicloud_fgs_function.test,
+  ]
+}
+`, name)
+}

--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_resource_tags.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_resource_tags.go
@@ -1,0 +1,153 @@
+package fgs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API FunctionGraph GET /v2/{project_id}/functions/tags
+func DataSourceResourceTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceResourceTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the resource tags are located.`,
+			},
+
+			// Attribute(s).
+			"tags": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of resource tags.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The key of the tag.`,
+						},
+						"values": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The values of the tag.`,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+
+			// Internal attribute(s).
+			"sys_tags": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The key of the system tag.`,
+						},
+						"values": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The values of the system tag.`,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+				Description: utils.SchemaDesc(
+					`The list of system tags.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func getResourceTags(client *golangsdk.ServiceClient) (interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/functions/tags"
+	)
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func flattenResourceTags(tags []interface{}) []map[string]interface{} {
+	if len(tags) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(tags))
+	for _, tag := range tags {
+		result = append(result, map[string]interface{}{
+			"key":    utils.PathSearch("key", tag, nil),
+			"values": utils.PathSearch("values", tag, make([]interface{}, 0)),
+		})
+	}
+
+	return result
+}
+
+func dataSourceResourceTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	respBody, err := getResourceTags(client)
+	if err != nil {
+		return diag.Errorf("error querying resource tags: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("tags", flattenResourceTags(utils.PathSearch("tags", respBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("sys_tags", flattenResourceTags(utils.PathSearch("sys_tags", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new data source that used to query all resource tags under a specified region.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports a new data source that used to query all resource tags under a specified region.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccDataResourceTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataResourceTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataResourceTags_basic
=== PAUSE TestAccDataResourceTags_basic
=== CONT  TestAccDataResourceTags_basic
--- PASS: TestAccDataResourceTags_basic (13.01s)
PASS
coverage: 14.5% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       13.076s coverage: 14.5% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
