### PR TITLE
feat(aad): new datasource to query waf geoip rules

### DIFF
--- a/docs/data-sources/aad_geoip_rules.md
+++ b/docs/data-sources/aad_geoip_rules.md
@@ -1,0 +1,57 @@
+---
+subcategory: "Advanced Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aad_geoip_rules"
+description: |-
+  Use this data source to get the list of Geo IP rules within HuaweiCloud.
+---
+
+# huaweicloud_aad_geoip_rules
+
+Use this data source to get the list of Geo IP rules within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "domain_name" {}
+
+data "huaweicloud_aad_geoip_rules" "test" {
+  domain_name   = var.domain_name
+  overseas_type = "0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_name` - (Required, String) Specifies the domain name to query.
+
+* `overseas_type` - (Required, String) Specifies the protection region.
+  + `0`: Mainland China.
+  + `1`: Outside Mainland China.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `items` - The list of Geo IP rules.
+  The [items](#items_struct) structure is documented below.
+
+<a name="items_struct"></a>
+The `items` block supports:
+
+* `id` - The ID of the rule.
+
+* `name` - The name of the rule.
+
+* `geoip` - The geographical location code.
+
+* `overseas_type` - The protection region.
+
+* `timestamp` - The creation timestamp of the rule.
+
+* `white` - The protection action. The options are as follows:
+  + `0`: Block.
+  + `1`: Allow.
+  + `2`: Log only.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -464,6 +464,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aad_unblock_quota_statistics": aad.DataSourceUnblockQuotaStatistics(),
 			"huaweicloud_aad_black_white_lists":        aad.DataSourceAadBlackWhiteLists(),
 			"huaweicloud_aad_web_protection_policies":  aad.DataSourceAadWebProtectionPolicies(),
+			"huaweicloud_aad_geoip_rules":              aad.DataSourceGeoIpRules(),
 			"huaweicloud_aad_block_statistics":         aad.DataSourceBlockStatistics(),
 			"huaweicloud_aad_unblock_records":          aad.DataSourceUnblockRecords(),
 			"huaweicloud_aad_domains":                  aad.DataSourceAadDomains(),

--- a/huaweicloud/services/aad/data_source_huaweicloud_aad_geoip_rules.go
+++ b/huaweicloud/services/aad/data_source_huaweicloud_aad_geoip_rules.go
@@ -1,0 +1,148 @@
+package aad
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AAD GET /v2/aad/policies/waf/geoip-rule
+func DataSourceGeoIpRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGeoIpRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"domain_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the domain name to query.`,
+			},
+			"overseas_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the protection region.`,
+			},
+			"items": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of Geo IP rules.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the rule.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the rule.`,
+						},
+						"geoip": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The geographical location code.`,
+						},
+						"overseas_type": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The protection region.`,
+						},
+						"timestamp": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The creation timestamp of the rule.`,
+						},
+						"white": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The protection action.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildGeoIpRulesQueryParams(d *schema.ResourceData) string {
+	domainName := d.Get("domain_name").(string)
+	oversightType := d.Get("overseas_type").(string)
+
+	return fmt.Sprintf("?domain_name=%s&overseas_type=%s", domainName, oversightType)
+}
+
+func dataSourceGeoIpRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v2/aad/policies/waf/geoip-rule"
+	)
+
+	client, err := cfg.NewServiceClient("aad", region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath += buildGeoIpRulesQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving AAD Geo IP rules: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("items", flattenGeoIpRules(utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGeoIpRules(rules []interface{}) []map[string]interface{} {
+	if len(rules) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(rules))
+	for _, rule := range rules {
+		result = append(result, map[string]interface{}{
+			"id":            utils.PathSearch("id", rule, nil),
+			"name":          utils.PathSearch("name", rule, nil),
+			"geoip":         utils.PathSearch("geoip", rule, nil),
+			"overseas_type": utils.PathSearch("overseas_type", rule, nil),
+			"timestamp":     utils.PathSearch("timestamp", rule, nil),
+			"white":         utils.PathSearch("white", rule, nil),
+		})
+	}
+
+	return result
+}

--- a/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_geoip_rules_test.go
+++ b/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_geoip_rules_test.go
@@ -1,0 +1,43 @@
+package antiddos
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGeoIpRulesDataSource_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_aad_geoip_rules.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDomainName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeoIpRulesDataSource_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGeoIpRulesDataSource_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_aad_geoip_rules" "test" {
+  domain_name   = "%s"
+  overseas_type = "0"
+}
+`, acceptance.HW_DOMAIN_NAME)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query waf geoip rules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o aad -f TestAccWafGeoIpRulesDataSource_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/aad" -v -coverprofile="./huaweicloud/services/acceptance/aad/aad_coverage.cov" -coverpkg="./huaweicloud/services/aad" -run TestAccWafGeoIpRulesDataSource_basic -timeout 360m -parallel 10
=== RUN   TestAccWafGeoIpRulesDataSource_basic
=== PAUSE TestAccWafGeoIpRulesDataSource_basic
=== CONT  TestAccWafGeoIpRulesDataSource_basic
--- PASS: TestAccWafGeoIpRulesDataSource_basic (9.29s)
PASS
coverage: 8.3% of statements in ./huaweicloud/services/aad
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aad       9.397s  coverage: 8.3% of statements in ./huaweicloud/services/aad
```
<img width="1273" height="75" alt="image" src="https://github.com/user-attachments/assets/5d3890ab-f177-484c-8292-258c5a8deea9" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
