### PR TITLE
feat(cae/application): add enterprise_project_id for resource and data source

### DIFF
--- a/docs/data-sources/cae_applications.md
+++ b/docs/data-sources/cae_applications.md
@@ -2,20 +2,37 @@
 subcategory: "Cloud Application Engine (CAE)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_cae_applications"
-description: ""
+description: |-
+  Use this data source to get the list of CAE applications within HuaweiCloud.
 ---
 
 # huaweicloud_cae_applications
 
-Use this data source to get the list of CAE applications.
+Use this data source to get the list of CAE applications within HuaweiCloud.
 
 ## Example Usage
+
+### Query the all applications under the default enterprise project
 
 ```hcl
 variable "environment_id" {}
 
 data "huaweicloud_cae_applications" "test" {
   environment_id = var.environment_id
+}
+```
+
+### Query the application under the specified enterprise project by application ID
+
+```hcl
+variable "environment_id" {}
+variable "application_id" {}
+variable "enterprise_project_id" {}
+
+data "huaweicloud_cae_applications" "filter_by_application_id" {
+  environment_id        = var.environment_id
+  application_id        = var.application_id
+  enterprise_project_id = var.enterprise_project_id
 }
 ```
 
@@ -33,6 +50,11 @@ The following arguments are supported:
 * `name` - (Optional, String) Specifies the name of the application to be queried.
   The name can contain `2` to `64` characters, only lowercase letters, digits, and hyphens (-) allowed.
   The name must start with a lowercase letter and end with lowercase letters and digits.
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the applications
+  belong.  
+  If the `environment_id` belongs to the non-default enterprise project, this parameter is required and is only valid for
+  enterprise users.
 
 ## Attribute Reference
 

