### PR TITLE
feat(antiddos): new resource to manage LTS config

### DIFF
--- a/docs/resources/antiddos_lts_config.md
+++ b/docs/resources/antiddos_lts_config.md
@@ -1,0 +1,54 @@
+---
+subcategory: "Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_antiddos_lts_config"
+description: |-
+  Manages Anti-DDoS LTS configuration resource within HuaweiCloud.
+---
+
+# huaweicloud_antiddos_lts_config
+
+Manages Anti-DDoS LTS configuration resource within HuaweiCloud.
+
+-> Destroying the resource will disable the LTS configuration.
+
+## Example Usage
+
+```hcl
+variable "lts_group_id" {}
+variable "lts_attack_stream_id" {}
+variable "enterprise_project_id" {}
+
+resource "huaweicloud_antiddos_lts_config" "test" {
+  lts_group_id          = var.lts_group_id
+  lts_attack_stream_id  = var.lts_attack_stream_id
+  enterprise_project_id = var.enterprise_project_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create new resource.
+
+* `lts_group_id` - (Required, String) Specifies the LTS group ID.
+
+* `lts_attack_stream_id` - (Required, String) Specifies the LTS attack stream ID.
+
+* `enterprise_project_id` - (Required, String, NonUpdatable) Specifies the enterprise project ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (same as `enterprise_project_id`).
+
+## Import
+
+Anti-DDoS LTS configuration can be imported using `id`. e.g.
+
+```bash
+$ terraform import huaweicloud_antiddos_lts_config.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1864,6 +1864,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_antiddos_basic":                     antiddos.ResourceCloudNativeAntiDdos(),
 			"huaweicloud_antiddos_default_protection_policy": antiddos.ResourceDefaultProtectionPolicy(),
 			"huaweicloud_antiddos_open_protection":           antiddos.ResourceAntiDdosOpenProtection(),
+			"huaweicloud_antiddos_lts_config":                antiddos.ResourceLtsConfig(),
 
 			"huaweicloud_access_analyzer":                    accessanalyzer.ResourceAccessAnalyzer(),
 			"huaweicloud_access_analyzer_archive_rule":       accessanalyzer.ResourceArchiveRule(),

