### PR TITLE
feat(fgs): add new resource to manage function tracing

### DIFF
--- a/docs/resources/fgs_function_tracing_configuration.md
+++ b/docs/resources/fgs_function_tracing_configuration.md
@@ -1,0 +1,71 @@
+---
+subcategory: "FunctionGraph"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_fgs_function_tracing_configuration"
+description: |-
+  Manages a FunctionGraph function tracing configuration resource within HuaweiCloud.
+---
+
+# huaweicloud_fgs_function_tracing_configuration
+
+Manages a FunctionGraph function tracing configuration resource within HuaweiCloud.
+
+-> This feature is only supported by version `v2` and runtime `JAVA`, the function memory cannot be less than `512`.
+
+## Example Usage
+
+```hcl
+variable "function_urn" {}
+variable "tracing_access_key" {}
+variable "tracing_secret_key" {}
+
+resource "huaweicloud_fgs_function_tracing_configuration" "test" {
+  function_urn = var.function_urn
+  tracing_ak   = var.tracing_access_key
+  tracing_sk   = var.tracing_secret_key
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the function tracing configuration is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `function_urn` - (Required, String, NonUpdatable) Specifies the URN of the function to which the tracing configuration
+  belongs.  
+  Changing this parameter will create a new resource.
+
+* `tracing_ak` - (Required, String) Specifies the APM access key for tracing configuration.
+
+* `tracing_sk` - (Required, String) Specifies the APM secret key for tracing configuration.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, which is the function URN.
+
+## Import
+
+Tracing configuration can be imported by `id` (also the functin URN), e.g.
+
+```bash
+$ terraform import huaweicloud_fgs_function_tracing_configuration.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to security reason.
+The missing attribute is `tracing_sk`. It is generally recommended running `terraform plan` after importing an instance.
+You can then decide if changes should be applied to the resource, or the script definition should be updated to align
+with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_fgs_function_tracing_configuration" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      tracing_sk,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2416,6 +2416,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_function":                       fgs.ResourceFgsFunction(),
 			"huaweicloud_fgs_function_event":                 fgs.ResourceFunctionEvent(),
 			"huaweicloud_fgs_function_topping":               fgs.ResourceFunctionTopping(),
