### PR TITLE
feat(cnad): new resource to update package name

### DIFF
--- a/docs/resources/cnad_advanced_update_package_name.md
+++ b/docs/resources/cnad_advanced_update_package_name.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Cloud Native Anti-DDoS Advanced"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cnad_advanced_update_package_name"
+description: |-
+  Updates the name of a CNAD advanced package within HuaweiCloud.
+---
+
+# huaweicloud_cnad_advanced_update_package_name
+
+Updates the name of a CNAD advanced package within HuaweiCloud.
+
+-> This resource is a one-time action resource for updating the name of a CNAD package. Deleting this resource
+   will not revert the package name, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "package_id" {}
+variable "package_name" {}
+
+resource "huaweicloud_cnad_advanced_update_package_name" "test" {
+  package_id = var.package_id
+  name       = var.package_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `package_id` - (Required, String, NonUpdatable) Specifies the ID of the CNAD package.
+
+* `name` - (Required, String, NonUpdatable) Specifies the new name for the CNAD package.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2069,6 +2069,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_cnad_advanced_alarm_notification":  cnad.ResourceAlarmNotification(),
 			"huaweicloud_cnad_advanced_black_white_list":    cnad.ResourceBlackWhiteList(),
+			"huaweicloud_cnad_advanced_update_package_name": cnad.ResourceUpdatePackageName(),
 			"huaweicloud_cnad_advanced_policy":              cnad.ResourceCNADAdvancedPolicy(),
 			"huaweicloud_cnad_advanced_policy_associate":    cnad.ResourcePolicyAssociate(),
 			"huaweicloud_cnad_advanced_protected_object":    cnad.ResourceProtectedObject(),

--- a/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_update_package_name_test.go
+++ b/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_update_package_name_test.go
@@ -1,0 +1,34 @@
+package cnad
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Note: Due to limited test conditions, this test case only verifies the expected error scenario.
+func TestAccResourceUpdatePackageName_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testUpdatePackageName_basic,
+				ExpectError: regexp.MustCompile(`Resource Not Found.|资源不存在。`),
+			},
+		},
+	})
+}
+
+// The value of field `package_id` is mock data.
+const testUpdatePackageName_basic = `
+resource "huaweicloud_cnad_advanced_update_package_name" "test" {
+  package_id = "1d8c03c4-a1d0-49cf-808a-ab50bfd7f0d8"
+  name       = "test-package-name"
+}`

--- a/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_update_package_name.go
+++ b/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_update_package_name.go
@@ -1,0 +1,106 @@
+package cnad
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AAD PUT /v1/cnad/packages/{package_id}/name
+func ResourceUpdatePackageName() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceUpdatePackageNameCreate,
+		ReadContext:   resourceUpdatePackageNameRead,
+		UpdateContext: resourceUpdatePackageNameUpdate,
+		DeleteContext: resourceUpdatePackageNameDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{"package_id", "name"}),
+
+		Schema: map[string]*schema.Schema{
+			"package_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the CNAD package.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the new name of the CNAD package.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceUpdatePackageNameCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/cnad/packages/{package_id}/name"
+		product = "aad"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CNAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{package_id}", d.Get("package_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"name": d.Get("name"),
+		},
+	}
+
+	_, err = client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error updating CNAD package name: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	return resourceUpdatePackageNameRead(ctx, d, meta)
+}
+
+func resourceUpdatePackageNameRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceUpdatePackageNameUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceUpdatePackageNameDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to update the name of a CNAD package. 
+Deleting this resource will not change the current CNAD package name, but will only remove the resource 
+information from the tfstate file.`
+
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to update package name.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cnad -f TestAccResourcePackageName_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cnad" -v -coverprofile="./huaweicloud/services/acceptance/cnad/cnad_coverage.cov" -coverpkg="./huaweicloud/services/cnad" -run TestAccResourcePackageName_basic -timeout 360m -parallel 10
=== RUN   TestAccResourcePackageName_basic
=== PAUSE TestAccResourcePackageName_basic
=== CONT  TestAccResourcePackageName_basic
--- PASS: TestAccResourcePackageName_basic (4.61s)
PASS
coverage: 5.2% of statements in ./huaweicloud/services/cnad
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cnad      4.700s  coverage: 5.2% of statements in ./huaweicloud/services/cnad
```
<img width="1379" height="97" alt="image" src="https://github.com/user-attachments/assets/d54b4c0c-6005-4bfe-904f-9af10efbd8d2" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