--- a/docs/resources/cae_application.md
+++ b/docs/resources/cae_application.md
@@ -38,6 +38,13 @@ The following arguments are supported:
   The name must start with a lowercase letter and end with a lowercase letter or a digit.  
   Changing this creates a new resource.
 
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project to which
+  the application belongs.  
+  Changing this creates a new resource.
+
+  -> This parameter value must be the same as the enterprise project ID of the environment, if it is the default
+     enterprise project ID, it can be omitted. And this parameter is only valid for enterprise users.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -54,4 +61,11 @@ The application can be imported using `environment_id` and `id`, separated by a 
 
 ```bash
 $ terraform import huaweicloud_cae_application.test <environment_id>/<id>
+```
+
+For the application with the `enterprise_project_id`, its enterprise project ID need to be specified additionanlly when
+importing. All fields are separated by slashes (/), e.g.
+
+```bash
+$ terraform import huaweicloud_cae_application.test <environment_id>/<id>/<enterprise_project_id>
 ```

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -77,7 +77,10 @@ var (
 	HW_APIG_DEDICATED_INSTANCE_ID             = os.Getenv("HW_APIG_DEDICATED_INSTANCE_ID")
 	HW_APIG_DEDICATED_INSTANCE_USED_SUBNET_ID = os.Getenv("HW_APIG_DEDICATED_INSTANCE_USED_SUBNET_ID")
 
-	HW_CAE_ENVIRONMENT_ID     = os.Getenv("HW_CAE_ENVIRONMENT_ID")
+	HW_CAE_ENVIRONMENT_ID = os.Getenv("HW_CAE_ENVIRONMENT_ID")
+	// The list of CAE environment IDs. Using commas (,) to separate multiple IDs. At least one ID is required.
+	// The first environment ID belongs to the default enterprise project ID, and the second belongs to non-default.
+	HW_CAE_ENVIRONMENT_IDs    = os.Getenv("HW_CAE_ENVIRONMENT_IDs")
 	HW_CAE_APPLICATION_ID     = os.Getenv("HW_CAE_APPLICATION_ID")
 	HW_CAE_CODE_URL           = os.Getenv("HW_CAE_CODE_URL")
 	HW_CAE_CODE_BRANCH        = os.Getenv("HW_CAE_CODE_BRANCH")
@@ -754,6 +757,15 @@ func TestAccPreCheckMultiAccount(t *testing.T) {
 func TestAccPreCheckCaeEnvironment(t *testing.T) {
 	if HW_CAE_ENVIRONMENT_ID == "" {
 		t.Skip("HW_CAE_ENVIRONMENT_ID must be set for the CAE acceptance test")
+	}
+}
+
+// Before the CAE environment resource is released, temporarily use this environment variables for acceptance tests.
+// lintignore:AT003
+func TestAccPreCheckCaeEnvironmentIds(t *testing.T, min int) {
+	if HW_CAE_ENVIRONMENT_IDs == "" || len(strings.Split(HW_CAE_ENVIRONMENT_IDs, ",")) < min {
+		t.Skipf("At least %d environment IDs must be must be supported during the HW_CAE_ENVIRONMENT_IDs, "+
+			"separated by commas (,).", min)
 	}
 }
 

--- a/huaweicloud/services/acceptance/cae/data_source_huaweicloud_cae_applications_test.go
+++ b/huaweicloud/services/acceptance/cae/data_source_huaweicloud_cae_applications_test.go
@@ -2,6 +2,7 @@ package cae
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -10,42 +11,129 @@ import (
 )
 
 func TestAccDatasourceApplications_basic(t *testing.T) {
-	rName := "data.huaweicloud_cae_applications.test"
-	dc := acceptance.InitDataSourceCheck(rName)
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		resourceName = "data.huaweicloud_cae_applications.test"
+		all          = acceptance.InitDataSourceCheck(resourceName)
+
+		byApplicationId   = "data.huaweicloud_cae_applications.filter_by_application_id"
+		dcByApplicationId = acceptance.InitDataSourceCheck(byApplicationId)
+
+		byName   = "data.huaweicloud_cae_applications.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byEnterpriseProjectId   = "data.huaweicloud_cae_applications.filter_by_enterprise_project_id"
+		dcByEnterpriseProjectId = acceptance.InitDataSourceCheck(byEnterpriseProjectId)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCaeEnvironment(t)
-			acceptance.TestAccPreCheckCaeApplication(t)
+			acceptance.TestAccPreCheckCaeEnvironmentIds(t, 2)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceApplications_basic(),
+				Config: testAccDatasourceApplications_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-
+					all.CheckResourceExists(),
+					resource.TestMatchResourceAttr(resourceName, "applications.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByApplicationId.CheckResourceExists(),
 					resource.TestCheckOutput("application_id_filter_is_useful", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "applications.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "applications.0.name"),
+					resource.TestCheckResourceAttrSet(resourceName, "applications.0.created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "applications.0.updated_at"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					dcByEnterpriseProjectId.CheckResourceExists(),
+					resource.TestCheckOutput("enterprise_project_id_filter_is_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDatasourceApplications_basic() string {
+func testAccDatasourceApplications_base(name string) string {
 	return fmt.Sprintf(`
+locals {
+  env_ids = split(",", "%[1]s")
+}
+
+# Query the enterprise project ID of the environment.
+data "huaweicloud_cae_environments" "test" {
+  environment_id = local.env_ids[1]
+}
+
+# The first application belongs to the default enterprise project.
+# The second application belongs to the non-default enterprise project.
+resource "huaweicloud_cae_application" "test" {
+  count = 2
+
+  environment_id        = local.env_ids[count.index]
+  name                  = "%[2]s${count.index}"
+  enterprise_project_id = count.index == 1 ? try(data.huaweicloud_cae_environments.test.environments[0].annotations.enterprise_project_id,
+  null) : null
+}
+`, acceptance.HW_CAE_ENVIRONMENT_IDs, name)
+}
+
+func testAccDatasourceApplications_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
 data "huaweicloud_cae_applications" "test" {
-  environment_id = "%[1]s"
-  application_id = "%[2]s"
+  environment_id = huaweicloud_cae_application.test[0].environment_id
+}
+
+# Filter by application ID.
+locals {
+  application_id = huaweicloud_cae_application.test[0].id
+}
+
+data "huaweicloud_cae_applications" "filter_by_application_id" {
+  environment_id = huaweicloud_cae_application.test[0].environment_id
+  application_id = local.application_id
 }
 
 locals {
-  application_id_filter_result = [for v in data.huaweicloud_cae_applications.test.applications : v.id == "%[2]s"]
+  application_id_filter_result = [for v in data.huaweicloud_cae_applications.filter_by_application_id.applications[*].id : v == local.application_id]
 }
 
 output "application_id_filter_is_useful" {
-  value = alltrue(local.application_id_filter_result) && length(local.application_id_filter_result) > 0
+  value = length(local.application_id_filter_result) > 0 && alltrue(local.application_id_filter_result)
 }
-`, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID)
+
+# Filter by application name.
+locals {
+  application_name = huaweicloud_cae_application.test[0].name
+}
+
+data "huaweicloud_cae_applications" "filter_by_name" {
+  environment_id = huaweicloud_cae_application.test[0].environment_id
+  name           = local.application_name
+
+  depends_on = [huaweicloud_cae_application.test]
+}
+
+locals {
+  name_filter_result = [for v in data.huaweicloud_cae_applications.filter_by_name.applications[*].name : v == local.application_name]
+}
+
+output "name_filter_is_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by enterprise project ID.	
+data "huaweicloud_cae_applications" "filter_by_enterprise_project_id" {
+  environment_id        = huaweicloud_cae_application.test[1].environment_id
+  enterprise_project_id = huaweicloud_cae_application.test[1].enterprise_project_id
+}
+
+# Only check the enterprise_project_id parameter is valid.
+output "enterprise_project_id_filter_is_useful" {
+  value = length(data.huaweicloud_cae_applications.filter_by_enterprise_project_id.applications) > 0
+}
+`, testAccDatasourceApplications_base(name))
 }

--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_application_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_application_test.go
@@ -19,53 +19,72 @@ func getApplicationFunc(cfg *config.Config, state *terraform.ResourceState) (int
 		return nil, fmt.Errorf("error creating CAE client: %s", err)
 	}
 
-	envId := state.Primary.Attributes["environment_id"]
-	return cae.GetApplicationById(client, envId, state.Primary.ID)
+	return cae.GetApplicationById(
+		client,
+		state.Primary.Attributes["environment_id"],
+		state.Primary.ID,
+		state.Primary.Attributes["enterprise_project_id"],
+	)
 }
 
 func TestAccApplication_basic(t *testing.T) {
 	var (
-		obj interface{}
-
-		resourceName = "huaweicloud_cae_application.test"
-		rc           = acceptance.InitResourceCheck(resourceName, &obj, getApplicationFunc)
-
 		invalidName = "-tf-test-invalid-name"
 		name        = acceptance.RandomAccResourceNameWithDash()
-		baseConfig  = testAccApplication_base(name)
+
+		obj          interface{}
+		resourceName = "huaweicloud_cae_application.test.0"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getApplicationFunc)
+
+		withNotDefaultEpsId   = "huaweicloud_cae_application.test.1"
+		rcWithNotDefaultEpsId = acceptance.InitResourceCheck(withNotDefaultEpsId, &obj, getApplicationFunc)
 	)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCaeEnvironmentIds(t, 2)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccApplication_basic(baseConfig, invalidName),
+				Config:      testAccApplication_basic(invalidName),
 				ExpectError: regexp.MustCompile(`CAE.01500214`),
 			},
 			{
-				Config: testAccApplication_basic(baseConfig, name),
+				Config: testAccApplication_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile(fmt.Sprintf("^%s\\d$", name))),
+					resource.TestCheckNoResourceAttr(resourceName, "enterprise_project_id"),
 					resource.TestMatchResourceAttr(resourceName, "created_at",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 					resource.TestMatchResourceAttr(resourceName, "updated_at",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					rcWithNotDefaultEpsId.CheckResourceExists(),
+					resource.TestMatchResourceAttr(withNotDefaultEpsId, "name", regexp.MustCompile(fmt.Sprintf("^%s\\d$", name))),
+					resource.TestCheckResourceAttrPair(withNotDefaultEpsId, "enterprise_project_id",
+						"data.huaweicloud_cae_environments.test", "environments.0.annotations.enterprise_project_id"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      "huaweicloud_cae_application.test[0]",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccApplicationImportStateFunc(resourceName),
+				ImportStateIdFunc: testAccApplicationImportStateFunc(resourceName, false),
+			},
+			{
+				ResourceName:      "huaweicloud_cae_application.test[1]",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApplicationImportStateFunc(withNotDefaultEpsId, true),
 			},
 		},
 	})
 }
 
-func testAccApplicationImportStateFunc(rsName string) resource.ImportStateIdFunc {
+func testAccApplicationImportStateFunc(rsName string, isNotDefaultEpsId bool) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[rsName]
 		if !ok {
@@ -81,57 +100,37 @@ func testAccApplicationImportStateFunc(rsName string) resource.ImportStateIdFunc
 				environmentId, applicationId)
 		}
 
+		if isNotDefaultEpsId {
+			epsId := rs.Primary.Attributes["enterprise_project_id"]
+			if epsId == "" {
+				return "", fmt.Errorf("some import IDs are missing, want '<environment_id>/<id>/<enterprise_project_id>', but got '%s/%s/%s'",
+					environmentId, applicationId, epsId)
+			}
+			return fmt.Sprintf("%s/%s/%s", environmentId, applicationId, epsId), nil
+		}
+
 		return fmt.Sprintf("%s/%s", environmentId, applicationId), nil
 	}
 }
 
