### PR TITLE
feat(waf): add new data source to get the list of attack events

### DIFF
--- a/docs/data-sources/waf_events.md
+++ b/docs/data-sources/waf_events.md
@@ -1,0 +1,129 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_events"
+description: |-
+  Use this data source to get the list of WAF attack events.
+---
+
+# huaweicloud_waf_events
+
+Use this data source to get the list of WAF attack events.
+
+## Example Usage
+
+```hcl
+variable "recent" {}
+
+data "huaweicloud_waf_events" "test" {
+  recent = var.recent
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `recent` - (Optional, String) Specifies the time range for querying logs.
+  The value can be **yesterday**, **today**, **3days**, **1week** or **1month**.
+
+* `from` - (Optional, Int) Specifies the start time.
+  The format is 13-digit timestamp in millisecond.
+
+  -> The field `from` must be used together with field `to`.
+
+* `to` - (Optional, Int) Specifies the end time.
+  The format is 13-digit timestamp in millisecond.
+
+  -> The field `to` must be used together with field `from`.
+
+-> Exactly one of `recent` or `from`, `to` must be set. If both `recent` and `from`, `to` are set, `recent`
+  takes effect.
+
+* `attacks` - (Optional, List) Specifies the attack type.
+  The valid values are as follows:
+  + **vuln**: Other attack types.
+  + **sqli**: SQL injections.
+  + **lfi**: Local file inclusion attacks.
+  + **cmdi**: Command injections.
+  + **xss**: XSS attacks.
+  + **robot**: Malicious crawlers.
+  + **rfi**: Remote file inclusion attacks.
+  + **custom_custom**: Precise protection.
+  + **cc**: CC attacks.
+  + **webshell**: Website Trojans.
+  + **custom_whiteblackip**: Attacks blocked based on blacklist and whitelist settings.
+  + **custom_geoip**: Attacks blocked based on geolocations.
+  + **antitamper**: Anti-tamper events.
+  + **anticrawler**: Anti-crawler events.
+  + **leakage**: Website data leakage prevention.
+  + **illegal**: Unauthorized request.
+  + **antiscan_high_freq_scan**: Blocking of high-frequency scanning.
+  + **antiscan_dir_traversal**: Directory traversal protection.
+
+* `hosts` - (Optional, List) Specifies the domain ID list.
+
+* `sips` - (Optional, List) Specifies the source IP addresses.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  The default value is **0**.
+  If you want to query resources under all enterprise projects, set this parameter to **all_granted_eps**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `items` - The attack event list.
+  The [items](#items_struct) structure is documented below.
+
+<a name="items_struct"></a>
+The `items` block supports:
+
+* `id` - The event ID.
+
+* `time` - The timestamp when the attack occurred, in milliseconds.
+
+* `policyid` - The policy ID.
+
+* `sip` - The source IP address.
+
+* `host` - The domain name.
+
+* `url` - The attacked URL link.
+
+* `attack` - The attack type.
+
+* `rule` - The hit rule ID.
+
+* `payload` - The hit payload.
+
+* `payload_location` - The hit payload location.
+
+* `action` - The protection action.
+
+* `request_line` - The request method and path.
+
+* `headers` - The HTTP request headers.
+
+* `cookie` - The request cookie.
+
+* `status` - The response code status.
+
+* `process_time` - The processing time.
+
+* `region` - The geographic location.
+
+* `host_id` - The domain ID.
+
+* `response_time` - The response time.
+
+* `response_size` - The response body size.
+
+* `response_body` - The response body.
+
+* `request_body` - The request body.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1644,6 +1644,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_dedicated_instances":                  waf.DataSourceWafDedicatedInstances(),
 			"huaweicloud_waf_domain_status":                        waf.DataSourceWafDomainStatus(),
 			"huaweicloud_waf_domains":                              waf.DataSourceWafDomains(),
+			"huaweicloud_waf_events":                               waf.DataSourceWafAttackEvents(),
 			"huaweicloud_waf_geolocation_detail":                   waf.DataSourceGeolocationDetail(),
 			"huaweicloud_waf_instance_groups":                      waf.DataSourceWafInstanceGroups(),
 			"huaweicloud_waf_overviews_attack_top_domains":         waf.DataSourceOverviewsAttackTopDomains(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_events_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_events_test.go
@@ -1,0 +1,47 @@
+package waf
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourcAttackEvents_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_waf_events.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			// Because there is no available data for testing, the test case is only
+			// used to verify that the API can be invoked.
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcAttackEvents_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.#"),
+
+					resource.TestCheckOutput("test_verify", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourcAttackEvents_basic = `
+data "huaweicloud_waf_events" "test" {
+  recent = "3days"
+}
+
+output "test_verify" {
+  value = length(data.huaweicloud_waf_events.test.items) == 0
+}
+`

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_events.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_events.go
@@ -1,0 +1,297 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/waf/event
+func DataSourceWafAttackEvents() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceWafAttackEventsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"recent": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"from": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"to": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"attacks": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"hosts": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"sips": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"policyid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"attack": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"rule": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"payload": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"payload_location": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"action": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"request_line": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"headers": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"cookie": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"process_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"region": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"response_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"response_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"response_body": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"request_body": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAttackEventsQueryParams(d *schema.ResourceData, epsId string) string {
+	res := "?pagesize=100"
+	if epsId != "" {
+		res = fmt.Sprintf("%s&enterprise_project_id=%s", res, epsId)
+	}
+	if v, ok := d.GetOk("recent"); ok {
+		res = fmt.Sprintf("%s&recent=%v", res, v)
+	}
+	if v, ok := d.GetOk("from"); ok {
+		res = fmt.Sprintf("%s&from=%v", res, v)
+	}
+	if v, ok := d.GetOk("to"); ok {
+		res = fmt.Sprintf("%s&to=%v", res, v)
+	}
+	if v, ok := d.GetOk("attacks"); ok {
+		attacks, ok := v.([]interface{})
+		if ok {
+			for _, attack := range attacks {
+				res = fmt.Sprintf("%s&attacks=%v", res, attack)
+			}
+		}
+	}
+	if v, ok := d.GetOk("hosts"); ok {
+		hosts, ok := v.([]interface{})
+		if ok {
+			for _, host := range hosts {
+				res = fmt.Sprintf("%s&hosts=%v", res, host)
+			}
+		}
+	}
+	if v, ok := d.GetOk("sips"); ok {
+		sips, ok := v.([]interface{})
+		if ok {
+			for _, sip := range sips {
+				res = fmt.Sprintf("%s&sips=%v", res, sip)
+			}
+		}
+	}
+
+	return res
+}
+
+func dataSourceWafAttackEventsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v1/{project_id}/waf/event"
+		epsId       = cfg.GetEnterpriseProjectID(d)
+		result      = make([]interface{}, 0)
+		currentPage = 1
+	)
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildAttackEventsQueryParams(d, epsId)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithPage := fmt.Sprintf("%s&page=%d", requestPath, currentPage)
+		resp, err := client.Request("GET", requestPathWithPage, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving WAF events: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		event := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		if len(event) == 0 {
+			break
+		}
+
+		result = append(result, event...)
+		currentPage++
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("items", flattenAttackEvents(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAttackEvents(rawEvents []interface{}) []interface{} {
+	if len(rawEvents) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(rawEvents))
+	for _, v := range rawEvents {
+		rst = append(rst, map[string]interface{}{
+			"id":               utils.PathSearch("id", v, nil),
+			"time":             utils.PathSearch("time", v, nil),
+			"policyid":         utils.PathSearch("policyid", v, nil),
+			"sip":              utils.PathSearch("sip", v, nil),
+			"host":             utils.PathSearch("host", v, nil),
+			"url":              utils.PathSearch("url", v, nil),
+			"attack":           utils.PathSearch("attack", v, nil),
+			"rule":             utils.PathSearch("rule", v, nil),
+			"payload":          utils.PathSearch("payload", v, nil),
+			"payload_location": utils.PathSearch("payload_location", v, nil),
+			"action":           utils.PathSearch("action", v, nil),
+			"request_line":     utils.PathSearch("request_line", v, nil),
+			"headers":          utils.PathSearch("headers", v, nil),
+			"cookie":           utils.PathSearch("cookie", v, nil),
+			"status":           utils.PathSearch("status", v, nil),
+			"process_time":     utils.PathSearch("process_time", v, nil),
+			"region":           utils.PathSearch("region", v, nil),
+			"host_id":          utils.PathSearch("host_id", v, nil),
+			"response_time":    utils.PathSearch("response_time", v, nil),
+			"response_size":    utils.PathSearch("response_size", v, nil),
+			"response_body":    utils.PathSearch("response_body", v, nil),
+			"request_body":     utils.PathSearch("request_body", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get the list of attack events.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccDataSourcAttackEvents_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourcAttackEvents_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourcAttackEvents_basic
=== PAUSE TestAccDataSourcAttackEvents_basic
=== CONT  TestAccDataSourcAttackEvents_basic
--- PASS: TestAccDataSourcAttackEvents_basic (17.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       17.886s
```
<img width="957" height="25" alt="image" src="https://github.com/user-attachments/assets/54afd027-d20e-41af-a32c-f46343ecdce8" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
