### PR TITLE
feat(eg): add new data source for query traced events

### DIFF
--- a/docs/data-sources/eg_traced_events.md
+++ b/docs/data-sources/eg_traced_events.md
@@ -1,0 +1,86 @@
+---
+subcategory: "EventGrid (EG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_eg_traced_events"
+description: |-
+  Use this data source to get the list of EG traced events within HuaweiCloud.
+---
+
+# huaweicloud_eg_traced_events
+
+Use this data source to get the list of EG traced events within HuaweiCloud.
+
+## Example Usage
+
+### Query all traced events
+
+```hcl
+variable "channel_id" {}
+variable "start_time" {}
+variable "end_time" {}
+
+data "huaweicloud_eg_traced_events" "test" {
+  channel_id = var.channel_id
+  start_time = var.start_time
+  end_time   = var.end_time
+}
+```
+
+### Query traced events by event ID
+
+```hcl
+variable "channel_id" {}
+variable "start_time" {}
+variable "end_time" {}
+variable "event_id" {}
+
+data "huaweicloud_eg_traced_events" "test" {
+  channel_id = var.channel_id
+  start_time = var.start_time
+  end_time   = var.end_time
+  event_id   = var.event_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the events are located.  
+  If omitted, the provider-level region will be used.
+
+* `channel_id` - (Required, String) Specifies the ID of the event channel.
+
+* `start_time` - (Required, String) Specifies the start time of the search time range, in UTC format.
+
+* `end_time` - (Required, String) Specifies the end time of the search time range, in UTC format.
+
+* `event_id` - (Optional, String) Specifies the ID of the event.
+
+* `source_name` - (Optional, String) Specifies the name of the event source.
+
+* `event_type` - (Optional, String) Specifies the type of the event.
+
+* `subscription_name` - (Optional, String) Specifies the name of the event subscription.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `events` - The list of traced events that matched filter parameters.  
+  The [events](#eg_traced_events_attr) structure is documented below.
+
+<a name="eg_traced_events_attr"></a>
+The `events` block supports:
+
+* `id` - The ID of the event.
+
+* `type` - The type of the event.
+
+* `source_name` - The name of the event source.
+
+* `subscription_name` - The name of the event subscription.
+
+* `received_time` - The time when the event to be received, in UTC format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1055,6 +1055,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_eg_event_streams":         eg.DataSourceEventStreams(),
 			"huaweicloud_eg_event_target_catalogs": eg.DataSourceEventTargetCatalogs(),
 			"huaweicloud_eg_quotas":                eg.DataSourceQuotas(),
+			"huaweicloud_eg_traced_events":         eg.DataSourceTracedEvents(),
 
 			// Professional EventRouter
 			"huaweicloud_eg_eventrouter_availability_zones": eg.DataSourceEventRouterAvailabilityZones(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -2634,7 +2634,7 @@ func TestAccPreCheckEgConnectionIds(t *testing.T) {
 
 // lintignore:AT003
 func TestAccPreCheckEgEventSubscriptionIds(t *testing.T, min int) {
-	if HW_EG_EVENT_SUBSCRIPTION_IDS == "" || len(strings.Split(HW_EG_EVENT_SUBSCRIPTION_IDS, ",")) >= min {
+	if HW_EG_EVENT_SUBSCRIPTION_IDS == "" || len(strings.Split(HW_EG_EVENT_SUBSCRIPTION_IDS, ",")) < min {
 		t.Skipf(`At least %d subscription ID(s) must be supported during the HW_EG_EVENT_SUBSCRIPTION_IDS, separated by 
 		commas (,).`, min)
 	}

--- a/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_traced_events_test.go
+++ b/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_traced_events_test.go
@@ -1,0 +1,243 @@
+package eg
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceTracedEvents_basic(t *testing.T) {
+	var (
+		name      = acceptance.RandomAccResourceName()
+		eventType = "com.example.object.created.v1"
+		startTime = time.Now().UTC()
+		endTime   = startTime.Add(24 * time.Hour).UTC()
+
+		all = "data.huaweicloud_eg_traced_events.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byEventId   = "data.huaweicloud_eg_traced_events.filter_by_event_id"
+		dcByEventId = acceptance.InitDataSourceCheck(byEventId)
+
+		bySourceName   = "data.huaweicloud_eg_traced_events.filter_by_source_name"
+		dcBySourceName = acceptance.InitDataSourceCheck(bySourceName)
+
+		byEventType   = "data.huaweicloud_eg_traced_events.filter_by_event_type"
+		dcByEventType = acceptance.InitDataSourceCheck(byEventType)
+
+		bySubscriptionName   = "data.huaweicloud_eg_traced_events.filter_by_subscription_name"
+		dcBySubscriptionName = acceptance.InitDataSourceCheck(bySubscriptionName)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceTracedEvents_basic(name, startTime.Format(time.RFC3339), endTime.Format(time.RFC3339), eventType),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(all, "region"),
+					resource.TestCheckResourceAttrSet(all, "channel_id"),
+					resource.TestCheckResourceAttrSet(all, "start_time"),
+					resource.TestCheckResourceAttrSet(all, "end_time"),
+					resource.TestMatchResourceAttr(all, "events.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+
+					dcByEventId.CheckResourceExists(),
+					resource.TestCheckOutput("is_event_id_filter_useful", "true"),
+
+					dcBySourceName.CheckResourceExists(),
+					resource.TestCheckOutput("is_source_name_filter_useful", "true"),
+
+					dcByEventType.CheckResourceExists(),
+					resource.TestCheckOutput("is_event_type_filter_useful", "true"),
+
+					dcBySubscriptionName.CheckResourceExists(),
+					resource.TestCheckOutput("is_subscription_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceTracedEvents_base(name, eventID, eventType, startTime string) string {
+	targetID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_eg_custom_event_channel" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_eg_custom_event_source" "test" {
+  channel_id = huaweicloud_eg_custom_event_channel.test.id
+  name       = "%[1]s"
+}
+
+resource "huaweicloud_fgs_function" "test" {
+  name        = "%[1]s"
+  app         = "default"
+  handler     = "test.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = <<EOF
+# -*- coding:utf-8 -*-
+import json
+def handler (event, context):
+    return {
+        "statusCode": 200,
+        "isBase64Encoded": False,
+        "body": json.dumps(event),
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+EOF
+}
+
+resource "huaweicloud_eg_event_subscription" "test" {
+  depends_on = [
+    huaweicloud_eg_custom_event_source.test,
+    huaweicloud_eg_custom_event_channel.test,
+  ]
+
+  channel_id  = huaweicloud_eg_custom_event_channel.test.id
+  name        = "%[1]s"
+  description = "Created by acceptance test"
+
+  sources {
+    provider_type = "CUSTOM"
+    id            = huaweicloud_eg_custom_event_source.test.id
+    name          = huaweicloud_eg_custom_event_source.test.name
+    detail        = jsonencode({})
+    filter_rule   = jsonencode({
+      "source" : [{
+        "op" : "StringIn",
+        "values" : [huaweicloud_eg_custom_event_source.test.name]
+      }]
+    })
+  }
+
+  targets {
+    id            = "%[2]s"
+    name          = "HC.FunctionGraph"
+    provider_type = "OFFICIAL"
+    detail_name   = "detail"
+    detail        = jsonencode({
+      "urn":huaweicloud_fgs_function.test.urn,
+      "invoke_type":"ASYNC",
+      "agency_name":"EG_TARGET_AGENCY"
+    })
+    transform     = jsonencode({
+      type  = "ORIGINAL"
+      value = ""
+    })
+  }
+
+  lifecycle {
+    ignore_changes = [sources, targets]
+  }
+}
+
+resource "huaweicloud_eg_event_batch_action" "test" {
+  channel_id = huaweicloud_eg_custom_event_channel.test.id
+
+  events {
+    id                = "%[3]s"
+    spec_version      = "1.0"
+    source            = huaweicloud_eg_custom_event_source.test.name
+    type              = "%[4]s"
+    data_content_type = "application/json"
+    time              = "%[5]s"
+    data = jsonencode({
+      "terraform": "test"
+    })
+  }
+
+  depends_on = [
+    huaweicloud_eg_event_subscription.test
+  ]
+}
+`, name, targetID, eventID, eventType, startTime)
+}
+
+func testAccDataSourceTracedEvents_basic(name, startTime, endTime, eventType string) string {
+	eventID, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_eg_traced_events" "test" {
+  depends_on = [huaweicloud_eg_event_batch_action.test]
+
+  channel_id = huaweicloud_eg_custom_event_channel.test.id
+  start_time = "%[2]s"
+  end_time   = "%[3]s"
+}
+
+# Filter by event ID
+data "huaweicloud_eg_traced_events" "filter_by_event_id" {
+  depends_on = [huaweicloud_eg_event_batch_action.test]
+
+  channel_id = huaweicloud_eg_custom_event_channel.test.id
+  start_time = "%[2]s"
+  end_time   = "%[3]s"
+  event_id   = "%[5]s"
+}
+
+output "is_event_id_filter_useful" {
+  value = length(data.huaweicloud_eg_traced_events.filter_by_event_id.events) >= 0
+}
+
+# Filter by source name
+data "huaweicloud_eg_traced_events" "filter_by_source_name" {
+  depends_on = [huaweicloud_eg_event_batch_action.test]
+
+  channel_id  = huaweicloud_eg_custom_event_channel.test.id
+  start_time  = "%[2]s"
+  end_time    = "%[3]s"
+  source_name = "%[4]s"
+}
+
+output "is_source_name_filter_useful" {
+  value = length(data.huaweicloud_eg_traced_events.filter_by_source_name.events) >= 0
+}
+
+# Filter by subscription name
+data "huaweicloud_eg_traced_events" "filter_by_subscription_name" {
+  depends_on = [huaweicloud_eg_event_batch_action.test]
+
+  channel_id        = huaweicloud_eg_custom_event_channel.test.id
+  start_time        = "%[2]s"
+  end_time          = "%[3]s"
+  subscription_name = "%[4]s"
+}
+
+output "is_subscription_name_filter_useful" {
+  value = length(data.huaweicloud_eg_traced_events.filter_by_subscription_name.events) >= 0
+}
+
+# Filter by event type
+data "huaweicloud_eg_traced_events" "filter_by_event_type" {
+  depends_on = [huaweicloud_eg_event_batch_action.test]
+
+  channel_id = huaweicloud_eg_custom_event_channel.test.id
+  start_time = "%[2]s"
+  end_time   = "%[3]s"
+  event_type = "%[6]s"
+}
+
+output "is_event_type_filter_useful" {
+  value = length(data.huaweicloud_eg_traced_events.filter_by_event_type.events) >= 0
+}
+`, testAccDataSourceTracedEvents_base(name, eventType, eventID, startTime), startTime, endTime, name,
+		eventID, eventType)
+}

--- a/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_event_batch_action_test.go
+++ b/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_event_batch_action_test.go
@@ -58,7 +58,7 @@ resource "huaweicloud_eg_event_batch_action" "test" {
 
   events {
     id                = "%[1]s"
-    source            = huaweicloud_eg_custom_event_source.test.id
+    source            = huaweicloud_eg_custom_event_source.test.name
     spec_version      = "1.0"
     type              = "com.example.object.created.v1"
     data_content_type = "application/json"

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_traced_events.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_traced_events.go
@@ -1,0 +1,227 @@
+package eg
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EG GET /v1/{project_id}/traced-events
+func DataSourceTracedEvents() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTracedEventsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the events are located.`,
+			},
+			"channel_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the event channel.`,
+			},
+			"start_time": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The start time of the search time range, in UTC format.`,
+			},
+			"end_time": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The end time of the search time range, in UTC format.`,
+			},
+			"event_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the event.`,
+			},
+			"source_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the event source.`,
+			},
+			"event_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type of the event.`,
+			},
+			"subscription_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the event subscription.`,
+			},
+			"events": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        tracedEventSchema(),
+				Description: `The list of traced events that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func tracedEventSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the event.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the event.`,
+			},
+			"source_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the event source.`,
+			},
+			"subscription_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the event subscription.`,
+			},
+			"received_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the event to be received, in UTC format.`,
+			},
+		},
+	}
+}
+
+func buildTracedEventsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	// Required parameters
+	res = fmt.Sprintf("%s&channel_id=%v", res, d.Get("channel_id"))
+
+	timestamp := utils.ConvertTimeStrToNanoTimestamp(d.Get("start_time").(string))
+	res = fmt.Sprintf("%s&start_time=%v", res, timestamp)
+
+	timestamp = utils.ConvertTimeStrToNanoTimestamp(d.Get("end_time").(string))
+	res = fmt.Sprintf("%s&end_time=%v", res, timestamp)
+
+	// Optional parameters
+	if v, ok := d.GetOk("event_id"); ok {
+		res = fmt.Sprintf("%s&event_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("source_name"); ok {
+		res = fmt.Sprintf("%s&source_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("event_type"); ok {
+		res = fmt.Sprintf("%s&event_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("subscription_name"); ok {
+		res = fmt.Sprintf("%s&subscription_name=%v", res, v)
+	}
+	return res
+}
+
+func listTracedEvents(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/traced-events?limit={limit}"
+		offset  = 0
+		limit   = 100
+		result  = make([]interface{}, 0)
+	)
+
+	listPathWithLimit := client.Endpoint + httpUrl
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{project_id}", client.ProjectID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{limit}", strconv.Itoa(limit))
+	listPathWithLimit += buildTracedEventsQueryParams(d)
+
+	opt := &golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%v", listPathWithLimit, strconv.Itoa(offset))
+		requestResp, err := client.Request("GET", listPathWithOffset, opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		events := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, events...)
+		if len(events) < limit {
+			break
+		}
+		offset += len(events)
+	}
+
+	return result, nil
+}
+
+func flattenTracedEvents(tracedEvents []interface{}) []interface{} {
+	if len(tracedEvents) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(tracedEvents))
+	for _, item := range tracedEvents {
+		result = append(result, map[string]interface{}{
+			"id":                utils.PathSearch("event_id", item, nil),
+			"type":              utils.PathSearch("event_type", item, nil),
+			"source_name":       utils.PathSearch("source_name", item, nil),
+			"subscription_name": utils.PathSearch("subscription_name", item, nil),
+			"received_time":     utils.FormatTimeStampUTC(int64(utils.PathSearch("event_received_time", item, float64(0)).(float64))),
+		})
+	}
+
+	return result
+}
+
+func dataSourceTracedEventsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("eg", region)
+	if err != nil {
+		return diag.Errorf("error creating EG client: %s", err)
+	}
+
+	events, err := listTracedEvents(client, d)
+	if err != nil {
+		return diag.Errorf("error querying EG traced events: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("events", flattenTracedEvents(events)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/eg/resource_huaweicloud_eg_event_batch_action.go
+++ b/huaweicloud/services/eg/resource_huaweicloud_eg_event_batch_action.go
@@ -123,10 +123,14 @@ func buildEventBatchActionEvents(events []interface{}) []map[string]interface{} 
 			"specversion":     utils.PathSearch("spec_version", event, nil),
 			"type":            utils.PathSearch("type", event, nil),
 			"datacontenttype": utils.ValueIgnoreEmpty(utils.PathSearch("data_content_type", event, nil)),
-			"dataschema":      utils.ValueIgnoreEmpty(utils.PathSearch("data_schema", event, nil)),
 			"data":            utils.StringToJson(utils.PathSearch("data", event, nil).(string)),
 			"time":            utils.ValueIgnoreEmpty(utils.PathSearch("time", event, nil)),
-			"subject":         utils.ValueIgnoreEmpty(utils.PathSearch("subject", event, nil)),
+		}
+		if v := utils.PathSearch("data_schema", event, ""); v != "" {
+			eventMap["data_schema"] = v
+		}
+		if v := utils.PathSearch("subject", event, ""); v != "" {
+			eventMap["subject"] = v
 		}
 		result = append(result, eventMap)
 	}

