### PR TITLE
feat(waf): add new data source to query the top service exceptions

### DIFF
--- a/docs/data-sources/waf_overviews_abnormal.md
+++ b/docs/data-sources/waf_overviews_abnormal.md
@@ -1,0 +1,69 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_overviews_abnormal"
+description: |-
+  Use this data source to query the top service exceptions.
+---
+
+# huaweicloud_waf_overviews_abnormal
+
+Use this data source to query the top service exceptions.
+
+## Example Usage
+
+```hcl
+variable "start_time" {}
+variable "end_time" {}
+
+data "huaweicloud_waf_overviews_abnormal" "test" {
+  from = var.start_time
+  to   = var.end_time
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `from` - (Required, Int) Specifies the query start time.
+  The format is 13-digit timestamp in millisecond.
+
+* `to` - (Required, Int) Specifies the query end time.
+  The format is 13-digit timestamp in millisecond.
+
+* `top` - (Optional, Int) The first several results to query.
+  The valid value ranges from `1` to `10`. Defaults to `5`.
+
+* `code` - (Optional, Int) Specifies the abnormal status code.
+  The value can be **404**, **500** or **502**. Defaults to **404**.
+
+* `hosts` - (Optional, String) Specifies the ID of the domain.
+
+* `instances` - (Optional, String) Specifies the ID of the dedicated WAF instance.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  The default value is **0**.
+  If you want to query resources under all enterprise projects, set this parameter to **all_granted_eps**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `items` - The abnormal request information.
+
+  The [items](#items_struct) structure is documented below.
+
+<a name="items_struct"></a>
+The `items` block supports:
+
+* `key` - The attack type.
+
+* `num` - The attack count.
+
+* `host` - The protected domain.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1635,6 +1635,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_geolocation_detail":                   waf.DataSourceGeolocationDetail(),
 			"huaweicloud_waf_instance_groups":                      waf.DataSourceWafInstanceGroups(),
 			"huaweicloud_waf_overviews_bandwidth_timeline":         waf.DataSourceWafOverviewsBandwidthTimeline(),
+			"huaweicloud_waf_overviews_abnormal":                   waf.DataSourceWafOverviewsAbnormal(),
 			"huaweicloud_waf_overviews_classification":             waf.DataSourceWafOverviewsClassification(),
 			"huaweicloud_waf_overviews_qps_timeline":               waf.DataSourceWafOverviewsQPSTimeline(),
 			"huaweicloud_waf_overviews_request_timeline":           waf.DataSourceWafOverviewsRequestTimeline(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_overviews_abnormal_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_overviews_abnormal_test.go
@@ -1,0 +1,54 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceOverviewsAbnormal_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_waf_overviews_abnormal.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		startTime      = time.Now().Add(-24*time.Hour).UnixNano() / int64(time.Millisecond)
+		endTime        = time.Now().UnixNano() / int64(time.Millisecond)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			// Because there is no available data for testing, the test case is only
+			// used to verify that the API can be invoked.
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceOverviewsAbnormal_basic(startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.#"),
+
+					resource.TestCheckOutput("test_verify", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceOverviewsAbnormal_basic(startTime, endTime int64) string {
+	return fmt.Sprintf(`
+data "huaweicloud_waf_overviews_abnormal" "test" {
+  from = %[1]d
+  to   = %[2]d
+}
+
+output "test_verify" {
+  value = length(data.huaweicloud_waf_overviews_abnormal.test.items) == 0
+}
+`, startTime, endTime)
+}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_overviews_abnormal.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_overviews_abnormal.go
@@ -1,0 +1,174 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/waf/overviews/abnormal
+func DataSourceWafOverviewsAbnormal() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceWafOverviewsAbnormalRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"from": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"to": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"top": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"code": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"hosts": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instances": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"host": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildOverviewsAbnormalQueryParams(cfg *config.Config, d *schema.ResourceData) string {
+	epsId := cfg.GetEnterpriseProjectID(d)
+	rst := fmt.Sprintf("?from=%v&to=%v", d.Get("from"), d.Get("to"))
+
+	if epsId != "" {
+		rst += fmt.Sprintf("&enterprise_project_id=%v", epsId)
+	}
+
+	if top, ok := d.GetOk("top"); ok {
+		rst += fmt.Sprintf("&top=%v", top)
+	}
+
+	if code, ok := d.GetOk("code"); ok {
+		rst += fmt.Sprintf("&code=%v", code)
+	}
+
+	if hostId, ok := d.GetOk("hosts"); ok {
+		rst += fmt.Sprintf("&hosts=%v", hostId)
+	}
+
+	if instanceId, ok := d.GetOk("instances"); ok {
+		rst += fmt.Sprintf("&instances=%v", instanceId)
+	}
+
+	return rst
+}
+
+func dataSourceWafOverviewsAbnormalRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/overviews/abnormal"
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildOverviewsAbnormalQueryParams(cfg, d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	listResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving top service exceptions: %s", err)
+	}
+
+	listRespBody, err := utils.FlattenResponse(listResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataList := utils.PathSearch("items", listRespBody, make([]interface{}, 0)).([]interface{})
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("items", flattenOverviewsAbnormalItems(dataList)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenOverviewsAbnormalItems(rawItems []interface{}) []interface{} {
+	if len(rawItems) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(rawItems))
+	for _, v := range rawItems {
+		rst = append(rst, map[string]interface{}{
+			"key":  utils.PathSearch("key", v, nil),
+			"num":  utils.PathSearch("num", v, nil),
+			"host": utils.PathSearch("host", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to query the top service exceptions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccDataSourceOverviewsAbnormal_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceOverviewsAbnormal_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceOverviewsAbnormal_basic
=== PAUSE TestAccDataSourceOverviewsAbnormal_basic
=== CONT  TestAccDataSourceOverviewsAbnormal_basic
--- PASS: TestAccDataSourceOverviewsAbnormal_basic (15.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       15.997s
```
<img width="1047" height="23" alt="image" src="https://github.com/user-attachments/assets/aad95c3b-1cc3-4242-9440-a292074c8b06" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
