### PR TITLE
feat(rocketmq): add new data source to get azs

### DIFF
--- a/docs/data-sources/dms_rocketmq_availability_zones.md
+++ b/docs/data-sources/dms_rocketmq_availability_zones.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_rocketmq_availability_zones"
+description: |-
+  Use this data source to get the list of DMS rocketMQ availability zones within HuaweiCloud.
+---
+
+# huaweicloud_dms_rocketmq_availability_zones
+
+Use this data source to get the list of DMS rocketMQ availability zones within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_dms_rocketmq_availability_zones" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the availability zones are located.  
+  If omitted, the provider-level region will be used.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `availability_zones` - The list of availability zones.  
+  The [availability_zones](#rocketmq_availability_zones_attr) structure is documented below.
+
+<a name="rocketmq_availability_zones_attr"></a>
+The `availability_zones` block supports:
+
+* `id` - The ID of the availability zone.
+
+* `name` - The name of the availability zone. e.g. `AZ1`.
+
+* `code` - The code of the availability zone. e.g. `cn-north-4a`.
+
+* `port` - The port of the availability zone.
+
+* `sold_out` - Whether the availability zone is sold out.
+
+* `resource_availability` - The resource availability of the availability zone.
+
+* `default_az` - Whether the availability zone is the default availability zone.
+
+* `remain_time` - The remaining time of the availability zone.
+
+* `ipv6_enable` - Whether the availability zone supports IPv6.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -933,6 +933,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rabbitmq_queues":           rabbitmq.DataSourceDmsRabbitmqQueues(),
 			"huaweicloud_dms_rabbitmq_users":            rabbitmq.DataSourceDmsRabbitmqUsers(),
 
+			"huaweicloud_dms_rocketmq_availability_zones":          rocketmq.DataSourceRocketMQAvailabilityZones(),
 			"huaweicloud_dms_rocketmq_broker":                      rocketmq.DataSourceDmsRocketMQBroker(),
 			"huaweicloud_dms_rocketmq_instances":                   rocketmq.DataSourceDmsRocketMQInstances(),
 			"huaweicloud_dms_rocketmq_topics":                      rocketmq.DataSourceDmsRocketMQTopics(),

--- a/huaweicloud/services/acceptance/rocketmq/data_source_huaweicloud_dms_rocketmq_availability_zones_test.go
+++ b/huaweicloud/services/acceptance/rocketmq/data_source_huaweicloud_dms_rocketmq_availability_zones_test.go
@@ -1,0 +1,42 @@
+package rocketmq
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataRocketMQAvailabilityZones_basic(t *testing.T) {
+	all := "data.huaweicloud_dms_rocketmq_availability_zones.test"
+	dc := acceptance.InitDataSourceCheck(all)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataRocketMQAvailabilityZones_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "availability_zones.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "availability_zones.0.id"),
+					resource.TestCheckResourceAttrSet(all, "availability_zones.0.name"),
+					resource.TestCheckResourceAttrSet(all, "availability_zones.0.code"),
+					resource.TestCheckResourceAttrSet(all, "availability_zones.0.port"),
+					resource.TestCheckResourceAttrSet(all, "availability_zones.0.sold_out"),
+					resource.TestCheckResourceAttrSet(all, "availability_zones.0.resource_availability"),
+					resource.TestCheckResourceAttrSet(all, "availability_zones.0.default_az"),
+					resource.TestCheckResourceAttrSet(all, "availability_zones.0.remain_time"),
+					resource.TestCheckResourceAttrSet(all, "availability_zones.0.ipv6_enable"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataRocketMQAvailabilityZones_basic = `
+data "huaweicloud_dms_rocketmq_availability_zones" "test" {}
+`

--- a/huaweicloud/services/rocketmq/data_source_huaweicloud_dms_rocketmq_availability_zones.go
+++ b/huaweicloud/services/rocketmq/data_source_huaweicloud_dms_rocketmq_availability_zones.go
@@ -1,0 +1,145 @@
+package rocketmq
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RocketMQ GET /v2/available-zones
+func DataSourceRocketMQAvailabilityZones() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRocketMQAvailabilityZonesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The region where the availability zones are located.",
+			},
+			"availability_zones": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the availability zone.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the availability zone.",
+						},
+						"code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The code of the availability zone.",
+						},
+						"port": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The port number of the availability zone.",
+						},
+						"sold_out": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether the availability zone is sold out.",
+						},
+						"resource_availability": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Whether there are available resources in the availability zone.",
+						},
+						"default_az": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether the availability zone is default.",
+						},
+						"remain_time": {
+							Type:        schema.TypeFloat,
+							Computed:    true,
+							Description: "The remaining time of the availability zone.",
+						},
+						"ipv6_enable": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether IPv6 is supported in the availability zone.",
+						},
+					},
+				},
+				Description: "The list of availability zones.",
+			},
+		},
+	}
+}
+
+func dataSourceRocketMQAvailabilityZonesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/available-zones"
+		listOpt = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+	)
+
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	resp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return diag.Errorf("error querying availability zones: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("availability_zones", flattenRocketMQAvailabilityZones(utils.PathSearch("available_zones",
+			respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRocketMQAvailabilityZones(azs []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(azs))
+	for i, az := range azs {
+		result[i] = map[string]interface{}{
+			"id":                    utils.PathSearch("id", az, nil),
+			"name":                  utils.PathSearch("name", az, nil),
+			"code":                  utils.PathSearch("code", az, nil),
+			"port":                  utils.PathSearch("port", az, nil),
+			"sold_out":              utils.PathSearch("soldOut", az, nil),
+			"resource_availability": utils.PathSearch("resource_availability", az, nil),
+			"default_az":            utils.PathSearch("default_az", az, nil),
+			"remain_time":           utils.PathSearch("remain_time", az, nil),
+			"ipv6_enable":           utils.PathSearch("ipv6_enable", az, nil),
+		}
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data source (`huaweicloud_dms_rocketmq_availability_zones`) to query availability zone list of the  DMS rocketMQ under specified region.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
2. add corresponding documation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o rocketmq -f TestAccDat
aRocketMQAvailabilityZones_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rocketmq" -v -coverprofile="./huaweicloud/services/acceptance/rocketmq/rocketmq_coverage.cov" -coverpkg="./huaweicloud/services/rocketmq" -run TestAccDataRocketMQAvailabilityZones_basic -timeout 360m -parallel 10
=== RUN   TestAccDataRocketMQAvailabilityZones_basic
=== PAUSE TestAccDataRocketMQAvailabilityZones_basic
=== CONT  TestAccDataRocketMQAvailabilityZones_basic
--- PASS: TestAccDataRocketMQAvailabilityZones_basic (19.96s)
PASS
coverage: 5.4% of statements in ./huaweicloud/services/rocketmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rocketmq  20.115s coverage: 5.4% of statements in ./huaweicloud/services/rocketmq
```
<img width="1074" height="287" alt="image" src="https://github.com/user-attachments/assets/3f647819-eb1c-458b-a7c1-52e5c2365c3d" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
