### PR TITLE
feat(aad): new datasource to query QPS curve

### DIFF
--- a/docs/data-sources/aad_qps_curve.md
+++ b/docs/data-sources/aad_qps_curve.md
@@ -1,0 +1,74 @@
+---
+subcategory: "Advanced Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aad_qps_curve"
+description: |-
+  Use this data source to get the list of Advanced Anti-DDoS QPS curve within HuaweiCloud.
+---
+
+# huaweicloud_aad_qps_curve
+
+Use this data source to get the list of Advanced Anti-DDoS QPS curve within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_aad_qps_curve" "test" {
+  value_type = "mean"
+  recent     = "today"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `value_type` - (Required, String) Specifies the value type.
+  The valid values are as follows:
+  + **mean**: Average QPS value.
+  + **peak**: Peak QPS value.
+  + **source**: Response status code from origin server.
+  + **proxy**: Response status code from AAD protection.
+
+* `domains` - (Optional, String) Specifies the domain name to query. If not specified, data for all domains will be returned.
+
+* `start_time` - (Optional, String) Specifies the start time of the query.
+
+* `end_time` - (Optional, String) Specifies the end time of the query.
+
+* `recent` - (Optional, String) Specifies the recent time range.
+  The valid values are:
+  + **yesterday**
+  + **today**
+  + **3days**
+  + **1week**
+  + **1month**
+
+* `overseas_type` - (Optional, String) Specifies the instance type.
+  The valid values are:
+  + **0**: Mainland China.
+  + **1**: Outside Mainland China.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `curve` - The list of QPS curve detail.
+  The [curve](#curve_struct) structure is documented below.
+
+<a name="curve_struct"></a>
+The `curve` block supports:
+
+* `time` - The timestamp of the QPS curve.
+
+* `total` - The total number of requests.
+
+* `attack` - The number of attack requests.
+
+* `basic` - The number of requests processed by web basic protection.
+
+* `cc` - The number of requests processed by CC attack protection.
+
+* `custom_custom` - The number of requests processed by precise protection.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -465,6 +465,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aad_black_white_lists":        aad.DataSourceAadBlackWhiteLists(),
 			"huaweicloud_aad_web_protection_policies":  aad.DataSourceAadWebProtectionPolicies(),
 			"huaweicloud_aad_geoip_rules":              aad.DataSourceGeoIpRules(),
+			"huaweicloud_aad_qps_curve":                aad.DataSourceQPSCurve(),
 			"huaweicloud_aad_block_statistics":         aad.DataSourceBlockStatistics(),
 			"huaweicloud_aad_cc_attack_protection_qps": aad.DataSourceCcAttackProtectionQPS(),
 			"huaweicloud_aad_unblock_records":          aad.DataSourceUnblockRecords(),

--- a/huaweicloud/services/aad/data_source_huaweicloud_aad_qps_curve.go
+++ b/huaweicloud/services/aad/data_source_huaweicloud_aad_qps_curve.go
@@ -1,0 +1,170 @@
+package aad
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AAD GET /v2/aad/domains/waf-info/flow/qps
+func DataSourceQPSCurve() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceQPSCurveRead,
+
+		Schema: map[string]*schema.Schema{
+			"value_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"domains": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"recent": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"overseas_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"curve": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"total": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"attack": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"basic": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"cc": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"custom_custom": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildQPSCurveQueryParams(d *schema.ResourceData) string {
+	queryParams := fmt.Sprintf("?value_type=%v", d.Get("value_type"))
+
+	if v, ok := d.GetOk("domains"); ok {
+		queryParams = fmt.Sprintf("%s&domains=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("start_time"); ok {
+		queryParams = fmt.Sprintf("%s&start_time=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("end_time"); ok {
+		queryParams = fmt.Sprintf("%s&end_time=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("recent"); ok {
+		queryParams = fmt.Sprintf("%s&recent=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("overseas_type"); ok {
+		queryParams = fmt.Sprintf("%s&overseas_type=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceQPSCurveRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+		httpUrl = "v2/aad/domains/waf-info/flow/qps"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath += buildQPSCurveQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving AAD QPS curve: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("curve", flattenQPSCurve(utils.PathSearch("curve", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenQPSCurve(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		result = append(result, map[string]interface{}{
+			"time":          utils.PathSearch("time", v, nil),
+			"total":         utils.PathSearch("total", v, nil),
+			"attack":        utils.PathSearch("attack", v, nil),
+			"basic":         utils.PathSearch("basic", v, nil),
+			"cc":            utils.PathSearch("cc", v, nil),
+			"custom_custom": utils.PathSearch("custom_custom", v, nil),
+		})
+	}
+
+	return result
+}

--- a/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_qps_curve_test.go
+++ b/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_qps_curve_test.go
@@ -1,0 +1,40 @@
+package antiddos
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Due to testing environment limitations, this test case can only test the scenario with empty `curve`.
+func TestAccDataSourceQPSCurve_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_aad_qps_curve.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceQPSCurve_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "curve.#"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceQPSCurve_basic = `
+data "huaweicloud_aad_qps_curve" "test" {
+  value_type = "mean"
+  recent     = "today"
+}
+`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query QPS curve.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o aad -f TestAccDataSourceQPSCurve_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/aad" -v -coverprofile="./huaweicloud/services/acceptance/aad/aad_coverage.cov" -coverpkg="./huaweicloud/services/aad" -run TestAccDataSourceQPSCurve_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceQPSCurve_basic
=== PAUSE TestAccDataSourceQPSCurve_basic
=== CONT  TestAccDataSourceQPSCurve_basic
--- PASS: TestAccDataSourceQPSCurve_basic (9.27s)
PASS
coverage: 7.5% of statements in ./huaweicloud/services/aad
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aad       9.368s  coverage: 7.5% of statements in ./huaweicloud/services/aad
```
<img width="1270" height="81" alt="image" src="https://github.com/user-attachments/assets/84a79983-8ee7-4604-9c3a-831e5ce0ee7e" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
