### PR TITLE
feat(DEW): add a data source to query the list of KMS aliases

### DIFF
--- a/docs/data-sources/kms-aliases.md
+++ b/docs/data-sources/kms-aliases.md
@@ -1,0 +1,50 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_kms_aliases"
+description: |-
+  Use this data source to query the list of KMS aliases within HuaweiCloud.
+---
+
+# huaweicloud_kms_aliases
+
+Use this data source to query the list of KMS aliases within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_kms_aliases" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `key_id` - (Optional, String) Specifies the key ID used to query the alias.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - The data source ID.
+
+* `aliases` - The list of key aliases.
+  The [aliases](#aliases_struct) structure is documented below.
+
+<a name="aliases_struct"></a>
+The `aliases` block supports:
+
+* `domain_id` - The ID of the account to which the alias belongs.
+
+* `key_id` - The key ID.
+
+* `alias` - The alias of the key.
+
+* `alias_urn` - The alias resource locator.
+
+* `create_time` - The creation time of the alias.
+
+* `update_time` - The update time of the alias.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1192,6 +1192,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_quotas":                dew.DataSourceKMSQuotas(),
 			"huaweicloud_kms_public_key":            dew.DataSourceKmsPublicKey(),
 			"huaweicloud_kms_custom_keys_by_tags":   dew.DataSourceKmsCustomKeysByTags(),
+			"huaweicloud_kms_aliases":               dew.DataSourceKmsAliases(),
 			"huaweicloud_kms_parameters_for_import": dew.DataSourceKmsParametersForImport(),
 			"huaweicloud_kps_failed_tasks":          dew.DataSourceDewKpsFailedTasks(),
 			"huaweicloud_kps_running_tasks":         dew.DataSourceDewKpsRunningTasks(),

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_kms_aliases_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_kms_aliases_test.go
@@ -1,0 +1,63 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccKMSAliasesDataSource_basic(t *testing.T) {
+	var (
+		dataSourceName1 = "data.huaweicloud_kms_aliases.test"
+		dc1             = acceptance.InitDataSourceCheck(dataSourceName1)
+		dataSourceName2 = "data.huaweicloud_kms_aliases.filter_by_key_id"
+		dc2             = acceptance.InitDataSourceCheck(dataSourceName2)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare a import KMS key ID with an alias and config it to the environment variable.
+			acceptance.TestAccPreCheckKmsKeyID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceKmsAliases_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc1.CheckResourceExists(),
+					dc2.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName1, "aliases.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName1, "aliases.0.domain_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName1, "aliases.0.key_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName1, "aliases.0.alias"),
+					resource.TestCheckResourceAttrSet(dataSourceName1, "aliases.0.alias_urn"),
+					resource.TestCheckResourceAttrSet(dataSourceName1, "aliases.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName1, "aliases.0.update_time"),
+					resource.TestCheckOutput("is_key_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceKmsAliases_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_kms_aliases" "test" {}
+
+data "huaweicloud_kms_aliases" "filter_by_key_id" {
+  key_id = "%[1]s"
+}
+
+locals {
+  key_id_filter_result = [for v in data.huaweicloud_kms_aliases.filter_by_key_id.aliases[*].key_id : v == "%[1]s"]
+}
+
+output "is_key_id_filter_useful" {
+  value = alltrue(local.key_id_filter_result) && length(local.key_id_filter_result) > 0
+}
+`, acceptance.HW_KMS_KEY_ID)
+}

--- a/huaweicloud/services/dew/data_source_huaweicloud_kms_aliases.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_kms_aliases.go
@@ -1,0 +1,186 @@
+package dew
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW GET /v1.0/{project_id}/kms/aliases
+func DataSourceKmsAliases() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceKmsAliasRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource.`,
+			},
+			"key_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the key ID used to query the alias.`,
+			},
+			"aliases": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        aliasSchema(),
+				Description: `The list of key aliases.`,
+			},
+		},
+	}
+}
+
+func aliasSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"domain_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the account to which the alias belongs.`,
+			},
+			"key_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The key ID`,
+			},
+			"alias": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The alias of the key`,
+			},
+			"alias_urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The alias resource locator.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the alias.`,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time of the alias.`,
+			},
+		},
+	}
+}
+
+func buildListKmsAliasParams(d *schema.ResourceData) string {
+	res := "?limit=50"
+
+	if keyId, ok := d.GetOk("key_id"); ok {
+		res = fmt.Sprintf("%s&key_id=%v", res, keyId)
+	}
+
+	return res
+}
+
+func listKmsAlias(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		getHttpUrl = "v1.0/{project_id}/kms/aliases"
+		result     = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + getHttpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	queryParams := buildListKmsAliasParams(d)
+	listPath += queryParams
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	marker := ""
+	for {
+		getListPath := listPath
+		if marker != "" {
+			getListPath = listPath + fmt.Sprintf("&marker=%s", marker)
+		}
+
+		requestResp, err := client.Request("GET", getListPath, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving KMS aliases: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		aliases := utils.PathSearch("aliases", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, aliases...)
+
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func dataSourceKmsAliasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		product = "kms"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	aliases, err := listKmsAlias(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(id)
+
+	mErr = multierror.Append(mErr,
+		d.Set("region", region),
+		d.Set("aliases", flattenKmsAlias(aliases)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenKmsAlias(aliases []interface{}) []interface{} {
+	if len(aliases) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(aliases))
+	for _, alias := range aliases {
+		result = append(result, map[string]interface{}{
+			"domain_id":   utils.PathSearch("domain_id", alias, nil),
+			"key_id":      utils.PathSearch("key_id", alias, nil),
+			"alias":       utils.PathSearch("alias", alias, nil),
+			"alias_urn":   utils.PathSearch("alias_urn", alias, nil),
+			"create_time": utils.PathSearch("create_time", alias, nil),
+			"update_time": utils.PathSearch("update_time", alias, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports new data source to get kms aliases and names huaweicloud_kms_aliases.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccKMSAliasesDataSource_basic -timeout 360m -parallel 10
=== RUN   TestAccKMSAliasesDataSource_basic
=== PAUSE TestAccKMSAliasesDataSource_basic
=== CONT  TestAccKMSAliasesDataSource_basic
--- PASS: TestAccKMSAliasesDataSource_basic (29.27s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       29.341s coverage: 4.7% of statements in ./huaweicloud/services/dew
```
<img width="865" height="66" alt="image" src="https://github.com/user-attachments/assets/09effc0a-fc48-4afb-8bb1-2c7a79f97d36" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