--- a/huaweicloud/services/acceptance/antiddos/resource_huaweicloud_antiddos_lts_config_test.go
+++ b/huaweicloud/services/acceptance/antiddos/resource_huaweicloud_antiddos_lts_config_test.go
@@ -1,0 +1,146 @@
+package antiddos_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getLtsConfigFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("anti-ddos", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Anti-DDoS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v1/{project_id}/antiddos/lts-config"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?enterprise_project_id=%s", state.Primary.Attributes["enterprise_project_id"])
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Anti-DDoS LTS config: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, fmt.Errorf("error flattening Anti-DDoS LTS config response: %s", err)
+	}
+
+	enabled := utils.PathSearch("enabled", respBody, false).(bool)
+	if !enabled {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return respBody, nil
+}
+
+func TestAccAntiddosLtsConfig_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_antiddos_lts_config.test"
+		name  = acceptance.RandomAccResourceName()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getLtsConfigFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testLtsConfig_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "lts_group_id", "huaweicloud_lts_group.test1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_attack_stream_id", "huaweicloud_lts_stream.test1", "id"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
+				),
+			},
+			{
+				Config: testLtsConfig_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "lts_group_id", "huaweicloud_lts_group.test2", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_attack_stream_id", "huaweicloud_lts_stream.test2", "id"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testLtsConfig_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lts_group" "test1" {
+  group_name  = "%[1]s-1"
+  ttl_in_days = 30
+}
+
+resource "huaweicloud_lts_stream" "test1" {
+  group_id    = huaweicloud_lts_group.test1.id
+  stream_name = "%[1]s-1"
+  is_favorite = true
+}
+
+resource "huaweicloud_lts_group" "test2" {
+  group_name  = "%[1]s-2"
+  ttl_in_days = 30
+}
+
+resource "huaweicloud_lts_stream" "test2" {
+  group_id    = huaweicloud_lts_group.test2.id
+  stream_name = "%[1]s-2"
+  is_favorite = true
+}
+`, name)
+}
+
+func testLtsConfig_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_antiddos_lts_config" "test" {
+  lts_group_id          = huaweicloud_lts_group.test1.id
+  lts_attack_stream_id  = huaweicloud_lts_stream.test1.id
+  enterprise_project_id = "0"
+}
+`, testLtsConfig_base(name))
+}
+
+func testLtsConfig_basic_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_antiddos_lts_config" "test" {
+  lts_group_id          = huaweicloud_lts_group.test2.id
+  lts_attack_stream_id  = huaweicloud_lts_stream.test2.id
+  enterprise_project_id = "0"
+}
+`, testLtsConfig_base(name))
+}

--- a/huaweicloud/services/antiddos/resource_huaweicloud_antiddos_lts_config.go
+++ b/huaweicloud/services/antiddos/resource_huaweicloud_antiddos_lts_config.go
@@ -1,0 +1,222 @@
+package antiddos
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ANTI-DDOS PUT /v1/{project_id}/antiddos/lts-config
+// @API ANTI-DDOS GET /v1/{project_id}/antiddos/lts-config
+func ResourceLtsConfig() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceLtsConfigCreate,
+		ReadContext:   resourceLtsConfigRead,
+		UpdateContext: resourceLtsConfigUpdate,
+		DeleteContext: resourceLtsConfigDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceLtsConfigImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{"enterprise_project_id"}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to create the resource.`,
+			},
+			"lts_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the LTS group ID.`,
+			},
+			"lts_attack_stream_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the LTS attack stream ID.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the enterprise project ID.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildUpdateLtsConfigBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"enabled": true,
+		"lts_id_info": map[string]interface{}{
+			"lts_group_id":         d.Get("lts_group_id"),
+			"lts_attack_stream_id": d.Get("lts_attack_stream_id"),
+		},
+	}
+}
+
+func buildLtcConfigQueryParams(cfg *config.Config, d *schema.ResourceData) string {
+	return fmt.Sprintf("?enterprise_project_id=%s", cfg.GetEnterpriseProjectID(d))
+}
+
+func updateLtsConfig(client *golangsdk.ServiceClient, d *schema.ResourceData, cfg *config.Config) error {
+	requestPath := client.Endpoint + "v1/{project_id}/antiddos/lts-config"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildLtcConfigQueryParams(cfg, d)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+		JSONBody:         buildUpdateLtsConfigBodyParams(d),
+	}
+
+	_, err := client.Request("PUT", requestPath, &requestOpt)
+	return err
+}
+
+func resourceLtsConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "anti-ddos"
+		epsID   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Anti-DDoS client: %s", err)
+	}
+
+	if err := updateLtsConfig(client, d, cfg); err != nil {
+		return diag.Errorf("error updating Anti-DDoS LTS config in create operation: %s", err)
+	}
+
+	d.SetId(epsID)
+
+	return resourceLtsConfigRead(ctx, d, meta)
+}
+
+func resourceLtsConfigRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "anti-ddos"
+		httpUrl = "v1/{project_id}/antiddos/lts-config"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Anti-DDoS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildLtcConfigQueryParams(cfg, d)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving Anti-DDoS LTS config: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	enabled := utils.PathSearch("enabled", respBody, false).(bool)
+	if !enabled {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("lts_group_id", utils.PathSearch("lts_id_info.lts_group_id", respBody, nil)),
+		d.Set("lts_attack_stream_id", utils.PathSearch("lts_id_info.lts_attack_stream_id", respBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceLtsConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "anti-ddos"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Anti-DDoS client: %s", err)
+	}
+
+	if err := updateLtsConfig(client, d, cfg); err != nil {
+		return diag.Errorf("error updating Anti-DDoS LTS config in update operation: %s", err)
+	}
+
+	return resourceLtsConfigRead(ctx, d, meta)
+}
+
+func deleteLtsConfig(client *golangsdk.ServiceClient, d *schema.ResourceData, cfg *config.Config) error {
+	requestPath := client.Endpoint + "v1/{project_id}/antiddos/lts-config"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildLtcConfigQueryParams(cfg, d)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"enabled": false,
+		},
+	}
+
+	_, err := client.Request("PUT", requestPath, &requestOpt)
+	return err
+}
+
+func resourceLtsConfigDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "anti-ddos"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Anti-DDoS client: %s", err)
+	}
+
+	if err := deleteLtsConfig(client, d, cfg); err != nil {
+		return diag.Errorf("error disabling Anti-DDoS LTS config: %s", err)
+	}
+	return nil
+}
+
+func resourceLtsConfigImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	return []*schema.ResourceData{d}, d.Set("enterprise_project_id", d.Id())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to manage LTS config.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o antiddos -f TestAccAntiddosLtsConfig_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/antiddos" -v -coverprofile="./huaweicloud/services/acceptance/antiddos/antiddos_coverage.cov" -coverpkg="./huaweicloud/services/antiddos" -run TestAccAntiddosLtsConfig_basic -timeout 360m -parallel 10
=== RUN   TestAccAntiddosLtsConfig_basic
=== PAUSE TestAccAntiddosLtsConfig_basic
=== CONT  TestAccAntiddosLtsConfig_basic
--- PASS: TestAccAntiddosLtsConfig_basic (23.79s)
PASS
coverage: 13.1% of statements in ./huaweicloud/services/antiddos
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/antiddos  23.873s coverage: 13.1% of statements in ./huaweicloud/services/antiddos
```
<img width="1350" height="79" alt="image" src="https://github.com/user-attachments/assets/9dafdfda-8c20-4390-89ef-36189a3a1f91" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1117" height="414" alt="image" src="https://github.com/user-attachments/assets/285e26cb-95ff-4545-83d3-5a93c8ef90e5" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
