### PR TITLE
feat(fgs): add new data source to filter resources

### DIFF
--- a/docs/data-sources/fgs_resources_filter.md
+++ b/docs/data-sources/fgs_resources_filter.md
@@ -1,0 +1,101 @@
+---
+subcategory: "FunctionGraph"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_fgs_resources_filter"
+description: |-
+  Use this data source to query basic information about resources within HuaweiCloud.
+---
+
+# huaweicloud_fgs_resources_filter
+
+Use this data source to query basic information about resources within HuaweiCloud.
+
+## Example Usage
+
+### Filter resources by function name using filter matches
+
+```hcl
+variable "function_name" {}
+
+data "huaweicloud_fgs_resources_filter" "test" {
+  resource_type = "functions"
+
+  matches {
+    key   = "resource_name"
+    value = var.function_name
+  }
+}
+```
+
+### Filter resources by tags
+
+```hcl
+data "huaweicloud_fgs_resources_filter" "test" {
+  resource_type = "functions"
+
+  tags {
+    key    = "owner"
+    values = ["Administrator", "User"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the target resources are located.  
+  If omitted, the provider-level region will be used.
+
+* `resource_type` - (Required, String) Specifies the type of the resource used to filter the target resources.  
+  Only **functions** is supported currently.
+
+* `matches` - (Optional, List) Specifies the key-value pairs used to filter the target resources.  
+  The [matches](#fgs_resources_filter_matches) structure is documented below.
+
+* `tags` - (Optional, List) Specifies the resource tags used to filter the target resources.  
+  The [tags](#fgs_resources_filter_tags) structure is documented below.
+
+<a name="fgs_resources_filter_matches"></a>
+The `matches` block supports:
+
+* `key` - (Required, String) The match key used to filter the target resources.  
+  Only **resource_name** is supported currently.
+
+* `value` - (Required, String) The match value used to filter the target resources.  
+  The value is fuzzy match if `key` is **resource_name**.
+
+<a name="fgs_resources_filter_tags"></a>
+The `tags` block supports:
+
+* `key` - (Required, String) The key of the resource tag used to filter the target resources.
+
+* `values` - (Required, List) The values corresponding to the current key used to filter the target resources.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `resources` - The list of target resources that matched filter parameters.  
+  The [resources](#fgs_filtered_resources_attr) structure is documented below.
+
+<a name="fgs_filtered_resources_attr"></a>
+The `resources` block supports:
+
+* `id` - The ID of the resource.
+
+* `name` - The name of the resource.
+
+* `detail` - The detailed information of the resource, in JSON format.
+
+* `tags` - The tags of the resource.  
+  The [tags](#fgs_filtered_resource_tags) structure is documented below.
+
+<a name="fgs_filtered_resource_tags"></a>
+The `tags` block supports:
+
+* `key` - The key of the tag.
+
+* `value` - The value of the tag.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1055,6 +1055,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_functions":             fgs.DataSourceFunctions(),
 			"huaweicloud_fgs_quotas":                fgs.DataSourceQuotas(),
 			"huaweicloud_fgs_resource_tags":         fgs.DataSourceResourceTags(),
+			"huaweicloud_fgs_resources_filter":      fgs.DataSourceResourcesFilter(),
 
 			"huaweicloud_ga_accelerators":       ga.DataSourceAccelerators(),
 			"huaweicloud_ga_access_logs":        ga.DataSourceGaAccessLogs(),

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_resources_filter_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_resources_filter_test.go
@@ -1,0 +1,172 @@
+package fgs
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataResourcesFilter_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all               = "data.huaweicloud_fgs_resources_filter.all"
+		dcForAllResources = acceptance.InitDataSourceCheck(all)
+
+		byMatches   = "data.huaweicloud_fgs_resources_filter.filter_by_matches"
+		dcByMatches = acceptance.InitDataSourceCheck(byMatches)
+
+		byTags   = "data.huaweicloud_fgs_resources_filter.filter_by_tags"
+		dcByTags = acceptance.InitDataSourceCheck(byTags)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataResourcesFilter_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without filter parameters.
+					dcForAllResources.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "resources.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+
+					// Filter by matches.
+					dcByMatches.CheckResourceExists(),
+					resource.TestMatchResourceAttr(byMatches, "resources.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckOutput("is_matches_filter_useful", "true"),
+
+					resource.TestCheckResourceAttrPair(byMatches, "resources.0.id", "huaweicloud_fgs_function.with_tags", "id"),
+					resource.TestCheckResourceAttrPair(byMatches, "resources.0.name", "huaweicloud_fgs_function.with_tags", "name"),
+					resource.TestCheckResourceAttrSet(byMatches, "resources.0.detail"),
+					resource.TestMatchResourceAttr(byMatches, "resources.0.tags.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(byMatches, "resources.0.tags.0.key"),
+					resource.TestCheckResourceAttrSet(byMatches, "resources.0.tags.0.value"),
+
+					// Filter by tags.
+					dcByTags.CheckResourceExists(),
+					resource.TestMatchResourceAttr(byTags, "resources.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataResourcesFilter_base(name string) string {
+	return fmt.Sprintf(`
+variable "function_code_content" {
+  type    = string
+  default = <<EOT
+def main():
+    print("Hello, World!")
+
+if __name__ == "__main__":
+    main()
+EOT
+}
+
+resource "huaweicloud_fgs_function" "with_tags" {
+  name        = "%[1]s_with_tags"
+  memory_size = 128
+  runtime     = "Python2.7"
+  timeout     = 3
+  app         = "default"
+  handler     = "index.handler"
+  code_type   = "inline"
+  func_code   = base64encode(var.function_code_content)
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+resource "huaweicloud_fgs_function" "without_tags" {
+  name        = "%[1]s_without_tags"
+  memory_size = 128
+  runtime     = "Python2.7"
+  timeout     = 3
+  app         = "default"
+  handler     = "index.handler"
+  code_type   = "inline"
+  func_code   = base64encode(var.function_code_content)
+}
+`, name)
+}
+
+func testAccDataResourcesFilter_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_fgs_resources_filter" "all" {
+  depends_on = [
+    huaweicloud_fgs_function.with_tags,
+    huaweicloud_fgs_function.without_tags,
+  ]
+
+  resource_type = "functions"
+}
+
+# Filter by matches
+locals {
+  function_name = huaweicloud_fgs_function.with_tags.name
+}
+
+data "huaweicloud_fgs_resources_filter" "filter_by_matches" {
+  depends_on = [
+    huaweicloud_fgs_function.with_tags,
+    huaweicloud_fgs_function.without_tags,
+  ]
+
+  resource_type = "functions"
+
+  matches {
+    key   = "resource_name"
+    value = local.function_name
+  }
+}
+
+locals {
+  matches_filter_result = [
+    for v in data.huaweicloud_fgs_resources_filter.filter_by_matches.resources[*].name : strcontains(v, local.function_name)
+  ]
+}
+
+output "is_matches_filter_useful" {
+  value = length(local.matches_filter_result) > 0 && alltrue(local.matches_filter_result)
+}
+
+# Filter by tags
+data "huaweicloud_fgs_resources_filter" "filter_by_tags" {
+  depends_on = [
+    huaweicloud_fgs_function.with_tags,
+    huaweicloud_fgs_function.without_tags,
+  ]
+
+  resource_type = "functions"
+
+  tags {
+    key   = "foo"
+    values = ["bar"]
+  }
+}
+
+locals {
+  tags_filter_result = [
+    for v in data.huaweicloud_fgs_resources_filter.filter_by_tags.resources[*].tags : contains(v[*].key, "foo") && alltrue(
+	  [for vv in v : vv.value == "bar" if vv.key == "foo"])
+  ]
+}
+
+output "is_tags_filter_useful" {
+  value = length(local.tags_filter_result) > 0 && alltrue(local.tags_filter_result)
+}
+`, testAccDataResourcesFilter_base(name), name)
+}

