### PR TITLE
refactor(error): use ErrDefault409 instead of ErrUnexpectedResponseCode

### DIFF
--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance_feature.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance_feature.go
@@ -135,7 +135,7 @@ func handleOperationError409(err error) (bool, error) {
 	if err == nil {
 		return false, nil
 	}
-	if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok && errCode.Actual == 409 {
+	if errCode, ok := err.(golangsdk.ErrDefault409); ok {
 		var apiError interface{}
 		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
 			return false, jsonErr

--- a/huaweicloud/services/ddm/common.go
+++ b/huaweicloud/services/ddm/common.go
@@ -21,7 +21,7 @@ func handleMultiOperationsError(err error) (bool, error) {
 		// The operation was executed successfully and does not need to be executed again.
 		return false, nil
 	}
-	if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok && errCode.Actual == 409 {
+	if errCode, ok := err.(golangsdk.ErrDefault409); ok {
 		var apiError interface{}
 		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
 			return false, fmt.Errorf("unmarshal the response body failed: %s", jsonErr)

--- a/huaweicloud/services/ddm/resource_huaweicloud_ddm_schema.go
+++ b/huaweicloud/services/ddm/resource_huaweicloud_ddm_schema.go
@@ -448,7 +448,7 @@ func handleOperationError(err error, operateType string, operateObj string) (boo
 	if err == nil {
 		return false, nil
 	}
-	if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok && errCode.Actual == 409 {
+	if errCode, ok := err.(golangsdk.ErrDefault409); ok {
 		var apiError ddmError
 		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
 			return false, fmt.Errorf("error %s DDM %s: error format error: %s", operateType,

--- a/huaweicloud/services/deprecated/resource_huaweicloud_csbs_backup_policy_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_csbs_backup_policy_v1.go
@@ -324,10 +324,8 @@ func waitForVBSPolicyDelete(policyClient *golangsdk.ServiceClient, policyID stri
 				logp.Printf("[INFO] Successfully deleted Backup Policy %s", policyID)
 				return r, "deleted", nil
 			}
-			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					return r, "available", nil
-				}
+			if _, ok := err.(golangsdk.ErrDefault409); ok {
+				return r, "available", nil
 			}
 			return r, "available", err
 		}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_csbs_backup_v1.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_csbs_backup_v1.go
@@ -355,10 +355,8 @@ func waitForCSBSBackupDelete(backupClient *golangsdk.ServiceClient, backupId str
 				logp.Printf("[INFO] Successfully deleted Backup %s", backupId)
 				return r, "deleted", nil
 			}
-			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					return r, "deleting", nil
-				}
+			if _, ok := err.(golangsdk.ErrDefault409); ok {
+				return r, "deleting", nil
 			}
 			if _, ok := err.(golangsdk.ErrDefault400); ok {
 				return r, "deleting", nil

--- a/huaweicloud/services/deprecated/resource_huaweicloud_fw_policy_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_fw_policy_v2.go
@@ -226,13 +226,11 @@ func waitForFirewallPolicyDeletion(fwClient *golangsdk.ServiceClient, id string)
 			return "", "DELETED", nil
 		}
 
-		if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
-			if errCode.Actual == 409 {
-				// This error usually means that the policy is attached
-				// to a firewall. At this point, the firewall is probably
-				// being delete. So, we retry a few times.
-				return nil, "ACTIVE", nil
-			}
+		if _, ok := err.(golangsdk.ErrDefault409); ok {
+			// This error usually means that the policy is attached
+			// to a firewall. At this point, the firewall is probably
+			// being delete. So, we retry a few times.
+			return nil, "ACTIVE", nil
 		}
 
 		return nil, "ACTIVE", err

--- a/huaweicloud/services/deprecated/resource_huaweicloud_networking_network_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_networking_network_v2.go
@@ -315,10 +315,8 @@ func waitForNetworkDelete(networkingClient *golangsdk.ServiceClient, networkId s
 				logp.Printf("[DEBUG] Successfully deleted HuaweiCloud Network %s", networkId)
 				return n, "DELETED", nil
 			}
-			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					return n, "ACTIVE", nil
-				}
+			if _, ok := err.(golangsdk.ErrDefault409); ok {
+				return n, "ACTIVE", nil
 			}
 			return n, "ACTIVE", err
 		}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_networking_router_interface_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_networking_router_interface_v2.go
@@ -195,11 +195,9 @@ func waitForRouterInterfaceDelete(networkingClient *golangsdk.ServiceClient, d *
 				logp.Printf("[DEBUG] Successfully deleted HuaweiCloud Router Interface %s.", routerInterfaceId)
 				return r, "DELETED", nil
 			}
-			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					logp.Printf("[DEBUG] Router Interface %s is still in use.", routerInterfaceId)
-					return r, "ACTIVE", nil
-				}
+			if _, ok := err.(golangsdk.ErrDefault409); ok {
+				logp.Printf("[DEBUG] Router Interface %s is still in use.", routerInterfaceId)
+				return r, "ACTIVE", nil
 			}
 
 			return r, "ACTIVE", err

--- a/huaweicloud/services/deprecated/resource_huaweicloud_networking_subnet_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_networking_subnet_v2.go
@@ -433,10 +433,8 @@ func waitForSubnetDelete(networkingClient *golangsdk.ServiceClient, subnetId str
 				logp.Printf("[DEBUG] Successfully deleted HuaweiCloud Subnet %s", subnetId)
 				return s, "DELETED", nil
 			}
-			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					return s, "ACTIVE", nil
-				}
+			if _, ok := err.(golangsdk.ErrDefault409); ok {
+				return s, "ACTIVE", nil
 			}
 			return s, "ACTIVE", err
 		}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vbs_backup_policy_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vbs_backup_policy_v2.go
@@ -356,10 +356,8 @@ func resourceVBSBackupPolicyV2Delete(d *schema.ResourceData, meta interface{}) e
 			logp.Printf("[INFO] Successfully deleted Huaweicloud VBS Backup Policy %s", d.Id())
 
 		}
