### PR TITLE
feat(antiddos): new datasource to query v2 eip defense statuses

### DIFF
--- a/docs/data-sources/antiddosv2_eip_defense_statuses.md
+++ b/docs/data-sources/antiddosv2_eip_defense_statuses.md
@@ -1,0 +1,71 @@
+---
+subcategory: "Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_antiddosv2_eip_defense_statuses"
+description: |-
+  Use this data source to query the defense statuses of EIPs protected by Anti-DDoS V2.
+---
+
+# huaweicloud_antiddosv2_eip_defense_statuses
+
+Use this data source to query the defense statuses of EIPs protected by Anti-DDoS V2.
+
+## Example Usage
+
+```hcl
+variable "eip_status" {}
+variable "eip_address" {}
+
+data "huaweicloud_antiddosv2_eip_defense_statuses" "test" {
+  status = var.eip_status
+  ips    = var.eip_address
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `status` - (Optional, String) Specifies the protection status of the EIP. Options are:
+  + **normal**: Normal.
+  + **configging**: Configuring.
+  + **notConfig**: Not configured.
+  + **packetcleaning**: Packet cleaning.
+  + **packetdropping**: Packet dropping.
+
+* `ips` - (Optional, String) Specifies the IP address for filtering, supports partial matching.
+  For example, if you enter **192.168**, it will match IPs like **192.168.111.1** and **10.192.168.8**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `ddos_status` - The list of EIP defense statuses.
+  The [ddos_status](#ddos_status_struct) structure is documented below.
+
+<a name="ddos_status_struct"></a>
+The `ddos_status` block supports:
+
+* `floating_ip_id` - The ID of the EIP.
+
+* `floating_ip_address` - The IP address of the EIP.
+
+* `product_type` - The type of the EIP protection service. Options are:
+  + **Anti-DDoS**: EIP belongs to Anti-DDoS traffic cleaning.
+  + **CNAD**: EIP belongs to DDoS native advanced protection.
+
+* `status` - The protection status of the EIP. Valid values are:
+  + **normal**: Normal.
+  + **configging**: Configuring.
+  + **notConfig**: Not configured.
+  + **packetcleaning**: Packet cleaning.
+  + **packetdropping**: Packet dropping.
+
+* `clean_threshold` - The cleaning threshold.
+
+* `block_threshold` - The blackhole threshold.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -480,6 +480,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_antiddos_config_ranges":                antiddos.DataSourceConfigRanges(),
 			"huaweicloud_antiddos_weekly_protection_statistics": antiddos.DataSourceWeeklyProtectionStatistics(),
 			"huaweicloud_antiddos_eip_defense_statuses":         antiddos.DataSourceEipDefenseStatuses(),
+			"huaweicloud_antiddosv2_eip_defense_statuses":       antiddos.DataSourceEipDefenseStatusesV2(),
 			"huaweicloud_antiddos_eip_protection_traffic":       antiddos.DataSourceEipProtectionTraffic(),
 			"huaweicloud_antiddos_eip_exception_events":         antiddos.DataSourceEipExceptionEvents(),
 

--- a/huaweicloud/services/acceptance/antiddos/data_source_huaweicloud_antiddosv2_eip_defense_statuses_test.go
+++ b/huaweicloud/services/acceptance/antiddos/data_source_huaweicloud_antiddosv2_eip_defense_statuses_test.go
@@ -1,0 +1,101 @@
+package antiddos
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceEipDefenseStatusesV2_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_antiddosv2_eip_defense_statuses.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceEipDefenseStatusesV2_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "ddos_status.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "ddos_status.0.floating_ip_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "ddos_status.0.floating_ip_address"),
+					resource.TestCheckResourceAttrSet(dataSource, "ddos_status.0.product_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "ddos_status.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "ddos_status.0.clean_threshold"),
+					resource.TestCheckResourceAttrSet(dataSource, "ddos_status.0.block_threshold"),
+
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					resource.TestCheckOutput("is_ip_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceEipDefenseStatusesV2_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_eip" "test" {
+  name = "%[1]s"
+
+  publicip {
+    type       = "5_bgp"
+    ip_version = 4
+  }
+
+  bandwidth {
+    share_type  = "PER"
+    name        = "%[1]s"
+    size        = 5
+    charge_mode = "traffic"
+  }
+}
+`, name)
+}
+
+func testDataSourceEipDefenseStatusesV2_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_antiddosv2_eip_defense_statuses" "test" {
+  depends_on = [huaweicloud_vpc_eip.test]
+}
+
+locals {
+  status              = data.huaweicloud_antiddosv2_eip_defense_statuses.test.ddos_status[0].status
+  floating_ip_address = data.huaweicloud_antiddosv2_eip_defense_statuses.test.ddos_status[0].floating_ip_address
+}
+
+data "huaweicloud_antiddosv2_eip_defense_statuses" "filter_by_status" {
+  status = local.status
+}
+
+data "huaweicloud_antiddosv2_eip_defense_statuses" "filter_by_ip" {
+  ips = local.floating_ip_address
+}
+
+locals {
+  list_by_status = data.huaweicloud_antiddosv2_eip_defense_statuses.filter_by_status.ddos_status
+  list_by_ip     = data.huaweicloud_antiddosv2_eip_defense_statuses.filter_by_ip.ddos_status
+}
+
+output "is_status_filter_useful" {
+  value = length(local.list_by_status) > 0 && alltrue(
+    [for v in local.list_by_status[*].status : v == local.status]
+  )
+}
+
+output "is_ip_filter_useful" {
+  value = length(local.list_by_ip) > 0 && alltrue(
+    [for v in local.list_by_ip[*].floating_ip_address : v == local.floating_ip_address]
+  )
+}
+`, testDataSourceEipDefenseStatusesV2_base(name))
+}

--- a/huaweicloud/services/antiddos/data_source_huaweicloud_antiddosv2_eip_defense_statuses.go
+++ b/huaweicloud/services/antiddos/data_source_huaweicloud_antiddosv2_eip_defense_statuses.go
@@ -1,0 +1,177 @@
+package antiddos
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Anti-DDOS GET /v2/{project_id}/antiddos
+func DataSourceEipDefenseStatusesV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEipDefenseStatusesV2Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the protection status of the EIP.`,
+			},
+			"ips": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the IP address for filtering, supports partial matching.`,
+			},
+			"ddos_status": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of EIP defense statuses.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"floating_ip_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the EIP.`,
+						},
+						"floating_ip_address": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The IP address of the EIP.`,
+						},
+						"product_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the EIP protection service.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The protection status of the EIP.`,
+						},
+						"clean_threshold": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The cleaning threshold.`,
+						},
+						"block_threshold": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The blackhole threshold.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildEipDefenseStatusesV2QueryParams(d *schema.ResourceData) string {
+	queryParams := "?limit=100"
+
+	if v, ok := d.GetOk("status"); ok {
+		queryParams += fmt.Sprintf("&status=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("ips"); ok {
+		queryParams += fmt.Sprintf("&ips=%s", v.(string))
+	}
+
+	return queryParams
+}
+
+func dataSourceEipDefenseStatusesV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/antiddos"
+		product = "anti-ddos"
+		offset  = 0
+		allData = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Anti-DDoS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildEipDefenseStatusesV2QueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithOffset := requestPath + fmt.Sprintf("&offset=%d", offset)
+
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving Anti-DDoS V2 EIP defense statuses: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataList := utils.PathSearch("ddosStatus", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataList) == 0 {
+			break
+		}
+
+		allData = append(allData, dataList...)
+		offset += len(dataList)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("ddos_status", flattenV2EipDefenseStatuses(allData)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenV2EipDefenseStatuses(respArray []interface{}) []map[string]interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(respArray))
+	for _, respBody := range respArray {
+		result = append(result, map[string]interface{}{
+			"floating_ip_id":      utils.PathSearch("floating_ip_id", respBody, nil),
+			"floating_ip_address": utils.PathSearch("floating_ip_address", respBody, nil),
+			"product_type":        utils.PathSearch("product_type", respBody, nil),
+			"status":              utils.PathSearch("status", respBody, nil),
+			"clean_threshold":     utils.PathSearch("clean_threshold", respBody, nil),
+			"block_threshold":     utils.PathSearch("block_threshold", respBody, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query v2 eip defense statuses.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o antiddos -f TestAccDataSourceEipDefenseStatusesV2_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/antiddos" -v -coverprofile="./huaweicloud/services/acceptance/antiddos/antiddos_coverage.cov" -coverpkg="./huaweicloud/services/antiddos" -run TestAccDataSourceEipDefenseStatusesV2_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceEipDefenseStatusesV2_basic
=== PAUSE TestAccDataSourceEipDefenseStatusesV2_basic
=== CONT  TestAccDataSourceEipDefenseStatusesV2_basic
--- PASS: TestAccDataSourceEipDefenseStatusesV2_basic (25.91s)
PASS
coverage: 10.7% of statements in ./huaweicloud/services/antiddos
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/antiddos  25.998s coverage: 10.7% of statements in ./huaweicloud/services/antiddos
```
<img width="1349" height="83" alt="image" src="https://github.com/user-attachments/assets/daa791fb-441e-4906-a494-6dcada4d5775" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
