### PR TITLE
feat(antiddos): new datasource to query eip exception events

### DIFF
--- a/docs/data-sources/antiddos_eip_exception_events.md
+++ b/docs/data-sources/antiddos_eip_exception_events.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_antiddos_eip_exception_events"
+description: |-
+  Use this data source to query the exception events of an EIP protected by Anti-DDoS.
+---
+
+# huaweicloud_antiddos_eip_exception_events
+
+Use this data source to query the exception events of an EIP protected by Anti-DDoS.
+
+## Example Usage
+
+```hcl
+variable "floating_ip_id" {}
+variable "eip_address" {}
+
+data "huaweicloud_antiddos_eip_exception_events" "test" {
+  floating_ip_id = var.floating_ip_id
+  ip             = var.eip_address
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `floating_ip_id` - (Required, String) Specifies the ID of the EIP.
+
+* `ip` - (Optional, String) Specifies the EIP address.
+
+* `sort_dir` - (Optional, String) Specifies the sort direction. The value can be **asc** or **desc**.
+  Defaults to **desc**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `logs` - The list of exception events.
+  The [logs](#logs_block) structure is documented below.
+
+<a name="logs_block"></a>
+The `logs` block supports:
+
+* `start_time` - The start time of the exception event.
+
+* `end_time` - The end time of the exception event.
+
+* `status` - The protection status. The valid values are:
+  + `1`: Cleaning.
+  + `2`: Blackhole.
+
+* `trigger_bps` - The traffic when the exception event is triggered, in bit/s.
+
+* `trigger_pps` - The packet rate when the exception event is triggered, in pps.
+
+* `trigger_http_pps` - The HTTP request rate when the exception event is triggered, in pps.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -474,6 +474,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_antiddos_weekly_protection_statistics": antiddos.DataSourceWeeklyProtectionStatistics(),
 			"huaweicloud_antiddos_eip_defense_statuses":         antiddos.DataSourceEipDefenseStatuses(),
 			"huaweicloud_antiddos_eip_protection_traffic":       antiddos.DataSourceEipProtectionTraffic(),
+			"huaweicloud_antiddos_eip_exception_events":         antiddos.DataSourceEipExceptionEvents(),
 
 			"huaweicloud_aom_access_codes":                    aom.DataSourceAomAccessCodes(),
 			"huaweicloud_aom_cloud_service_authorizations":    aom.DataSourceCloudServiceAuthorizations(),

--- a/huaweicloud/services/acceptance/antiddos/data_source_huaweicloud_antiddos_eip_exception_events_test.go
+++ b/huaweicloud/services/acceptance/antiddos/data_source_huaweicloud_antiddos_eip_exception_events_test.go
@@ -1,0 +1,46 @@
+package antiddos
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Please prepare the EIP ID and IP address in advance and ensure that the EIP has been bound to Anti-DDoS.
+// Due to testing environment limitations, this test case can only test the scenario with empty `logs`.
+func TestAccDataSourceEipExceptionEvents_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_antiddos_eip_exception_events.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckEipIDAndIP(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceEipExceptionEvents_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "logs.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceEipExceptionEvents_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_antiddos_eip_exception_events" "test" {
+  floating_ip_id = "%s"
+  ip             = "%s"
+  sort_dir       = "asc"
+}
+`, acceptance.HW_EIP_ID, acceptance.HW_EIP_ADDRESS)
+}

--- a/huaweicloud/services/antiddos/data_source_huaweicloud_antiddos_eip_exception_events.go
+++ b/huaweicloud/services/antiddos/data_source_huaweicloud_antiddos_eip_exception_events.go
@@ -1,0 +1,174 @@
+package antiddos
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ANTI-DDOS GET /v1/{project_id}/antiddos/{floating_ip_id}/logs
+func DataSourceEipExceptionEvents() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEipExceptionEventsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"floating_ip_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the EIP.`,
+			},
+			"ip": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the EIP address.`,
+			},
+			"sort_dir": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the sort direction.`,
+			},
+			"logs": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of exception logs.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"start_time": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The start time of the exception event.`,
+						},
+						"end_time": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The end time of the exception event.`,
+						},
+						"status": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The protection status.`,
+						},
+						"trigger_bps": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The traffic when the exception event is triggered.`,
+						},
+						"trigger_pps": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The packet rate when the exception event is triggered.`,
+						},
+						"trigger_http_pps": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The HTTP request rate when the exception event is triggered.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildEipExceptionEventsQueryParams(d *schema.ResourceData) string {
+	rst := ""
+
+	if v, ok := d.GetOk("ip"); ok {
+		rst += fmt.Sprintf("&ip=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%s", v.(string))
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+// When the limit and offset fields are not included, the API defaults to querying the full data.
+// Therefore, no paging logic is done here.
+func dataSourceEipExceptionEventsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/antiddos/{floating_ip_id}/logs"
+		product = "anti-ddos"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Anti-DDoS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{floating_ip_id}", d.Get("floating_ip_id").(string))
+	requestPath += buildEipExceptionEventsQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving Anti-DDoS exception events: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("logs", flattenExceptionEvents(utils.PathSearch("logs", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenExceptionEvents(logsRaw []interface{}) []map[string]interface{} {
+	if len(logsRaw) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(logsRaw))
+	for _, log := range logsRaw {
+		result = append(result, map[string]interface{}{
+			"start_time":       utils.PathSearch("start_time", log, nil),
+			"end_time":         utils.PathSearch("end_time", log, nil),
+			"status":           utils.PathSearch("status", log, nil),
+			"trigger_bps":      utils.PathSearch("trigger_bps", log, nil),
+			"trigger_pps":      utils.PathSearch("trigger_pps", log, nil),
+			"trigger_http_pps": utils.PathSearch("trigger_http_pps", log, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query eip exception events.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o antiddos -f TestAccDataSourceEipExceptionEvents_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/antiddos" -v -coverprofile="./huaweicloud/services/acceptance/antiddos/antiddos_coverage.cov" -coverpkg="./huaweicloud/services/antiddos" -run TestAccDataSourceEipExceptionEvents_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceEipExceptionEvents_basic
=== PAUSE TestAccDataSourceEipExceptionEvents_basic
=== CONT  TestAccDataSourceEipExceptionEvents_basic
--- PASS: TestAccDataSourceEipExceptionEvents_basic (11.63s)
PASS
coverage: 10.4% of statements in ./huaweicloud/services/antiddos
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/antiddos  11.693s coverage: 10.4% of statements in ./huaweicloud/services/antiddos
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