-func testAccApplication_base(name string) string {
+func testAccApplication_basic(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_vpc" "test" {
-  name = "%[1]s"
-  cidr = "192.168.0.0/16"
+locals {
+  env_ids = split(",", "%[1]s")
 }
 
-resource "huaweicloud_vpc_subnet" "test" {
-  vpc_id     = huaweicloud_vpc.test.id
-  name       = "%[1]s"
-  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1)
-  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1), 1)
+# Query by environment ID under non-default enterprise project ID.
+data "huaweicloud_cae_environments" "test" {
+  environment_id = local.env_ids[1]
 }
-
-resource "huaweicloud_networking_secgroup" "test" {
-  name                 = "%[1]s"
-  delete_default_rules = true
-}
-
-resource "huaweicloud_swr_organization" "test" {
-  name = "%[1]s"
-}
-
-resource "huaweicloud_cae_environment" "test" {
-  name = "%[1]s"
-
-  annotations = {
-    type              = "exclusive"
-    vpc_id            = huaweicloud_vpc.test.id
-    subnet_id         = huaweicloud_vpc_subnet.test.id
-    security_group_id = huaweicloud_networking_secgroup.test.id
-    group_name        = huaweicloud_swr_organization.test.name
-  }
-
-  // To avoid k8s container deploy failed.
-  max_retries = 1
-}
-`, name)
-}
-
-func testAccApplication_basic(baseConfig, name string) string {
-	return fmt.Sprintf(`
-%[1]s
 
 resource "huaweicloud_cae_application" "test" {
-  environment_id = huaweicloud_cae_environment.test.id
-  name           = "%[2]s"
+  count = 2
+
+  environment_id        = local.env_ids[count.index]
+  name                  = "%[2]s${count.index}"
+  enterprise_project_id = count.index == 1 ? try(data.huaweicloud_cae_environments.test.environments[0].annotations.enterprise_project_id,
+  null) : null
 }
