### PR TITLE
feat(waf): add new data source to query domain running status

### DIFF
--- a/docs/data-sources/waf_domain_status.md
+++ b/docs/data-sources/waf_domain_status.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_domain_status"
+description: |-
+  Use this data source to query the domain running status information.
+---
+
+# huaweicloud_waf_domain_status
+
+Use this data source to query the domain running status information.
+
+## Example Usage
+
+```hcl
+variable "domain_id" {}
+
+data "huaweicloud_waf_domain_status" "test" {
+  host_id = var.domain_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `host_id` - (Required, String) Specifies the domain ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `name` - The domain name.
+
+* `status` - The protection status of the domain.
+  The value can be **enabled**, **disabled**, or **bypassed**.
+  + **enabled**: The WAF protection is enabled. WAF detects attacks based on the policy you configure.
+  + **disabled**: The WAF protection is suspended. WAF only forwards requests destined for the domain and does not
+  detect attacks.
+  + **bypassed**: The WAF protection is bypassed. Requests of the domain are directly sent to the backend server and
+  do not pass through WAF.
+
+* `waf_instance_id` - The domain ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1618,6 +1618,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_config":                               waf.DataSourceWafConfig(),
 			"huaweicloud_waf_dedicated_domains":                    waf.DataSourceWafDedicatedDomains(),
 			"huaweicloud_waf_dedicated_instances":                  waf.DataSourceWafDedicatedInstances(),
+			"huaweicloud_waf_domain_status":                        waf.DataSourceWafDomainStatus(),
 			"huaweicloud_waf_domains":                              waf.DataSourceWafDomains(),
 			"huaweicloud_waf_instance_groups":                      waf.DataSourceWafInstanceGroups(),
 			"huaweicloud_waf_overviews_bandwidth_timeline":         waf.DataSourceWafOverviewsBandwidthTimeline(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_domain_status_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_domain_status_test.go
@@ -1,0 +1,44 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDomainStatus_basic(t *testing.T) {
+	var (
+		datasource = "data.huaweicloud_waf_domain_status.test"
+		dc         = acceptance.InitDataSourceCheck(datasource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWafDomainId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDomainStatus_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(datasource, "name"),
+					resource.TestCheckResourceAttrSet(datasource, "status"),
+					resource.TestCheckResourceAttrSet(datasource, "waf_instance_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDomainStatus_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_waf_domain_status" "test" {
+  host_id = "%s"
+}
+`, acceptance.HW_WAF_DOMAIN_ID)
+}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_domain_status.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_domain_status.go
@@ -1,0 +1,98 @@
+package waf
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/waf/instance/{host_id}/host-status
+func DataSourceWafDomainStatus() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceWafDomainStatusRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"waf_instance_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceWafDomainStatusRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/instance/{host_id}/host-status"
+		hostId  = d.Get("host_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{host_id}", hostId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the WAF domain running status: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("waf_instance_id", utils.PathSearch("waf_instance_id", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to query domain running status.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccDataSourceDomainStatus_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceDomainStatus_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDomainStatus_basic
=== PAUSE TestAccDataSourceDomainStatus_basic
=== CONT  TestAccDataSourceDomainStatus_basic
--- PASS: TestAccDataSourceDomainStatus_basic (16.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       16.133s
```
<img width="1010" height="29" alt="image" src="https://github.com/user-attachments/assets/072bd8e9-f0ac-4665-b98c-d44f51c762f7" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
