### PR TITLE
feat(cnad): new bind and unbind resources for policy IP

### DIFF
--- a/docs/resources/cnad_advanced_policy_ip_binding.md
+++ b/docs/resources/cnad_advanced_policy_ip_binding.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Cloud Native Anti-DDoS Advanced"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cnad_advanced_policy_ip_binding"
+description: |-
+  Manages a CNAD advanced policy IP binding resource within HuaweiCloud.
+---
+
+# huaweicloud_cnad_advanced_policy_ip_binding
+
+Manages a CNAD advanced policy IP binding resource within HuaweiCloud.
+
+-> This resource is a one-time action resource for binding IP addresses to a protection policy. Deleting this resource
+   will not remove the IP bindings from the policy, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "policy_id" {}
+variable "ip_list" {
+  type = list(string)
+}
+
+resource "huaweicloud_cnad_advanced_policy_ip_binding" "test" {
+  policy_id = var.policy_id
+  ip_list   = var.ip_list
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_id` - (Required, String, NonUpdatable) Specifies the ID of the protection policy.
+
+* `ip_list` - (Required, List, NonUpdatable) Specifies the list of IP addresses to bind the policy.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/docs/resources/cnad_advanced_policy_ip_unbinding.md
+++ b/docs/resources/cnad_advanced_policy_ip_unbinding.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Cloud Native Anti-DDoS Advanced"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cnad_advanced_policy_ip_unbinding"
+description: |-
+  Manages a CNAD advanced policy IP unbinding resource within HuaweiCloud.
+---
+
+# huaweicloud_cnad_advanced_policy_ip_unbinding
+
+Manages a CNAD advanced policy IP unbinding resource within HuaweiCloud.
+
+-> This resource is a one-time action resource for unbinding IP addresses from a protection policy. Deleting this resource
+   will not change the current CNAD policy IP binding, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "policy_id" {}
+variable "ip_list" {
+  type = list(string)
+}
+
+resource "huaweicloud_cnad_advanced_policy_ip_unbinding" "test" {
+  policy_id = var.policy_id
+  ip_list   = var.ip_list
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_id` - (Required, String, NonUpdatable) Specifies the ID of the protection policy to unbind IPs from.
+
+* `ip_list` - (Required, List, NonUpdatable) Specifies the list of IP addresses to unbind from the policy.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2047,13 +2047,14 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_cloudtable_cluster": cloudtable.ResourceCloudTableCluster(),
 
-			"huaweicloud_cnad_advanced_alarm_notification": cnad.ResourceAlarmNotification(),
-			"huaweicloud_cnad_advanced_black_white_list":   cnad.ResourceBlackWhiteList(),
-			"huaweicloud_cnad_advanced_policy":             cnad.ResourceCNADAdvancedPolicy(),
-			"huaweicloud_cnad_advanced_policy_associate":   cnad.ResourcePolicyAssociate(),
-			"huaweicloud_cnad_advanced_protected_object":   cnad.ResourceProtectedObject(),
-			"huaweicloud_cnad_advanced_protected_ip_tag":   cnad.ResourceProtectedIpTag(),
-			"huaweicloud_cnad_advanced_policy_ip_binding":  cnad.ResourcePolicyIpBinding(),
+			"huaweicloud_cnad_advanced_alarm_notification":  cnad.ResourceAlarmNotification(),
+			"huaweicloud_cnad_advanced_black_white_list":    cnad.ResourceBlackWhiteList(),
+			"huaweicloud_cnad_advanced_policy":              cnad.ResourceCNADAdvancedPolicy(),
+			"huaweicloud_cnad_advanced_policy_associate":    cnad.ResourcePolicyAssociate(),
+			"huaweicloud_cnad_advanced_protected_object":    cnad.ResourceProtectedObject(),
+			"huaweicloud_cnad_advanced_protected_ip_tag":    cnad.ResourceProtectedIpTag(),
+			"huaweicloud_cnad_advanced_policy_ip_binding":   cnad.ResourcePolicyIpBinding(),
+			"huaweicloud_cnad_advanced_policy_ip_unbinding": cnad.ResourcePolicyIpUnbinding(),
 
 			"huaweicloud_compute_instance":          ecs.ResourceComputeInstance(),
 			"huaweicloud_compute_interface_attach":  ecs.ResourceComputeInterfaceAttach(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2053,6 +2053,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cnad_advanced_policy_associate":   cnad.ResourcePolicyAssociate(),
 			"huaweicloud_cnad_advanced_protected_object":   cnad.ResourceProtectedObject(),
 			"huaweicloud_cnad_advanced_protected_ip_tag":   cnad.ResourceProtectedIpTag(),
+			"huaweicloud_cnad_advanced_policy_ip_binding":  cnad.ResourcePolicyIpBinding(),
 
 			"huaweicloud_compute_instance":          ecs.ResourceComputeInstance(),
 			"huaweicloud_compute_interface_attach":  ecs.ResourceComputeInterfaceAttach(),

--- a/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_policy_ip_binding_test.go
+++ b/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_policy_ip_binding_test.go
@@ -1,0 +1,34 @@
+package cnad
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Note: Due to limited test conditions, this test case only verifies the expected error scenario.
+func TestAccResourcePolicyIpBinding_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testPolicyIpBinding_basic,
+				ExpectError: regexp.MustCompile(`Resource Not Found.|资源不存在。`),
+			},
+		},
+	})
+}
+
+// The values of fields `policy_id` and `ip_list` are mock data.
+const testPolicyIpBinding_basic = `
+resource "huaweicloud_cnad_advanced_policy_ip_binding" "test" {
+  policy_id = "1d8c03c4-a1d0-49cf-808a-ab50bfd7f0d8"
+  ip_list   = ["192.168.1.1", "192.168.1.2"]
+}`

