### PR TITLE
feat(cae): add enterprise_project_id parameter for some resources

### DIFF
--- a/docs/resources/cae_certificate.md
+++ b/docs/resources/cae_certificate.md
@@ -49,6 +49,13 @@ The following arguments are supported:
 * `key` - (Required, String) Specifies the private key of the certificate.  
   Base64 format corresponding to PEM encoding.
 
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project to which the
+  certificate belongs.  
+  Changing this creates a new resource.
+
+-> If the `environment_id` belongs to the non-default enterprise project, this parameter is required and is only valid
+   for enterprise users.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -63,4 +70,11 @@ The certificate resource can be imported using `environment_id` and `name`, sepa
 
 ```bash
 $ terraform import huaweicloud_cae_certificate.test <environment_id>/<name>
+```
+
+For the certificate with a non-default enterprise project ID, its enterprise project ID need to be specified
+additionanlly when importing. All fields are separated by slashes (/), e.g.
+
+```bash
+$ terraform import huaweicloud_cae_certificate.test <environment_id>/<name>/<enterprise_project_id>
 ```

--- a/docs/resources/cae_domain.md
+++ b/docs/resources/cae_domain.md
@@ -39,6 +39,13 @@ The following arguments are supported:
   The domain name consists of multiple strings separated by dots (.), and the maximum length of a single string is `63` characters.
   Only letters, digits, and hyphens (-) allowed, and must start with a letter or a digit.
 
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project to which the
+  domain name belongs.  
+  Changing this creates a new resource.
+
+-> If the `environment_id` belongs to the non-default enterprise project, this parameter is required and is
+   only valid for enterprise users.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -53,4 +60,11 @@ The resource can be imported using `environment_id` and `name`, separated by a s
 
 ```bash
 $ terraform import huaweicloud_cae_domain.test <environment_id>/<name>
+```
+
+For the domain with the non-default enterprise project ID, its enterprise project ID need to be specified
+additionanlly when importing. All fields are separated by slashes (/), e.g.
+
+```bash
+$ terraform import huaweicloud_cae_domain.test <environment_id>/<name>/<enterprise_project_id>
 ```

