### PR TITLE
feat(rocketmq): add new data source to get dead letter messages

### DIFF
--- a/docs/data-sources/dms_rocketmq_dead_letter_messages.md
+++ b/docs/data-sources/dms_rocketmq_dead_letter_messages.md
@@ -1,0 +1,88 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_rocketmq_dead_letter_messages"
+description: |-
+  Use this data source to get the list of RocketMQ dead letter messages within HuaweiCloud.
+---
+
+# huaweicloud_dms_rocketmq_dead_letter_messages
+
+Use this data source to get the list of RocketMQ dead letter messages within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "topic_name" {}
+variable "msg_id_list" {
+  type = list(string)
+}
+
+data "huaweicloud_dms_rocketmq_dead_letter_messages" "test" {
+  instance_id  = var.instance_id
+  topic        = var.topic_name
+  msg_id_list  = var.msg_id_list
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the dead letter messages are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the RocketMQ instance.
+
+* `topic` - (Required, String) Specifies the name of the topic to which the dead letter messages belong.
+
+* `msg_id_list` - (Required, List) Specifies the list of dead letter message IDs.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `messages` - All dead letter messages that match the filter parameters.  
+  The [messages](#dead_letter_messages) structure is documented below.
+
+<a name="dead_letter_messages"></a>
+The `messages` block supports:
+
+* `msg_id` - The ID of the dead letter message.
+
+* `instance_id` - The ID of the RocketMQ instance.
+
+* `topic` - The name of the topic to which the dead letter message belongs.
+
+* `store_time` - The time when the dead letter message was stored, in RFC3339 format.
+
+* `born_time` - The time when the dead letter message was generated, in RFC3339 format.
+
+* `reconsume_times` - The number of times the message has been retried.
+
+* `body` - The body of the message.
+
+* `body_crc` - The checksum of the message body.
+
+* `store_size` - The storage size of the message.
+
+* `born_host` - The IP address of the host that generated the message.
+
+* `store_host` - The IP address of the host that stored the message.
+
+* `queue_id` - The ID of the queue.
+
+* `queue_offset` - The offset in the queue.
+
+* `property_list` - The list of message properties.  
+  The [property_list](#dead_letter_messages_property_list) structure is documented below.
+
+<a name="dead_letter_messages_property_list"></a>
+The `property_list` block supports:
+
+* `name` - The name of the property.
+
+* `value` - The value of the property.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -950,6 +950,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rocketmq_consumer_groups":             rocketmq.DataSourceDmsRocketMQConsumerGroups(),
 			"huaweicloud_dms_rocketmq_consumers":                   rocketmq.DataSourceDmsRocketmqConsumers(),
 			"huaweicloud_dms_rocketmq_consumer_group_access_users": rocketmq.DataSourceDmsRocketmqConsumerGroupAccessUsers(),
+			"huaweicloud_dms_rocketmq_dead_letter_messages":        rocketmq.DataSourceDeadLetterMessages(),
 			"huaweicloud_dms_rocketmq_flavors":                     rocketmq.DataSourceRocketMQFlavors(),
 			"huaweicloud_dms_rocketmq_migration_tasks":             rocketmq.DataSourceDmsRocketmqMigrationTasks(),
 			"huaweicloud_dms_rocketmq_topic_consumer_groups":       rocketmq.DataSourceDmsRocketmqTopicConsumerGroups(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -688,6 +688,9 @@ var (
 	HW_DMS_ROCKETMQ_INSTANCE_ID = os.Getenv("HW_DMS_ROCKETMQ_INSTANCE_ID")
 	HW_DMS_ROCKETMQ_TOPIC_NAME  = os.Getenv("HW_DMS_ROCKETMQ_TOPIC_NAME")
 	HW_DMS_ROCKETMQ_GROUP_NAME  = os.Getenv("HW_DMS_ROCKETMQ_GROUP_NAME")
+	// The list of dead letter message IDs. Using commas (,) to separate multiple IDs.
+	// At least one ID is required.
+	HW_DMS_ROCKETMQ_DEAD_LETTER_MESSAGE_IDs = os.Getenv("HW_DMS_ROCKETMQ_DEAD_LETTER_MESSAGE_IDs")
 
 	HW_SFS_TURBO_SHARE_ID                = os.Getenv("HW_SFS_TURBO_SHARE_ID")
 	HW_SFS_TURBO_BACKUP_ID               = os.Getenv("HW_SFS_TURBO_BACKUP_ID")
@@ -3527,6 +3530,14 @@ func TestAccPreCheckDMSRocketMQGroupName(t *testing.T) {
 func TestAccPreCheckDMSRocketMQTopicName(t *testing.T) {
 	if HW_DMS_ROCKETMQ_TOPIC_NAME == "" {
 		t.Skip("HW_DMS_ROCKETMQ_TOPIC_NAME must be set for DMS acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDMSRocketMQDeadLetterMessageIDs(t *testing.T, min int) {
+	if HW_DMS_ROCKETMQ_DEAD_LETTER_MESSAGE_IDs == "" || len(strings.Split(HW_DMS_ROCKETMQ_DEAD_LETTER_MESSAGE_IDs, ",")) < min {
+		t.Skipf("At least %d dead letter message IDs must be must be supported during the HW_DMS_ROCKETMQ_DEAD_LETTER_MESSAGE_IDs, "+
+			"separated by commas (,).", min)
 	}
 }
 

--- a/huaweicloud/services/acceptance/rocketmq/data_source_huaweicloud_dms_rocketmq_dead_letter_messages_test.go
+++ b/huaweicloud/services/acceptance/rocketmq/data_source_huaweicloud_dms_rocketmq_dead_letter_messages_test.go
@@ -1,0 +1,94 @@
+package rocketmq
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this test, ensure that the consumer group is online and that there are dead letter messages generated.
+func TestAccDataDeadLetterMessages_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_dms_rocketmq_dead_letter_messages.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSRocketMQInstanceID(t)
+			acceptance.TestAccPreCheckDMSRocketMQGroupName(t)
+			acceptance.TestAccPreCheckDMSRocketMQDeadLetterMessageIDs(t, 2)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDeadLetterMessages_instanceNotFound(),
+				ExpectError: regexp.MustCompile(`This DMS instance does not exist`),
+			},
+			{
+				Config:      testAccDeadLetterMessages_topicNotFound(),
+				ExpectError: regexp.MustCompile(`Query topic failed. No topic route info in name server for topic`),
+			},
+			{
+				Config: testDataSourceDeadLetterMessages_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "messages.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "messages.0.msg_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "messages.0.instance_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "messages.0.topic"),
+					resource.TestMatchResourceAttr(dataSource, "messages.0.store_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(dataSource, "messages.0.born_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "messages.0.reconsume_times"),
+					resource.TestCheckResourceAttrSet(dataSource, "messages.0.body_crc"),
+					resource.TestCheckResourceAttrSet(dataSource, "messages.0.store_size"),
+					resource.TestCheckResourceAttrSet(dataSource, "messages.0.born_host"),
+					resource.TestCheckResourceAttrSet(dataSource, "messages.0.store_host"),
+					resource.TestCheckResourceAttrSet(dataSource, "messages.0.queue_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "messages.0.queue_offset"),
+					resource.TestMatchResourceAttr(dataSource, "messages.0.property_list.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDeadLetterMessages_instanceNotFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dms_rocketmq_dead_letter_messages" "test" {
+  instance_id = "%[1]s"
+  topic       = "%[2]s"
+  msg_id_list = split(",", "%[3]s")
+}
+`, randomId, acceptance.HW_DMS_ROCKETMQ_GROUP_NAME, acceptance.HW_DMS_ROCKETMQ_DEAD_LETTER_MESSAGE_IDs)
+}
+
+func testAccDeadLetterMessages_topicNotFound() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dms_rocketmq_dead_letter_messages" "test" {
+  instance_id = "%[1]s"
+  topic       = "not_found"
+  msg_id_list = split(",", "%[2]s")
+}
+`, acceptance.HW_DMS_ROCKETMQ_INSTANCE_ID, acceptance.HW_DMS_ROCKETMQ_DEAD_LETTER_MESSAGE_IDs)
+}
+
+func testDataSourceDeadLetterMessages_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dms_rocketmq_dead_letter_messages" "test" {
+  instance_id = "%[1]s"
+  topic       = "%%DLQ%%%[2]s"
+  msg_id_list = split(",", "%[3]s")
+}
+`, acceptance.HW_DMS_ROCKETMQ_INSTANCE_ID,
+		acceptance.HW_DMS_ROCKETMQ_GROUP_NAME,
+		acceptance.HW_DMS_ROCKETMQ_DEAD_LETTER_MESSAGE_IDs,
+	)
+}

--- a/huaweicloud/services/rocketmq/data_source_huaweicloud_dms_rocketmq_dead_letter_messages.go
+++ b/huaweicloud/services/rocketmq/data_source_huaweicloud_dms_rocketmq_dead_letter_messages.go
@@ -1,0 +1,237 @@
+package rocketmq
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RocketMQ POST /v2/{project_id}/instances/{instance_id}/messages/export
+func DataSourceDeadLetterMessages() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDeadLetterMessagesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the dead letter messages are located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the RocketMQ instance.`,
+			},
+			"topic": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the topic to which the dead letter messages belong.`,
+			},
+			"msg_id_list": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of dead letter message IDs.`,
+			},
+			"messages": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the RocketMQ instance.`,
+						},
+						"msg_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the dead letter message.`,
+						},
+						"topic": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the topic to which the dead letter message belongs.`,
+						},
+						"store_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time when the dead letter message was stored, in RFC3339 format.`,
+						},
+						"born_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time when the dead letter message was generated, in RFC3339 format.`,
+						},
+						"reconsume_times": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The number of times the message has been retried.`,
+						},
+						"body": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The body of the message.`,
+						},
+						"body_crc": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The checksum of the message body.`,
+						},
+						"store_size": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The storage size of the message.`,
+						},
+						"born_host": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The IP address of the host that generated the message.`,
+						},
+						"store_host": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The IP address of the host that stored the message.`,
+						},
+						"queue_id": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The ID of the queue.`,
+						},
+						"queue_offset": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The offset in the queue.`,
+						},
+						"property_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the property.`,
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The value of the property.`,
+									},
+								},
+							},
+							Description: `The list of message properties.`,
+						},
+					},
+				},
+				Description: `All dead letter messages that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildDeadLetterMessagesQueryParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"topic":       d.Get("topic"),
+		"msg_id_list": d.Get("msg_id_list"),
+	}
+}
+
+func dataSourceDeadLetterMessagesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	httpUrl := "v2/{project_id}/instances/{instance_id}/messages/export"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", d.Get("instance_id").(string))
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildDeadLetterMessagesQueryParams(d)),
+	}
+
+	listResp, err := client.Request("POST", listPath, &listOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving dead letter messages: %s", err)
+	}
+
+	listRespBody, err := utils.FlattenResponse(listResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(randomId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("messages", flattenDeadLetterMessages(utils.PathSearch("[]", listRespBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDeadLetterMessages(messages []interface{}) []interface{} {
+	if len(messages) == 0 {
+		return nil
+	}
+
+	results := make([]interface{}, 0, len(messages))
+	for _, message := range messages {
+		results = append(results, map[string]interface{}{
+			"instance_id":     utils.PathSearch("instance_id", message, nil),
+			"msg_id":          utils.PathSearch("msg_id", message, nil),
+			"topic":           utils.PathSearch("topic", message, nil),
+			"reconsume_times": utils.PathSearch("reconsume_times", message, nil),
+			"body":            utils.PathSearch("body", message, nil),
+			"body_crc":        utils.PathSearch("body_crc", message, nil),
+			"store_size":      utils.PathSearch("store_size", message, nil),
+			"born_host":       utils.PathSearch("born_host", message, nil),
+			"store_host":      utils.PathSearch("store_host", message, nil),
+			"queue_id":        utils.PathSearch("queue_id", message, nil),
+			"queue_offset":    utils.PathSearch("queue_offset", message, nil),
+			"store_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("store_timestamp", message,
+				float64(0)).(float64))/1000, false),
+			"born_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("born_timestamp", message,
+				float64(0)).(float64))/1000, false),
+			"property_list": flattenDeadLetterMessagePropertyList(
+				utils.PathSearch("property_list", message, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return results
+}
+
+func flattenDeadLetterMessagePropertyList(properties []interface{}) interface{} {
+	if len(properties) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(properties))
+	for _, property := range properties {
+		rst = append(rst, map[string]interface{}{
+			"name":  utils.PathSearch("name", property, nil),
+			"value": utils.PathSearch("value", property, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source (`huaweicloud_dms_rocketmq_dead_letter_messages`) to get dead letter messages.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
2. add coreesponding document and acceptance test.
3. After testing, the uniq_key_list parameter is invalid.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o rocketmq -f TestAccDataSourceRocketMQDeadLetterMessages_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rocketmq" -v -coverprofile="./huaweicloud/services/acceptance/rocketmq/rocketmq_coverage.cov" -coverpkg="./huaweicloud/services/rocketmq" -run TestAccDataSourceRocketMQDeadLetterMessages_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceRocketMQDeadLetterMessages_basic
=== PAUSE TestAccDataSourceRocketMQDeadLetterMessages_basic
=== CONT  TestAccDataSourceRocketMQDeadLetterMessages_basic
--- PASS: TestAccDataSourceRocketMQDeadLetterMessages_basic (17.31s)
PASS
coverage: 5.9% of statements in ./huaweicloud/services/rocketmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rocketmq  17.387s coverage: 5.9% of statements in ./huaweicloud/services/rocketmq
```

<img width="1087" height="198" alt="image" src="https://github.com/user-attachments/assets/a01e921b-e5dd-4f09-ae75-404f1e5a5d5c" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
