### PR TITLE
feat(dli/elastic_resource_pool): the resource supports prepaid mode

### DIFF
--- a/docs/resources/dli_elastic_resource_pool.md
+++ b/docs/resources/dli_elastic_resource_pool.md
@@ -46,6 +46,25 @@ resource "huaweicloud_dli_elastic_resource_pool" "test" {
 }
 ```
 
+### Create a basic elastic resource pool with prePaid mode
+
+```hcl
+variable "resoure_pool_name" {}
+
+resource "huaweicloud_dli_elastic_resource_pool" "test" {
+  name          = var.resoure_pool_name
+  min_cu        = 32
+  max_cu        = 64
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+
+  label = {
+    spec = "basic"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -87,6 +106,25 @@ The following arguments are supported:
   Changing this will create a new resource.  
   If not specified, the default is the standard edition. The key/value corresponding to the basic edition is `spec = "basic"`.
 
+* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the elastic resource pool.  
+  Defaults to **postPaid**.  
+  The valid values are **postPaid** and **prePaid**.  
+  Changing this creates a new resource.
+
+* `period_unit` - (Optional, String, ForceNew) Specifies the period unit of the elastic resource pool.  
+  The valid values are **month** and **year**.  
+  This parameter is **required** and available only when `charging_mode` is set to **prePaid**.  
+  Changing this creates a new resource.
+
+* `period` - (Optional, Int, ForceNew) Specifies the period of the elastic resource pool.  
+  This parameter is **required** and available only when `charging_mode` is set to **prePaid**.  
+  Changing this creates a new resource.
+
+* `auto_renew` - (Optional, String) Specifies whether to enable auto-renew for the elastic resource pool.  
+  Defaults to **false**.  
+  The valid values are **true** and **false**.
+  This parameter is available only when `charging_mode` is set to **prePaid**.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -104,6 +142,8 @@ In addition to all arguments above, the following attributes are exported:
 * `current_cu` - The current CU number of the elastic resource pool.
 
 * `actual_cu` - The current CU number of the elastic resource pool.
+
+* `prepay_cu` - The number of prepaid CUs of the elastic resource pool.
 
 * `created_at` - The creation time of the elastic resource pool.  
   The format is `YYYY-MM-DDThh:mm:ss{timezone}`, e.g. `2024-01-01T08:00:00+08:00`.
@@ -125,8 +165,8 @@ $ terraform import huaweicloud_dli_elastic_resource_pool.test <name>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: `tags` and `label`.
-It is generally recommended running `terraform plan` after importing a resource.
+API response, security or some other reason. The missing attributes include: `tags`, `period`, `period_unit`
+and `auto_renew`. It is generally recommended running `terraform plan` after importing a resource.
 You can then decide if changes should be applied to the resource, or the resource definition should be updated to
 align with the resource. Also you can ignore changes as below.
 
@@ -136,7 +176,7 @@ resource "huaweicloud_dli_elastic_resource_pool" "test" {
 
   lifecycle {
     ignore_changes = [
-      tags, label,
+      tags, period, period_unit, auto_renew,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -1620,15 +1620,6 @@ func TestAccPreCheckDliFlinkStreamGraph(t *testing.T) {
 	}
 }
 
-// Since it takes at least one hour to execute the elastic resource pool resource test case,
-// this variable is provided to distinguish the full test cases.
-// lintignore:AT003
-func TestAccPreCheckDliElasticResourcePool(t *testing.T) {
-	if HW_DLI_ELASTIC_RESOURCE_POOL == "" {
-		t.Skip("HW_DLI_ELASTIC_RESOURCE_POOL must be set for DLI acceptance tests.")
-	}
-}
-
 // lintignore:AT003
 func TestAccPreCheckRepoTokenAuth(t *testing.T) {
 	if HW_GITHUB_PERSONAL_TOKEN == "" {

--- a/huaweicloud/services/cbc/common.go
+++ b/huaweicloud/services/cbc/common.go
@@ -1,0 +1,33 @@
+package cbc
+
+import (
+	"strings"
+
+	"github.com/chnsz/golangsdk"
+)
+
+// PaySubscriptionOrder is a method used to pay for a subscription order.
+func PaySubscriptionOrder(client *golangsdk.ServiceClient, orderId string) error {
+	httpUrl := "v3/orders/customer-orders/pay"
+	payPath := client.Endpoint + httpUrl
+	payPath = strings.ReplaceAll(payPath, "{project_id}", client.ProjectID)
+
+	payOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildPaySubscriptionOrderBodyParams(orderId),
+		OkCodes:          []int{204},
+	}
+
+	_, err := client.Request("POST", payPath, &payOpts)
+	return err
+}
+
+func buildPaySubscriptionOrderBodyParams(orderId string) map[string]interface{} {
+	// `use_coupon`: Whether to use a coupon, the valid values are "YES" and "NO".
+	// `use_discount`: Whether to use a discount, the valid values are "YES" and "NO".
+	return map[string]interface{}{
+		"order_id":     orderId,
+		"use_coupon":   "NO",
+		"use_discount": "NO",
+	}
+}

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -16,10 +17,13 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API DLI POST /v3/{project_id}/elastic-resource-pools
+// @API DLI POST /v3/{project_id}/orders/elastic-resource-pools
+// @API BSS POST /v3/orders/customer-orders/pay
 // @API DLI GET /v3/{project_id}/elastic-resource-pools
 // @API DLI PUT /v3/{project_id}/elastic-resource-pools/{elastic_resource_pool_name}
 // @API DLI DELETE /v3/{project_id}/elastic-resource-pools/{elastic_resource_pool_name}
@@ -95,6 +99,10 @@ func ResourceElasticResourcePool() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `The attribute fields of the elastic resource pool.`,
 			},
+			"charging_mode": common.SchemaChargingMode(nil),
+			"period_unit":   common.SchemaPeriodUnit(nil),
+			"period":        common.SchemaPeriod(nil),
+			"auto_renew":    common.SchemaAutoRenewUpdatable(nil),
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -110,6 +118,11 @@ func ResourceElasticResourcePool() *schema.Resource {
 				Computed:    true,
 				Description: `The actual CU number of the elastic resource pool.`,
 			},
+			"prepay_cu": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of prepaid CUs of the elastic resource pool.`,
+			},
 			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -121,9 +134,9 @@ func ResourceElasticResourcePool() *schema.Resource {
 
 func resourceElasticResourcePoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		httpUrl = "v3/{project_id}/elastic-resource-pools"
+		cfg                     = meta.(*config.Config)
+		region                  = cfg.GetRegion(d)
+		elasticResourcePoolName = d.Get("name").(string)
 	)
 
 	client, err := cfg.NewServiceClient("dli", region)
@@ -131,32 +144,47 @@ func resourceElasticResourcePoolCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("error creating DLI client: %s", err)
 	}
 
-	createPath := client.Endpoint + httpUrl
-	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
-	createOpts := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateElasticResourcePoolBodyParams(cfg, d)),
+	if d.Get("charging_mode").(string) == "prePaid" {
+		bssClient, err := cfg.NewServiceClient("bssv2", cfg.GetRegion(d))
+		if err != nil {
+			return diag.Errorf("error creating BSS client: %s", err)
+		}
+
+		orderId, err := createPrePaidElasticResourcePool(client, d, cfg.GetEnterpriseProjectID(d))
+		if err != nil {
+			return diag.Errorf("error creating prepaid elastic resource pool (%s): %s", elasticResourcePoolName, err)
+		}
+
+		if orderId == "" {
+			return diag.Errorf("unable to find the order ID from the API response")
+		}
+
+		// The DLI create elastic resource pool interface does not support auto-payment,
+		// so the CBC side interface is called to pay for the order.
+		if err := cbc.PaySubscriptionOrder(bssClient, orderId); err != nil {
+			return diag.Errorf("error paying for the elastic resource pool (%s): %s", elasticResourcePoolName, err)
+		}
+
+		if err := common.WaitOrderComplete(ctx, bssClient, orderId, d.Timeout(schema.TimeoutDefault)); err != nil {
+			return diag.FromErr(err)
+		}
+
+		resourceId, err := common.WaitOrderResourceComplete(ctx, bssClient, orderId, d.Timeout(schema.TimeoutDefault))
+		if err != nil {
+			return diag.Errorf("error waiting for elastic resource pool (%s) order (%s) to complete: %s",
+				elasticResourcePoolName, orderId, err)
+		}
+
+		d.SetId(resourceId)
+
+		return resourceElasticResourcePoolRead(ctx, d, meta)
 	}
 
-	requestResp, err := client.Request("POST", createPath, &createOpts)
-	if err != nil {
-		return diag.Errorf("error creating DLI elastic resource pool: %s", err)
-	}
-	respBody, err := utils.FlattenResponse(requestResp)
+	resourceId, err := createPostPaidElasticResourcePool(cfg, client, d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if !utils.PathSearch("is_success", respBody, true).(bool) {
-		return diag.Errorf("unable to create the elastic resource pool: %s",
-			utils.PathSearch("message", respBody, "Message Not Found"))
-	}
 
-	resourceName := utils.PathSearch("elastic_resource_pool_name", respBody, "").(string)
-	respBody, err = GetElasticResourcePoolByName(client, resourceName)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	resourceId := utils.PathSearch("resource_id", respBody, "").(string)
 	d.SetId(resourceId)
 
 	err = waitForElasticResourcePoolStatusCompleted(ctx, client, d)
@@ -167,17 +195,92 @@ func resourceElasticResourcePoolCreate(ctx context.Context, d *schema.ResourceDa
 	return resourceElasticResourcePoolRead(ctx, d, meta)
 }
 
-func buildCreateElasticResourcePoolBodyParams(cfg *config.Config, d *schema.ResourceData) map[string]interface{} {
-	return map[string]interface{}{
+func createPrePaidElasticResourcePool(client *golangsdk.ServiceClient, d *schema.ResourceData, epsId string) (string, error) {
+	httpUrl := "v3/{project_id}/orders/elastic-resource-pools"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateElasticResourcePoolBodyParams(d, epsId)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return "", err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return "", err
+	}
+
+	return utils.PathSearch("order_id", respBody, "").(string), nil
+}
+
+func createPostPaidElasticResourcePool(cfg *config.Config, client *golangsdk.ServiceClient, d *schema.ResourceData) (string, error) {
+	httpUrl := "v3/{project_id}/elastic-resource-pools"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateElasticResourcePoolBodyParams(d, cfg.GetEnterpriseProjectID(d))),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return "", fmt.Errorf("error creating DLI elastic resource pool: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return "", err
+	}
+
+	if !utils.PathSearch("is_success", respBody, true).(bool) {
+		return "", fmt.Errorf("unable to create the elastic resource pool: %s",
+			utils.PathSearch("message", respBody, "Message Not Found"))
+	}
+
+	resourceName := utils.PathSearch("elastic_resource_pool_name", respBody, "").(string)
+	respBody, err = GetElasticResourcePoolByName(client, resourceName)
+	if err != nil {
+		return "", err
+	}
+
+	return utils.PathSearch("resource_id", respBody, "").(string), nil
+}
+
+func buildCreateElasticResourcePoolBodyParams(d *schema.ResourceData, epsId string) map[string]interface{} {
+	params := map[string]interface{}{
 		"elastic_resource_pool_name": d.Get("name"),
-		"description":                d.Get("description"),
+		"description":                utils.ValueIgnoreEmpty(d.Get("description")),
 		"max_cu":                     d.Get("max_cu"),
 		"min_cu":                     d.Get("min_cu"),
-		"cidr_in_vpc":                utils.StringIgnoreEmpty(d.Get("cidr").(string)),
-		"enterprise_project_id":      utils.StringIgnoreEmpty(cfg.GetEnterpriseProjectID(d)),
+		"cidr_in_vpc":                utils.ValueIgnoreEmpty(d.Get("cidr").(string)),
+		"enterprise_project_id":      utils.ValueIgnoreEmpty(epsId),
 		"tags":                       utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{})),
 		"label":                      utils.ValueIgnoreEmpty(d.Get("label")),
 	}
+
+	if d.Get("charging_mode").(string) == "prePaid" {
+		params["charging_mode"] = 2
+		params["period_type"] = d.Get("period_unit")
+		params["period_num"] = d.Get("period")
+		params["auto_renew"] = parseElasticResourcePoolAutoRenew(d.Get("auto_renew").(string))
+	}
+
+	return params
+}
+
+func parseElasticResourcePoolAutoRenew(autoRenew string) bool {
+	result, err := strconv.ParseBool(autoRenew)
+	if err != nil {
+		log.Printf("[ERROR] unable to convert auto_renew to bool value")
+		return false
+	}
+
+	return result
 }
 
 func waitForElasticResourcePoolStatusCompleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
@@ -248,14 +351,29 @@ func resourceElasticResourcePoolRead(_ context.Context, d *schema.ResourceData, 
 		// The `tags` is a Computed behavior, but the API doesn't return this field, using `ignore_changes` in a script won't work,
 		// so we need to set this value to ensure `ignore_changes` takes effect during import.
 		d.Set("tags", d.Get("tags")),
+		d.Set("label", utils.PathSearch("label", respBody, nil)),
+		d.Set("charging_mode", convertElasticResourcePoolChargingMode(int(utils.PathSearch("charging_mode", respBody, float64(0)).(float64)))),
 		d.Set("status", utils.PathSearch("status", respBody, nil)),
 		d.Set("current_cu", utils.PathSearch("current_cu", respBody, nil)),
 		d.Set("actual_cu", utils.PathSearch("actual_cu", respBody, nil)),
+		d.Set("prepay_cu", utils.PathSearch("prepay_cu", respBody, nil)),
 		d.Set("created_at", utils.FormatTimeStampRFC3339(
 			int64(utils.PathSearch("create_time", respBody, float64(0)).(float64))/1000, false)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func convertElasticResourcePoolChargingMode(chargingMode int) string {
+	switch chargingMode {
+	case 2:
+		return "prePaid"
+	case 1:
+		return "postPaid"
+	}
+
+	log.Printf("[WARN] error parsing charging_mode from API response")
+	return ""
 }
 
 // GetElasticResourcePools is a method used to query all elastic resource pools in a specified region.
@@ -382,6 +500,17 @@ func resourceElasticResourcePoolUpdate(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 
+	if d.HasChange("auto_renew") {
+		bssClient, err := cfg.NewServiceClient("bssv2", region)
+		if err != nil {
+			return diag.Errorf("error creating BSS client: %s", err)
+		}
+
+		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), resourceId); err != nil {
+			return diag.Errorf("error updating the auto-renew of the elastic resource pool (%s): %s", resourceId, err)
+		}
+	}
+
 	return resourceElasticResourcePoolRead(ctx, d, meta)
 }
 
@@ -397,7 +526,6 @@ func resourceElasticResourcePoolDelete(ctx context.Context, d *schema.ResourceDa
 	var (
 		cfg          = meta.(*config.Config)
 		region       = cfg.GetRegion(d)
-		httpUrl      = "v3/{project_id}/elastic-resource-pools/{elastic_resource_pool_name}"
 		resourceName = d.Get("name").(string)
 	)
 
@@ -406,34 +534,52 @@ func resourceElasticResourcePoolDelete(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("error creating DLI client: %s", err)
 	}
 
-	deletePath := client.Endpoint + httpUrl
-	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
-	deletePath = strings.ReplaceAll(deletePath, "{elastic_resource_pool_name}", resourceName)
-	// Due to API restrictions, the request body must pass in an empty JSON.
-	deleteOpts := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-	}
-
-	requestResp, err := client.Request("DELETE", deletePath, &deleteOpts)
-	if err != nil {
-		return diag.Errorf("error deleting DLI elastic resource pool (%s): %s", resourceName, err)
-	}
-	respBody, err := utils.FlattenResponse(requestResp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	if !utils.PathSearch("is_success", respBody, true).(bool) {
-		return diag.Errorf("unable to delete the elastic resource pool: %s",
-			utils.PathSearch("message", respBody, "Message Not Found"))
+	if d.Get("charging_mode").(string) == "prePaid" {
+		if err := common.UnsubscribePrePaidResource(d, cfg, []string{d.Id()}); err != nil {
+			// CBC.30000067: The resource has been unsubscribed.
+			return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", "CBC.30000067"),
+				fmt.Sprintf("error unsubscribing elastic resource pool (%s)", resourceName))
+		}
+	} else {
+		err = deleteElasticResourcePool(client, resourceName)
+		if err != nil {
+			// DLI.0002: The resource pool has been deleted.
+			return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", "DLI.0002"),
+				fmt.Sprintf("error deleting elastic resource pool (%s)", resourceName))
+		}
 	}
 
 	err = waitForElasticResourcePoolDeleted(ctx, client, d)
 	if err != nil {
-		diag.Errorf("error waiting for the elastic resource pool (%s) status to become deleted: %s", d.Id(), err)
+		diag.Errorf("error waiting for the elastic resource pool (%s) status to become deleted: %s", resourceName, err)
 	}
+	return nil
+}
+
+func deleteElasticResourcePool(client *golangsdk.ServiceClient, resourceName string) error {
+	httpUrl := "v3/{project_id}/elastic-resource-pools/{elastic_resource_pool_name}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{elastic_resource_pool_name}", resourceName)
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("DELETE", deletePath, &deleteOpts)
+	if err != nil {
+		return err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return err
+	}
+
+	if !utils.PathSearch("is_success", respBody, true).(bool) {
+		return fmt.Errorf("unable to delete the elastic resource pool: %s",
+			utils.PathSearch("message", respBody, "Message Not Found"))
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Add common method to automatically pay for orders of resources.
2. Added new billing mode fields to support the creation of prepaid elastic resource pools.
+ new parameters
  - charging_mode
  -  period_unit
  - period
  - auto_renew
+ new atrribute
  + prepay_cu

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dli -f TestAccElasticResourcePool_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dli" -v -coverprofile="./huaweicloud/services/acceptance/dli/dli_coverage.cov" -coverpkg="./huaweicloud/services/dli" -run TestAccElasticResourcePool_ -timeout 360m -parallel 10
=== RUN   TestAccElasticResourcePool_basic
=== PAUSE TestAccElasticResourcePool_basic
=== RUN   TestAccElasticResourcePool_prePaid
=== PAUSE TestAccElasticResourcePool_prePaid
=== CONT  TestAccElasticResourcePool_basic
=== CONT  TestAccElasticResourcePool_prePaid
--- PASS: TestAccElasticResourcePool_prePaid (720.67s)
--- PASS: TestAccElasticResourcePool_basic (1597.44s)
PASS
coverage: 7.2% of statements in ./huaweicloud/services/dli
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       1597.669s       coverage: 7.2% of statements in ./huaweicloud/services/dli
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    + Delete a non-existent resource pool.
    <img width="1079" height="830" alt="image" src="https://github.com/user-attachments/assets/eaa059ae-c8bd-4bd9-babb-1d1d8e425249" />

      + unsubscribe a non-existent resource pool.
      <img width="948" height="903" alt="image" src="https://github.com/user-attachments/assets/baa016e3-cbc2-44ac-83a3-640c7f73d05e" />

    
