### PR TITLE
feat(rocketmq): add new data source to get background tasks

### DIFF
--- a/docs/data-sources/dms_rocketmq_background_tasks.md
+++ b/docs/data-sources/dms_rocketmq_background_tasks.md
@@ -1,0 +1,80 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_rocketmq_background_tasks"
+description: |-
+  Use this data source to get the background task list under the specified RocketMQ instance within HuaweiCloud.
+---
+
+# huaweicloud_dms_rocketmq_background_tasks
+
+Use this data source to query the background task list under the specified RocketMQ instance within HuaweiCloud.
+
+## Example Usage
+
+### Query all background tasks
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_dms_rocketmq_background_tasks" "test" {
+  instance_id = var.instance_id
+}
+```
+
+### Query background tasks within a specified time range
+
+```hcl
+variable "instance_id" {}
+variable "begin_time" {}
+variable "end_time" {}
+
+data "huaweicloud_dms_rocketmq_background_tasks" "test" {
+  instance_id = var.instance_id
+  begin_time  = var.begin_time
+  end_time    = var.end_time
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the background tasks are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the RocketMQ instance.
+
+* `begin_time` - (Optional, String) Specifies the start time of the background tasks, in UTC format.  
+  The format is `YYYYMMDDHHmmss`.
+
+* `end_time` - (Optional, String) Specifies the end time of the background tasks, in UTC format.  
+  The format is `YYYYMMDDHHmmss`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tasks` - The list of the background tasks under the specified RocketMQ instance.  
+  The [tasks](#data_rocketmq_background_tasks) structure is documented below.
+
+<a name="data_rocketmq_background_tasks"></a>
+The `tasks` block supports:
+
+* `id` - The ID of the background task.
+
+* `name` - The name of the background task.
+
+* `user_name` - The username of the user who executed the background task.
+
+* `user_id` - The ID of the user who executed the background task.
+
+* `params` - The parameters of the background task.
+
+* `status` - The status of the background task.
+
+* `created_at` - The creation time of the background task, in UTC format.
+
+* `updated_at` - The latest update time of the background task, in UTC format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -950,6 +950,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rabbitmq_users":            rabbitmq.DataSourceDmsRabbitmqUsers(),
 
 			"huaweicloud_dms_rocketmq_availability_zones":          rocketmq.DataSourceRocketMQAvailabilityZones(),
+			"huaweicloud_dms_rocketmq_background_tasks":            rocketmq.DataSourceBackgroundTasks(),
 			"huaweicloud_dms_rocketmq_broker":                      rocketmq.DataSourceDmsRocketMQBroker(),
 			"huaweicloud_dms_rocketmq_instances":                   rocketmq.DataSourceDmsRocketMQInstances(),
 			"huaweicloud_dms_rocketmq_instance_nodes":              rocketmq.DataSourceDmsRocketMQInstanceNodes(),

--- a/huaweicloud/services/acceptance/rocketmq/data_source_huaweicloud_dms_rocketmq_background_tasks_test.go
+++ b/huaweicloud/services/acceptance/rocketmq/data_source_huaweicloud_dms_rocketmq_background_tasks_test.go
@@ -1,0 +1,89 @@
+package rocketmq
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataBackgroundTasks_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_dms_rocketmq_background_tasks.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byTime   = "data.huaweicloud_dms_rocketmq_background_tasks.filter_by_time"
+		dcByTime = acceptance.InitDataSourceCheck(byTime)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSRocketMQInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataBackgroundTasks_notFound(),
+				ExpectError: regexp.MustCompile(`This DMS instance does not exist`),
+			},
+			{
+				Config: testAccDataBackgroundTasks_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "tasks.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.params"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.user_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.user_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "tasks.0.updated_at"),
+					dcByTime.CheckResourceExists(),
+					resource.TestCheckOutput("is_filter_by_time_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataBackgroundTasks_notFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dms_rocketmq_background_tasks" "test" {
+  instance_id = "%s"
+}
+`, randomId)
+}
+
+func testAccDataBackgroundTasks_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dms_rocketmq_background_tasks" "test" {
+  instance_id = "%[1]s"
+}
+
+locals {
+  created_at = data.huaweicloud_dms_rocketmq_background_tasks.test.tasks[0].created_at
+  begin_time = formatdate("YYYYMMDDhhmmss", local.created_at)
+}
+
+data "huaweicloud_dms_rocketmq_background_tasks" "filter_by_time" {
+  instance_id = "%[1]s"
+  begin_time  = local.begin_time
+  end_time    = formatdate("YYYYMMDDhhmmss", timeadd(local.created_at, "2h"))
+}
+
+locals {
+  filter_by_time_result = [for v in data.huaweicloud_dms_rocketmq_background_tasks.filter_by_time.tasks :
+  formatdate("YYYYMMDDhhmmss", v.created_at) >= local.begin_time]
+}
+
+output "is_filter_by_time_useful" {
+  value = length(local.filter_by_time_result) > 0 && alltrue(local.filter_by_time_result)
+}
+`, acceptance.HW_DMS_ROCKETMQ_INSTANCE_ID)
+}

--- a/huaweicloud/services/rocketmq/data_source_huaweicloud_dms_rocketmq_background_tasks.go
+++ b/huaweicloud/services/rocketmq/data_source_huaweicloud_dms_rocketmq_background_tasks.go
@@ -1,0 +1,202 @@
+package rocketmq
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RocketMQ GET /v2/{project_id}/instances/{instance_id}/tasks
+func DataSourceBackgroundTasks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBackgroundTasksRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The region where the background tasks are located.",
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the RocketMQ instance.",
+			},
+			"begin_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The start time of the background task, in UTC format.",
+			},
+			"end_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The end time of the background task, in UTC format.",
+			},
+			"tasks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the background task.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the background task.",
+						},
+						"user_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The username of the user who executed the background task.",
+						},
+						"user_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the user who executed the background task.",
+						},
+						"params": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The parameters of the background task.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The status of the background task.",
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The creation time of the background task, in UTC format.",
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The latest update time of the background task, in UTC format.",
+						},
+					},
+				},
+				Description: "The list of the background tasks under the specified RocketMQ instance.",
+			},
+		},
+	}
+}
+
+func buildQueryBackgroundTasksListPath(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("begin_time"); ok {
+		res = fmt.Sprintf("%s&begin_time=%s", res, v)
+	}
+
+	if v, ok := d.GetOk("end_time"); ok {
+		res = fmt.Sprintf("%s&end_time=%s", res, v)
+	}
+	return res
+}
+
+func queryBackgroundTasks(client *golangsdk.ServiceClient, d *schema.ResourceData, instanceId string) ([]interface{}, error) {
+	var (
+		listPath = "v2/{project_id}/instances/{instance_id}/tasks"
+		// The `start` starts from `1`.
+		start = 1
+		// The `limit` default value is `10`.
+		limit   = 100
+		results = make([]interface{}, 0)
+		listOpt = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+	)
+
+	listPath = client.Endpoint + listPath
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath = fmt.Sprintf("%s?limit=%d", listPath, limit)
+	listPath += buildQueryBackgroundTasksListPath(d)
+
+	for {
+		listPathWithStart := fmt.Sprintf("%s&start=%d", listPath, start)
+		listResp, err := client.Request("GET", listPathWithStart, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(listResp)
+		if err != nil {
+			return nil, err
+		}
+
+		backgroundTasks := utils.PathSearch("tasks", respBody, make([]interface{}, 0)).([]interface{})
+		results = append(results, backgroundTasks...)
+		if len(backgroundTasks) < limit {
+			break
+		}
+
+		start += len(backgroundTasks)
+	}
+
+	return results, nil
+}
+
+func dataSourceBackgroundTasksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	tasks, err := queryBackgroundTasks(client, d, instanceId)
+	if err != nil {
+		return diag.Errorf("error getting background tasks under the specified RocketMQ instance (%s): %s",
+			instanceId, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate data source ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("tasks", flattenBackgroundTasks(tasks)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenBackgroundTasks(tasks []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(tasks))
+	for i, v := range tasks {
+		result[i] = map[string]interface{}{
+			"id":         utils.PathSearch("id", v, nil),
+			"name":       utils.PathSearch("name", v, nil),
+			"user_name":  utils.PathSearch("user_name", v, nil),
+			"user_id":    utils.PathSearch("user_id", v, nil),
+			"params":     utils.PathSearch("params", v, nil),
+			"status":     utils.PathSearch("status", v, nil),
+			"created_at": utils.PathSearch("created_at", v, nil),
+			"updated_at": utils.PathSearch("updated_at", v, nil),
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source (`huaweicloud_dms_rocketmq_background_tasks`) to query the background task list under the specified RocketMQ instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source.
2. add corresponding documation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o rocketmq -f TestAccDataRocketmqBackgroundTasks_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rocketmq" -v -coverprofile="./huaweicloud/services/acceptance/rocketmq/rocketmq_coverage.cov" -coverpkg="./huaweicloud/services/rocketmq" -run TestAccDataRocketmqBackgroundTasks_basic -timeout 360m -parallel 10
=== RUN   TestAccDataRocketmqBackgroundTasks_basic
=== PAUSE TestAccDataRocketmqBackgroundTasks_basic
=== CONT  TestAccDataRocketmqBackgroundTasks_basic
--- PASS: TestAccDataRocketmqBackgroundTasks_basic (676.53s)
PASS
coverage: 13.7% of statements in ./huaweicloud/services/rocketmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rocketmq  676.651s        coverage: 13.7% of statements in ./huaweicloud/services/rocketmq
```
<img width="1114" height="363" alt="image" src="https://github.com/user-attachments/assets/6005dbee-dd53-43a0-a771-dfc2b39bb911" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