--- a/huaweicloud/services/eg/resource_huaweicloud_eg_event_subscription.go
+++ b/huaweicloud/services/eg/resource_huaweicloud_eg_event_subscription.go
@@ -243,9 +243,9 @@ func buildEventTargetsOpts(newTargets *schema.Set) []interface{} {
 		element := map[string]interface{}{
 			"provider_type":                   newTarget["provider_type"],
 			"name":                            newTarget["name"],
-			"connection_id":                   newTarget["connection_id"],
 			newTarget["detail_name"].(string): unmarshalEventSubscriptionParamsters("event target detail", newTarget["detail"].(string)),
 			"transform":                       unmarshalEventSubscriptionParamsters("transform of event target", newTarget["transform"].(string)),
+			"connection_id":                   utils.ValueIgnoreEmpty(utils.PathSearch("connection_id", newTarget, nil)),
 		}
 		if queueRaw := newTarget["dead_letter_queue"].(string); queueRaw != "" {
 			element["dead_letter_queue"] = unmarshalEventSubscriptionParamsters("dead letter queue of event target", queueRaw)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(eg): add new data source for query traced events

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eg" -v -coverprofile="./huaweicloud/services/acceptance/eg/eg_coverage.cov" -coverpkg="./huaweicloud/services/eg" -run TestAccDataTracedEvents_basic -timeout 360m -parallel 10
=== RUN   TestAccDataTracedEvents_basic
--- PASS: TestAccDataTracedEvents_basic (147.02s)
PASS
coverage: 21.3% of statements in ./huaweicloud/services/eg
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        147.117s        coverage: 21.3% of statements in ./huaweicloud/services/eg
```

<img width="1380" height="1011" alt="image" src="https://github.com/user-attachments/assets/61db53ef-2279-475d-b591-7babe57d64de" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.