### PR TITLE
fix(DC): change dc virtual interface priorty from attribute to param

### DIFF
--- a/docs/resources/dc_virtual_interface.md
+++ b/docs/resources/dc_virtual_interface.md
@@ -101,6 +101,12 @@ The following arguments are supported:
   `local_gateway_v6_ip`) and remote subnet (corresponding to the parameter `remote_gateway_v4_ip` or
   `remote_gateway_v6_ip`) must exist in the list.
 
+* `priority` - (Optional, String) The priority of a virtual interface. The value can be **normal** or **low**.
+  If the priorities are the same, the virtual interfaces work in load balancing mode.
+  If the priorities are different, the virtual interfaces work in active/standby pairs.
+  Outbound traffic is preferentially forwarded to the normal virtual interface with a higher priority.
+  This option is only supported by virtual interfaces that use BGP routing.
+
 * `service_ep_group` - (Optional, List) Specifies the subnets that access Internet services through a connection.
   This field is required in public network connections.
 
@@ -193,12 +199,6 @@ In addition to all arguments above, the following attributes are exported:
 * `ies_id` - The edge site ID.
 
 * `lgw_id` - The ID of the local gateway, which is used in IES scenarios.
-
-* `priority` - The priority of a virtual interface. The value can be **normal** or **low**.
-  If the priorities are the same, the virtual interfaces work in load balancing mode.
-  If the priorities are different, the virtual interfaces work in active/standby pairs.
-  Outbound traffic is preferentially forwarded to the normal virtual interface with a higher priority.
-  This option is only supported by virtual interfaces that use BGP routing.
 
 * `rate_limit` - Whether rate limiting is enabled on a virtual interface.
 

--- a/huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_interface_test.go
+++ b/huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_interface_test.go
@@ -72,6 +72,7 @@ func TestAccVirtualInterface_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "route_mode", "static"),
 					resource.TestCheckResourceAttr(rName, "vlan", fmt.Sprintf("%v", vlan)),
 					resource.TestCheckResourceAttr(rName, "bandwidth", "5"),
+					resource.TestCheckResourceAttr(rName, "priority", "low"),
 					resource.TestCheckResourceAttr(rName, "enable_bfd", "true"),
 					resource.TestCheckResourceAttr(rName, "enable_nqa", "false"),
 					resource.TestCheckResourceAttr(rName, "remote_ep_group.0", "1.1.1.0/30"),
@@ -115,6 +116,7 @@ func TestAccVirtualInterface_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "route_mode", "static"),
 					resource.TestCheckResourceAttr(rName, "vlan", fmt.Sprintf("%v", vlan)),
 					resource.TestCheckResourceAttr(rName, "bandwidth", "10"),
+					resource.TestCheckResourceAttr(rName, "priority", "normal"),
 					resource.TestCheckResourceAttr(rName, "enable_bfd", "false"),
 					resource.TestCheckResourceAttr(rName, "enable_nqa", "true"),
 					resource.TestCheckResourceAttr(rName, "remote_ep_group.0", "1.1.1.0/30"),
@@ -473,6 +475,7 @@ resource "huaweicloud_dc_virtual_interface" "test" {
   route_mode        = "static"
   vlan              = %[4]d
   bandwidth         = 5
+  priority          = "low"
   enable_bfd        = true
   enable_nqa        = false
 
@@ -504,6 +507,7 @@ resource "huaweicloud_dc_virtual_interface" "test" {
   route_mode        = "static"
   vlan              = %[4]d
   bandwidth         = 10
+  priority          = "normal"
   enable_bfd        = false
   enable_nqa        = true
 
@@ -536,6 +540,7 @@ resource "huaweicloud_dc_virtual_interface" "test" {
   route_mode        = "static"
   vlan              = %[4]d
   bandwidth         = 10
+  priority          = "normal"
   enable_bfd        = true
   enable_nqa        = false
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  change dc virtual interface priorty from attribute to param
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  change dc virtual interface priorty from attribute to param
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dc/ TESTARGS='-run TestAccVirtualInterface_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dc/ -v -run TestAccVirtualInterface_basic -timeout 360m -parallel 4
=== RUN   TestAccVirtualInterface_basic
=== PAUSE TestAccVirtualInterface_basic
=== CONT  TestAccVirtualInterface_basic
--- PASS: TestAccVirtualInterface_basic (184.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dc        184.673s

 make testacc TEST=./huaweicloud/services/acceptance/dc/ TESTARGS='-run TestAccVirtualInterface_gdgw'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dc/ -v -run TestAccVirtualInterface_gdgw -timeout 360m -parallel 4
=== RUN   TestAccVirtualInterface_gdgw
=== PAUSE TestAccVirtualInterface_gdgw
=== CONT  TestAccVirtualInterface_gdgw
--- PASS: TestAccVirtualInterface_gdgw (127.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dc        127.481s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
