### PR TITLE
feat(antiddos): new datasource to query quota

### DIFF
--- a/docs/data-sources/antiddos_quota.md
+++ b/docs/data-sources/antiddos_quota.md
@@ -1,0 +1,34 @@
+---
+subcategory: "Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_antiddos_quota"
+description: |-
+  Use this data source to query the quota information of Anti-DDoS service.
+---
+
+# huaweicloud_antiddos_quota
+
+Use this data source to query the quota information of Anti-DDoS service.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_antiddos_quota" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `current` - The current used quota.
+
+* `quota` - The maximum quota limit.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -488,6 +488,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_antiddosv2_eip_defense_statuses":       antiddos.DataSourceEipDefenseStatusesV2(),
 			"huaweicloud_antiddos_eip_protection_traffic":       antiddos.DataSourceEipProtectionTraffic(),
 			"huaweicloud_antiddos_eip_exception_events":         antiddos.DataSourceEipExceptionEvents(),
+			"huaweicloud_antiddos_quota":                        antiddos.DataSourceAntiDdosQuota(),
 
 			"huaweicloud_aom_access_codes":                    aom.DataSourceAomAccessCodes(),
 			"huaweicloud_aom_cloud_service_authorizations":    aom.DataSourceCloudServiceAuthorizations(),

--- a/huaweicloud/services/acceptance/antiddos/data_source_huaweicloud_antiddos_quota_test.go
+++ b/huaweicloud/services/acceptance/antiddos/data_source_huaweicloud_antiddos_quota_test.go
@@ -1,0 +1,37 @@
+package antiddos_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAntiDdosQuota_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_antiddos_quota.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAntiDdosQuota_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "current"),
+					resource.TestCheckResourceAttrSet(dataSource, "quota"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceAntiDdosQuota_basic = `
+data "huaweicloud_antiddos_quota" "test" {}
+`

--- a/huaweicloud/services/antiddos/data_source_huaweicloud_antiddos_quota.go
+++ b/huaweicloud/services/antiddos/data_source_huaweicloud_antiddos_quota.go
@@ -1,0 +1,88 @@
+package antiddos
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ANTI-DDOS GET /v1/{project_id}/antiddos/quotas
+func DataSourceAntiDdosQuota() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAntiDdosQuotaRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"current": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The current used quota.`,
+			},
+			"quota": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The maximum quota limit.`,
+			},
+		},
+	}
+}
+
+func dataSourceAntiDdosQuotaRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/antiddos/quotas"
+		product = "anti-ddos"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Anti-DDoS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving Anti-DDoS quota: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("current", utils.PathSearch("ddos_quota.current", respBody, nil)),
+		d.Set("quota", utils.PathSearch("ddos_quota.quota", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query quota.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o antiddos -f TestAccDataSourceAntiDdosQuota_basic        
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/antiddos" -v -coverprofile="./huaweicloud/services/acceptance/antiddos/antiddos_coverage.cov" -coverpkg="./huaweicloud/services/antiddos" -run TestAccDataSourceAntiDdosQuota_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAntiDdosQuota_basic
=== PAUSE TestAccDataSourceAntiDdosQuota_basic
=== CONT  TestAccDataSourceAntiDdosQuota_basic
--- PASS: TestAccDataSourceAntiDdosQuota_basic (12.53s)
PASS
coverage: 5.0% of statements in ./huaweicloud/services/antiddos
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/antiddos  12.610s coverage: 5.0% of statements in ./huaweicloud/services/antiddos
```
<img width="1335" height="83" alt="image" src="https://github.com/user-attachments/assets/1f48d603-2c88-4ea1-b2d5-cd4548b3cb08" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
