### PR TITLE
feat(antiddos): new resource to open protection

### DIFF
--- a/docs/resources/antiddos_open_protection.md
+++ b/docs/resources/antiddos_open_protection.md
@@ -1,0 +1,98 @@
+---
+subcategory: "Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_antiddos_open_protection"
+description: |-
+  Use this resource to open Anti-DDoS protection for an EIP.
+---
+
+# huaweicloud_antiddos_open_protection
+
+Use this resource to open Anti-DDoS protection for an EIP.
+
+-> This resource is a one-time action resource for opening Anti-DDoS protection. Deleting this resource will not
+disable the protection, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "eip_id" {
+  type = string
+}
+variable "app_type_id" {
+  type = number
+}
+variable "cleaning_access_pos_id" {
+  type = number
+}
+variable "enable_l7" {
+  type = bool
+}
+variable "http_request_pos_id" {
+  type = number
+}
+variable "traffic_pos_id" {
+  type = number
+}
+variable "antiddos_config_id" {
+  type = string
+}
+
+resource "huaweicloud_antiddos_open_protection" "test" {
+  floating_ip_id         = var.eip_id
+  app_type_id            = var.app_type_id
+  cleaning_access_pos_id = var.cleaning_access_pos_id
+  enable_l7              = var.enable_l7
+  http_request_pos_id    = var.http_request_pos_id
+  traffic_pos_id         = var.traffic_pos_id
+  antiddos_config_id     = var.antiddos_config_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create new resource.
+
+* `floating_ip_id` - (Required, String, NonUpdatable) Specifies the ID of the EIP to enable Anti-DDoS protection for.
+
+* `app_type_id` - (Required, Int, NonUpdatable) Specifies the application type ID. Only `0` is supported.
+
+* `cleaning_access_pos_id` - (Required, Int, NonUpdatable) Specifies the cleaning access position ID.
+  The value can be:
+  + `1`: 10M.
+  + `2`: 30M.
+  + `3`: 50M.
+  + `4`: 70M.
+  + `5`: 100M.
+  + `6`: 150M.
+  + `7`: 200M.
+  + `8`: 250M.
+  + `9`: 300M.
+  + `10`: 500M.
+  + `11`: 800M.
+  + `88`: 1000M.
+  + `99`: Default protection.
+
+* `enable_l7` - (Required, Bool, NonUpdatable) Specifies whether to enable L7 protection. Only **false** is supported.
+
+* `http_request_pos_id` - (Required, Int, NonUpdatable) Specifies the HTTP request position ID. Only `1` is supported.
+
+* `traffic_pos_id` - (Required, Int, NonUpdatable) Specifies the traffic position ID.
+  This field can be configured with the same value as `cleaning_access_pos_id`.
+
+* `antiddos_config_id` - (Optional, String, NonUpdatable) Specifies the Anti-DDoS configuration ID.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1847,6 +1847,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_antiddos_basic":                     antiddos.ResourceCloudNativeAntiDdos(),
 			"huaweicloud_antiddos_default_protection_policy": antiddos.ResourceDefaultProtectionPolicy(),
+			"huaweicloud_antiddos_open_protection":           antiddos.ResourceAntiDdosOpenProtection(),
 
 			"huaweicloud_access_analyzer":                    accessanalyzer.ResourceAccessAnalyzer(),
 			"huaweicloud_access_analyzer_archive_rule":       accessanalyzer.ResourceArchiveRule(),

--- a/huaweicloud/services/acceptance/antiddos/resource_huaweicloud_antiddos_open_protection_test.go
+++ b/huaweicloud/services/acceptance/antiddos/resource_huaweicloud_antiddos_open_protection_test.go
@@ -1,0 +1,40 @@
+package antiddos
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Note: Due to limited test conditions, this test case only verifies the expected error scenario.
+func TestAccResourceOpenProtection_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testOpenProtection_basic,
+				ExpectError: regexp.MustCompile(`VPC access failed or EIP is not exist|访问VPC平台异常或EIP不存在`),
+			},
+		},
+	})
+}
+
+// The value of field `floating_ip_id` is mock data.
+const testOpenProtection_basic = `
+resource "huaweicloud_antiddos_open_protection" "test" {
+  floating_ip_id         = "85f523db-9d00-42af-abf6-24c64738e7a2"
+  app_type_id            = 0
+  cleaning_access_pos_id = 99
+  enable_l7              = false
+  http_request_pos_id    = 1
+  traffic_pos_id         = 7
+  antiddos_config_id     = "1234567890"
+}
+`