--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_resources_filter.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_resources_filter.go
@@ -1,0 +1,360 @@
+package fgs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API FunctionGraph POST /v2/{project_id}/{resource_type}/resource-instances/{action}
+func DataSourceResourcesFilter() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceResourcesFilterRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the target resources are located.`,
+			},
+
+			// Required parameter(s).
+			"resource_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the resource used to filter the target resources.`,
+			},
+
+			// Optional parameter(s).
+			"matches": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The match key used to filter the target resources.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The match value used to filter the target resources.`,
+						},
+					},
+				},
+				Description: `The key-value pairs used to filter the target resources.`,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The key of the resource tag used to filter the target resources.`,
+						},
+						"values": {
+							Type:        schema.TypeList,
+							Required:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The values corresponding to the current key used to filter the target resources.`,
+						},
+					},
+				},
+				Description: utils.SchemaDesc(
+					`The resource tags used to filter the target resources.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+
+			// Internal parameter(s).
+			"sys_tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The key of the system tag used to filter the target resources.`,
+						},
+						"values": {
+							Type:        schema.TypeList,
+							Required:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The values of the system tag used to filter the target resources.`,
+						},
+					},
+				},
+				Description: utils.SchemaDesc(
+					`The system tags used to filter the target resources.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+
+			// Attributes.
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the resource.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the resource.`,
+						},
+						"detail": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The detailed information of the resource, in JSON format.`,
+						},
+						"tags": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The key of the tag.`,
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The value of the tag.`,
+									},
+								},
+							},
+							Description: `The tags of the resource.`,
+						},
+
+						// Internal attribute(s).
+						"sys_tags": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The key of the system tag.`,
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The value of the system tag.`,
+									},
+								},
+							},
+							Description: utils.SchemaDesc(
+								`The system tags of the resource.`,
+								utils.SchemaDescInput{
+									Internal: true,
+								},
+							),
+						},
+					},
+				},
+				Description: `The list of target resources that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildResourcesFilterBodyParams(d *schema.ResourceData, actionType string, limit int, offset int) map[string]interface{} {
+	result := map[string]interface{}{
+		"limit":  limit,
+		"offset": offset,
+		"action": actionType,
+	}
+
+	if v, ok := d.GetOk("matches"); ok {
+		result["matches"] = buildResourcesFilterMatches(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		result["tags"] = buildResourcesFilterTags(v.([]interface{}))
+	}
+
+	// Internal parameter(s).
+	if v, ok := d.GetOk("sys_tags"); ok {
+		result["sys_tags"] = buildResourcesFilterTags(v.([]interface{}))
+	}
+
+	return result
+}
+
+func buildResourcesFilterMatches(matches []interface{}) []map[string]interface{} {
+	if len(matches) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(matches))
+	for _, match := range matches {
+		result = append(result, map[string]interface{}{
+			"key":   utils.PathSearch("key", match, nil),
+			"value": utils.PathSearch("value", match, nil),
+		})
+	}
+
+	return result
+}
+
+func buildResourcesFilterTags(tags []interface{}) []map[string]interface{} {
+	if len(tags) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(tags))
+	for _, tag := range tags {
+		result = append(result, map[string]interface{}{
+			"key":    utils.PathSearch("key", tag, nil),
+			"values": utils.PathSearch("values", tag, nil),
+		})
+	}
+
+	return result
+}
+
+func listResourceInstances(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl          = "v2/{project_id}/{resource_type}/resource-instances/{action}"
+		result           = make([]interface{}, 0)
+		actionTypeFilter = "filter"
+		limit            = 100
+		offset           = 0
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{resource_type}", d.Get("resource_type").(string))
+	listPath = strings.ReplaceAll(listPath, "{action}", actionTypeFilter)
+
+	for {
+		listOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody:         buildResourcesFilterBodyParams(d, actionTypeFilter, limit, offset),
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+		}
+
+		requestResp, err := client.Request("POST", listPath, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		resources := utils.PathSearch("resources", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, resources...)
+		if len(resources) < limit {
+			break
+		}
+		offset += limit
+	}
+	return result, nil
+}
+
+func flattenResourcesFilterTags(tags []interface{}) []map[string]interface{} {
+	if len(tags) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(tags))
+	for _, tag := range tags {
+		result = append(result, map[string]interface{}{
+			"key":   utils.PathSearch("key", tag, nil),
+			"value": utils.PathSearch("value", tag, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenResourcesFilterSysTags(sysTags []interface{}) []map[string]interface{} {
+	if len(sysTags) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(sysTags))
+	for _, sysTag := range sysTags {
+		result = append(result, map[string]interface{}{
+			"key":   utils.PathSearch("key", sysTag, nil),
+			"value": utils.PathSearch("value", sysTag, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenResourcesFilterResources(resources []interface{}) []map[string]interface{} {
+	if len(resources) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(resources))
+	for _, resource := range resources {
+		result = append(result, map[string]interface{}{
+			"id":     utils.PathSearch("resource_id", resource, nil),
+			"name":   utils.PathSearch("resource_name", resource, nil),
+			"detail": utils.JsonToString(utils.PathSearch("resource_detail", resource, nil)),
+			"tags": flattenResourcesFilterTags(utils.PathSearch("tags", resource,
+				make([]interface{}, 0)).([]interface{})),
+			// Internal attribute(s).
+			"sys_tags": flattenResourcesFilterSysTags(utils.PathSearch("sys_tags", resource,
+				make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func dataSourceResourcesFilterRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	resources, err := listResourceInstances(client, d)
+	if err != nil {
+		return diag.Errorf("error querying FunctionGraph resource instances: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("resources", flattenResourcesFilterResources(resources)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source to filter resources and allow these filter parameters:
- matches
- tags

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new data source to filter resources.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccDataResourcesFilter_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataResourcesFilter_basic -timeout 360m -parallel 10
=== RUN   TestAccDataResourcesFilter_basic
=== PAUSE TestAccDataResourcesFilter_basic
=== CONT  TestAccDataResourcesFilter_basic
--- PASS: TestAccDataResourcesFilter_basic (15.55s)
PASS
coverage: 16.3% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       15.615s coverage: 16.3% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