--- a/docs/resources/cae_timer_rule.md
+++ b/docs/resources/cae_timer_rule.md
@@ -91,6 +91,13 @@ The following arguments are supported:
   The [components](#timer_rule_components) structure is documented below.  
   This parameter is required and available only when the `effective_range` parameter is set to **component**.
 
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project to which the
+  timer rule belongs.  
+  Changing this creates a new resource.
+
+-> If the `environment_id` belongs to the non-default enterprise project, this parameter is required and is
+   only valid for enterprise users.
+
 <a name="timer_rule_applications"></a>
 The `applications` block supports:
 
@@ -117,6 +124,13 @@ The resource can be imported using `environment_id` and `name`, separated by a s
 
 ```bash
 $ terraform import huaweicloud_cae_timer_rule.test <environment_id>/<name>
+```
+
+For the timer rule with the non-default enterprise project ID, its enterprise project ID need to be specified
+additionanlly when importing. All fields are separated by slashes (/), e.g.
+
+```bash
+$ terraform import huaweicloud_cae_timer_rule.test <environment_id>/<name>/<enterprise_project_id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the

--- a/docs/resources/cae_vpc_egress.md
+++ b/docs/resources/cae_vpc_egress.md
@@ -43,6 +43,13 @@ The following arguments are supported:
   to which the CAE environment belongs.  
   Changing this creates a new resource.
 
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project to which the
+  VPC egress belongs.  
+  Changing this creates a new resource.
+
+-> If the `environment_id` belongs to the non-default enterprise project, this parameter is required and is only valid
+  for enterprise users.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -55,4 +62,11 @@ The resource can be imported using `environment_id`, `route_table_id`, and `cidr
 
 ```bash
 $ terraform import huaweicloud_cae_vpc_egress.test <environment_id>,<route_table_id>,<cidr>
+```
+
+For the VPC egress with the non-default enterprise project ID, its enterprise project ID need to be specified
+additionanlly when importing. All fields are separated by commas (,), e.g.
+
+```bash
+$ terraform import huaweicloud_cae_vpc_egress.test <environment_id>,<route_table_id>,<cidr>,<enterprise_project_id>
 ```

--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_certificate_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_certificate_test.go
@@ -17,29 +17,30 @@ func getCertificateFunc(cfg *config.Config, state *terraform.ResourceState) (int
 	if err != nil {
 		return nil, fmt.Errorf("error creating CAE client: %s", err)
 	}
-
-	environmentId := state.Primary.Attributes["environment_id"]
-	return cae.GetCertificateById(client, environmentId, state.Primary.ID)
+	return cae.GetCertificateById(
+		client,
+		state.Primary.Attributes["environment_id"],
+		state.Primary.ID,
+		state.Primary.Attributes["enterprise_project_id"],
+	)
 }
 
 func TestAccCertificate_basic(t *testing.T) {
 	var (
-		obj interface{}
-
 		name = acceptance.RandomAccResourceNameWithDash()
 
-		rName = "huaweicloud_cae_certificate.test"
-		rc    = acceptance.InitResourceCheck(
-			rName,
-			&obj,
-			getCertificateFunc,
-		)
+		certificate interface{}
+		rName       = "huaweicloud_cae_certificate.test.0"
+		rc          = acceptance.InitResourceCheck(rName, &certificate, getCertificateFunc)
+
+		withNotDefaultEpsId   = "huaweicloud_cae_certificate.test.1"
+		rcWithNotDefaultEpsId = acceptance.InitResourceCheck(withNotDefaultEpsId, &certificate, getCertificateFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCaeEnvironment(t)
+			acceptance.TestAccPreCheckCaeEnvironmentIds(t, 2)
 			acceptance.TestAccPreCheckCertificateWithoutRootCA(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
@@ -49,10 +50,18 @@ func TestAccCertificate_basic(t *testing.T) {
 				Config: testAccCertificate_basic(name, acceptance.HW_CERTIFICATE_CONTENT, acceptance.HW_CERTIFICATE_PRIVATE_KEY),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "environment_id", acceptance.HW_CAE_ENVIRONMENT_ID),
-					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrSet(rName, "environment_id"),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s0", name)),
 					resource.TestCheckResourceAttr(rName, "crt", acceptance.HW_CERTIFICATE_CONTENT),
 					resource.TestCheckResourceAttr(rName, "key", acceptance.HW_CERTIFICATE_PRIVATE_KEY),
+					resource.TestCheckNoResourceAttr(rName, "enterprise_project_id"),
+					rcWithNotDefaultEpsId.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(withNotDefaultEpsId, "environment_id"),
+					resource.TestCheckResourceAttr(withNotDefaultEpsId, "name", fmt.Sprintf("%s1", name)),
+					resource.TestCheckResourceAttr(withNotDefaultEpsId, "crt", acceptance.HW_CERTIFICATE_CONTENT),
+					resource.TestCheckResourceAttr(withNotDefaultEpsId, "key", acceptance.HW_CERTIFICATE_PRIVATE_KEY),
+					resource.TestCheckResourceAttrPair(withNotDefaultEpsId, "enterprise_project_id",
+						"data.huaweicloud_cae_environments.test", "environments.0.annotations.enterprise_project_id"),
 				),
 			},
 			{
@@ -61,13 +70,22 @@ func TestAccCertificate_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "crt", acceptance.HW_NEW_CERTIFICATE_CONTENT),
 					resource.TestCheckResourceAttr(rName, "key", acceptance.HW_NEW_CERTIFICATE_PRIVATE_KEY),
+					rcWithNotDefaultEpsId.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withNotDefaultEpsId, "crt", acceptance.HW_NEW_CERTIFICATE_CONTENT),
+					resource.TestCheckResourceAttr(withNotDefaultEpsId, "key", acceptance.HW_NEW_CERTIFICATE_PRIVATE_KEY),
 				),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:      "huaweicloud_cae_certificate.test[0]",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccCertificateImportStateFunc(rName),
+				ImportStateIdFunc: testAccCertificateImportStateFunc(rName, true),
+			},
+			{
+				ResourceName:      "huaweicloud_cae_certificate.test[1]",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCertificateImportStateFunc(withNotDefaultEpsId, false),
 			},
 		},
 	})