-		if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
-			if errCode.Actual == 409 {
-				logp.Printf("[INFO] Error deleting Huaweicloud VBS Backup Policy %s", d.Id())
-			}
+		if _, ok := err.(golangsdk.ErrDefault409); ok {
+			logp.Printf("[INFO] Error deleting Huaweicloud VBS Backup Policy %s", d.Id())
 		}
 		logp.Printf("[INFO] Successfully deleted Huaweicloud VBS Backup Policy %s", d.Id())
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vpc_route_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vpc_route_v2.go
@@ -166,10 +166,8 @@ func waitForVpcRouteDelete(vpcRouteClient *golangsdk.ServiceClient, routeId stri
 				log.Printf("[INFO] Successfully deleted vpc route %s", routeId)
 				return r, "DELETED", nil
 			}
-			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					return r, "ACTIVE", nil
-				}
+			if _, ok := err.(golangsdk.ErrDefault409); ok {
+				return r, "ACTIVE", nil
 			}
 			return r, "ACTIVE", err
 		}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_ipsec_policy_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vpnaas_ipsec_policy_v2.go
@@ -308,10 +308,8 @@ func waitForIPSecPolicyDeletion(networkingClient *golangsdk.ServiceClient, id st
 			return "", "DELETED", nil
 		}
 
-		if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
-			if errCode.Actual == 409 {
-				return nil, "ACTIVE", nil
-			}
+		if _, ok := err.(golangsdk.ErrDefault409); ok {
+			return nil, "ACTIVE", nil
 		}
 
 		return nil, "ACTIVE", err

--- a/huaweicloud/services/gaussdb/common.go
+++ b/huaweicloud/services/gaussdb/common.go
@@ -26,7 +26,7 @@ func handleMultiOperationsError(err error) (bool, error) {
 		// The operation was executed successfully and does not need to be executed again.
 		return false, nil
 	}
