### PR TITLE
feat(aad): new resource to manage policy black white rule

### DIFF
--- a/docs/resources/aad_policy_black_white_rule.md
+++ b/docs/resources/aad_policy_black_white_rule.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Advanced Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aad_policy_black_white_rule"
+description: |-
+  Manages a WAF black and white rule resource within HuaweiCloud AAD service.
+---
+
+# huaweicloud_aad_policy_black_white_rule
+
+Manages a WAF black and white rule resource within HuaweiCloud AAD service.
+
+## Example Usage
+
+```hcl
+variable "domain_name" {}
+variable "ip" {}
+
+resource "huaweicloud_aad_policy_black_white_rule" "white_rule" {
+  domain_name   = var.domain_name
+  ip            = var.ip
+  overseas_type = 0
+  type          = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_name` - (Required, String, NonUpdatable) Specifies the domain name.
+
+* `ip` - (Required, String, NonUpdatable) Specifies the IP address or IP segment.
+
+* `overseas_type` - (Required, Int, NonUpdatable) Specifies the protection area. The value can be:
+  + `0`: Chinese mainland.
+  + `1`: Outside Chinese mainland.
+
+* `type` - (Required, Int, NonUpdatable) Specifies the rule type. The value can be:
+  + `0`: Blacklist.
+  + `1`: Whitelist.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (rule ID).
+
+* `domain_id` - The domain ID.
+
+## Import
+
+The AAD policy black white rule can be imported using the `domain_name`, `overseas_type`, `ip` and `type`,
+separated by slashes (/), e.g.
+
+```bash
+$ terraform import huaweicloud_aad_policy_black_white_rule.test <domain_name>/<overseas_type>/<ip>/<type>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1866,6 +1866,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aad_black_white_list":           aad.ResourceBlackWhiteList(),
 			"huaweicloud_aad_change_specification":       aad.ResourceChangeSpecification(),
 			"huaweicloud_aad_domain_security_protection": aad.ResourceDomainSecurityProtection(),
+			"huaweicloud_aad_policy_black_white_rule":    aad.ResourcePolicyBlackWhiteRule(),
 			"huaweicloud_aad_unblock_ip":                 aad.ResourceUnblockIp(),
 
 			"huaweicloud_antiddos_basic":                     antiddos.ResourceCloudNativeAntiDdos(),

--- a/huaweicloud/services/aad/resource_huaweicloud_aad_policy_black_white_rule.go
+++ b/huaweicloud/services/aad/resource_huaweicloud_aad_policy_black_white_rule.go
@@ -1,0 +1,267 @@
+package aad
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AAD POST /v2/aad/policies/waf/blackwhite-list
+// @API AAD DELETE /v2/aad/policies/waf/blackwhite-list
+// @API AAD GET /v2/aad/policies/waf/blackwhite-list
+func ResourcePolicyBlackWhiteRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePolicyBlackWhiteRuleCreate,
+		UpdateContext: resourcePolicyBlackWhiteRuleUpdate,
+		ReadContext:   resourcePolicyBlackWhiteRuleRead,
+		DeleteContext: resourcePolicyBlackWhiteRuleDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourcePolicyBlackWhiteRuleImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{"domain_name", "ip", "overseas_type", "type"}),
+
+		Schema: map[string]*schema.Schema{
+			"domain_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the domain name.`,
+			},
+			"overseas_type": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the protection area.`,
+			},
+			"ip": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the IP address or IP segment.`,
+			},
+			"type": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the rule type.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"domain_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The domain ID.`,
+			},
+		},
+	}
+}
+
+func buildCreatePolicyBlackWhiteRuleBodyParams(domainName string, overseasType int, ip string,
+	ruleType int) map[string]interface{} {
+	return map[string]interface{}{
+		"domain_name":   domainName,
+		"ips":           []interface{}{ip},
+		"overseas_type": overseasType,
+		"type":          ruleType,
+	}
+}
+
+func buildPolicyBlackWhiteRuleQueryParams(domainName string, overseasType int) string {
+	return fmt.Sprintf("?domain_name=%v&overseas_type=%v", domainName, overseasType)
+}
+
+func GetPolicyBlackWhiteRule(client *golangsdk.ServiceClient, domainName string, overseasType int, ip string,
+	ruleType int) (interface{}, error) {
+	requestPath := client.Endpoint + "v2/aad/policies/waf/blackwhite-list"
+	requestPath += buildPolicyBlackWhiteRuleQueryParams(domainName, overseasType)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	expression := fmt.Sprintf("[black, white][] | [?ip == '%s' && type == `%d`] | [0]", ip, ruleType)
+	ruleResp := utils.PathSearch(expression, respBody, nil)
+
+	if ruleResp == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return ruleResp, nil
+}
+
+func resourcePolicyBlackWhiteRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		product      = "aad"
+		httpUrl      = "v2/aad/policies/waf/blackwhite-list"
+		domainName   = d.Get("domain_name").(string)
+		overseasType = d.Get("overseas_type").(int)
+		ip           = d.Get("ip").(string)
+		ruleType     = d.Get("type").(int)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: buildCreatePolicyBlackWhiteRuleBodyParams(domainName, overseasType, ip, ruleType),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error creating AAD policy black white rule: %s", err)
+	}
+
+	ruleResp, err := GetPolicyBlackWhiteRule(client, domainName, overseasType, ip, ruleType)
+	if err != nil {
+		return diag.Errorf("error creating AAD policy black white rule: target rule not found in query API response: %s", err)
+	}
+
+	ruleID := utils.PathSearch("id", ruleResp, "").(string)
+	if ruleID == "" {
+		return diag.Errorf("error creating AAD policy black white rule: ID is not found in query API response")
+	}
+
+	d.SetId(ruleID)
+
+	return resourcePolicyBlackWhiteRuleRead(ctx, d, meta)
+}
+
+func resourcePolicyBlackWhiteRuleUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourcePolicyBlackWhiteRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		product      = "aad"
+		domainName   = d.Get("domain_name").(string)
+		overseasType = d.Get("overseas_type").(int)
+		ip           = d.Get("ip").(string)
+		ruleType     = d.Get("type").(int)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	ruleResp, err := GetPolicyBlackWhiteRule(client, domainName, overseasType, ip, ruleType)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving AAD policy black white rule")
+	}
+
+	// Backfill the value of ID. Valid in import operation scenarios.
+	ruleID := utils.PathSearch("id", ruleResp, "").(string)
+	if ruleID != "" {
+		d.SetId(ruleID)
+	}
+
+	mErr := multierror.Append(
+		d.Set("type", utils.PathSearch("type", ruleResp, nil)),
+		d.Set("ip", utils.PathSearch("ip", ruleResp, nil)),
+		d.Set("domain_id", utils.PathSearch("domain_id", ruleResp, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildDeletePolicyBlackWhiteRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"ids":           []interface{}{d.Id()},
+		"domain_name":   d.Get("domain_name"),
+		"overseas_type": d.Get("overseas_type"),
+	}
+}
+
+func resourcePolicyBlackWhiteRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+		httpUrl = "v2/aad/policies/waf/blackwhite-list"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: buildDeletePolicyBlackWhiteRuleBodyParams(d),
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error deleting AAD policy black white rule: %s", err)
+	}
+
+	return nil
+}
+
+func resourcePolicyBlackWhiteRuleImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 4 {
+		return nil, errors.New("invalid format specified for import ID, must be <domain_name>/<overseas_type>/<type>/<ip>")
+	}
+
+	mErr := multierror.Append(
+		d.Set("domain_name", parts[0]),
+		d.Set("overseas_type", convertStringtoInt(parts[1])),
+		d.Set("ip", parts[2]),
+		d.Set("type", convertStringtoInt(parts[3])),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return nil, fmt.Errorf("failed to set value to state when import, %s", err)
+	}
+	return []*schema.ResourceData{d}, nil
+}
+
+func convertStringtoInt(s string) int {
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		log.Printf("[ERROR] convert the string %s to int failed.", s)
+	}
+	return i
+}

