### PR TITLE
feat(DNS): support to associate private zone to vpc

### DIFF
--- a/docs/resources/dns_private_zone_associate.md
+++ b/docs/resources/dns_private_zone_associate.md
@@ -1,0 +1,62 @@
+---
+subcategory: "Domain Name Service (DNS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dns_private_zone_associate"
+description: |-
+  Manages a DNS private zone associate resource within HuaweiCloud.
+---
+
+
+# huaweicloud_dns_private_zone_associate
+
+Manages a DNS private zone associate resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "zone_id" {}
+variable "router_id" {}
+
+resource "huaweicloud_dns_private_zone_associate" "test" {
+  zone_id   = var.zone_id
+  router_id = var.router_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `zone_id` - (Required, String, NonUpdatable) The ID of the zone to which the record set belongs.
+  Changing this creates a new resource.
+
+* `router_id` - (Required, String, NonUpdatable) The ID of the associated VPC.
+
+* `router_region` - (Optional, String, NonUpdatable) The region of the VPC. Default to the region of resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - The status of the associated VPC.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The associated relationship of private zone and VPC can be imported using `zone_id` and `router_id`, e.g.
+
+```bash
+$ terraform import huaweicloud_dns_private_zone_associate.test <zone_id>/<router_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2274,6 +2274,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dnsv21_ptrrecord":            dns.ResourceDNSV21PtrRecord(),
 			"huaweicloud_dns_recordset":               dns.ResourceDNSRecordset(),
 			"huaweicloud_dns_zone":                    dns.ResourceDNSZone(),
+			"huaweicloud_dns_private_zone_associate":  dns.ResourceDNSPrivateZoneAssociate(),
 			"huaweicloud_dns_endpoint_assignment":     dns.ResourceEndpointAssignment(),
 			"huaweicloud_dns_endpoint":                dns.ResourceDNSEndpoint(),
 			"huaweicloud_dns_resolver_rule":           dns.ResourceResolverRule(),

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_private_zone_associate_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_private_zone_associate_test.go
@@ -1,0 +1,116 @@
+package dns
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDNSPrivateZoneAssociateResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dns_region", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DNS client: %s", err)
+	}
+
+	httpUrl := "v2/zones/{zone_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{zone_id}", state.Primary.Attributes["zone_id"])
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	searchPath := fmt.Sprintf("routers[?router_id=='%s']|[0]", state.Primary.Attributes["router_id"])
+	router := utils.PathSearch(searchPath, getRespBody, nil)
+	if router == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return router, nil
+}
+
+func TestAccDNSPrivateZoneAssociate_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		name  = fmt.Sprintf("acpttest-zone-%s.com", acctest.RandString(5))
+		rName = "huaweicloud_dns_private_zone_associate.test"
+	)
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDNSPrivateZoneAssociateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDNSPrivateZoneAssociate_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "zone_id", "huaweicloud_dns_zone.private", "id"),
+					resource.TestCheckResourceAttrPair(rName, "router_id", "huaweicloud_vpc.test.1", "id"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testDNSPrivateZoneAssociate_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  count = 2
+
+  name = "%[1]s_${count.index}"
+  cidr = cidrsubnet("192.168.0.0/16", 4, count.index)
+}
+
+resource "huaweicloud_dns_zone" "private" {
+  name        = "%[1]s"
+  email       = "email@example.com"
+  description = "a private zone"
+  zone_type   = "private"
+  status      = "ENABLE"
+
+  router {
+    router_id = huaweicloud_vpc.test[0].id
+  }
+
+  proxy_pattern = "RECURSIVE"
+
+  lifecycle {
+    ignore_changes = [router]
+  }
+}
+
+resource "huaweicloud_dns_private_zone_associate" "test" {
+  zone_id   = huaweicloud_dns_zone.private.id
+  router_id = huaweicloud_vpc.test[1].id
+}`, rName)
+}

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_private_zone_associate.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_private_zone_associate.go
@@ -1,0 +1,275 @@
+package dns
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var privateZoneAssociateNonUpdatableParams = []string{
+	"zone_id", "router_id", "router_region",
+}
+
+// @API DNS POST /v2/zones/{zone_id}/associaterouter
+// @API DNS POST /v2/zones/{zone_id}/disassociaterouter
+// @API DNS GET /v2/zones/{zone_id}
+func ResourceDNSPrivateZoneAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDNSPrivateZoneAssociateCreate,
+		UpdateContext: resourceDNSPrivateZoneAssociateUpdate,
+		ReadContext:   resourceDNSPrivateZoneAssociateRead,
+		DeleteContext: resourceDNSPrivateZoneAssociateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDNSPrivateZoneAssociateImportStateFunc,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(privateZoneAssociateNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"zone_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the zone to which the record set belongs.`,
+			},
+			"router_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the associated VPC.`,
+			},
+			"router_region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region of the VPC.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the associated VPC.`,
+			},
+		},
+	}
+}
+
+func resourceDNSPrivateZoneAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dns_region", region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	zoneId := d.Get("zone_id").(string)
+	routerId := d.Get("router_id").(string)
+
+	httpUrl := "v2/zones/{zone_id}/associaterouter"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{zone_id}", zoneId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateOrDeleteDNSPrivateZoneAssociateBodyParams(d, region)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error associating DNS private zone with VPC: %s", err)
+	}
+
+	id := fmt.Sprintf("%s/%s", zoneId, routerId)
+	d.SetId(id)
+
+	stateRouterConf := &resource.StateChangeConf{
+		Target:     []string{"COMPLETED"},
+		Pending:    []string{"PENDING"},
+		Refresh:    waitForDNSZoneRouterStatus(client, zoneId, routerId),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateRouterConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for associating zone (%s) to router (%s) become ACTIVE: %s",
+			d.Id(), routerId, err)
+	}
+
+	return resourceDNSPrivateZoneAssociateRead(ctx, d, meta)
+}
+
+func buildCreateOrDeleteDNSPrivateZoneAssociateBodyParams(d *schema.ResourceData, region string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"router_id": d.Get("router_id"),
+	}
+
+	if v, ok := d.GetOk("router_region"); ok {
+		bodyParams["router_region"] = v
+	} else {
+		bodyParams["router_region"] = region
+	}
+
+	return map[string]interface{}{
+		"router": bodyParams,
+	}
+}
+
+func resourceDNSPrivateZoneAssociateUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDNSPrivateZoneAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dns_region", region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	getRespBody, err := getDNSZone(client, d.Get("zone_id").(string))
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DNS zone")
+	}
+
+	searchPath := fmt.Sprintf("routers[?router_id=='%s']|[0]", d.Get("router_id").(string))
+	router := utils.PathSearch(searchPath, getRespBody, nil)
+	if router == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving DNS zone router")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("router_id", utils.PathSearch("router_id", router, nil)),
+		d.Set("router_region", utils.PathSearch("router_region", router, nil)),
+		d.Set("status", utils.PathSearch("status", router, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func getDNSZone(client *golangsdk.ServiceClient, zoneId string) (interface{}, error) {
+	httpUrl := "v2/zones/{zone_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{zone_id}", zoneId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return getRespBody, nil
+}
+
+func resourceDNSPrivateZoneAssociateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dns_region", region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	zoneId := d.Get("zone_id").(string)
+	routerId := d.Get("router_id").(string)
+
+	httpUrl := "v2/zones/{zone_id}/disassociaterouter"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{zone_id}", zoneId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateOrDeleteDNSPrivateZoneAssociateBodyParams(d, region)),
+	}
+
+	_, err = client.Request("POST", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "code", "DNS.0707"),
+			"error disassociating DNS private zone with VPC")
+	}
+
+	stateRouterConf := &resource.StateChangeConf{
+		Target:     []string{"DELETED"},
+		Pending:    []string{"COMPLETED", "PENDING"},
+		Refresh:    waitForDNSZoneRouterStatus(client, zoneId, routerId),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateRouterConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for disassociating zone (%s) to router (%s): %s", d.Id(), routerId, err)
+	}
+
+	return nil
+}
+
+func waitForDNSZoneRouterStatus(client *golangsdk.ServiceClient, zoneId string, routerId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		zone, err := getDNSZone(client, zoneId)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		searchPath := fmt.Sprintf("routers[?router_id=='%s']|[0]", routerId)
+		router := utils.PathSearch(searchPath, zone, nil)
+		if router != nil {
+			status := utils.PathSearch("status", router, "").(string)
+			if status == "ACTIVE" {
+				return zone, "COMPLETED", nil
+			}
+
+			return zone, "PENDING", nil
+		}
+
+		return zone, "DELETED", nil
+	}
+}
+
+func resourceDNSPrivateZoneAssociateImportStateFunc(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<zone_id>/<router_id>', but got '%s'", d.Id())
+	}
+	mErr := multierror.Append(nil,
+		d.Set("zone_id", parts[0]),
+		d.Set("router_id", parts[1]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to associate private zone to vpc
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support to associate private zone to vpc
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dns TESTARGS='-run TestAccDNSPrivateZoneAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSPrivateZoneAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccDNSPrivateZoneAssociate_basic
=== PAUSE TestAccDNSPrivateZoneAssociate_basic
=== CONT  TestAccDNSPrivateZoneAssociate_basic
--- PASS: TestAccDNSPrivateZoneAssociate_basic (64.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       64.250s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
    <img width="1542" height="221" alt="image" src="https://github.com/user-attachments/assets/0bc23043-16ea-46ef-94d4-9735d8e32b63" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
    <img width="1512" height="177" alt="image" src="https://github.com/user-attachments/assets/7e2dc6f2-943a-4cd8-8022-7d3f4f26ee63" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
