### PR TITLE
fix(CodeArts/Pipeline): fix available plugins list result

### DIFF
--- a/huaweicloud/services/codeartspipeline/data_source_huaweicloud_codearts_pipeline_available_plugins.go
+++ b/huaweicloud/services/codeartspipeline/data_source_huaweicloud_codearts_pipeline_available_plugins.go
@@ -261,17 +261,30 @@ func dataSourceCodeartsPipelineAvailablePluginsRead(_ context.Context, d *schema
 		}
 
 		for _, plugin := range plugins {
-			rst = append(rst, map[string]interface{}{
-				"unique_id":     utils.PathSearch("unique_id", plugin, nil),
-				"display_name":  utils.PathSearch("display_name", plugin, nil),
-				"business_type": utils.PathSearch("business_type", plugin, nil),
-				"conditions":    utils.PathSearch("conditions", plugin, nil),
-				"removable":     utils.PathSearch("removable", plugin, nil),
-				"cloneable":     utils.PathSearch("cloneable", plugin, nil),
-				"disabled":      utils.PathSearch("disabled", plugin, nil),
-				"editable":      utils.PathSearch("editable", plugin, nil),
-				"plugins_list":  flattenPipelineAvailablePluginsPluginsList(plugin),
-			})
+			id := utils.PathSearch("unique_id", plugin, "").(string)
+			found := false
+			for _, r := range rst {
+				if r["unique_id"].(string) == id {
+					temp := r["plugins_list"].([]interface{})
+					temp = append(temp, flattenPipelineAvailablePluginsPluginsList(plugin)...)
+					r["plugins_list"] = temp
+					found = true
+					break
+				}
+			}
+			if !found {
+				rst = append(rst, map[string]interface{}{
+					"unique_id":     utils.PathSearch("unique_id", plugin, nil),
+					"display_name":  utils.PathSearch("display_name", plugin, nil),
+					"business_type": utils.PathSearch("business_type", plugin, nil),
+					"conditions":    utils.PathSearch("conditions", plugin, nil),
+					"removable":     utils.PathSearch("removable", plugin, nil),
+					"cloneable":     utils.PathSearch("cloneable", plugin, nil),
+					"disabled":      utils.PathSearch("disabled", plugin, nil),
+					"editable":      utils.PathSearch("editable", plugin, nil),
+					"plugins_list":  flattenPipelineAvailablePluginsPluginsList(plugin),
+				})
+			}
 		}
 
 		// use total, which is the total of `plugins_list` in actual


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix available plugins list result
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fix available plugins list result
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