--- a/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_policy_ip_unbinding_test.go
+++ b/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_policy_ip_unbinding_test.go
@@ -1,0 +1,34 @@
+package cnad
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Note: Due to limited test conditions, this test case only verifies the expected error scenario.
+func TestAccResourcePolicyIpUnbinding_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testPolicyIpUnbinding_basic,
+				ExpectError: regexp.MustCompile(`Resource Not Found.|资源不存在。`),
+			},
+		},
+	})
+}
+
+// The values of fields `policy_id` and `ip_list` are mock data.
+const testPolicyIpUnbinding_basic = `
+resource "huaweicloud_cnad_advanced_policy_ip_unbinding" "test" {
+  policy_id = "1d8c03c4-a1d0-49cf-808a-ab50bfd7f0d8"
+  ip_list   = ["192.168.1.1", "192.168.1.2"]
+}`

--- a/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_policy_ip_binding.go
+++ b/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_policy_ip_binding.go
@@ -1,0 +1,98 @@
+package cnad
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API AAD POST /v3/cnad/policies/{policy_id}/bind
+func ResourcePolicyIpBinding() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePolicyIpBindingCreate,
+		ReadContext:   resourcePolicyIpBindingRead,
+		UpdateContext: resourcePolicyIpBindingUpdate,
+		DeleteContext: resourcePolicyIpBindingDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{"policy_id", "ip_list"}),
+
+		Schema: map[string]*schema.Schema{
+			"policy_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the protection policy.`,
+			},
+			"ip_list": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Specifies the list of IP addresses to bind the policy.`,
+			},
+		},
+	}
+}
+
+func resourcePolicyIpBindingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/cnad/policies/{policy_id}/bind"
+		product = "aad"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CNAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{policy_id}", d.Get("policy_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"ip_list": d.Get("ip_list"),
+		},
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error binding IPs to CNAD policy: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	return resourcePolicyIpBindingRead(ctx, d, meta)
+}
+
+func resourcePolicyIpBindingRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourcePolicyIpBindingUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourcePolicyIpBindingDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to bind IP addresses to a policy. Deleting this 
+resource will not change the current CNAD policy IP binding, but will only remove the resource information from the 
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}

--- a/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_policy_ip_unbinding.go
+++ b/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_policy_ip_unbinding.go
@@ -15,13 +15,13 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API AAD POST /v3/cnad/policies/{policy_id}/bind
-func ResourcePolicyIpBinding() *schema.Resource {
+// @API AAD POST /v3/cnad/policies/{policy_id}/unbind
+func ResourcePolicyIpUnbinding() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourcePolicyIpBindingCreate,
-		ReadContext:   resourcePolicyIpBindingRead,
-		UpdateContext: resourcePolicyIpBindingUpdate,
-		DeleteContext: resourcePolicyIpBindingDelete,
+		CreateContext: resourcePolicyIpUnbindingCreate,
+		ReadContext:   resourcePolicyIpUnbindingRead,
+		UpdateContext: resourcePolicyIpUnbindingUpdate,
+		DeleteContext: resourcePolicyIpUnbindingDelete,
 
 		CustomizeDiff: config.FlexibleForceNew([]string{"policy_id", "ip_list"}),
 
@@ -29,13 +29,13 @@ func ResourcePolicyIpBinding() *schema.Resource {
 			"policy_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `Specifies the ID of the protection policy.`,
+				Description: `Specifies the ID of the protection policy to unbind the IPs from.`,
 			},
 			"ip_list": {
 				Type:        schema.TypeList,
 				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: `Specifies the list of IP addresses to bind the policy.`,
+				Description: `Specifies the list of IP addresses to unbind from the policy.`,
 			},
 			"enable_force_new": {
 				Type:         schema.TypeString,
@@ -47,15 +47,14 @@ func ResourcePolicyIpBinding() *schema.Resource {
 	}
 }
 
-func resourcePolicyIpBindingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePolicyIpUnbindingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		httpUrl = "v3/cnad/policies/{policy_id}/bind"
+		httpUrl = "v3/cnad/policies/{policy_id}/unbind"
 		product = "aad"
 	)
 
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient(product, cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating CNAD client: %s", err)
 	}
@@ -71,7 +70,7 @@ func resourcePolicyIpBindingCreate(ctx context.Context, d *schema.ResourceData, 
 
 	_, err = client.Request("POST", requestPath, &requestOpt)
 	if err != nil {
-		return diag.Errorf("error binding IPs to CNAD policy: %s", err)
+		return diag.Errorf("error unbinding IPs from CNAD policy: %s", err)
 	}
 
 	id, err := uuid.GenerateUUID()
@@ -80,21 +79,21 @@ func resourcePolicyIpBindingCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 	d.SetId(id)
 
-	return resourcePolicyIpBindingRead(ctx, d, meta)
+	return resourcePolicyIpUnbindingRead(ctx, d, meta)
 }
 
-func resourcePolicyIpBindingRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourcePolicyIpUnbindingRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
 	return nil
 }
 
-func resourcePolicyIpBindingUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourcePolicyIpUnbindingUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
 	return nil
 }
 
-func resourcePolicyIpBindingDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	errorMsg := `This resource is a one-time action resource using to bind IP addresses to a policy. Deleting this 
+func resourcePolicyIpUnbindingDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to unbind IP addresses from a policy. Deleting this 
 resource will not change the current CNAD policy IP binding, but will only remove the resource information from the 
 tfstate file.`
 	return diag.Diagnostics{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New bind and unbind resources for policy IP

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cnad -f TestAccResourcePolicyIpBinding_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cnad" -v -coverprofile="./huaweicloud/services/acceptance/cnad/cnad_coverage.cov" -coverpkg="./huaweicloud/services/cnad" -run TestAccResourcePolicyIpBinding_basic -timeout 360m -parallel 10
=== RUN   TestAccResourcePolicyIpBinding_basic
=== PAUSE TestAccResourcePolicyIpBinding_basic
=== CONT  TestAccResourcePolicyIpBinding_basic
--- PASS: TestAccResourcePolicyIpBinding_basic (5.36s)
PASS
coverage: 5.2% of statements in ./huaweicloud/services/cnad
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cnad      5.445s  coverage: 5.2% of statements in ./huaweicloud/services/cnad
```
<img width="1320" height="85" alt="image" src="https://github.com/user-attachments/assets/8c502c3e-1754-413f-ac64-3d1b9a6d3257" />


```
./scripts/coverage.sh -o cnad -f TestAccResourcePolicyIpUnbinding_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cnad" -v -coverprofile="./huaweicloud/services/acceptance/cnad/cnad_coverage.cov" -coverpkg="./huaweicloud/services/cnad" -run TestAccResourcePolicyIpUnbinding_basic -timeout 360m -parallel 10
=== RUN   TestAccResourcePolicyIpUnbinding_basic
=== PAUSE TestAccResourcePolicyIpUnbinding_basic
=== CONT  TestAccResourcePolicyIpUnbinding_basic
--- PASS: TestAccResourcePolicyIpUnbinding_basic (4.04s)
PASS
coverage: 5.2% of statements in ./huaweicloud/services/cnad
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cnad      4.113s  coverage: 5.2% of statements in ./huaweicloud/services/cnad
```
<img width="1318" height="79" alt="image" src="https://github.com/user-attachments/assets/8ba00da6-d6ce-49a5-9417-1a9a4b86eab2" />




* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
