### PR TITLE
feat(rocketmq): add one-time resource to send message

### DIFF
--- a/docs/resources/dms_rocketmq_message_send.md
+++ b/docs/resources/dms_rocketmq_message_send.md
@@ -1,0 +1,80 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_rocketmq_message_send"
+description: |-
+  Use this resource to send a message to specified DMS RocketMQ topic within HuaweiCloud.
+---
+
+# huaweicloud_dms_rocketmq_message_send
+
+Use this resource to send a message to specified DMS RocketMQ topic within HuaweiCloud.
+
+-> This resource is only a one-time action resource for sending message to specified RocketMQ topic. Deleting this
+  resource will not clear the corresponding message record, but will only remove the resource information from the
+  tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "topic_name" {}
+variable "body" {}
+variable "property_list" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+}
+
+resource "huaweicloud_dms_rocketmq_message_send" "test" {
+  instance_id = var.instance_id
+  topic       = var.topic_name
+  body        = var.body
+
+  dynamic "property_list" {
+    for_each = var.property_list
+    content {
+      name  = property_list.value.name
+      value = property_list.value.value
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the message to be sent is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the RocketMQ instance.
+
+* `topic` - (Required, String, NonUpdatable) Specifies the name of the topic to send the message.
+
+* `body` - (Required, String, NonUpdatable) Specifies the content of the message to be sent.
+
+* `property_list` - (Optional, List, NonUpdatable) Specifies the list of message properties.  
+  The [property_list](#rocketmq_message_send_property_list) structure is documented below.
+
+<a name="rocketmq_message_send_property_list"></a>
+The `property_list` block supports:
+
+* `name` - (Required, String) Specifies the name of the property.
+
+* `value` - (Required, String) Specifies the value of the property.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `msg_id` - The ID of the message that was sent.
+
+* `queue_id` - The queue ID of the message.
+
+* `queue_offset` - The queue offset of the message.
+
+* `broker_name` - The broker name of the message.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2263,6 +2263,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rocketmq_consumer_group":       rocketmq.ResourceDmsRocketMQConsumerGroup(),
 			"huaweicloud_dms_rocketmq_consumption_verify":   rocketmq.ResourceDmsRocketMQConsumptionVerify(),
 			"huaweicloud_dms_rocketmq_message_offset_reset": rocketmq.ResourceDmsRocketMQMessageOffsetReset(),
+			"huaweicloud_dms_rocketmq_message_send":         rocketmq.ResourceRocketMQMessageSend(),
 			"huaweicloud_dms_rocketmq_dead_letter_resend":   rocketmq.ResourceDmsRocketMQDeadLetterResend(),
 			"huaweicloud_dms_rocketmq_topic":                rocketmq.ResourceDmsRocketMQTopic(),
 			"huaweicloud_dms_rocketmq_user":                 rocketmq.ResourceDmsRocketMQUser(),

--- a/huaweicloud/services/acceptance/rocketmq/resource_huaweicloud_dms_rocketmq_message_send_test.go
+++ b/huaweicloud/services/acceptance/rocketmq/resource_huaweicloud_dms_rocketmq_message_send_test.go
@@ -1,0 +1,87 @@
+package rocketmq
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccRocketMQMessageSend_basic(t *testing.T) {
+	resourceName := "huaweicloud_dms_rocketmq_message_send.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSRocketMQInstanceID(t)
+			acceptance.TestAccPreCheckDMSRocketMQTopicName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		//  This is a one-time action resource not delete logic.
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccRocketMQMessageSend_instanceNotFound(),
+				ExpectError: regexp.MustCompile(`This DMS instance does not exist`),
+			},
+			{
+				Config:      testAccRocketMQMessageSend_topicNotFound(),
+				ExpectError: regexp.MustCompile(`Topic does not exist`),
+			},
+			{
+				Config: testAccRocketMQMessageSend_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "property_list.#", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "msg_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "queue_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "broker_name"),
+					// `queue_offset` value may be 0, so we don't check it.
+				),
+			},
+		},
+	})
+}
+
+func testAccRocketMQMessageSend_instanceNotFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_rocketmq_message_send" "test" {
+  instance_id = "%[1]s"
+  topic       = "%[2]s"
+  body        = "tf terraform script test"
+}
+`, randomId, acceptance.HW_DMS_ROCKETMQ_TOPIC_NAME)
+}
+
+func testAccRocketMQMessageSend_topicNotFound() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_rocketmq_message_send" "test" {
+  instance_id = "%s"
+  topic       = "not_found"
+  body        = "tf terraform script test"
+}
+`, acceptance.HW_DMS_ROCKETMQ_INSTANCE_ID)
+}
+
+func testAccRocketMQMessageSend_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_rocketmq_message_send" "test" {
+  instance_id = "%[1]s"
+  topic       = "%[2]s"
+  body        = "tf terraform script test"
+
+  property_list {
+    name  = "KEYS"
+    value = "owner"
+  }
+  property_list {
+    name  = "TAGS"
+    value = "terraform"
+  }
+}
+`, acceptance.HW_DMS_ROCKETMQ_INSTANCE_ID, acceptance.HW_DMS_ROCKETMQ_TOPIC_NAME)
+}

--- a/huaweicloud/services/rocketmq/resource_huaweicloud_dms_rocketmq_message_send.go
+++ b/huaweicloud/services/rocketmq/resource_huaweicloud_dms_rocketmq_message_send.go
@@ -1,0 +1,199 @@
+package rocketmq
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var rocketmqMessageSendNonUpdatableParams = []string{
+	"instance_id",
+	"topic",
+	"body",
+	"property_list",
+}
+
+// @API RocketMQ POST /v2/{engine}/{project_id}/instances/{instance_id}/messages
+func ResourceRocketMQMessageSend() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRocketMQMessageSendCreate,
+		ReadContext:   resourceRocketMQMessageSendRead,
+		UpdateContext: resourceRocketMQMessageSendUpdate,
+		DeleteContext: resourceRocketMQMessageSendDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(rocketmqMessageSendNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the message to be sent is located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the RocketMQ instance.`,
+			},
+			"topic": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the topic to send the message.`,
+			},
+			"body": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The content of the message to be sent.`,
+			},
+			"property_list": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `The list of message properties.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The name of the property.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The value of the property.`,
+						},
+					},
+				},
+			},
+			"msg_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the message that was sent.`,
+			},
+			"queue_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The queue ID of the message.`,
+			},
+			"queue_offset": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The queue offset of the message.`,
+			},
+			"broker_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The broker name of the message.`,
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildRocketMQMessageSendBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"topic":         d.Get("topic").(string),
+		"body":          d.Get("body").(string),
+		"property_list": buildRocketMQMessageSendPropertyList(d.Get("property_list").([]interface{})),
+	}
+}
+
+func buildRocketMQMessageSendPropertyList(properties []interface{}) []map[string]interface{} {
+	if len(properties) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(properties))
+	for i, property := range properties {
+		result[i] = map[string]interface{}{
+			"name":  utils.PathSearch("name", property, nil),
+			"value": utils.PathSearch("value", property, nil),
+		}
+	}
+	return result
+}
+
+func resourceRocketMQMessageSendCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v2/rocketmq/{project_id}/instances/{instance_id}/messages"
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildRocketMQMessageSendBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("unable to send message to RocketMQ topic: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate resource ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("msg_id", utils.PathSearch("msg_id", respBody, nil)),
+		d.Set("queue_id", utils.PathSearch("queue_id", respBody, nil)),
+		d.Set("queue_offset", utils.PathSearch("queue_offset", respBody, nil)),
+		d.Set("broker_name", utils.PathSearch("broker_name", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceRocketMQMessageSendRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceRocketMQMessageSendUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceRocketMQMessageSendDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to send message to RocketMQ topic. Deleting this resource will
+not clear the corresponding message record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a one-time action resource (`huaweicloud_dms_rocketmq_message_send`) to send a message to specified topic.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o rocketmq -f TestAccRocketMQMessageSend_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rocketmq" -v -coverprofile="./huaweicloud/services/acceptance/rocketmq/rocketmq_coverage.cov" -coverpkg="./huaweicloud/services/rocketmq" -run TestAccRocketMQMessageSend_basic -timeout 360m -parallel 10
=== RUN   TestAccRocketMQMessageSend_basic
=== PAUSE TestAccRocketMQMessageSend_basic
=== CONT  TestAccRocketMQMessageSend_basic
--- PASS: TestAccRocketMQMessageSend_basic (23.49s)
PASS
coverage: 6.1% of statements in ./huaweicloud/services/rocketmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rocketmq  23.588s coverage: 6.1% of statements in ./huaweicloud/services/rocketmq
```
<img width="1067" height="516" alt="image" src="https://github.com/user-attachments/assets/41588b7d-933e-4234-9995-5d2efbd85383" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
