### PR TITLE
feat(fgs): add new resource to manage VPC endpoint via FGS side

### DIFF
--- a/docs/resources/fgs_vpc_endpoint.md
+++ b/docs/resources/fgs_vpc_endpoint.md
@@ -1,0 +1,65 @@
+---
+subcategory: "FunctionGraph"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_fgs_vpc_endpoint"
+description: |-
+  Manages the VPC endpoint via FunctionGraph side within HuaweiCloud.
+---
+
+# huaweicloud_fgs_vpc_endpoint
+
+Manages the VPC endpoint via FunctionGraph side within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_fgs_vpc_endpoint" "test" {
+  xrole     = var.iam_agency_name
+  vpc_id    = var.vpc_id
+  subnet_id = var.subnet_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region where the VPC endpoint is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `vpc_id` - (Required, String, NonUpdatable) The ID of the VPC to which the VPC endpoint belongs.
+
+* `subnet_id` - (Required, String, NonUpdatable) The ID of the subnet to which the VPC endpoint belongs.
+
+  -> This `subnet_id` must belong to the `vpc_id`.
+
+* `flavor` - (Optional, String, NonUpdatable) The flavor of the VPC endpoint.  
+  By default, the large specification will be used.
+
+* `xrole` - (Optional, String, NonUpdatable) The IAM agency name of the VPC endpoint.  
+  
+  -> The agency must include these roles:<br>
+     `vpc:zone:get`<br>
+     `vpc:subnets:get`<br>
+     `vpc:vpcs:get`<br>
+     `vpc:securityGroups:get`<br>
+     `vpc:securityGroups:list`<br>
+     `vpcep:endpoints:create`<br>
+     `vpcep:endpoints:delete`<br>
+     `vpcep:endpoints:get`<br>
+     `dns:zone:create`<br>
+     `dns:zone:delete`<br>
+     `dns:zone:get`<br>
+     `dns:recordset:create`<br>
+     `dns:recordset:update`<br>
+     `dns:recordset:list`
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `endpoints` - The list of IP addresses of the VPC endpoint.
+
+* `address` - The domain address of the endpoint.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2325,6 +2325,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_function_trigger":               fgs.ResourceFunctionTrigger(),
 			"huaweicloud_fgs_function_trigger_status_action": fgs.ResourceFunctionTriggerStatusAction(),
 			"huaweicloud_fgs_lts_log_enable":                 fgs.ResourceLtsLogEnable(),
+			"huaweicloud_fgs_vpc_endpoint":                   fgs.ResourceFgsVpcEndpoint(),
 
 			"huaweicloud_ga_accelerator":    ga.ResourceAccelerator(),
 			"huaweicloud_ga_access_log":     ga.ResourceAccessLog(),

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_vpc_endpoint_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_vpc_endpoint_test.go
@@ -1,0 +1,61 @@
+package fgs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccFgsVpcEndpoint_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_fgs_vpc_endpoint.test"
+		name         = acceptance.RandomAccResourceName()
+	)
+
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckFgsAgency(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource does not have the read method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFgsVpcEndpoint_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "xrole", acceptance.HW_FGS_AGENCY_NAME),
+				),
+			},
+		},
+	})
+}
+
+func testAccFgsVpcEndpoint_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id     = huaweicloud_vpc.test.id
+  name       = "%[1]s"
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 8, 0)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 8, 0), 1)
+}
+
+resource "huaweicloud_fgs_vpc_endpoint" "test" {
+  vpc_id    = huaweicloud_vpc.test.id
+  subnet_id = huaweicloud_vpc_subnet.test.id
+  xrole     = "%[2]s"
+}
+`, name, acceptance.HW_FGS_AGENCY_NAME)
+}

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_vpc_endpoint.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_vpc_endpoint.go
@@ -1,0 +1,175 @@
+package fgs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var vpcEndpointNonUpdatableParams = []string{"vpc_id", "subnet_id", "flavor", "xrole"}
+
+// @API FunctionGraph POST /v2/{project_id}/fgs/vpc-endpoint
+// @API FunctionGraph DELETE /v2/{project_id}/fgs/vpc-endpoint/{vpc_id}/{subnet_id}
+func ResourceFgsVpcEndpoint() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceFgsVpcEndpointCreate,
+		ReadContext:   resourceFgsVpcEndpointRead,
+		UpdateContext: resourceFgsVpcEndpointUpdate,
+		DeleteContext: resourceFgsVpcEndpointDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(vpcEndpointNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the VPC endpoint is located.`,
+			},
+
+			// Required parameter(s).
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the VPC to which the VPC endpoint belongs.`,
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the subnet to which the VPC endpoint belongs.`,
+			},
+
+			// Optional parameter(s).
+			"flavor": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The flavor of the VPC endpoint.`,
+			},
+			"xrole": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The IAM agency name of the VPC endpoint.`,
+			},
+
+			// Attributes.
+			"endpoints": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of IP addresses of the VPC endpoint.`,
+			},
+			"address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The domain address of the VPC endpoint.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildFgsVpcEndpointBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"vpc_id":    d.Get("vpc_id"),
+		"subnet_id": d.Get("subnet_id"),
+		"flavor":    utils.ValueIgnoreEmpty(d.Get("flavor")),
+		"xrole":     utils.ValueIgnoreEmpty(d.Get("xrole")),
+	}
+}
+
+func resourceFgsVpcEndpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	httpUrl := "v2/{project_id}/fgs/vpc-endpoint"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildFgsVpcEndpointBodyParams(d),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph VPC endpoint: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("endpoints", utils.PathSearch("endpoints", respBody, nil)),
+		d.Set("address", utils.PathSearch("address", respBody, nil)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving VPC endpoint fields: %s", err)
+	}
+	return resourceFgsVpcEndpointRead(ctx, d, meta)
+}
+
+func resourceFgsVpcEndpointRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceFgsVpcEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceFgsVpcEndpointRead(ctx, d, meta)
+}
+
+func resourceFgsVpcEndpointDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	httpUrl := "v2/{project_id}/fgs/vpc-endpoint/{vpc_id}/{subnet_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{vpc_id}", d.Get("vpc_id").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{subnet_id}", d.Get("subnet_id").(string))
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	// Deleting a not exist VPC endpoint will not report an error.
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting FunctionGraph VPC endpoint: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add new resource to manage VPC endpoint via FGS side

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new resource to manage VPC endpoint via FGS side
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFgsVpcEndpoint_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFgsVpcEndpoint_basic -timeout 360m -parallel 10
=== RUN   TestAccFgsVpcEndpoint_basic
=== PAUSE TestAccFgsVpcEndpoint_basic
=== CONT  TestAccFgsVpcEndpoint_basic
--- PASS: TestAccFgsVpcEndpoint_basic (53.64s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       53.704s coverage: 3.8% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
