### PR TITLE
feat(eg): add new data source to get target catalogs

### DIFF
--- a/docs/data-sources/eg_event_target_catalogs.md
+++ b/docs/data-sources/eg_event_target_catalogs.md
@@ -1,0 +1,88 @@
+---
+subcategory: "EventGrid (EG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_eg_event_target_catalogs"
+description: |-
+  Use this data source to get list of EG event target catalogs within HuaweiCloud.
+---
+
+# huaweicloud_eg_event_target_catalogs
+
+Use this data source to get list of EG event target catalogs within HuaweiCloud.
+
+## Example Usage
+
+### Query all event target catalogs
+
+```hcl
+data "huaweicloud_eg_event_target_catalogs" "test" {}
+```
+
+### Query event target catalogs with support types
+
+```hcl
+data "huaweicloud_eg_event_target_catalogs" "test" {
+  support_types = ["SUBSCRIPTION", "FLOW"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the event target catalogs are located.  
+  If omitted, the provider-level region will be used.
+
+* `fuzzy_label` - (Optional, String) Specifies the label of the event target catalog to be queried.  
+  Fuzzy search is supported.
+
+* `support_types` - (Optional, List) Specifies the support type list of event targets to be queried.  
+  The valid values are as follows:
+  + **SUBSCRIPTION**
+  + **FLOW**
+
+* `sort` - (Optional, String) Specifies the sort order for querying event target catalogs.  
+  The format is `field:order`, where `field` is the field name and `order` is `ASC` or `DESC`.
+  e.g. `created_time:ASC`. Only `created_time` and `updated_time` fields are supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `catalogs` - All event target catalogs that match the filter parameters.  
+  The [catalogs](#eg_event_target_catalogs_attr) structure is documented below.
+
+<a name="eg_event_target_catalogs_attr"></a>
+The `catalogs` block supports:
+
+* `id` - The ID of the event target catalog.
+
+* `name` - The name of the event target catalog.
+
+* `label` - The display name of the event target catalog.
+
+* `description` - The description of the event target catalog.
+
+* `support_types` - The support type list of event target catalog.
+
+* `provider_type` - The provider type of the event target catalog.
+  + **OFFICIAL**
+  + **CUSTOM**
+
+* `parameters` - The parameter list of the event target catalog.  
+  The [parameters](#eg_event_target_catalogs_parameters_attr) structure is documented below.
+
+* `created_time` - The creation time of the event target catalog, in UTC format.
+
+* `updated_time` - The latest update time of the event target catalog, in UTC format.
+
+<a name="eg_event_target_catalogs_parameters_attr"></a>
+The `parameters` block supports:
+
+* `name` - The name of the target parameter.
+
+* `label` - The display name of the target parameter.
+
+* `metadata` - The metadata of the target parameter, in JSON format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -968,6 +968,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_eg_event_channels":        eg.DataSourceEventChannels(),
 			"huaweicloud_eg_event_sources":         eg.DataSourceEventSources(),
 			"huaweicloud_eg_event_streams":         eg.DataSourceEventStreams(),
+			"huaweicloud_eg_event_target_catalogs": eg.DataSourceEventTargetCatalogs(),
 
 			"huaweicloud_enterprise_project":        eps.DataSourceEnterpriseProject(),
 			"huaweicloud_enterprise_projects":       eps.DataSourceEnterpriseProjects(),

--- a/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_event_target_catalogs_test.go
+++ b/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_event_target_catalogs_test.go
@@ -1,0 +1,120 @@
+package eg
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataEventTargetCatalogs_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_eg_event_target_catalogs.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byFuzzyLabel   = "data.huaweicloud_eg_event_target_catalogs.filter_by_fuzzy_label"
+		dcByFuzzyLabel = acceptance.InitDataSourceCheck(byFuzzyLabel)
+
+		bySupportTypes   = "data.huaweicloud_eg_event_target_catalogs.filter_by_support_types"
+		dcBySupportTypes = acceptance.InitDataSourceCheck(bySupportTypes)
+
+		bySortDesc   = "data.huaweicloud_eg_event_target_catalogs.filter_by_sort_desc"
+		dcBySortDesc = acceptance.InitDataSourceCheck(bySortDesc)
+
+		bySortAsc   = "data.huaweicloud_eg_event_target_catalogs.filter_by_sort_asc"
+		dcBySortAsc = acceptance.InitDataSourceCheck(bySortAsc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataEventTargetCatalogs_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "catalogs.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "catalogs.0.id"),
+					resource.TestCheckResourceAttrSet(all, "catalogs.0.name"),
+					resource.TestCheckResourceAttrSet(all, "catalogs.0.label"),
+					resource.TestCheckResourceAttrSet(all, "catalogs.0.provider_type"),
+					resource.TestCheckResourceAttrSet(all, "catalogs.0.support_types.#"),
+					resource.TestCheckResourceAttrSet(all, "catalogs.0.created_time"),
+					resource.TestCheckResourceAttrSet(all, "catalogs.0.updated_time"),
+					dcByFuzzyLabel.CheckResourceExists(),
+					resource.TestCheckOutput("is_fuzzy_label_filter_useful", "true"),
+					dcBySupportTypes.CheckResourceExists(),
+					resource.TestCheckOutput("is_support_types_filter_useful", "true"),
+					dcBySortDesc.CheckResourceExists(),
+					dcBySortAsc.CheckResourceExists(),
+					resource.TestCheckOutput("is_sort_filter_useful", "true"),
+					// description and parameters may be empty, so we don't check them.
+				),
+			},
+		},
+	})
+}
+
+func testAccDataEventTargetCatalogs_basic() string {
+	return `
+data "huaweicloud_eg_event_target_catalogs" "test" {}
+
+locals {
+  label         = try(lookup(data.huaweicloud_eg_event_target_catalogs.test.catalogs[0], "label", null), null)
+  support_types = try([for v in data.huaweicloud_eg_event_target_catalogs.test.catalogs[*].support_types : v if length(v) >= 2][0], [])
+}
+
+# Filter by fuzzy label.
+data "huaweicloud_eg_event_target_catalogs" "filter_by_fuzzy_label" {
+  fuzzy_label = local.label
+}
+
+locals {
+  fuzzy_label_filter_result = [for v in data.huaweicloud_eg_event_target_catalogs.filter_by_fuzzy_label.catalogs[*].label :
+  strcontains(v, local.label)]
+}
+
+output "is_fuzzy_label_filter_useful" {
+  value = length(local.fuzzy_label_filter_result) > 0 && alltrue(local.fuzzy_label_filter_result)
+}
+
+# Filter by support types.
+data "huaweicloud_eg_event_target_catalogs" "filter_by_support_types" {
+  support_types = local.support_types
+}
+
+locals {
+  support_types_filter_result = [for v in data.huaweicloud_eg_event_target_catalogs.filter_by_support_types.catalogs[*].support_types :
+  alltrue([for item in local.support_types : contains(v, item)])]
+}
+
+output "is_support_types_filter_useful" {
+  value = length(local.support_types_filter_result) > 0 && alltrue(local.support_types_filter_result)
+}
+
+# Filter by sort.
+data "huaweicloud_eg_event_target_catalogs" "filter_by_sort_desc" {
+  sort = "created_time:DESC"
+}
+
+data "huaweicloud_eg_event_target_catalogs" "filter_by_sort_asc" {
+  sort = "created_time:ASC"
+}
+
+locals {
+  sort_desc_filter_result = data.huaweicloud_eg_event_target_catalogs.filter_by_sort_desc.catalogs[*].created_time
+  sort_asc_filter_result  = data.huaweicloud_eg_event_target_catalogs.filter_by_sort_asc.catalogs[*].created_time
+}
+
+output "is_sort_filter_useful" {
+  value = (
+    length(local.sort_desc_filter_result) == length(local.sort_asc_filter_result) &&
+    try(local.sort_desc_filter_result[0], "") == try(element(local.sort_asc_filter_result, -1), "")
+  )
+}
+`
+}

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_event_target_catalogs.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_event_target_catalogs.go
@@ -1,0 +1,256 @@
+package eg
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EG GET /v1/{project_id}/target-catalogs
+func DataSourceEventTargetCatalogs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEventTargetCatalogsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the event target catalogs are located.`,
+			},
+			"fuzzy_label": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The label of the event target catalog to be queried.`,
+			},
+			"support_types": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `The support type list of event targets to be queried.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"sort": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The sort order for querying event target catalogs.`,
+			},
+			"catalogs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the event target catalog.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the event target catalog.`,
+						},
+						"label": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The display name of the event target catalog.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the event target catalog.`,
+						},
+						"support_types": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The support type list of event target catalog.`,
+						},
+						"provider_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The provider type of the event target catalog.`,
+						},
+						"parameters": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the target parameter.`,
+									},
+									"label": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The display name of the target parameter.`,
+									},
+									"metadata": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The metadata of the target parameter, in JSON format.`,
+									},
+								},
+							},
+							Description: `The parameters of the event target catalog.`,
+						},
+						"created_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the event target catalog, in UTC format.`,
+						},
+						"updated_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the event target catalog, in UTC format.`,
+						},
+					},
+				},
+				Description: `All event target catalogs that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildEventTargetCatalogsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if fuzzyLabel, ok := d.GetOk("fuzzy_label"); ok {
+		res = fmt.Sprintf("%s&fuzzy_label=%v", res, fuzzyLabel)
+	}
+
+	if supportTypes, ok := d.GetOk("support_types"); ok {
+		for _, supportType := range supportTypes.([]interface{}) {
+			res = fmt.Sprintf("%s&support_types=%v", res, supportType)
+		}
+	}
+
+	if sort, ok := d.GetOk("sort"); ok {
+		res = fmt.Sprintf("%s&sort=%v", res, sort)
+	}
+
+	return res
+}
+
+func queryEventTargetCatalogs(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/target-catalogs"
+		offset  = 0
+		limit   = 500
+		result  = make([]interface{}, 0)
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += fmt.Sprintf("?limit=%d", limit)
+	listPath += buildEventTargetCatalogsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		eventTargetCatalogs := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, eventTargetCatalogs...)
+		if len(eventTargetCatalogs) < limit {
+			break
+		}
+
+		offset += len(eventTargetCatalogs)
+	}
+
+	return result, nil
+}
+
+func flattenEventTargetCatalogParameters(parameters []interface{}) []map[string]interface{} {
+	if len(parameters) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(parameters))
+	for _, parameter := range parameters {
+		result = append(result, map[string]interface{}{
+			"name":     utils.PathSearch("name", parameter, nil),
+			"label":    utils.PathSearch("label", parameter, nil),
+			"metadata": utils.JsonToString(utils.PathSearch("metadata", parameter, nil)),
+		})
+	}
+
+	return result
+}
+
+func flattenDataEventTargetCatalogs(catalogs []interface{}) []map[string]interface{} {
+	if len(catalogs) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(catalogs))
+	for _, catalog := range catalogs {
+		result = append(result, map[string]interface{}{
+			"id":            utils.PathSearch("id", catalog, nil),
+			"name":          utils.PathSearch("name", catalog, nil),
+			"label":         utils.PathSearch("label", catalog, nil),
+			"description":   utils.PathSearch("description", catalog, nil),
+			"support_types": utils.PathSearch("support_types", catalog, nil),
+			"provider_type": utils.PathSearch("provider_type", catalog, nil),
+			"parameters": flattenEventTargetCatalogParameters(utils.PathSearch("parameters",
+				catalog, make([]interface{}, 0)).([]interface{})),
+			"created_time": utils.PathSearch("created_time", catalog, nil),
+			"updated_time": utils.PathSearch("updated_time", catalog, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceEventTargetCatalogsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("eg", region)
+	if err != nil {
+		return diag.Errorf("error creating EG client: %s", err)
+	}
+
+	catalogs, err := queryEventTargetCatalogs(client, d)
+	if err != nil {
+		return diag.Errorf("error querying event target catalogs: %s", err)
+	}
+
+	randomID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("catalogs", flattenDataEventTargetCatalogs(catalogs)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source (`huaweicloud_eg_event_target_catalogs`) to get event target catalogs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source.
2. add corresponding documation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o eg -f TestAccDataEventTargetCatalogs_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eg" -v -coverprofile="./huaweicloud/services/acceptance/eg/eg_coverage.cov" -coverpkg="./huaweicloud/services/eg" -run TestAccDataEventTargetCatalogs_basic -timeout 360m -parallel 10
=== RUN   TestAccDataEventTargetCatalogs_basic
=== PAUSE TestAccDataEventTargetCatalogs_basic
=== CONT  TestAccDataEventTargetCatalogs_basic
--- PASS: TestAccDataEventTargetCatalogs_basic (14.68s)
PASS
coverage: 8.1% of statements in ./huaweicloud/services/eg
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        14.775s coverage: 8.1% of statements in ./huaweicloud/services/eg
```


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
