### PR TITLE
feat(aad): new datasource to query cc attack protection qps

### DIFF
--- a/docs/data-sources/aad_cc_attack_protection_qps.md
+++ b/docs/data-sources/aad_cc_attack_protection_qps.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Advanced Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aad_cc_attack_protection_qps"
+description: |-
+  Use this data source to get the QPS information of CC attack protection within HuaweiCloud.
+---
+
+# huaweicloud_aad_cc_attack_protection_qps
+
+Use this data source to get the QPS information of CC attack protection within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_aad_cc_attack_protection_qps" "test" {
+  recent = "1month"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `recent` - (Required, String) Specifies the time range for querying CC attack protection QPS data.
+  Valid values are **yesterday**, **today**, **3days**, **1week**, **1month**.
+
+* `domains` - (Optional, String) Specifies the domain name to query.
+
+* `start_time` - (Optional, String) Specifies the start time for querying CC attack protection QPS data.
+
+* `end_time` - (Optional, String) Specifies the end time for querying CC attack protection QPS data.
+
+* `overseas_type` - (Optional, String) Specifies the protection region.
+  The options are as follows:
+  + `0`: Mainland China.
+  + `1`: Outside Mainland China.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `qps` - The QPS value of CC attack protection.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -465,6 +465,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aad_black_white_lists":        aad.DataSourceAadBlackWhiteLists(),
 			"huaweicloud_aad_web_protection_policies":  aad.DataSourceAadWebProtectionPolicies(),
 			"huaweicloud_aad_block_statistics":         aad.DataSourceBlockStatistics(),
+			"huaweicloud_aad_cc_attack_protection_qps": aad.DataSourceCcAttackProtectionQPS(),
 			"huaweicloud_aad_unblock_records":          aad.DataSourceUnblockRecords(),
 			"huaweicloud_aad_domains":                  aad.DataSourceAadDomains(),
 			"huaweicloud_aad_source_ips":               aad.DataSourceAadSourceIps(),

--- a/huaweicloud/services/aad/data_source_huaweicloud_aad_cc_attack_protection_qps.go
+++ b/huaweicloud/services/aad/data_source_huaweicloud_aad_cc_attack_protection_qps.go
@@ -1,0 +1,123 @@
+package aad
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AAD GET /v2/aad/domains/waf-info/flow/request/peak
+func DataSourceCcAttackProtectionQPS() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCcAttackProtectionQPSRead,
+
+		Schema: map[string]*schema.Schema{
+			"recent": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specified the time range for querying CC attack protection QPS data.`,
+			},
+			"domains": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specified the domain name to query.`,
+			},
+			"start_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specified the start time for querying CC attack protection QPS data.`,
+			},
+			"end_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specified the end time for querying CC attack protection QPS data.`,
+			},
+			"overseas_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specified the protection region.`,
+			},
+			"qps": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The QPS value of CC attack protection.`,
+			},
+		},
+	}
+}
+
+func buildCcAttackProtectionQPSQueryParams(d *schema.ResourceData) string {
+	rst := fmt.Sprintf("?recent=%s", d.Get("recent").(string))
+
+	if v, ok := d.GetOk("domains"); ok {
+		rst += fmt.Sprintf("&domains=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("start_time"); ok {
+		rst += fmt.Sprintf("&start_time=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("end_time"); ok {
+		rst += fmt.Sprintf("&end_time=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("overseas_type"); ok {
+		rst += fmt.Sprintf("&overseas_type=%s", v.(string))
+	}
+
+	return rst
+}
+
+func dataSourceCcAttackProtectionQPSRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v2/aad/domains/waf-info/flow/request/peak"
+	)
+
+	client, err := cfg.NewServiceClient("aad", region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath += buildCcAttackProtectionQPSQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving AAD CC attack protection QPS data: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr = multierror.Append(
+		d.Set("qps", utils.PathSearch("qps", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_cc_attack_protection_qps_test.go
+++ b/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_cc_attack_protection_qps_test.go
@@ -1,0 +1,38 @@
+package antiddos
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Due to the lack of test scenarios, this test case only verifies that the API request is normal, not the response result.
+func TestAccCcAttackProtectionQPSDataSource_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_aad_cc_attack_protection_qps.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testCcAttackProtectionQps_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+const testCcAttackProtectionQps_basic = `
+data "huaweicloud_aad_cc_attack_protection_qps" "test" {
+  recent = "1month"
+}
+`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query cc attack protection qps.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o aad -f TestAccCcAttackProtectionQPSDataSource_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/aad" -v -coverprofile="./huaweicloud/services/acceptance/aad/aad_coverage.cov" -coverpkg="./huaweicloud/services/aad" -run TestAccCcAttackProtectionQPSDataSource_basic -timeout 360m -parallel 10
=== RUN   TestAccCcAttackProtectionQPSDataSource_basic
=== PAUSE TestAccCcAttackProtectionQPSDataSource_basic
=== CONT  TestAccCcAttackProtectionQPSDataSource_basic
--- PASS: TestAccCcAttackProtectionQPSDataSource_basic (8.55s)
PASS
coverage: 8.3% of statements in ./huaweicloud/services/aad
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aad       8.611s  coverage: 8.3% of statements in ./huaweicloud/services/aad
```
<img width="1287" height="79" alt="image" src="https://github.com/user-attachments/assets/22f1f877-a6a7-4d53-961a-78c632ae1bde" />



* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