--- a/huaweicloud/services/antiddos/resource_huaweicloud_antiddos_open_protection.go
+++ b/huaweicloud/services/antiddos/resource_huaweicloud_antiddos_open_protection.go
@@ -1,0 +1,233 @@
+package antiddos
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableAntiDdosOpenProtectionParams = []string{
+	"floating_ip_id",
+	"app_type_id",
+	"cleaning_access_pos_id",
+	"enable_l7",
+	"http_request_pos_id",
+	"traffic_pos_id",
+	"antiddos_config_id",
+}
+
+// @API ANTI-DDOS POST /v1/{project_id}/antiddos/{floating_ip_id}
+func ResourceAntiDdosOpenProtection() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAntiDdosOpenProtectionCreate,
+		ReadContext:   resourceAntiDdosOpenProtectionRead,
+		UpdateContext: resourceAntiDdosOpenProtectionUpdate,
+		DeleteContext: resourceAntiDdosOpenProtectionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableAntiDdosOpenProtectionParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"floating_ip_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the EIP ID.`,
+			},
+			"app_type_id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the application type ID.`,
+			},
+			"cleaning_access_pos_id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the cleaning access position ID.`,
+			},
+			"enable_l7": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: `Specifies whether to enable L7 protection.`,
+			},
+			"http_request_pos_id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the HTTP request position ID.`,
+			},
+			"traffic_pos_id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the traffic position ID.`,
+			},
+			"antiddos_config_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the anti-DDoS configuration ID.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildAntiDdosOpenProtectionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"floating_ip_id":         d.Get("floating_ip_id"),
+		"app_type_id":            d.Get("app_type_id"),
+		"cleaning_access_pos_id": d.Get("cleaning_access_pos_id"),
+		"enable_L7":              d.Get("enable_l7"),
+		"http_request_pos_id":    d.Get("http_request_pos_id"),
+		"traffic_pos_id":         d.Get("traffic_pos_id"),
+		"antiddos_config_id":     utils.ValueIgnoreEmpty(d.Get("antiddos_config_id")),
+	}
+}
+
+func waitingAntiDdosOpenProtectionTaskSuccess(ctx context.Context, client *golangsdk.ServiceClient, taskID string,
+	timeout time.Duration) error {
+	var (
+		errorStatuses = []string{"failed"}
+		httpUrl       = "v2/{project_id}/query-task-status"
+	)
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (result interface{}, state string, err error) {
+			requestPath := client.Endpoint + httpUrl
+			requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+			requestPath = fmt.Sprintf("%s?task_id=%s", requestPath, taskID)
+			requestOpt := golangsdk.RequestOpts{
+				MoreHeaders: map[string]string{
+					"Content-Type": "application/json;charset=utf8",
+				},
+				KeepResponseBody: true,
+			}
+
+			resp, err := client.Request("GET", requestPath, &requestOpt)
+			if err != nil {
+				return nil, "ERROR", fmt.Errorf("error retrieving Anti-DDoS task: %s", err)
+			}
+
+			respBody, err := utils.FlattenResponse(resp)
+			if err != nil {
+				return nil, "ERROR", fmt.Errorf("error retrieving Anti-DDoS task: Failed to flatten response (%s)", err)
+			}
+
+			taskStatus := utils.PathSearch("task_status", respBody, "").(string)
+			if taskStatus == "" {
+				return nil, "ERROR", errors.New("error retrieving Anti-DDoS task: Task status is not found in API response")
+			}
+
+			if utils.StrSliceContains(errorStatuses, taskStatus) {
+				return respBody, "ERROR", fmt.Errorf("unexpected status: '%s'", taskStatus)
+			}
+
+			if taskStatus == "success" {
+				return respBody, "COMPLETED", nil
+			}
+
+			return respBody, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceAntiDdosOpenProtectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/antiddos/{floating_ip_id}"
+		product = "anti-ddos"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Anti-DDoS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{floating_ip_id}", d.Get("floating_ip_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildAntiDdosOpenProtectionBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error opening Anti-DDoS protection: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	taskID := utils.PathSearch("task_id", respBody, "").(string)
+	if taskID == "" {
+		return diag.Errorf("error opening Anti-DDoS protection: task_id is not found in API response")
+	}
+
+	if err := waitingAntiDdosOpenProtectionTaskSuccess(ctx, client, taskID, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("error waiting for Anti-DDoS task to become success: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	return resourceAntiDdosOpenProtectionRead(ctx, d, meta)
+}
+
+func resourceAntiDdosOpenProtectionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceAntiDdosOpenProtectionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceAntiDdosOpenProtectionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to open Anti-DDoS protection. Deleting this 
+resource will not change the current Anti-DDoS opening status, but will only remove the resource information from the 
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to open protection.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o antiddos -f TestAccResourceOpenProtection_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/antiddos" -v -coverprofile="./huaweicloud/services/acceptance/antiddos/antiddos_coverage.cov" -coverpkg="./huaweicloud/services/antiddos" -run TestAccResourceOpenProtection_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceOpenProtection_basic
=== PAUSE TestAccResourceOpenProtection_basic
=== CONT  TestAccResourceOpenProtection_basic
--- PASS: TestAccResourceOpenProtection_basic (4.27s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/antiddos
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/antiddos  4.344s  coverage: 4.7% of statements in ./huaweicloud/services/antiddos
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
