### PR TITLE
feat(fgs): add new resource that used to manage asynchronous log configuration

### DIFF
--- a/docs/resources/fgs_async_log_configuration.md
+++ b/docs/resources/fgs_async_log_configuration.md
@@ -1,0 +1,83 @@
+---
+subcategory: "FunctionGraph"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_fgs_async_log_configuration"
+description: |-
+  Manages a FunctionGraph async log configuration resource under a specified region within HuaweiCloud.
+---
+
+# huaweicloud_fgs_async_log_configuration
+
+Manages a FunctionGraph async log configuration resource under a specified region within HuaweiCloud.
+
+-> After the resource is deployed, a log group named `function-async-log-group-{project_id}` will be automatically
+   created in the corresponding region, and a log stream named `function-async-log-stream-{project_id}` will be
+   automatically created in it.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_fgs_async_log_configuration" "test" {
+  force_delete = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region where the async log configuration is located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `force_delete` - (Optional, Bool) Specifies whether to force delete the LTS resources corresponding to the async log
+  configuration.  
+  Defaults to **false**.
+
+  -> Forced delete action will clear all data under the log group corresponding to all current asynchronous logs.<br>
+     Please back up the data before deletion.
+
+* `max_retries` - (Optional, Int) Specifies the maximum number of retries for the create operation when encountering
+  internal service errors.  
+  Defaults to **3**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The (random) resource ID.
+
+* `group_id` - The LTS log group ID used to manage async status logs.
+
+* `group_name` - The LTS log group name used to manage async status logs.
+
+* `stream_id` - The LTS log stream ID used to manage async status logs.
+
+* `stream_name` - The LTS log stream name used to manage async status logs.
+
+## Import
+
+Async log configuration can be imported using the `id` (any string ID format is allowed), e.g.
+
+```bash
+$ terraform import huaweicloud_fgs_async_log_configuration.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes includes: `force_delete`, `max_retries`.
+It is generally recommended running `terraform plan` after importing this resource.
+You can then decide if changes should be applied to the resource, or the script definition should be updated to
+align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_fgs_async_log_configuration" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      force_delete,
+      max_retries,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2336,6 +2336,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_fgs_application":                    fgs.ResourceApplication(),
 			"huaweicloud_fgs_async_invoke_configuration":     fgs.ResourceAsyncInvokeConfiguration(),
+			"huaweicloud_fgs_async_log_configuration":        fgs.ResourceAsyncLogConfiguration(),
 			"huaweicloud_fgs_dependency":                     fgs.ResourceDependency(),
 			"huaweicloud_fgs_dependency_version":             fgs.ResourceDependencyVersion(),
 			"huaweicloud_fgs_function":                       fgs.ResourceFgsFunction(),

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_async_log_configuration_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_async_log_configuration_test.go
@@ -1,0 +1,84 @@
+package fgs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
+)
+
+func getAsyncLogConfigurationResourceFunc(cfg *config.Config, _ *terraform.ResourceState) (interface{}, error) {
+	fgsClient, err := cfg.NewServiceClient("fgs", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating FunctionGraph client: %s", err)
+	}
+	ltsClient, err := cfg.NewServiceClient("lts", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating LTS client: %s", err)
+	}
+	return fgs.GetAsyncLogConfigurationAndCheck(fgsClient, ltsClient)
+}
+
+func TestAccAsyncLogConfiguration_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceName = "huaweicloud_fgs_async_log_configuration.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getAsyncLogConfigurationResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAsyncLogConfiguration_basic_step1,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "force_delete", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"max_retries",
+				},
+			},
+			{
+				Config: testAccAsyncLogConfiguration_basic_step2,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "force_delete", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccAsyncLogConfiguration_basic_step1 string = `
+resource "huaweicloud_fgs_async_log_configuration" "test" {
+  force_delete = false
+
+  lifecycle {
+    ignore_changes = [
+      force_delete,
+    ]
+  }
+}
+`
+
+const testAccAsyncLogConfiguration_basic_step2 string = `
+resource "huaweicloud_fgs_async_log_configuration" "test" {
+  force_delete = true
+}
+`

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_async_log_configuration.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_async_log_configuration.go
@@ -1,0 +1,286 @@
+package fgs
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lts"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API FunctionGraph POST /v2/{project_id}/fgs/functions/enable-async-status-logs
+// @API FunctionGraph GET /v2/{project_id}/fgs/functions/async-status-log-detail
+// @API LTS GET /v2/{project_id}/groups/{log_group_id}/streams
+// @API LTS GET /v2/{project_id}/transfers
+// @API LTS DELETE /v2/{project_id}/transfers
+// @API LTS DELETE /v2/{project_id}/groups/{log_group_id}
+func ResourceAsyncLogConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAsyncLogConfigurationCreate,
+		ReadContext:   resourceAsyncLogConfigurationRead,
+		UpdateContext: resourceAsyncLogConfigurationUpdate,
+		DeleteContext: resourceAsyncLogConfigurationDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the async log configuration is located.`,
+			},
+
+			// Optional parameter(s).
+			"force_delete": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether to force delete the LTS resources corresponding to the async log configuration.`,
+			},
+			"max_retries": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     3,
+				Description: `The maximum number of retries for the create operation when encountering internal service errors.`,
+			},
+
+			// Attribute(s).
+			"group_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The LTS log group ID used to manage async status logs.`,
+			},
+			"group_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The LTS log group name used to manage async status logs.`,
+			},
+			"stream_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The LTS log stream ID used to manage async status logs.`,
+			},
+			"stream_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The LTS log stream name used to manage async status logs.`,
+			},
+		},
+	}
+}
+
+func resourceAsyncLogConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	var (
+		httpUrl   = "v2/{project_id}/fgs/functions/enable-async-status-logs"
+		createOpt = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+		}
+		maxRetries = d.Get("max_retries").(int)
+	)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	log.Printf("[DEBUG] The max_retries is %d", maxRetries)
+	retryCount := 0
+	for retryCount < maxRetries+1 {
+		_, err = client.Request("POST", createPath, &createOpt)
+		if err == nil {
+			break
+		}
+
+		parsedErr := common.ConvertExpected500ErrInto404Err(err, "error_code", "FSS.0500")
+		if _, ok := parsedErr.(golangsdk.ErrDefault404); !ok {
+			break
+		}
+		// lintignore:R018
+		time.Sleep(10 * time.Second)
+		log.Printf("[DEBUG] Service is busy or environment variable of LTS is not refreshed, try again")
+
+		retryCount++
+		continue
+	}
+	if err != nil {
+		return diag.Errorf("after %d retries, the async log configuration still reports an error: %s",
+			maxRetries-1, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceAsyncLogConfigurationRead(ctx, d, meta)
+}
+
+func GetAsyncLogConfiguration(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v2/{project_id}/fgs/functions/async-status-log-detail"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func GetAsyncLogConfigurationAndCheck(fgsClient, ltsClient *golangsdk.ServiceClient) (interface{}, error) {
+	respBody, err := GetAsyncLogConfiguration(fgsClient)
+	if err != nil {
+		return nil, err
+	}
+
+	groupId := utils.PathSearch("group_id", respBody, "").(string)
+	streamId := utils.PathSearch("stream_id", respBody, "").(string)
+	_, err = lts.GetLogStreamById(ltsClient, groupId, streamId)
+	if err != nil {
+		return nil, err
+	}
+
+	return respBody, nil
+}
+
+func resourceAsyncLogConfigurationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	fgsClient, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+	ltsClient, err := cfg.NewServiceClient("lts", region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+
+	respBody, err := GetAsyncLogConfigurationAndCheck(fgsClient, ltsClient)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving async log configuration")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		// Optional parameter(s).
+		d.Set("force_delete", d.Get("force_delete").(bool)),
+		// Attribute(s).
+		d.Set("group_id", utils.PathSearch("group_id", respBody, "")),
+		d.Set("group_name", utils.PathSearch("group_name", respBody, "")),
+		d.Set("stream_id", utils.PathSearch("stream_id", respBody, "")),
+		d.Set("stream_name", utils.PathSearch("stream_name", respBody, "")),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceAsyncLogConfigurationUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func buildQueryTransfersBodyParams(logGroupName string) string {
+	return fmt.Sprintf("&log_group_name=%v", logGroupName)
+}
+
+func forceDeleteAsyncLogConfiguration(client *golangsdk.ServiceClient, groupId, groupName string) error {
+	log.Printf("[Lance] Ready to execute forceDeleteAsyncLogConfiguration")
+	log.Printf("[Lance] groupId: %s", groupId)
+	log.Printf("[Lance] groupName: %s", groupName)
+	transfers, err := lts.ListTransfers(client, buildQueryTransfersBodyParams(groupName))
+	if err != nil {
+		log.Printf("[Lance] Error querying log transfers: %s", err)
+		// error LTS.0201 means that the log group does not exist.
+		return common.ConvertExpected400ErrInto404Err(err, "error_code", "LTS.0201")
+	}
+
+	// Before forcibly deleting the log group, make sure that all log transfers have been deleted.
+	for _, transfer := range transfers {
+		transferId := utils.PathSearch("log_transfer_id", transfer, "").(string)
+		if transferId == "" {
+			log.Printf("[ERROR] Unable to find log_transfer_id from log transfer configuration of the log group (%s).",
+				groupName)
+			continue
+		}
+		err = lts.DeleteTransferById(client, transferId)
+		if err != nil {
+			return fmt.Errorf("error deleting log transfer (%s): %s", transferId, err)
+		}
+	}
+	log.Printf("[Lance] Successfully deleted all log transfers")
+
+	return lts.DeleteGroupById(client, groupId)
+}
+
+func resourceAsyncLogConfigurationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	if !d.Get("force_delete").(bool) {
+		warnMsg := `Skip the forced deletion of the log group log stream because force_delete is set to false.
+The remaining log group and log stream will affect the next deployment of the resource. Before that, make sure the
+corresponding log group and log stream are deleted.`
+		return diag.Diagnostics{
+			diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  warnMsg,
+			},
+		}
+	}
+
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	fgsClient, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+	ltsClient, err := cfg.NewServiceClient("lts", region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+
+	respBody, err := GetAsyncLogConfigurationAndCheck(fgsClient, ltsClient)
+	if err != nil {
+		return diag.Errorf("error retrieving async log configuration: %s", err)
+	}
+
+	var (
+		groupName = utils.PathSearch("group_name", respBody, "").(string)
+		groupId   = utils.PathSearch("group_id", respBody, "").(string)
+	)
+
+	err = forceDeleteAsyncLogConfiguration(ltsClient, groupId, groupName)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err,
+			fmt.Sprintf("error deleting LTS log group (%s) for the async log configuration", groupId))
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new resource that used to manage asynchronous log configuration, which will create a log group in LTS service side and create a log stream in it.
we are supports force delete function and allow delete all LTS configuration for async group when destroy the FGS async log configuration.

And this resource supports force destroy LTS resources which created by FunctionGraph (default is disable).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The query parameter `limit` is not available:
<img width="1306" height="1236" alt="image" src="https://github.com/user-attachments/assets/4315c882-c1c5-4e43-a470-cfdcccdcb68f" />
<img width="1354" height="702" alt="image" src="https://github.com/user-attachments/assets/b68dbdef-6e8b-41c6-873a-8e169d124c61" />
<img width="1368" height="1024" alt="image" src="https://github.com/user-attachments/assets/cb312e2c-f7f4-439f-aa64-7f59acd4eff9" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource that used to manage asynchronous log configuration
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccAsyncLogConfiguration_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccAsyncLogConfiguration_basic -timeout 360m -parallel 10
=== RUN   TestAccAsyncLogConfiguration_basic
=== PAUSE TestAccAsyncLogConfiguration_basic
=== CONT  TestAccAsyncLogConfiguration_basic
--- PASS: TestAccAsyncLogConfiguration_basic (22.15s)
PASS
coverage: 5.7% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       22.221s coverage: 5.7% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