--- a/huaweicloud/services/acceptance/aad/resource_huaweicloud_aad_policy_black_white_rule_test.go
+++ b/huaweicloud/services/acceptance/aad/resource_huaweicloud_aad_policy_black_white_rule_test.go
@@ -1,0 +1,120 @@
+package antiddos
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/aad"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getPolicyBlackWhiteRuleFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region       = acceptance.HW_REGION_NAME
+		product      = "aad"
+		domainName   = state.Primary.Attributes["domain_name"]
+		overseasType = state.Primary.Attributes["overseas_type"]
+		ip           = state.Primary.Attributes["ip"]
+		ruleType     = state.Primary.Attributes["type"]
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating AAD client: %s", err)
+	}
+
+	return aad.GetPolicyBlackWhiteRule(client, domainName, convertStringtoInt(overseasType), ip, convertStringtoInt(ruleType))
+}
+
+func convertStringtoInt(s string) int {
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		log.Printf("[ERROR] convert the string %s to int failed.", s)
+	}
+	return i
+}
+
+func TestAccPolicyBlackWhiteRule_basic(t *testing.T) {
+	var obj interface{}
+	rscName := "huaweicloud_aad_policy_black_white_rule.test"
+	rc := acceptance.InitResourceCheck(
+		rscName,
+		&obj,
+		getPolicyBlackWhiteRuleFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckAadDomainName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testPolicyBlackWhiteRule(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rscName, "domain_name", acceptance.HW_AAD_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(rscName, "type", "1"),
+					resource.TestCheckResourceAttr(rscName, "ip", "192.168.5.10"),
+					resource.TestCheckResourceAttr(rscName, "overseas_type", "0"),
+					resource.TestCheckResourceAttrSet(rscName, "domain_id"),
+				),
+			},
+			{
+				ResourceName:      rscName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testPolicyBlackWhiteRuleImportState(rscName),
+			},
+		},
+	})
+}
+
+func testPolicyBlackWhiteRule() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_aad_policy_black_white_rule" "test" {
+  domain_name   = "%s"
+  ip            = "192.168.5.10"
+  overseas_type = 0
+  type          = 1
+}
+`, acceptance.HW_AAD_DOMAIN_NAME)
+}
+
+func testPolicyBlackWhiteRuleImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+
+		domainName := rs.Primary.Attributes["domain_name"]
+		if domainName == "" {
+			return "", fmt.Errorf("attribute (domain_name) of Resource (%s) not found", name)
+		}
+
+		overseasType := rs.Primary.Attributes["overseas_type"]
+		if overseasType == "" {
+			return "", fmt.Errorf("attribute (overseas_type) of Resource (%s) not found", name)
+		}
+
+		ip := rs.Primary.Attributes["ip"]
+		if ip == "" {
+			return "", fmt.Errorf("attribute (ip) of Resource (%s) not found", name)
+		}
+
+		ruleType := rs.Primary.Attributes["type"]
+		if ruleType == "" {
+			return "", fmt.Errorf("attribute (type) of Resource (%s) not found", name)
+		}
+
+		return fmt.Sprintf("%s/%s/%s/%s", domainName, overseasType, ip, ruleType), nil
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to manage policy black white rule.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o aad -f TestAccPolicyBlackWhiteRule
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/aad" -v -coverprofile="./huaweicloud/services/acceptance/aad/aad_coverage.cov" -coverpkg="./huaweicloud/services/aad" -run TestAccPolicyBlackWhiteRule -timeout 360m -parallel 10
=== RUN   TestAccPolicyBlackWhiteRule
=== PAUSE TestAccPolicyBlackWhiteRule
=== CONT  TestAccPolicyBlackWhiteRule
--- PASS: TestAccPolicyBlackWhiteRule (12.51s)
PASS
coverage: 9.4% of statements in ./huaweicloud/services/aad
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aad       12.597s coverage: 9.4% of statements in ./huaweicloud/services/aad
```
<img width="1303" height="78" alt="image" src="https://github.com/user-attachments/assets/73b517f2-5283-4005-8011-9b4594d2d915" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
