### PR TITLE
feat(aad): support `aad_domain_certificate` resource

### DIFF
--- a/docs/resources/aad_domain_certificate.md
+++ b/docs/resources/aad_domain_certificate.md
@@ -1,0 +1,99 @@
+---
+subcategory: "Advanced Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aad_domain_certificate"
+description: |-
+  Manages an AAD domain certificate resource within HuaweiCloud.
+---
+
+# huaweicloud_aad_domain_certificate
+
+Manages an AAD domain certificate resource within HuaweiCloud.
+
+-> This resource is a one-time action resource using to upload the certificate corresponding to the domain. Deleting
+   this resource will not change the current request record, but will only remove the resource information from the tf
+   state file.
+
+## Example Usage
+
+```hcl
+variable "domain_id" {}
+variable "cert_name" {}
+
+resource "huaweicloud_aad_domain_certificate" "test" {
+  domain_id = var.domain_id
+  op_type   = 1
+  cert_name = var.cert_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_id` - (Required, String, NonUpdatable) Specifies the domain ID.
+
+* `op_type` - (Required, Int, NonUpdatable) Specifies the operation type.  
+  The valid values are as follows:
+  + **0**: Upload new certificate.
+  + **1**: Replace with existing certificate.
+
+* `cert_name` - (Required, String, NonUpdatable) Specifies the certificate name.
+
+* `cert_file` - (Optional, String, NonUpdatable) Specifies the certificate file content.  
+  + Required when `op_type` is `0` (Required when uploading a new certificate).
+  + Set empty when `op_type` is `1` (Empty when replacing with an existing certificate).
+
+* `cert_key_file` - (Optional, String, NonUpdatable) Specifies the private key file content.  
+  + Required when `op_type` is `0` (Required when uploading a new certificate).
+  + Set empty when `op_type` is `1` (Empty when replacing with an existing certificate).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which is also the domain ID.
+
+* `domain_name` - The domain name.
+
+* `cert_info` - The certificate information.  
+  The [cert_info](#cert_info_struct) structure is documented below.
+
+<a name="cert_info_struct"></a>
+The `cert_info` block supports:
+
+* `cert_name` - The certificate name.
+
+* `id` - The certificate ID.
+
+* `apply_domain` - The applicable domain.
+
+* `expire_time` - The expiration time.
+
+* `expire_status` - The expiration status.
+
+## Import
+
+The AAD domain certificate can be imported using the `domain_id`, e.g.
+
+```bash
+terraform import huaweicloud_aad_domain_certificate.test <domain_id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include: `op_type`, `cert_file`, and `cert_key_file`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_aad_domain_certificate" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      op_type, cert_file, cert_key_file,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1874,6 +1874,7 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 
 			"huaweicloud_aad_domain":                     aad.ResourceDomain(),
+			"huaweicloud_aad_domain_certificate":         aad.ResourceDomainCertificate(),
 			"huaweicloud_aad_forward_rule":               aad.ResourceForwardRule(),
 			"huaweicloud_aad_black_white_list":           aad.ResourceBlackWhiteList(),
 			"huaweicloud_aad_change_specification":       aad.ResourceChangeSpecification(),

--- a/huaweicloud/services/aad/resource_huaweicloud_aad_domain_certificate.go
+++ b/huaweicloud/services/aad/resource_huaweicloud_aad_domain_certificate.go
@@ -1,0 +1,240 @@
+package aad
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var domainCertificateNonUpdatableParams = []string{
+	"domain_id",
+	"op_type",
+	"cert_name",
+	"cert_file",
+	"cert_key_file",
+}
+
+// Due to limited testing conditions, the API in the creation method of this resource was not successfully called.
+
+// @API AAD POST /v1/{project_id}/aad/external/domains/certificate
+// @API AAD GET /v2/aad/domains/{domain_id}/certificate
+func ResourceDomainCertificate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDomainCertificateCreate,
+		ReadContext:   resourceDomainCertificateRead,
+		UpdateContext: resourceDomainCertificateUpdate,
+		DeleteContext: resourceDomainCertificateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(domainCertificateNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"domain_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the domain ID.",
+			},
+			"op_type": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "Specifies the operation type. `0` represents upload, `1` represents replace.",
+			},
+			"cert_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the certificate name.",
+			},
+			"cert_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the certificate file content.",
+			},
+			"cert_key_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the private key file content.",
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"domain_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The domain name.",
+			},
+			"cert_info": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The certificate information.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cert_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Specifies the certificate name.",
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The certificate ID.",
+						},
+						"apply_domain": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The applicable domain.",
+						},
+						"expire_time": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The expiration time.",
+						},
+						"expire_status": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The expiration status.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildDomainCertificateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"domain_id":     d.Get("domain_id"),
+		"op_type":       d.Get("op_type"),
+		"cert_name":     d.Get("cert_name"),
+		"cert_file":     utils.ValueIgnoreEmpty(d.Get("cert_file")),
+		"cert_key_file": utils.ValueIgnoreEmpty(d.Get("cert_key_file")),
+	}
+}
+
+func resourceDomainCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+		httpUrl = "v1/{project_id}/aad/external/domains/certificate"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildDomainCertificateBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating AAD domain certificate: %s", err)
+	}
+
+	d.SetId(d.Get("domain_id").(string))
+
+	return resourceDomainCertificateRead(ctx, d, meta)
+}
+
+func resourceDomainCertificateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+		httpUrl = "v2/aad/domains/{domain_id}/certificate"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{domain_id}", d.Id())
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		// When the `domain_id` does not exist, the API returns 400 and errCode is **AAD.50010037**, which needs to be
+		// handled as 404 to be handled by CheckDeletedDiag.
+		convertedErr := common.ConvertExpected400ErrInto404Err(err, "errCode", "AAD.50010037")
+		return common.CheckDeletedDiag(d, convertedErr, "error retrieving AAD domain certificate")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	certInfo := utils.PathSearch("cert_info", getRespBody, nil)
+
+	mErr := multierror.Append(
+		d.Set("domain_id", utils.PathSearch("domain_id", getRespBody, nil)),
+		d.Set("cert_name", utils.PathSearch("cert_name", certInfo, nil)),
+		d.Set("domain_name", utils.PathSearch("domain_name", getRespBody, nil)),
+		d.Set("cert_info", flattenDomainCertificateInfo(certInfo)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDomainCertificateInfo(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"cert_name":     utils.PathSearch("cert_name", resp, nil),
+			"id":            utils.PathSearch("id", resp, nil),
+			"apply_domain":  utils.PathSearch("apply_domain", resp, nil),
+			"expire_time":   utils.PathSearch("expire_time", resp, nil),
+			"expire_status": utils.PathSearch("expire_status", resp, nil),
+		},
+	}
+}
+
+func resourceDomainCertificateUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDomainCertificateDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to upload domain certificate. Deleting this resource
+    will not change the current request record, but will only remove the resource information from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}

--- a/huaweicloud/services/acceptance/aad/resource_huaweicloud_aad_domain_certificate_test.go
+++ b/huaweicloud/services/acceptance/aad/resource_huaweicloud_aad_domain_certificate_test.go
@@ -1,0 +1,39 @@
+package antiddos
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Note: Due to the lack of a test environment, this test case only verifies the expected error message.
+func TestAccAadDomainCertificate_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAadDomainID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testDomainCertificate_basic(),
+				ExpectError: regexp.MustCompile(`证书不存在。`),
+			},
+		},
+	})
+}
+
+func testDomainCertificate_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_aad_domain_certificate" "test" {
+  domain_id = "%[1]s"
+  op_type   = 1
+  cert_name = "test_cert_name"
+}
+`, acceptance.HW_AAD_DOMAIN_ID)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `aad_domain_certificate` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `aad_domain_certificate` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/aad" TESTARGS="-run TestAccAadDomainCertificate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aad -v -run TestAccAadDomainCertificate_basic -timeout 360m -parallel 4
=== RUN   TestAccAadDomainCertificate_basic
=== PAUSE TestAccAadDomainCertificate_basic
=== CONT  TestAccAadDomainCertificate_basic
--- PASS: TestAccAadDomainCertificate_basic (4.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aad       4.822s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