+			"huaweicloud_fgs_function_tracing_configuration": fgs.ResourceFunctionTracingConfiguration(),
 			"huaweicloud_fgs_function_trigger":               fgs.ResourceFunctionTrigger(),
 			"huaweicloud_fgs_function_trigger_status_action": fgs.ResourceFunctionTriggerStatusAction(),
 			"huaweicloud_fgs_lts_log_enable":                 fgs.ResourceLtsLogEnable(),

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_tracing_configuration_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_tracing_configuration_test.go
@@ -1,0 +1,128 @@
+package fgs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
+)
+
+func getFunctionTracingConfigurationFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("fgs", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	return fgs.GetFunctionTracingConfiguration(client, state.Primary.Attributes["function_urn"])
+}
+
+func TestAccFunctionTracingConfiguration_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		name         = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_fgs_function_tracing_configuration.test"
+
+		rc = acceptance.InitResourceCheck(resourceName, &obj, getFunctionTracingConfigurationFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckFgsAgency(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source:            "hashicorp/random",
+				VersionConstraint: "3.0.0",
+			},
+		},
+		CheckDestroy: rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionTracingConfiguration_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "tracing_ak", acceptance.HW_ACCESS_KEY),
+					resource.TestCheckResourceAttr(resourceName, "tracing_sk", acceptance.HW_SECRET_KEY),
+					resource.TestCheckResourceAttrSet(resourceName, "function_urn"),
+				),
+			},
+			{
+				Config: testAccFunctionTracingConfiguration_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "tracing_ak", "random_string.access_key", "result"),
+					resource.TestCheckResourceAttrPair(resourceName, "tracing_sk", "random_string.secret_key", "result"),
+					resource.TestCheckResourceAttrSet(resourceName, "function_urn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"tracing_sk",
+				},
+			},
+		},
+	})
+}
+
+func testAccFunctionTracingConfiguration_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_fgs_function" "test" {
+  name                   = "%[1]s"
+  runtime                = "Java11"
+  app                    = "default"
+  handler                = "com.huawei.demo.TriggerTests.apigTest"
+  memory_size            = 512
+  timeout                = 15
+  code_type              = "zip"
+  code_filename          = "java-demo.zip"
+  agency                 = "%[2]s"
+  functiongraph_version  = "v2"
+  enable_class_isolation = true
+}
+`, name, acceptance.HW_FGS_AGENCY_NAME)
+}
+
+func testAccFunctionTracingConfiguration_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_fgs_function_tracing_configuration" "test" {
+  function_urn = huaweicloud_fgs_function.test.urn
+  tracing_ak   = "%[2]s"
+  tracing_sk   = "%[3]s"
+}
+`, testAccFunctionTracingConfiguration_base(name), acceptance.HW_ACCESS_KEY, acceptance.HW_SECRET_KEY)
+}
+
+func testAccFunctionTracingConfiguration_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "random_string" "access_key" {
+  length  = 20
+  special = false
+}
+
+resource "random_string" "secret_key" {
+  length  = 40
+  special = false
+}
+
+resource "huaweicloud_fgs_function_tracing_configuration" "test" {
+  function_urn = huaweicloud_fgs_function.test.urn
+  tracing_ak   = random_string.access_key.result
+  tracing_sk   = random_string.secret_key.result
+}
+`, testAccFunctionTracingConfiguration_base(name))
+}

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_tracing_configuration.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_tracing_configuration.go
@@ -1,0 +1,205 @@
+package fgs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var functionTracingConfigurationNonUpdatableParams = []string{"function_urn"}
+
+// @API FunctionGraph PUT /v2/{project_id}/fgs/functions/{function_urn}/tracing
+// @API FunctionGraph GET /v2/{project_id}/fgs/functions/{function_urn}/tracing
+func ResourceFunctionTracingConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceFunctionTracingConfigurationCreate,
+		ReadContext:   resourceFunctionTracingConfigurationRead,
+		UpdateContext: resourceFunctionTracingConfigurationUpdate,
+		DeleteContext: resourceFunctionTracingConfigurationDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceFunctionTracingConfigurationImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(functionTracingConfigurationNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the function tracing configuration is located.`,
+			},
+
+			// Required parameters.
+			"function_urn": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The URN of the function to which the tracing configuration belongs.`,
+			},
+			"tracing_ak": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: `The APM access key for tracing configuration.`,
+			},
+			"tracing_sk": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: `The APM secret key for tracing configuration.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildFunctionTracingConfigurationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"tracing_ak": d.Get("tracing_ak"),
+		"tracing_sk": d.Get("tracing_sk"),
+	}
+}
+
+func resourceFunctionTracingConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	httpUrl := "v2/{project_id}/fgs/functions/{function_urn}/tracing"
+	functionUrn := d.Get("function_urn").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{function_urn}", functionUrn)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildFunctionTracingConfigurationBodyParams(d),
+	}
+
+	_, err = client.Request("PUT", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph function tracing configuration: %s", err)
+	}
+
+	d.SetId(functionUrn)
+
+	return resourceFunctionTracingConfigurationRead(ctx, d, meta)
+}
+
+func GetFunctionTracingConfiguration(client *golangsdk.ServiceClient, functionUrn string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/fgs/functions/{function_urn}/tracing"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{function_urn}", functionUrn)
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceFunctionTracingConfigurationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	respBody, err := GetFunctionTracingConfiguration(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving FunctionGraph function tracing configuration")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("tracing_ak", utils.PathSearch("tracing_ak", respBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceFunctionTracingConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	httpUrl := "v2/{project_id}/fgs/functions/{function_urn}/tracing"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{function_urn}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildFunctionTracingConfigurationBodyParams(d),
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating FunctionGraph function tracing configuration: %s", err)
+	}
+
+	return resourceFunctionTracingConfigurationRead(ctx, d, meta)
+}
+
+func resourceFunctionTracingConfigurationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	httpUrl := "v2/{project_id}/fgs/functions/{function_urn}/tracing"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{function_urn}", d.Id())
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         make(map[string]interface{}),
+	}
+
+	_, err = client.Request("PUT", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting FunctionGraph function tracing configuration: %s", err)
+	}
+
+	return nil
+}
+
+func resourceFunctionTracingConfigurationImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	return []*schema.ResourceData{d}, d.Set("function_urn", d.Id())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource to manage function tracing (AK/SK configuration).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new resource to manage function tracing (AK/SK configuration).
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
/scripts/coverage.sh -o fgs -f TestAccFunctionTracingConfiguration_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunctionTracingConfiguration_basic -timeout 360m -parallel 10
=== RUN   TestAccFunctionTracingConfiguration_basic
=== PAUSE TestAccFunctionTracingConfiguration_basic
=== CONT  TestAccFunctionTracingConfiguration_basic
--- PASS: TestAccFunctionTracingConfiguration_basic (33.34s)
PASS
coverage: 16.6% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       33.449s coverage: 16.6% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