@@ -75,19 +93,30 @@ func TestAccCertificate_basic(t *testing.T) {
 
 func testAccCertificate_basic(name, content, privateKey string) string {
 	return fmt.Sprintf(`
+locals {
+  env_ids = split(",", "%[1]s")
+}
+
+data "huaweicloud_cae_environments" "test" {
+  environment_id = local.env_ids[1]
+}
 
 resource "huaweicloud_cae_certificate" "test" {
-  environment_id = "%[1]s"
-  name           = "%[2]s"
+  count = 2
+
+  environment_id        = local.env_ids[count.index]
+  name                  = "%[2]s${count.index}"
+  enterprise_project_id = count.index == 1 ? try(data.huaweicloud_cae_environments.test.environments[0].annotations.enterprise_project_id,
+  null) : null
 
   # Base64 format corresponding to PEM encoding.
   crt = "%[3]s"
   key = "%[4]s"
 }
- `, acceptance.HW_CAE_ENVIRONMENT_ID, name, content, privateKey)
+ `, acceptance.HW_CAE_ENVIRONMENT_IDS, name, content, privateKey)
 }
 
-func testAccCertificateImportStateFunc(name string) resource.ImportStateIdFunc {
+func testAccCertificateImportStateFunc(name string, isDefaultEpsId bool) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -98,11 +127,21 @@ func testAccCertificateImportStateFunc(name string) resource.ImportStateIdFunc {
 			environmentId   = rs.Primary.Attributes["environment_id"]
 			certificateName = rs.Primary.Attributes["name"]
 		)
+
 		if environmentId == "" || certificateName == "" {
-			return "", fmt.Errorf("some import IDs are missing, want '<environment_id>/<name>', but got '%s/%s'",
-				environmentId, certificateName)
+			return "", fmt.Errorf("some import IDs are missing, want '<environment_id>/<name>' or "+
+				"'<environment_id>/<name>/<enterprise_project_id>', but got '%s/%s'", environmentId, certificateName)
 		}
 
-		return fmt.Sprintf("%s/%s", environmentId, certificateName), nil
+		if isDefaultEpsId {
+			return fmt.Sprintf("%s/%s", environmentId, certificateName), nil
+		}
+
+		epsId := rs.Primary.Attributes["enterprise_project_id"]
+		if epsId == "" {
+			return "", fmt.Errorf("some import IDs are missing, want '<environment_id>/<id>/<enterprise_project_id>', but got '%s/%s/%s'",
+				environmentId, certificateName, epsId)
+		}
+		return fmt.Sprintf("%s/%s/%s", environmentId, certificateName, epsId), nil
 	}
 }

--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_domain_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_domain_test.go
@@ -19,73 +19,112 @@ func getResourceDomainFunc(cfg *config.Config, state *terraform.ResourceState) (
 		return nil, fmt.Errorf("error creating CAE client: %s", err)
 	}
 
-	return cae.GetDomainById(client, state.Primary.Attributes["environment_id"], state.Primary.ID)
+	return cae.GetDomainById(
+		client,
+		state.Primary.Attributes["environment_id"],
+		state.Primary.ID,
+		state.Primary.Attributes["enterprise_project_id"],
+	)
 }
 
 func TestAccResourceDomain_basic(t *testing.T) {
 	var (
-		obj interface{}
+		domainName        = fmt.Sprintf("%s.com", acceptance.RandomAccResourceNameWithDash())
+		domainNameWithEps = fmt.Sprintf("%s.com", acceptance.RandomAccResourceNameWithDash())
 
-		domainName = fmt.Sprintf("%s.com", acceptance.RandomAccResourceNameWithDash())
+		domainObj interface{}
+		rName     = "huaweicloud_cae_domain.test.0"
+		rc        = acceptance.InitResourceCheck(rName, &domainObj, getResourceDomainFunc)
 
-		rName = "huaweicloud_cae_domain.test"
-		rc    = acceptance.InitResourceCheck(rName, &obj, getResourceDomainFunc)
+		nameWithSpecifiedEps = "huaweicloud_cae_domain.test.1"
+		rcWithSpecifiedEps   = acceptance.InitResourceCheck(nameWithSpecifiedEps, &domainObj, getResourceDomainFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCaeEnvironment(t)
+			acceptance.TestAccPreCheckCaeEnvironmentIds(t, 2)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rc.CheckResourceDestroy(),
+			rcWithSpecifiedEps.CheckResourceDestroy(),
+		),
 
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceDomain_basic(domainName),
+				Config: testAccResourceDomain_basic(domainName, domainNameWithEps),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "environment_id", acceptance.HW_CAE_ENVIRONMENT_ID),
+					resource.TestCheckResourceAttrSet(rName, "environment_id"),
 					resource.TestCheckResourceAttr(rName, "name", domainName),
 					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckNoResourceAttr(rName, "enterprise_project_id"),
+					rcWithSpecifiedEps.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(nameWithSpecifiedEps, "environment_id"),
+					resource.TestCheckResourceAttr(nameWithSpecifiedEps, "name", domainNameWithEps),
+					resource.TestCheckResourceAttrPair(nameWithSpecifiedEps, "enterprise_project_id",
+						"data.huaweicloud_cae_environments.test", "environments.0.annotations.enterprise_project_id"),
+					resource.TestMatchResourceAttr(nameWithSpecifiedEps, "created_at",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
 			{
-				Config:      testAccResourceDomain_existed(domainName),
+				Config:      testAccResourceDomain_existed(domainName, domainNameWithEps),
 				ExpectError: regexp.MustCompile(`the domain has already existed`),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:      "huaweicloud_cae_domain.test[0]",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccDomainImportFunc(rName),
+				ImportStateIdFunc: testAccDomainImportFunc(rName, true),
+			},
+			{
+				ResourceName:      "huaweicloud_cae_domain.test[1]",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccDomainImportFunc(nameWithSpecifiedEps, false),
 			},
 		},
 	})
 }
 
-func testAccResourceDomain_basic(domainName string) string {
+func testAccResourceDomain_basic(domainName, domainNameWithEps string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_cae_domain" "test" {
-  environment_id = "%[1]s"
-  name           = "%[2]s"
-}
-`, acceptance.HW_CAE_ENVIRONMENT_ID, domainName)
+locals {
+  env_ids = split(",", "%[1]s")
 }
 
-func testAccResourceDomain_existed(domainName string) string {
+data "huaweicloud_cae_environments" "test" {
+  environment_id = local.env_ids[1]
+}
+
+# Create two domains, the first one belonging to the default enterprise project and the second one belonging to the
+# specified enterprise project.
+resource "huaweicloud_cae_domain" "test" {
+  count = 2
+
+  environment_id        = local.env_ids[count.index]
+  name                  = count.index == 0 ? "%[2]s" : "%[3]s"
+  enterprise_project_id = count.index == 1 ? try(data.huaweicloud_cae_environments.test.environments[0].annotations.enterprise_project_id,
+  null) : null
+}
+`, acceptance.HW_CAE_ENVIRONMENT_IDS, domainName, domainNameWithEps)
+}
+
+func testAccResourceDomain_existed(domainName, domainNameWithEps string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_cae_domain" "test2" {
-  environment_id = "%[2]s"
-  name           = "%[3]s"
+  environment_id = local.env_ids[0]
+  name           = "%[2]s"
 }
-`, testAccResourceDomain_basic(domainName), acceptance.HW_CAE_ENVIRONMENT_ID, domainName)
+`, testAccResourceDomain_basic(domainName, domainNameWithEps), domainName)
 }
 
-func testAccDomainImportFunc(name string) resource.ImportStateIdFunc {
+func testAccDomainImportFunc(name string, isDefaultEps bool) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -96,11 +135,23 @@ func testAccDomainImportFunc(name string) resource.ImportStateIdFunc {
 			environmentId = rs.Primary.Attributes["environment_id"]
 			domainName    = rs.Primary.Attributes["name"]
 		)
+
 		if environmentId == "" || domainName == "" {
-			return "", fmt.Errorf("some import IDs are missing, want '<environment_id>/<name>', but got '%s/%s'",
+			return "", fmt.Errorf("some import IDs are missing, want '<environment_id>/<name>' or "+
+				"'<environment_id>/<name>/<enterprise_project_id>', but got '%s/%s'",
 				environmentId, domainName)
 		}
 
-		return fmt.Sprintf("%s/%s", environmentId, domainName), nil
+		if isDefaultEps {
+			return fmt.Sprintf("%s/%s", environmentId, domainName), nil
+		}
+
+		epsId := rs.Primary.Attributes["enterprise_project_id"]
+		if epsId == "" {
+			return "", fmt.Errorf("enterprise_project_id is missing, want '<environment_id>/<name>/<enterprise_project_id>', "+
+				"but got '%s/%s'", environmentId, domainName)
+		}
+
+		return fmt.Sprintf("%s/%s/%s", environmentId, domainName, epsId), nil
 	}
 }

--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_vpc_egress_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_vpc_egress_test.go
@@ -2,6 +2,7 @@ package cae
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -18,46 +19,64 @@ func getVpcEgressFunc(cfg *config.Config, state *terraform.ResourceState) (inter
 		return nil, fmt.Errorf("error creating CAE client: %s", err)
 	}
 
-	environmentId := state.Primary.Attributes["environment_id"]
-	return cae.GetVpcEgressById(client, environmentId, state.Primary.ID)
+	return cae.GetVpcEgressById(
+		client,
+		state.Primary.Attributes["environment_id"],
+		state.Primary.ID,
+		state.Primary.Attributes["enterprise_project_id"],
+	)
 }
 
 func TestAccVpcEgress_basic(t *testing.T) {
 	var (
-		obj interface{}
-
 		name = acceptance.RandomAccResourceName()
 
-		rName = "huaweicloud_cae_vpc_egress.test"
-		rc    = acceptance.InitResourceCheck(
-			rName,
-			&obj,
-			getVpcEgressFunc,
-		)
+		vpcEgress interface{}
+		rName     = "huaweicloud_cae_vpc_egress.test.0"
+		rc        = acceptance.InitResourceCheck(rName, &vpcEgress, getVpcEgressFunc)
+
+		nameWithSpecifiedEps = "huaweicloud_cae_vpc_egress.test.1"
+		rcWithSpecifiedEps   = acceptance.InitResourceCheck(nameWithSpecifiedEps, &vpcEgress, getVpcEgressFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCaeEnvironment(t)
+			acceptance.TestAccPreCheckCaeEnvironmentIds(t, 2)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rc.CheckResourceDestroy(),
+			rcWithSpecifiedEps.CheckResourceDestroy(),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcEgress_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "environment_id", acceptance.HW_CAE_ENVIRONMENT_ID),
-					resource.TestCheckResourceAttrPair(rName, "route_table_id", "huaweicloud_vpc_route_table.test", "id"),
-					resource.TestCheckResourceAttrPair(rName, "cidr", "huaweicloud_vpc_route_table.test", "route.0.destination"),
+					resource.TestCheckResourceAttrSet(rName, "environment_id"),
+					resource.TestCheckResourceAttrPair(rName, "route_table_id", "huaweicloud_vpc_route_table.test.0", "id"),
+					resource.TestCheckResourceAttrPair(rName, "cidr", "huaweicloud_vpc_route_table.test.0", "route.0.destination"),
+					resource.TestCheckNoResourceAttr(rName, "enterprise_project_id"),
+					rcWithSpecifiedEps.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(nameWithSpecifiedEps, "environment_id"),
+					resource.TestCheckResourceAttrPair(nameWithSpecifiedEps, "route_table_id", "huaweicloud_vpc_route_table.test.1", "id"),
+					resource.TestCheckResourceAttrPair(nameWithSpecifiedEps, "cidr", "huaweicloud_vpc_route_table.test.1", "route.0.destination"),
+					resource.TestCheckResourceAttrPair(nameWithSpecifiedEps, "enterprise_project_id",
+						"data.huaweicloud_cae_environments.test.1", "environments.0.annotations.enterprise_project_id"),
 				),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:      "huaweicloud_cae_vpc_egress.test[0]",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccVpcEgressImportStateFunc(rName),
+				ImportStateIdFunc: testAccVpcEgressImportStateFunc(rName, true),
+			},
+			{
+				ResourceName:      "huaweicloud_cae_vpc_egress.test[1]",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccVpcEgressImportStateFunc(nameWithSpecifiedEps, false),
 			},
 		},
 	})
@@ -65,45 +84,56 @@ func TestAccVpcEgress_basic(t *testing.T) {
 
 func testAccVpcEgress_base(name string) string {
 	return fmt.Sprintf(`
+locals {
+  env_ids     = split(",", "%[1]s")
+}
+
 data "huaweicloud_cae_environments" "test" {
-  environment_id = "%[1]s"
+  count          = 2
+  environment_id = local.env_ids[count.index]
 }
 
 locals {
-  vpc_id = data.huaweicloud_cae_environments.test.environments[0].annotations.vpc_id
+  env_vpc_ids = data.huaweicloud_cae_environments.test[*].environments[0].annotations.vpc_id
 }
 
-resource "huaweicloud_vpc" "test" {
-  name = "%[2]s"
-  cidr = "192.168.10.0/24"
+resource "huaweicloud_vpc" "peering" {
+  count = 2
+
+  name = "%[2]s${count.index}"
+  cidr = cidrsubnet("172.16.0.0/16", 4, count.index)
 }
 
 resource "huaweicloud_vpc_peering_connection" "test" {
-  name        = "%[2]s"
-  vpc_id      = local.vpc_id
-  peer_vpc_id = huaweicloud_vpc.test.id
+  count = 2
+
+  name        = "%[2]s${count.index}"
+  vpc_id      = local.env_vpc_ids[count.index]
+  peer_vpc_id = huaweicloud_vpc.peering[count.index].id
 }
 
 resource "huaweicloud_vpc_route_table" "test" {
-  name   = "%[2]s"
-  vpc_id = local.vpc_id
+  count = 2
+
+  name   = "%[2]s${count.index}"
+  vpc_id = local.env_vpc_ids[count.index]
 
   subnets = [
-    data.huaweicloud_cae_environments.test.environments[0].annotations.subnet_id,
+    data.huaweicloud_cae_environments.test[count.index].environments[0].annotations.subnet_id,
   ]
 
   route {
-    destination = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1)
+    destination = cidrsubnet(huaweicloud_vpc.peering[count.index].cidr, 4, 1)
     type        = "peering"
-    nexthop     = huaweicloud_vpc_peering_connection.test.id
+    nexthop     = huaweicloud_vpc_peering_connection.test[count.index].id
   }
   route {
-    destination = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 2)
+    destination = cidrsubnet(huaweicloud_vpc.peering[count.index].cidr, 4, 2)
     type        = "peering"
-    nexthop     = huaweicloud_vpc_peering_connection.test.id
+    nexthop     = huaweicloud_vpc_peering_connection.test[count.index].id
   }
 }