-	if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok && errCode.Actual == 409 {
+	if errCode, ok := err.(golangsdk.ErrDefault409); ok {
 		var apiError interface{}
 		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
 			return false, fmt.Errorf("unmarshal the response body failed: %s", jsonErr)

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_policy.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_policy.go
@@ -327,7 +327,7 @@ func handleAddVersionError409(err error) (bool, error) {
 	if err == nil {
 		return false, nil
 	}
-	if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok && errCode.Actual == 409 {
+	if errCode, ok := err.(golangsdk.ErrDefault409); ok {
 		var apiError interface{}
 		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
 			return false, jsonErr

--- a/huaweicloud/services/iec/resource_huaweicloud_iec_security_group.go
+++ b/huaweicloud/services/iec/resource_huaweicloud_iec_security_group.go
@@ -208,10 +208,8 @@ func waitForSecurityGroupDelete(iecClient *golangsdk.ServiceClient, groupID stri
 				log.Printf("[DEBUG] successfully deleted IEC security group %s", groupID)
 				return sg, "DELETED", nil
 			}
-			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					return sg, "ACTIVE", nil
-				}
+			if _, ok := err.(golangsdk.ErrDefault409); ok {
+				return sg, "ACTIVE", nil
 			}
 			return sg, "ACTIVE", err
 		}

--- a/huaweicloud/services/rds/common.go
+++ b/huaweicloud/services/rds/common.go
@@ -64,7 +64,7 @@ func handleMultiOperationsError(err error) (bool, error) {
 			return true, err
 		}
 	}
-	if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok && errCode.Actual == 409 {
+	if errCode, ok := err.(golangsdk.ErrDefault409); ok {
 		var apiError interface{}
 		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
 			return false, fmt.Errorf("unmarshal the response body failed: %s", jsonErr)
@@ -142,7 +142,7 @@ func handleDeletionError(err error) (bool, error) {
 		}
 	}
 	// delete fail
-	if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok && errCode.Actual == 409 {
+	if errCode, ok := err.(golangsdk.ErrDefault409); ok {
 		var apiError interface{}
 		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
 			return false, fmt.Errorf("unmarshal the response body failed: %s", jsonErr)

--- a/huaweicloud/services/taurusdb/common.go
+++ b/huaweicloud/services/taurusdb/common.go
@@ -25,7 +25,7 @@ func handleMultiOperationsError(err error) (bool, error) {
 		// The operation was executed successfully and does not need to be executed again.
 		return false, nil
 	}
-	if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok && errCode.Actual == 409 {
+	if errCode, ok := err.(golangsdk.ErrDefault409); ok {
 		var apiError interface{}
 		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
 			return false, fmt.Errorf("unmarshal the response body failed: %s", jsonErr)

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_gaussdb_mysql_database.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_gaussdb_mysql_database.go
@@ -427,7 +427,7 @@ func handleGaussDBMysqlOperationError(err error) (bool, error) {
 	if err == nil {
 		return false, nil
 	}
-	if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok && errCode.Actual == 409 {
+	if errCode, ok := err.(golangsdk.ErrDefault409); ok {
 		var apiError interface{}
 		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
 			return false, jsonErr

--- a/huaweicloud/services/vpc/resource_huaweicloud_networking_secgroup.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_networking_secgroup.go
@@ -502,10 +502,8 @@ func waitForSecGroupDelete(client *golangsdk.ServiceClient, secGroupId string) r
 				log.Printf("[DEBUG] Successfully deleted Security Group %s", secGroupId)
 				return r, "DELETED", nil
 			}
-			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					return r, "ACTIVE", nil
-				}
+			if _, ok := err.(golangsdk.ErrDefault409); ok {
+				return r, "ACTIVE", nil
 			}
 			return r, "ACTIVE", err
 		}

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
@@ -448,10 +448,8 @@ func waitForVpcDelete(vpcClient *golangsdk.ServiceClient, vpcId string) resource
 				log.Printf("[INFO] successfully delete VPC %s", vpcId)
 				return r, "DELETED", nil
 			}
-			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					return r, "ACTIVE", nil
-				}
+			if _, ok := err.(golangsdk.ErrDefault409); ok {
+				return r, "ACTIVE", nil
 			}
 			return r, "ACTIVE", err
 		}

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection.go
@@ -235,10 +235,8 @@ func waitForVpcPeeringDelete(peeringClient *golangsdk.ServiceClient, peeringId s
 				log.Printf("[INFO] Successfully deleted vpc peering connection %s", peeringId)
 				return r, "DELETED", nil
 			}
-			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					return r, "ACTIVE", nil
-				}
+			if _, ok := err.(golangsdk.ErrDefault409); ok {
+				return r, "ACTIVE", nil
 			}
 			return r, "ACTIVE", err
 		}

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
@@ -573,10 +573,8 @@ func waitForVpcSubnetDelete(subnetClient *golangsdk.ServiceClient, vpcId string,
 				log.Printf("[DEBUG] Got 500 error when delting subnet %s, it should be stream control on API server, try again later", subnetId)
 				return r, "ACTIVE", nil
 			}
-			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					return r, "ACTIVE", nil
-				}
+			if _, ok := err.(golangsdk.ErrDefault409); ok {
+				return r, "ACTIVE", nil
 			}
 			return r, "ACTIVE", err
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
