### PR TITLE
feat(aad): support `aad_instance_domains` and `aad_attack_events` data sources

### DIFF
--- a/docs/data-sources/aad_attack_events.md
+++ b/docs/data-sources/aad_attack_events.md
@@ -1,0 +1,85 @@
+---
+subcategory: "Advanced Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aad_attack_events"
+description: |-
+  Use this data source to get the list of Advanced Anti-DDos attack events within HuaweiCloud.
+---
+
+# huaweicloud_aad_attack_events
+
+Use this data source to get the list of Advanced Anti-DDos attack events within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_aad_attack_events" "test" {
+  recent        = "today"
+  overseas_type = "0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domains` - (Optional, String) Specifies the domain name. If not specified, all domains will be included.
+
+* `start_time` - (Optional, String) Specifies the start time.
+
+* `end_time` - (Optional, String) Specifies the end time.
+
+* `recent` - (Optional, String) Specifies the recent time period.  
+  The valid values are as follows:
+  + **yesterday**
+  + **today**
+  + **3days**
+  + **1week**
+  + **1month**
+
+  Choose between this parameter and the timestamp parameter(`start_time` and `end_time`).
+
+* `overseas_type` - (Optional, String) Specifies the instance type.  
+  The valid values are as follows:
+  + **0**: Mainland China.
+  + **1**: Overseas.
+
+* `sip` - (Optional, String) Specifies the attack source IP.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `events` - The attack events list.  
+  The [events](#events_struct) structure is documented below.
+
+<a name="events_struct"></a>
+The `events` block supports:
+
+* `id` - The event ID.
+
+* `domain` - The attack target domain.
+
+* `time` - The attack time.
+
+* `sip` - The attack source IP.
+
+* `action` - The defense action.
+
+* `url` - The attack URL.
+
+* `type` - The attack type.
+
+* `backend` - The current backend information.  
+  The [backend](#backend_struct) structure is documented below.
+
+<a name="backend_struct"></a>
+The `backend` block supports:
+
+* `protocol` - The current backend protocol.
+
+* `port` - The current backend port.
+
+* `host` - The current backend host value.

--- a/docs/data-sources/aad_instance_domains.md
+++ b/docs/data-sources/aad_instance_domains.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Advanced Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aad_instance_domains"
+description: |-
+  Use this data source to get the list of Advanced Anti-DDos instance domain information within HuaweiCloud.
+---
+
+# huaweicloud_aad_instance_domains
+
+Use this data source to get the list of Advanced Anti-DDos instance domains information within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_aad_instance_domains" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required, String) Specifies the instance ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `instance_name` - The instance name.
+
+* `domains` - The domain information list.  
+  The [domains](#domains_struct) structure is documented below.
+
+<a name="domains_struct"></a>
+The `domains` block supports:
+
+* `domain_id` - The domain ID.
+
+* `domain_name` - The domain name.
+
+* `cname` - The domain CNAME.
+
+* `domain_status` - The domain status. `0` represents normal, `1` represents freeze.
+
+* `cc_status` - The CC protection status.
+
+* `https_cert_status` - The certificate status. `1` represents uploaded, `2` represents not uploaded.
+
+* `cert_name` - The certificate name.
+
+* `protocol_type` - The domain protocol list.
+
+* `real_server_type` - The real server type.
+
+* `real_servers` - The real servers.
+
+* `waf_status` - The WAF protection status.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -480,6 +480,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aad_ip_ddos_statistics":          aad.DataSourceIpDdosStatistics(),
 			"huaweicloud_aad_flow_block":                  aad.DataSourceFlowBlock(),
 			"huaweicloud_aad_ddos_attack_protection_info": aad.DataSourceDdosAttackProtectionInfo(),
+			"huaweicloud_aad_attack_events":               aad.DataSourceAttackEvents(),
 
 			"huaweicloud_antiddos_config_ranges":                antiddos.DataSourceConfigRanges(),
 			"huaweicloud_antiddos_weekly_protection_statistics": antiddos.DataSourceWeeklyProtectionStatistics(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -470,6 +470,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aad_cc_attack_protection_qps":    aad.DataSourceCcAttackProtectionQPS(),
 			"huaweicloud_aad_unblock_records":             aad.DataSourceUnblockRecords(),
 			"huaweicloud_aad_domains":                     aad.DataSourceAadDomains(),
+			"huaweicloud_aad_instance_domains":            aad.DataSourceInstanceDomains(),
 			"huaweicloud_aad_source_ips":                  aad.DataSourceAadSourceIps(),
 			"huaweicloud_aad_domain_certificate":          aad.DataSourceAadDomainCertificate(),
 			"huaweicloud_aad_policy_black_white_lists":    aad.DataSourcePolicyBlackWhiteLists(),

--- a/huaweicloud/services/aad/data_source_huaweicloud_aad_attack_events.go
+++ b/huaweicloud/services/aad/data_source_huaweicloud_aad_attack_events.go
@@ -1,0 +1,247 @@
+package aad
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AAD GET /v2/aad/domains/waf-info/attack/event
+func DataSourceAttackEvents() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAttackEventsRead,
+
+		Schema: map[string]*schema.Schema{
+			"domains": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the domain name. If not specified, all domains will be included.",
+			},
+			"start_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the start time.",
+			},
+			"end_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the end time.",
+			},
+			"recent": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the recent time period.",
+			},
+			// In the API documentation, `overseas_type` is int type.
+			// But it needs to meet the scenario of `0`, so it is defined here as a string type.
+			"overseas_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the instance type. `0` represents  mainland China, `1` represents overseas.",
+			},
+			"sip": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the attack source IP.",
+			},
+			// The field in the API documentation is `list`.
+			"events": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The attack events list.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The event ID.",
+						},
+						"domain": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The attack target domain.",
+						},
+						"time": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The attack time.",
+						},
+						"sip": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The attack source IP.",
+						},
+						"action": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The defense action.",
+						},
+						"url": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The attack URL.",
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The attack type.",
+						},
+						"backend": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The current backend information.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"protocol": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The current backend protocol.",
+									},
+									"port": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "The current backend port.",
+									},
+									"host": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The current backend host value.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAttackEventsQueryParams(d *schema.ResourceData) string {
+	queryParams := "?limit=200"
+
+	if v, ok := d.GetOk("domains"); ok {
+		queryParams = fmt.Sprintf("%s&domains=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("start_time"); ok {
+		queryParams = fmt.Sprintf("%s&start_time=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("end_time"); ok {
+		queryParams = fmt.Sprintf("%s&end_time=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("recent"); ok {
+		queryParams = fmt.Sprintf("%s&recent=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("overseas_type"); ok {
+		queryParams = fmt.Sprintf("%s&overseas_type=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("sip"); ok {
+		queryParams = fmt.Sprintf("%s&sip=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceAttackEventsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+		httpUrl = "v2/aad/domains/waf-info/attack/event"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath += buildAttackEventsQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", currentPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving AAD attack events: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		eventResp := utils.PathSearch("list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(eventResp) == 0 {
+			break
+		}
+
+		result = append(result, eventResp...)
+		offset += len(eventResp)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("events", flattenAttackEvents(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAttackEvents(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"id":      utils.PathSearch("id", v, nil),
+			"domain":  utils.PathSearch("domain", v, nil),
+			"time":    utils.PathSearch("time", v, nil),
+			"sip":     utils.PathSearch("sip", v, nil),
+			"action":  utils.PathSearch("action", v, nil),
+			"url":     utils.PathSearch("url", v, nil),
+			"type":    utils.PathSearch("type", v, nil),
+			"backend": flattenAttackEventBackend(utils.PathSearch("backend", v, nil)),
+		})
+	}
+
+	return rst
+}
+
+func flattenAttackEventBackend(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"protocol": utils.PathSearch("protocol", resp, nil),
+			"port":     utils.PathSearch("port", resp, nil),
+			"host":     utils.PathSearch("host", resp, nil),
+		},
+	}
+}

--- a/huaweicloud/services/aad/data_source_huaweicloud_aad_instance_domains.go
+++ b/huaweicloud/services/aad/data_source_huaweicloud_aad_instance_domains.go
@@ -1,0 +1,175 @@
+package aad
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// Due to limited testing conditions, this data source cannot be tested and the API was not successfully called.
+
+// @API AAD GET /v2/aad/instances/{instance_id}/domains
+func DataSourceInstanceDomains() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstanceDomainsRead,
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the instance ID.",
+			},
+			"instance_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The instance name.",
+			},
+			"domains": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The domain information list.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"domain_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The domain ID.",
+						},
+						"domain_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The domain name.",
+						},
+						"cname": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The domain CNAME.",
+						},
+						"domain_status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The domain status. `0` represents normal, `1` represents freeze.",
+						},
+						"cc_status": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The CC protection status.",
+						},
+						"https_cert_status": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The certificate status. `1` represents uploaded, `2` represents not uploaded",
+						},
+						"cert_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The certificate name.",
+						},
+						"protocol_type": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The domain protocol list.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+						"real_server_type": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The real server type.",
+						},
+						"real_servers": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The real servers.",
+						},
+						"waf_status": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The WAF protection status.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceInstanceDomainsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+		httpUrl = "v2/aad/instances/{instance_id}/domains"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{instance_id}", d.Get("instance_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving AAD instance domains: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("instance_name", utils.PathSearch("instance_name", respBody, nil)),
+		d.Set("domains", flattenInstanceDomains(utils.PathSearch("domains", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenInstanceDomains(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"domain_id":         utils.PathSearch("domain_id", v, nil),
+			"domain_name":       utils.PathSearch("domain_name", v, nil),
+			"cname":             utils.PathSearch("cname", v, nil),
+			"domain_status":     utils.PathSearch("domain_status", v, nil),
+			"cc_status":         utils.PathSearch("cc_status", v, nil),
+			"https_cert_status": utils.PathSearch("https_cert_status", v, nil),
+			"cert_name":         utils.PathSearch("cert_name", v, nil),
+			"protocol_type":     utils.ExpandToStringList(utils.PathSearch("protocol_type", v, make([]interface{}, 0)).([]interface{})),
+			"real_server_type":  utils.PathSearch("real_server_type", v, nil),
+			"real_servers":      utils.PathSearch("real_servers", v, nil),
+			"waf_status":        utils.PathSearch("waf_status", v, nil),
+		})
+	}
+
+	return rst
+}

