### PR TITLE
feat(rocketmq): the instance resource supports 'tls_mode' field

### DIFF
--- a/docs/resources/dms_rocketmq_instance.md
+++ b/docs/resources/dms_rocketmq_instance.md
@@ -78,7 +78,9 @@ The following arguments are supported:
   The description can contain a maximum of `1,024` characters.
 
 * `ssl_enable` - (Optional, Bool, ForceNew) Specifies whether the RocketMQ SASL_SSL is enabled. Defaults to **false**.
-  Changing this parameter will create a new resource.
+  Changing this parameter will create a new resource.  
+  If this parameter is set to **true**, `tls_mode` can be omitted or must be set to **SSL**.
+  If this parameter is set to **false**, `tls_mode` cannot be set to **SSL**.
 
 * `ipv6_enable` - (Optional, Bool, ForceNew) Specifies whether to support IPv6. Defaults to **false**.
   Changing this parameter will create a new resource.
@@ -112,6 +114,12 @@ The following arguments are supported:
 
 * `configs` - (Optional, List) Specifies the instance configs.
   The [configs](#dms_configs) structure is documented below.
+
+* `tls_mode` - (Optional, String) Specifies TLS mode of the instance.  
+  The valid values are as follows:
+  + **PLAINTEXT**
+  + **SSL**
+  + **PERMISSIVE**
 
 <a name="dms_configs"></a>
 The `configs` block supports:

--- a/huaweicloud/services/acceptance/rocketmq/resource_huaweicloud_dms_rocketmq_instance_test.go
+++ b/huaweicloud/services/acceptance/rocketmq/resource_huaweicloud_dms_rocketmq_instance_test.go
@@ -71,6 +71,8 @@ func TestAccDmsRocketMQInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "storage_space", "500"),
 					resource.TestCheckResourceAttrPair(resourceName, "engine_version", "data.huaweicloud_dms_rocketmq_flavors.test", "versions.0"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor_id", "data.huaweicloud_dms_rocketmq_flavors.test", "flavors.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tls_mode", "SSL"),
 				),
 			},
 			{
@@ -89,6 +91,8 @@ func TestAccDmsRocketMQInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "flavor_id", "data.huaweicloud_dms_rocketmq_flavors.test", "flavors.1.id"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.name", "fileReservedTime"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.value", "72"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "tls_mode", "PLAINTEXT"),
 				),
 			},
 			{
@@ -337,6 +341,7 @@ resource "huaweicloud_dms_rocketmq_instance" "test" {
   flavor_id         = local.flavor.id
   storage_space     = 500  
   broker_num        = 1
+  tls_mode          = "SSL"
 
   tags = {
     key1 = "value1"
@@ -381,6 +386,7 @@ resource "huaweicloud_dms_rocketmq_instance" "test" {
   flavor_id         = local.newFlavor.id
   storage_space     = 1200 
   broker_num        = 2
+  tls_mode          = "PLAINTEXT"
 
   configs {
     name  = "fileReservedTime"

--- a/huaweicloud/services/rocketmq/common.go
+++ b/huaweicloud/services/rocketmq/common.go
@@ -1,10 +1,15 @@
 package rocketmq
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
+	"time"
 
 	"github.com/chnsz/golangsdk"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -31,4 +36,58 @@ func handleMultiOperationsError(err error) (bool, error) {
 		}
 	}
 	return false, err
+}
+
+func getInstanceTaskById(client *golangsdk.ServiceClient, instanceId, taskId string) (interface{}, error) {
+	getTaskHttpUrl := "v2/{project_id}/instances/{instance_id}/tasks/{task_id}"
+	getTaskPath := client.Endpoint + getTaskHttpUrl
+	getTaskPath = strings.ReplaceAll(getTaskPath, "{project_id}", client.ProjectID)
+	getTaskPath = strings.ReplaceAll(getTaskPath, "{instance_id}", instanceId)
+	getTaskPath = strings.ReplaceAll(getTaskPath, "{task_id}", taskId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	resp, err := client.Request("GET", getTaskPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func refreshInstanceTaskStatus(client *golangsdk.ServiceClient, instanceID, taskId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := getInstanceTaskById(client, instanceID, taskId)
+		if err != nil {
+			return respBody, "ERROR", err
+		}
+
+		// status options: DELETED, SUCCESS, EXECUTING, FAILED, CREATED
+		// CREATED means the task is in progress.
+		status := utils.PathSearch("tasks[0].status", respBody, "").(string)
+		if status == "FAILED" {
+			return respBody, "FAILED", fmt.Errorf("unexpect status (%s)", status)
+		}
+
+		if status == "SUCCESS" {
+			return respBody, "COMPLETED", nil
+		}
+
+		return "continue", "PENDING", nil
+	}
+}
+
+func waitForInstanceTaskStatusCompleted(ctx context.Context, client *golangsdk.ServiceClient, instanceId, taskId string,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshInstanceTaskStatus(client, instanceId, taskId),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 20 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new parameter `tls_mode`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o rocketmq -f TestAccDmsRocketM
QInstance_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rocketmq" -v -coverprofile="./huaweicloud/services/acceptance/rocketmq/rocketmq_coverage.cov" -coverpkg="./huaweicloud/services/rocketmq" -run TestAccDmsRocketMQInstance_basic -timeout 360m -parallel 10
=== RUN   TestAccDmsRocketMQInstance_basic
=== PAUSE TestAccDmsRocketMQInstance_basic
=== CONT  TestAccDmsRocketMQInstance_basic
--- PASS: TestAccDmsRocketMQInstance_basic (2514.49s)
PASS
coverage: 20.9% of statements in ./huaweicloud/services/rocketmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rocketmq      2514.568s coverage: 20.9% of statements in ./huaweicloud/services/rocketmq
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