-`, acceptance.HW_CAE_ENVIRONMENT_ID, name)
+`, acceptance.HW_CAE_ENVIRONMENT_IDS, name)
 }
 
 func testAccVpcEgress_basic(name string) string {
@@ -111,14 +141,18 @@ func testAccVpcEgress_basic(name string) string {
 %[1]s
 
 resource "huaweicloud_cae_vpc_egress" "test" {
-  environment_id = "%[2]s"
-  route_table_id = huaweicloud_vpc_route_table.test.id
-  cidr           = tolist(huaweicloud_vpc_route_table.test.route)[0].destination
+  count = 2
+
+  environment_id        = local.env_ids[count.index]
+  route_table_id        = huaweicloud_vpc_route_table.test[count.index].id
+  cidr                  = tolist(huaweicloud_vpc_route_table.test[count.index].route)[0].destination
+  enterprise_project_id = count.index == 1 ? try(data.huaweicloud_cae_environments.test[1].environments[0].annotations.enterprise_project_id,
+  null) : null
 }
- `, testAccVpcEgress_base(name), acceptance.HW_CAE_ENVIRONMENT_ID)
+ `, testAccVpcEgress_base(name))
 }
 
-func testAccVpcEgressImportStateFunc(name string) resource.ImportStateIdFunc {
+func testAccVpcEgressImportStateFunc(name string, isDefaultEps bool) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -132,10 +166,22 @@ func testAccVpcEgressImportStateFunc(name string) resource.ImportStateIdFunc {
 		)
 
 		if environmentId == "" || routeTableId == "" || cidr == "" {
-			return "", fmt.Errorf("some import IDs are missing, want '<environment_id>,<route_table_id>,<cidr>', but got '%s,%s,%s'",
+			return "", fmt.Errorf("some import IDs are missing, want '<environment_id>,<route_table_id>,<cidr>', "+
+				"or '<environment_id>,<route_table_id>,<cidr>,<enterprise_project_id>', but got '%s,%s,%s'",
 				environmentId, routeTableId, cidr)
 		}
 
-		return fmt.Sprintf("%s,%s,%s", environmentId, routeTableId, cidr), nil
+		if isDefaultEps {
+			log.Printf("[DEBUG] isDefaultEps: %s", fmt.Sprintf("%s,%s,%s", environmentId, routeTableId, cidr))
+			return fmt.Sprintf("%s,%s,%s", environmentId, routeTableId, cidr), nil
+		}
+
+		epsId := rs.Primary.Attributes["enterprise_project_id"]
+		if epsId == "" {
+			return "", fmt.Errorf("enterprise_project_id is missing, want '<environment_id>,<route_table_id>,<cidr>,<enterprise_project_id>', "+
+				"but got '%s,%s,%s,%s'", environmentId, routeTableId, cidr, epsId)
+		}
+
+		return fmt.Sprintf("%s,%s,%s,%s", environmentId, routeTableId, cidr, epsId), nil
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add `enterprise_project_id` for the resources.
+ **huaweicloud_cae_certificate**
+ **huaweicloud_cae_timer_rule**
+ **huaweicloud_cae_doamin**
+ **huaweicloud_cae_vpc_egress**

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o cae -f TestAccCertificate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccCertificate_basic -timeout 360m -parallel 10
=== RUN   TestAccCertificate_basic
=== PAUSE TestAccCertificate_basic
=== CONT  TestAccCertificate_basic
--- PASS: TestAccCertificate_basic (51.02s)
PASS
coverage: 11.3% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       52.841s coverage: 11.3% of statements in ./huaweicloud/services/cae
```
<img width="1412" height="843" alt="image" src="https://github.com/user-attachments/assets/8c4772ea-c9a2-4466-bc60-8b22197cb80d" />

```
./scripts/coverage.sh -o cae -f TestAccTimerRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccTimerRule_basic -timeout 360m -parallel 10
=== RUN   TestAccTimerRule_basic
=== PAUSE TestAccTimerRule_basic
=== CONT  TestAccTimerRule_basic
--- PASS: TestAccTimerRule_basic (65.22s)
PASS
coverage: 23.7% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       65.357s coverage: 23.7% of statements in ./huaweicloud/services/cae
```
<img width="1490" height="895" alt="image" src="https://github.com/user-attachments/assets/e72a0282-528a-4400-aa03-38a5583f110e" />

```
./scripts/coverage.sh -o cae -f TestAccResourceDomain_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccResourceDomain_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceDomain_basic
=== PAUSE TestAccResourceDomain_basic
=== CONT  TestAccResourceDomain_basic
--- PASS: TestAccResourceDomain_basic (157.48s)
PASS
coverage: 10.2% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       157.652s        coverage: 10.2% of statements in ./huaweicloud/services/cae
```
<img width="1194" height="801" alt="image" src="https://github.com/user-attachments/assets/6e953a62-a201-4f21-8967-79e1c6c37ad8" />

```
 ./scripts/coverage.sh -o cae -f TestAccVpcEgress_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccVpcEgress_basic -timeout 360m -parallel 10
=== RUN   TestAccVpcEgress_basic
=== PAUSE TestAccVpcEgress_basic
=== CONT  TestAccVpcEgress_basic
--- PASS: TestAccVpcEgress_basic (157.47s)
PASS
coverage: 10.2% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       157.587s        coverage: 10.2% of statements in ./huaweicloud/services/cae
```
<img width="1454" height="895" alt="image" src="https://github.com/user-attachments/assets/69af0cd8-6ec6-41c6-909a-0f3aab0f591d" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
