### PR TITLE
feat(cnad): new datasource to query block list

### DIFF
--- a/docs/data-sources/cnad_advanced_block_list.md
+++ b/docs/data-sources/cnad_advanced_block_list.md
@@ -1,0 +1,41 @@
+---
+subcategory: "Cloud Native Anti-DDoS Advanced"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cnad_advanced_block_list"
+description: |-
+  Use this data source to get the list of blocked IPs in CNAD Advanced.
+---
+
+# huaweicloud_cnad_advanced_block_list
+
+Use this data source to get the list of blocked IPs in CNAD Advanced.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cnad_advanced_block_list" "test" {}
+```
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `blocking_list` - The list of blocked IPs.
+
+  The [blocking_list](#advancedBlockList) structure is documented below.
+
+<a name="advancedBlockList"></a>
+The `blocking_list` block supports:
+
+* `ip` - The blocked IP address.
+
+* `blocking_time` - The timestamp when the IP was blocked.
+
+* `estimated_unblocking_time` - The estimated timestamp when the IP will be unblocked.
+
+* `status` - The status of the blocked IP. Possible values are:
+  + **unblocking**: The IP is being unblocked.
+  + **success**: The IP has been successfully unblocked.
+  + **failed**: The unblocking operation failed.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -698,6 +698,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cnad_advanced_instances":           cnad.DataSourceInstances(),
 			"huaweicloud_cnad_advanced_alarm_notifications": cnad.DataSourceAlarmNotifications(),
 			"huaweicloud_cnad_advanced_available_objects":   cnad.DataSourceAvailableProtectedObjects(),
+			"huaweicloud_cnad_advanced_block_list":          cnad.DataSourceAdvancedBlockList(),
 			"huaweicloud_cnad_advanced_protected_objects":   cnad.DataSourceProtectedObjects(),
 
 			"huaweicloud_coc_applications":                  coc.DataSourceCocApplications(),

--- a/huaweicloud/services/acceptance/cnad/data_source_huaweicloud_cnad_advanced_block_list_test.go
+++ b/huaweicloud/services/acceptance/cnad/data_source_huaweicloud_cnad_advanced_block_list_test.go
@@ -1,0 +1,35 @@
+package cnad
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceAdvancedBlockList_basic(t *testing.T) {
+	rName := "data.huaweicloud_cnad_advanced_block_list.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceAdvancedBlockList_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "blocking_list.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDatasourceAdvancedBlockList_basic = `
+data "huaweicloud_cnad_advanced_block_list" "test" {
+}
+`

--- a/huaweicloud/services/cnad/data_source_huaweicloud_cnad_advanced_block_list.go
+++ b/huaweicloud/services/cnad/data_source_huaweicloud_cnad_advanced_block_list.go
@@ -1,0 +1,117 @@
+package cnad
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AAD GET /v1/unblockservice/{domain_id}/block-list
+func DataSourceAdvancedBlockList() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAdvancedBlockListRead,
+		Schema: map[string]*schema.Schema{
+			"blocking_list": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of blocked IPs.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The blocked IP address.`,
+						},
+						"blocking_time": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The time when the IP was blocked.`,
+						},
+						"estimated_unblocking_time": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The estimated time when the IP will be unblocked.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the blocked IP.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAdvancedBlockListRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+		httpUrl = "v1/unblockservice/{domain_id}/block-list"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CNAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", cfg.DomainID)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CNAD advanced block list: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	blockingList := utils.PathSearch("blocking_list", respBody, make([]interface{}, 0)).([]interface{})
+	mErr := multierror.Append(
+		d.Set("blocking_list", flattenAdvancedBlockList(blockingList)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAdvancedBlockList(respArray []interface{}) []map[string]interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(respArray))
+	for _, item := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"ip":                        utils.PathSearch("ip", item, nil),
+			"blocking_time":             utils.PathSearch("blocking_time", item, nil),
+			"estimated_unblocking_time": utils.PathSearch("estimated_unblocking_time", item, nil),
+			"status":                    utils.PathSearch("status", item, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query block list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cnad -f TestAccDatasourceAdvancedBlockList_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cnad" -v -coverprofile="./huaweicloud/services/acceptance/cnad/cnad_coverage.cov" -coverpkg="./huaweicloud/services/cnad" -run TestAccDatasourceAdvancedBlockList_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourceAdvancedBlockList_basic
=== PAUSE TestAccDatasourceAdvancedBlockList_basic
=== CONT  TestAccDatasourceAdvancedBlockList_basic
--- PASS: TestAccDatasourceAdvancedBlockList_basic (12.76s)
PASS
coverage: 6.5% of statements in ./huaweicloud/services/cnad
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cnad      12.892s coverage: 6.5% of statements in ./huaweicloud/services/cnad
```
<img width="1292" height="79" alt="image" src="https://github.com/user-attachments/assets/7920aba0-1e63-42c5-8e99-95eada2cb866" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
