### PR TITLE
feat(aad): support `policy_black_white_lists` and  `bandwidth_curve` data sources

### DIFF
--- a/docs/data-sources/aad_bandwidth_curve.md
+++ b/docs/data-sources/aad_bandwidth_curve.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Advanced Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aad_bandwidth_curve"
+description: |-
+  Use this data source to get the list of Advanced Anti-DDos bandwidth curve within HuaweiCloud.
+---
+
+# huaweicloud_aad_bandwidth_curve
+
+Use this data source to get the list of Advanced Anti-DDos bandwidth curve within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_aad_bandwidth_curve" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `value_type` - (Required, String) Specifies the value type.  
+  The valid values are as follows:
+  + **mean**: Average value.
+  + **peak**: Peak value.
+
+* `domains` - (Optional, String) Specifies the domains. If not specified, all domains are queried.
+
+* `start_time` - (Optional, String) Specifies the start time.
+
+* `end_time` - (Optional, String) Specifies the end time.
+
+* `recent` - (Optional, String) Specifies recent.  
+  The valid values are as follows:
+  + **yesterday**
+  + **today**
+  + **3days**
+  + **1week**
+  + **1month**
+
+  `recent` cannot be empty when both `start_time` and `end_time` are empty.
+
+* `overseas_type` - (Optional, String) Specifies instance type.
+  The valid values are as follows:
+  + **0**: Mainland.
+  + **1**: Overseas.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `curve` - The list of bandwidth curve detail.  
+  The [curve](#curve_struct) structure is documented below.
+
+<a name="curve_struct"></a>
+The `curve` block supports:
+
+* `in` - The ingress bandwidth.
+
+* `out` - The egress bandwidth.
+
+* `time` - The timestamp.

--- a/docs/data-sources/aad_policy_black_white_lists.md
+++ b/docs/data-sources/aad_policy_black_white_lists.md
@@ -1,0 +1,62 @@
+---
+subcategory: "Advanced Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aad_policy_black_white_lists"
+description: |-
+  Use this data source to get the list of Advanced Anti-DDos policy black white list within HuaweiCloud.
+---
+
+# huaweicloud_aad_policy_black_white_lists
+
+Use this data source to get the list of Advanced Anti-DDos policy black white list within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_aad_policy_black_white_lists" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_name` - (Required, String) Specifies the domain name.
+
+* `overseas_type` - (Required, Int) Specifies protection zone.  
+  The valid values are as follows:
+  + **0**: Mainland.
+  + **1**: Overseas.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `black` - The black list detail.  
+  The [black](#black_struct) structure is documented below.
+
+* `white` - The white list detail.  
+  The [white](#white_struct) structure is documented below.
+
+<a name="black_struct"></a>
+The `black` block supports:
+
+* `id` - The ID.
+
+* `type` - The type. `0` indicates blacklist, and `1` indicates whitelist.
+
+* `ip` - The IP address.
+
+* `domain_id` - The domain ID.
+
+<a name="white_struct"></a>
+The `white` block supports:
+
+* `id` - The ID.
+
+* `type` - The type. `0` indicates blacklist, and `1` indicates whitelist.
+
+* `ip` - The IP address.
+
+* `domain_id` - The domain ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -470,6 +470,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aad_source_ips":               aad.DataSourceAadSourceIps(),
 			"huaweicloud_aad_domain_certificate":       aad.DataSourceAadDomainCertificate(),
 			"huaweicloud_aad_policy_black_white_lists": aad.DataSourcePolicyBlackWhiteLists(),
+			"huaweicloud_aad_bandwidth_curve":          aad.DataSourceBandwidthCurve(),
 
 			"huaweicloud_antiddos_config_ranges":                antiddos.DataSourceConfigRanges(),
 			"huaweicloud_antiddos_weekly_protection_statistics": antiddos.DataSourceWeeklyProtectionStatistics(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -469,6 +469,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aad_domains":                  aad.DataSourceAadDomains(),
 			"huaweicloud_aad_source_ips":               aad.DataSourceAadSourceIps(),
 			"huaweicloud_aad_domain_certificate":       aad.DataSourceAadDomainCertificate(),
+			"huaweicloud_aad_policy_black_white_lists": aad.DataSourcePolicyBlackWhiteLists(),
 
 			"huaweicloud_antiddos_config_ranges":                antiddos.DataSourceConfigRanges(),
 			"huaweicloud_antiddos_weekly_protection_statistics": antiddos.DataSourceWeeklyProtectionStatistics(),

--- a/huaweicloud/services/aad/data_source_huaweicloud_aad_bandwidth_curve.go
+++ b/huaweicloud/services/aad/data_source_huaweicloud_aad_bandwidth_curve.go
@@ -1,0 +1,158 @@
+package aad
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AAD GET /v2/aad/domains/waf-info/flow/bandwidth
+func DataSourceBandwidthCurve() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBandwidthCurveRead,
+
+		Schema: map[string]*schema.Schema{
+			"value_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"domains": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"recent": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// In the API documentation, `overseas_type` is int type.
+			// But it needs to meet the scenario of `0`, so it is defined here as a string type.
+			"overseas_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"curve": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"in": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"out": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildBandwidthCurveQueryParams(d *schema.ResourceData) string {
+	queryParams := fmt.Sprintf("?value_type=%v", d.Get("value_type"))
+
+	if v, ok := d.GetOk("domains"); ok {
+		queryParams = fmt.Sprintf("%s&domains=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("start_time"); ok {
+		queryParams = fmt.Sprintf("%s&start_time=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("end_time"); ok {
+		queryParams = fmt.Sprintf("%s&end_time=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("recent"); ok {
+		queryParams = fmt.Sprintf("%s&recent=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("overseas_type"); ok {
+		queryParams = fmt.Sprintf("%s&overseas_type=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceBandwidthCurveRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+		httpUrl = "v2/aad/domains/waf-info/flow/bandwidth"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath += buildBandwidthCurveQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving AAD bandwidth curve: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("curve",
+			flattenBandwidthCurve(utils.PathSearch("curve", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenBandwidthCurve(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"in":   utils.PathSearch("in", v, nil),
+			"out":  utils.PathSearch("out", v, nil),
+			"time": utils.PathSearch("time", v, nil),
+		})
+	}
+
+	return rst
+}

--- a/huaweicloud/services/aad/data_source_huaweicloud_aad_policy_black_white_lists.go
+++ b/huaweicloud/services/aad/data_source_huaweicloud_aad_policy_black_white_lists.go
@@ -1,0 +1,136 @@
+package aad
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AAD GET /v2/aad/policies/waf/blackwhite-list
+func DataSourcePolicyBlackWhiteLists() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePolicyBlackWhiteListsRead,
+
+		Schema: map[string]*schema.Schema{
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"overseas_type": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"black": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     blackWhiteSchema(),
+			},
+			"white": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     blackWhiteSchema(),
+			},
+		},
+	}
+}
+
+func blackWhiteSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePolicyBlackWhiteListsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+		httpUrl = "v2/aad/policies/waf/blackwhite-list"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = fmt.Sprintf("%s?domain_name=%v", requestPath, d.Get("domain_name"))
+	requestPath = fmt.Sprintf("%s&overseas_type=%v", requestPath, d.Get("overseas_type"))
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving AAD policy black white lists: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("black", flattenPolicyBlackOrWhiteListsAttribute(
+			utils.PathSearch("black", respBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("white", flattenPolicyBlackOrWhiteListsAttribute(
+			utils.PathSearch("white", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenPolicyBlackOrWhiteListsAttribute(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"id":        utils.PathSearch("id", v, nil),
+			"type":      utils.PathSearch("type", v, nil),
+			"ip":        utils.PathSearch("ip", v, nil),
+			"domain_id": utils.PathSearch("domain_id", v, nil),
+		})
+	}
+
+	return rst
+}

--- a/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_bandwidth_curve_test.go
+++ b/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_bandwidth_curve_test.go
@@ -1,0 +1,43 @@
+package antiddos
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Due to testing environment limitations, this test case can only test the scenario with empty `curve`.
+func TestAccDataSourceBandwidthCurve_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_aad_bandwidth_curve.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceBandwidthCurve_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "curve.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceBandwidthCurve_basic() string {
+	return `
+data "huaweicloud_aad_bandwidth_curve" "test" {
+  value_type    = "mean"
+  recent        = "1month"
+  overseas_type = "0"
+}
+`
+}

--- a/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_policy_black_white_lists_test.go
+++ b/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_policy_black_white_lists_test.go
@@ -1,0 +1,46 @@
+package antiddos
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourcePolicyBlackWhiteLists_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_aad_policy_black_white_lists.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare an AAD domain name that has been configured with the policy blackWhite list and configure
+			// it in the environment variable.
+			acceptance.TestAccPrecheckAadDomainName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourcePolicyBlackWhiteLists_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "black.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "white.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourcePolicyBlackWhiteLists_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_aad_policy_black_white_lists" "test" {
+  domain_name   = "%[1]s"
+  overseas_type = 0
+}
+`, acceptance.HW_AAD_DOMAIN_NAME)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

commit1: support `policy_black_white_lists` data source
commit2: support `bandwidth_curve` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

commit1: support `policy_black_white_lists` data source
commit2: support `bandwidth_curve` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/aad" TESTARGS="-run TestAccDataSourcePolicyBlackWhiteLists_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aad -v -run TestAccDataSourcePolicyBlackWhiteLists_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourcePolicyBlackWhiteLists_basic
=== PAUSE TestAccDataSourcePolicyBlackWhiteLists_basic
=== CONT  TestAccDataSourcePolicyBlackWhiteLists_basic
--- PASS: TestAccDataSourcePolicyBlackWhiteLists_basic (12.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aad       12.420s


$ make testacc TEST="./huaweicloud/services/acceptance/aad" TESTARGS="-run TestAccDataSourceBandwidthCurve_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aad -v -run TestAccDataSourceBandwidthCurve_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceBandwidthCurve_basic
=== PAUSE TestAccDataSourceBandwidthCurve_basic
=== CONT  TestAccDataSourceBandwidthCurve_basic
--- PASS: TestAccDataSourceBandwidthCurve_basic (17.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aad       17.466s

```
<img width="908" height="41" alt="image" src="https://github.com/user-attachments/assets/038ecc15-dead-4256-a736-c1ed2aac5ea2" />

<img width="867" height="52" alt="image" src="https://github.com/user-attachments/assets/32f279d8-415d-4a8f-92d0-46b0f0a35853" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