-`, baseConfig, name)
+`, acceptance.HW_CAE_ENVIRONMENT_IDs, name)
 }

--- a/huaweicloud/services/cae/common.go
+++ b/huaweicloud/services/cae/common.go
@@ -22,3 +22,15 @@ func marshalJsonFormatParamster(paramName, paramVal interface{}) interface{} {
 	}
 	return string(jsonDetail)
 }
+
+func buildRequestMoreHeaders(envId, epsId string) map[string]string {
+	moreHeaders := map[string]string{
+		"Content-Type":     "application/json",
+		"X-Environment-ID": envId,
+	}
+	if epsId != "" {
+		moreHeaders["X-Enterprise-Project-ID"] = epsId
+	}
+
+	return moreHeaders
+}

--- a/huaweicloud/services/cae/data_source_huaweicloud_cae_applications.go
+++ b/huaweicloud/services/cae/data_source_huaweicloud_cae_applications.go
@@ -39,7 +39,11 @@ func DataSourceApplications() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the enterprise project to which the applications belong.",
+			},
 			// attributes
 			"applications": {
 				Type:     schema.TypeList,
@@ -94,7 +98,7 @@ func dataSourceApplicationRead(_ context.Context, d *schema.ResourceData, meta i
 	listApplicationsPath = strings.ReplaceAll(listApplicationsPath, "{project_id}", listApplicationsClient.ProjectID)
 	listApplicationOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"X-Environment-ID": d.Get("environment_id").(string)},
+		MoreHeaders:      buildRequestMoreHeaders(d.Get("environment_id").(string), cfg.GetEnterpriseProjectID(d)),
 	}
 
 	listApplicationsResp, err := listApplicationsClient.Request("GET", listApplicationsPath, &listApplicationOpt)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add `enterprise_project_id` parameter for resource and data source, and add the enterprise project ID to the request header of all interfaces.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o cae -f TestAccApplication_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccApplication_basic -timeout 360m -parallel 10
=== RUN   TestAccApplication_basic
=== PAUSE TestAccApplication_basic
=== CONT  TestAccApplication_basic
--- PASS: TestAccApplication_basic (22.26s)
PASS
coverage: 9.5% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       22.516s coverage: 9.5% of statements in ./huaweicloud/services/cae
```

```
./scripts/coverage.sh -o cae -f TestAccDatasourceApplications_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccDatasourceApplications_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourceApplications_basic
=== PAUSE TestAccDatasourceApplications_basic
=== CONT  TestAccDatasourceApplications_basic
--- PASS: TestAccDatasourceApplications_basic (14.31s)
PASS
coverage: 11.4% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       14.438s coverage: 11.4% of statements in ./huaweicloud/services/cae
```

<img width="1360" height="890" alt="image" src="https://github.com/user-attachments/assets/a774ee19-bd71-4800-b18b-5d11934e6ed5" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