--- a/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_attack_events_test.go
+++ b/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_attack_events_test.go
@@ -1,0 +1,40 @@
+package antiddos
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Due to testing environment limitations, this test case can only test the scenario with empty `events`.
+func TestAccDataSourceAadAttackEvents_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_aad_attack_events.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAadAttackEvents_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "events.#"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceAadAttackEvents_basic = `
+data "huaweicloud_aad_attack_events" "test" {
+  start_time    = "1755734400"
+  end_time      = "1755820800"
+  recent        = "today"
+  overseas_type = "0"
+}
+`

--- a/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_instance_domains_test.go
+++ b/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_instance_domains_test.go
@@ -1,0 +1,42 @@
+package antiddos
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Note: Due to limited test conditions, this test case cannot be executed successfully.
+func TestAccDataSourceInstanceDomains_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_aad_instance_domains.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAadInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceInstanceDomains_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "domains.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceInstanceDomains_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_aad_instance_domains" "test" {
+  instance_id = "%s"
+}
+`, acceptance.HW_AAD_INSTANCE_ID)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

commit1: support `aad_instance_domains` data source
commit2: support `aad_attack_events` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

commit1: support `aad_instance_domains` data source
commit2: support `aad_attack_events` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/aad" TESTARGS="-run TestAccDataSourceAadAttackEvents_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aad -v -run TestAccDataSourceAadAttackEvents_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAadAttackEvents_basic
=== PAUSE TestAccDataSourceAadAttackEvents_basic
=== CONT  TestAccDataSourceAadAttackEvents_basic
--- PASS: TestAccDataSourceAadAttackEvents_basic (12.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aad       12.597s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
