### PR TITLE
feat(cae): component resource and data source support eps ID

### DIFF
--- a/docs/data-sources/cae_applications.md
+++ b/docs/data-sources/cae_applications.md
@@ -12,7 +12,7 @@ Use this data source to get the list of CAE applications within HuaweiCloud.
 
 ## Example Usage
 
-### Query the all applications under the default enterprise project
+### Query all applications under the default enterprise project or EPS service is not enable
 
 ```hcl
 variable "environment_id" {}
@@ -53,8 +53,8 @@ The following arguments are supported:
 
 * `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the applications
   belong.  
-  If the `environment_id` belongs to the non-default enterprise project, this parameter is required and is only valid for
-  enterprise users.
+  If the `environment_id` belongs to the non-default enterprise project, this parameter is required and is only valid
+  for enterprise users.
 
 ## Attribute Reference
 

--- a/docs/data-sources/cae_components.md
+++ b/docs/data-sources/cae_components.md
@@ -12,6 +12,8 @@ Use this data source to get the list of CAE components within HuaweiCloud.
 
 ## Example Usage
 
+### Query all components under the default enterprise project or EPS service is not enable
+
 ```hcl
 variable "environment_id" {}
 variable "application_id" {}
@@ -19,6 +21,20 @@ variable "application_id" {}
 data "huaweicloud_cae_components" "test" {
   environment_id = var.environment_id
   application_id = var.application_id
+}
+```
+
+### Query all components under the specified enterprise project
+
+```hcl
+variable "environment_id" {}
+variable "application_id" {}
+variable "enterprise_project_id" {}
+
+data "huaweicloud_cae_components" "test" {
+  environment_id        = var.environment_id
+  application_id        = var.application_id
+  enterprise_project_id = var.enterprise_project_id
 }
 ```
 
@@ -32,6 +48,11 @@ The following arguments are supported:
 * `environment_id` - (Required, String) Specifies the ID of the environment to which the components belong.
 
 * `application_id` - (Required, String) Specifies the ID of the application to which the components belong.
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the components
+  belong.  
+  If the `application_id` belongs to the non-default enterprise project, this parameter is required and is only valid
+  for enterprise users.
 
 ## Attribute Reference
 

--- a/docs/resources/cae_component.md
+++ b/docs/resources/cae_component.md
@@ -123,6 +123,11 @@ The following arguments are supported:
 
   -> This parameter must be used together with `action` parameter.
 
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project to which the
+  component belongs.  
+  If the `application_id` belongs to the non-default enterprise project, this parameter is required and is only valid
+  for enterprise users.
+
 <a name="component_metadata"></a>
 The `metadata` block supports:
 
@@ -254,10 +259,17 @@ This resource provides the following timeouts configuration options:
 
 ## Import
 
-The CAE component can be imported using `environment_id`, `application_id` and `id`, separated by slashes (/), e.g.
+The component can be imported using `environment_id`, `application_id` and `id`, separated by slashes (/), e.g.
 
 ```bash
 $ terraform import huaweicloud_cae_component.test <environment_id>/<application_id>/<id>
+```
+
+For the component with the `enterprise_project_id`, its enterprise project ID need to be specified additionanlly when
+importing. All fields are separated by slashes (/), e.g.
+
+```bash
+$ terraform import huaweicloud_cae_component.test <environment_id>/<application_id>/<id>/<enterprise_project_id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the

--- a/docs/resources/cae_component_action.md
+++ b/docs/resources/cae_component_action.md
@@ -74,6 +74,11 @@ The following arguments are supported:
   -> If the `spec` parameter specified in this resource is inconsistent with the `huaweicloud_cae_component` resource,
      you can handle the changes in the `huaweicloud_cae_component` resource by `lifecycle.ignore_changes` or manual synchronization.
 
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project to which the
+  component belongs.  
+  If the `application_id` belongs to the non-default enterprise project, this parameter is required and is only valid
+  for enterprise users.
+
 <a name="component_action_metadata"></a>
 The `metadata` block supports:
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -80,10 +80,8 @@ var (
 	HW_CAE_ENVIRONMENT_ID = os.Getenv("HW_CAE_ENVIRONMENT_ID")
 	// The list of CAE environment IDs. Using commas (,) to separate multiple IDs. At least one ID is required.
 	// The first environment ID belongs to the default enterprise project ID, and the second belongs to non-default.
-	HW_CAE_ENVIRONMENT_IDs    = os.Getenv("HW_CAE_ENVIRONMENT_IDs")
+	HW_CAE_ENVIRONMENT_IDS    = os.Getenv("HW_CAE_ENVIRONMENT_IDS")
 	HW_CAE_APPLICATION_ID     = os.Getenv("HW_CAE_APPLICATION_ID")
-	HW_CAE_CODE_URL           = os.Getenv("HW_CAE_CODE_URL")
-	HW_CAE_CODE_BRANCH        = os.Getenv("HW_CAE_CODE_BRANCH")
 	HW_CAE_CODE_AUTH_NAME     = os.Getenv("HW_CAE_CODE_AUTH_NAME")
 	HW_CAE_CODE_NAMESPACE     = os.Getenv("HW_CAE_CODE_NAMESPACE")
 	HW_CAE_ARTIFACT_NAMESPACE = os.Getenv("HW_CAE_ARTIFACT_NAMESPACE")
@@ -765,8 +763,8 @@ func TestAccPreCheckCaeEnvironment(t *testing.T) {
 // Before the CAE environment resource is released, temporarily use this environment variables for acceptance tests.
 // lintignore:AT003
 func TestAccPreCheckCaeEnvironmentIds(t *testing.T, min int) {
-	if HW_CAE_ENVIRONMENT_IDs == "" || len(strings.Split(HW_CAE_ENVIRONMENT_IDs, ",")) < min {
-		t.Skipf("At least %d environment IDs must be must be supported during the HW_CAE_ENVIRONMENT_IDs, "+
+	if HW_CAE_ENVIRONMENT_IDS == "" || len(strings.Split(HW_CAE_ENVIRONMENT_IDS, ",")) < min {
+		t.Skipf("At least %d environment IDs must be must be supported during the HW_CAE_ENVIRONMENT_IDS, "+
 			"separated by commas (,).", min)
 	}
 }
@@ -780,8 +778,8 @@ func TestAccPreCheckCaeApplication(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckCaeComponent(t *testing.T) {
-	if HW_CAE_CODE_URL == "" || HW_CAE_CODE_AUTH_NAME == "" || HW_CAE_CODE_BRANCH == "" || HW_CAE_CODE_NAMESPACE == "" ||
+func TestAccPreCheckCaeComponentRepoAuth(t *testing.T) {
+	if HW_GITHUB_REPO_URL == "" || HW_CAE_CODE_AUTH_NAME == "" || HW_CAE_CODE_NAMESPACE == "" ||
 		HW_CAE_ARTIFACT_NAMESPACE == "" || HW_CAE_BUILD_BASE_IMAGE == "" || HW_CAE_IMAGE_URL == "" {
 		t.Skip("Skip the CAE acceptance tests.")
 	}

--- a/huaweicloud/services/acceptance/cae/data_source_huaweicloud_cae_applications_test.go
+++ b/huaweicloud/services/acceptance/cae/data_source_huaweicloud_cae_applications_test.go
@@ -76,7 +76,7 @@ resource "huaweicloud_cae_application" "test" {
   enterprise_project_id = count.index == 1 ? try(data.huaweicloud_cae_environments.test.environments[0].annotations.enterprise_project_id,
   null) : null
 }
-`, acceptance.HW_CAE_ENVIRONMENT_IDs, name)
+`, acceptance.HW_CAE_ENVIRONMENT_IDS, name)
 }
 
 func testAccDatasourceApplications_basic(name string) string {

--- a/huaweicloud/services/acceptance/cae/data_source_huaweicloud_cae_components_test.go
+++ b/huaweicloud/services/acceptance/cae/data_source_huaweicloud_cae_components_test.go
@@ -10,27 +10,39 @@ import (
 )
 
 func TestAccDataSourceComponents_basic(t *testing.T) {
-	all := "data.huaweicloud_cae_components.test"
-	dc := acceptance.InitDataSourceCheck(all)
+	var (
+		allWithoutEps = "data.huaweicloud_cae_components.test.0"
+		dcWithoutEps  = acceptance.InitDataSourceCheck(allWithoutEps)
+
+		allWithEps = "data.huaweicloud_cae_components.test.1"
+		dcWithEps  = acceptance.InitDataSourceCheck(allWithEps)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCaeEnvironment(t)
-			acceptance.TestAccPreCheckCaeApplication(t)
+			acceptance.TestAccPreCheckCaeEnvironmentIds(t, 2)
+			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceComponents_basic(),
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckOutput("is_component_id_set_and_valid", "true"),
-					resource.TestCheckOutput("is_component_name_set_and_valid", "true"),
-					resource.TestCheckOutput("is_component_annotations_set_and_valid", "true"),
-					resource.TestCheckOutput("is_component_spec_set_and_valid", "true"),
-					resource.TestCheckOutput("is_component_created_at_set_and_valid", "true"),
-					resource.TestCheckOutput("is_component_updated_at_set_and_valid", "true"),
+					dcWithoutEps.CheckResourceExists(),
+					resource.TestCheckOutput("is_component_id_set_and_valid_without_eps", "true"),
+					resource.TestCheckOutput("is_component_name_set_and_valid_without_eps", "true"),
+					resource.TestCheckOutput("is_component_annotations_set_and_valid_without_eps", "true"),
+					resource.TestCheckOutput("is_component_spec_set_and_valid_without_eps", "true"),
+					resource.TestCheckOutput("is_component_created_at_set_and_valid_without_eps", "true"),
+					resource.TestCheckOutput("is_component_updated_at_set_and_valid_without_eps", "true"),
+					dcWithEps.CheckResourceExists(),
+					resource.TestCheckOutput("is_component_id_set_and_valid_with_eps", "true"),
+					resource.TestCheckOutput("is_component_name_set_and_valid_with_eps", "true"),
+					resource.TestCheckOutput("is_component_annotations_set_and_valid_with_eps", "true"),
+					resource.TestCheckOutput("is_component_spec_set_and_valid_with_eps", "true"),
+					resource.TestCheckOutput("is_component_created_at_set_and_valid_with_eps", "true"),
+					resource.TestCheckOutput("is_component_updated_at_set_and_valid_with_eps", "true"),
 				),
 			},
 		},
@@ -39,6 +51,28 @@ func TestAccDataSourceComponents_basic(t *testing.T) {
 
 func testAccDataSourceComponents_base(name string) string {
 	return fmt.Sprintf(`
+locals {
+  env_ids = split(",", "%[1]s")
+}
+
+# Query the enterprise project ID of the environment.
+data "huaweicloud_cae_environments" "test" {
+  count = 2
+
+  environment_id        = local.env_ids[count.index]
+  enterprise_project_id = count.index == 1 ? "%[2]s" : null
+}
+
+# The first application belongs to the default enterprise project.
+# The second application belongs to the non-default enterprise project.
+resource "huaweicloud_cae_application" "test" {
+  count = 2
+
+  environment_id        = try(data.huaweicloud_cae_environments.test[count.index].environments[0].id, "NOT_FOUND")
+  name                  = format("%[3]s-%%d", count.index)
+  enterprise_project_id = try(data.huaweicloud_cae_environments.test[count.index].environments[0].annotations.enterprise_project_id, null)
+}
+
 data "huaweicloud_swr_repositories" "test" {}
 
 locals {
@@ -46,11 +80,14 @@ locals {
 }
 
 resource "huaweicloud_cae_component" "test" {
-  environment_id = "%[1]s"
-  application_id = "%[2]s"
+  count = 2
+
+  environment_id        = local.env_ids[count.index]
+  application_id        = huaweicloud_cae_application.test[count.index].id
+  enterprise_project_id = try(data.huaweicloud_cae_environments.test[count.index].environments[0].annotations.enterprise_project_id, null)
 
   metadata {
-    name = "%[3]s"
+    name = format("%[3]s-%%d", count.index)
 
     annotations = {
       version = "1.0.0"
@@ -72,7 +109,7 @@ resource "huaweicloud_cae_component" "test" {
     }
   }
 }
-`, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID, name)
+`, acceptance.HW_CAE_ENVIRONMENT_IDS, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name)
 }
 
 func testAccDataSourceComponents_basic() string {
@@ -86,57 +123,103 @@ data "huaweicloud_cae_components" "test" {
     huaweicloud_cae_component.test
   ]
 
-  environment_id = "%[2]s"
-  application_id = "%[3]s"
+  count = 2
+
+  environment_id        = local.env_ids[count.index]
+  application_id        = huaweicloud_cae_application.test[count.index].id
+  enterprise_project_id = try(data.huaweicloud_cae_environments.test[count.index].environments[0].annotations.enterprise_project_id, null)
 }
 
 locals {
-  component_id            = huaweicloud_cae_component.test.id
-  component_filter_result = try([
-    for v in data.huaweicloud_cae_components.test.components : v if v.id == local.component_id
+  component_id_without_eps            = huaweicloud_cae_component.test[0].id
+  component_filter_result_without_eps = try([
+    for v in data.huaweicloud_cae_components.test[0].components : v if v.id == local.component_id_without_eps
+  ][0], null)
+
+  component_id_with_eps            = huaweicloud_cae_component.test[1].id
+  component_filter_result_with_eps = try([
+    for v in data.huaweicloud_cae_components.test[1].components : v if v.id == local.component_id_with_eps
   ][0], null)
 }
 
-output "is_component_id_set_and_valid" {
-  value = local.component_filter_result != null
+output "is_component_id_set_and_valid_without_eps" {
+  value = local.component_filter_result_without_eps != null
 }
 
-output "is_component_name_set_and_valid" {
-  value = try(local.component_filter_result.name == huaweicloud_cae_component.test.metadata[0].name, false)
+output "is_component_name_set_and_valid_without_eps" {
+  value = try(local.component_filter_result_without_eps.name == huaweicloud_cae_component.test[0].metadata[0].name, false)
 }
 
-output "is_component_annotations_set_and_valid" {
+output "is_component_annotations_set_and_valid_without_eps" {
   value = try(alltrue([
-    length(local.component_filter_result.annotations) > 0,
-    local.component_filter_result.annotations["version"] == huaweicloud_cae_component.test.metadata[0].annotations["version"]
+    length(local.component_filter_result_without_eps.annotations) > 0,
+    local.component_filter_result_without_eps.annotations["version"] == huaweicloud_cae_component.test[0].metadata[0].annotations["version"]
   ]), false)
 }
 
-output "is_component_spec_set_and_valid" {
+output "is_component_spec_set_and_valid_without_eps" {
   value = try(alltrue([
-    length(local.component_filter_result.spec) > 0,
-    local.component_filter_result.spec[0].runtime != "",
-    local.component_filter_result.spec[0].environment_id != "",
-    local.component_filter_result.spec[0].replica != 0,
-    local.component_filter_result.spec[0].available_replica >= 0,
-    local.component_filter_result.spec[0].source != "",
-    local.component_filter_result.spec[0].build != "",
-    local.component_filter_result.spec[0].resource_limit != "",
-    local.component_filter_result.spec[0].image_url != "",
-    local.component_filter_result.spec[0].status != "",
+    length(local.component_filter_result_without_eps.spec) > 0,
+    local.component_filter_result_without_eps.spec[0].runtime != "",
+    local.component_filter_result_without_eps.spec[0].environment_id != "",
+    local.component_filter_result_without_eps.spec[0].replica != 0,
+    local.component_filter_result_without_eps.spec[0].available_replica >= 0,
+    local.component_filter_result_without_eps.spec[0].source != "",
+    local.component_filter_result_without_eps.spec[0].build != "",
+    local.component_filter_result_without_eps.spec[0].resource_limit != "",
+    local.component_filter_result_without_eps.spec[0].image_url != "",
+    local.component_filter_result_without_eps.spec[0].status != "",
   ]), false)
 }
 
-output "is_component_created_at_set_and_valid" {
+output "is_component_created_at_set_and_valid_without_eps" {
   value = try(length(regexall("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
-    local.component_filter_result.created_at)) > 0, false)
+    local.component_filter_result_without_eps.created_at)) > 0, false)
 }
 
-output "is_component_updated_at_set_and_valid" {
+output "is_component_updated_at_set_and_valid_without_eps" {
   value = try(length(regexall("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
-    local.component_filter_result.updated_at)) > 0, false)
+    local.component_filter_result_without_eps.updated_at)) > 0, false)
 }
-`, testAccDataSourceComponents_base(name),
-		acceptance.HW_CAE_ENVIRONMENT_ID,
-		acceptance.HW_CAE_APPLICATION_ID)
+
+output "is_component_id_set_and_valid_with_eps" {
+  value = local.component_filter_result_with_eps != null
+}
+
+output "is_component_name_set_and_valid_with_eps" {
+  value = try(local.component_filter_result_with_eps.name == huaweicloud_cae_component.test[1].metadata[0].name, false)
+}
+
+output "is_component_annotations_set_and_valid_with_eps" {
+  value = try(alltrue([
+    length(local.component_filter_result_with_eps.annotations) > 0,
+    local.component_filter_result_with_eps.annotations["version"] == huaweicloud_cae_component.test[1].metadata[0].annotations["version"]
+  ]), false)
+}
+
+output "is_component_spec_set_and_valid_with_eps" {
+  value = try(alltrue([
+    length(local.component_filter_result_with_eps.spec) > 0,
+    local.component_filter_result_with_eps.spec[0].runtime != "",
+    local.component_filter_result_with_eps.spec[0].environment_id != "",
+    local.component_filter_result_with_eps.spec[0].replica != 0,
+    local.component_filter_result_with_eps.spec[0].available_replica >= 0,
+    local.component_filter_result_with_eps.spec[0].source != "",
+    local.component_filter_result_with_eps.spec[0].build != "",
+    local.component_filter_result_with_eps.spec[0].resource_limit != "",
+    local.component_filter_result_with_eps.spec[0].image_url != "",
+    local.component_filter_result_with_eps.spec[0].status != "",
+  ]), false)
+}
+
+output "is_component_created_at_set_and_valid_with_eps" {
+  value = try(length(regexall("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
+    local.component_filter_result_with_eps.created_at)) > 0, false)
+}
+
+output "is_component_updated_at_set_and_valid_with_eps" {
+  value = try(length(regexall("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
+    local.component_filter_result_with_eps.updated_at)) > 0, false)
+}
+`, testAccDataSourceComponents_base(name))
 }

--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_application_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_application_test.go
@@ -132,5 +132,5 @@ resource "huaweicloud_cae_application" "test" {
   enterprise_project_id = count.index == 1 ? try(data.huaweicloud_cae_environments.test.environments[0].annotations.enterprise_project_id,
   null) : null
 }
-`, acceptance.HW_CAE_ENVIRONMENT_IDs, name)
+`, acceptance.HW_CAE_ENVIRONMENT_IDS, name)
 }

--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_test.go
@@ -21,7 +21,8 @@ func getComponentFunc(cfg *config.Config, state *terraform.ResourceState) (inter
 
 	environmentId := state.Primary.Attributes["environment_id"]
 	applicationId := state.Primary.Attributes["application_id"]
-	return cae.GetComponentById(client, environmentId, applicationId, state.Primary.ID)
+	enterpriseProjectId := state.Primary.Attributes["enterprise_project_id"]
+	return cae.GetComponentById(client, enterpriseProjectId, environmentId, applicationId, state.Primary.ID)
 }
 
 func TestAccComponent_basic(t *testing.T) {
@@ -40,27 +41,27 @@ func TestAccComponent_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCaeEnvironment(t)
-			acceptance.TestAccPreCheckCaeApplication(t)
-			acceptance.TestAccPreCheckCaeComponent(t)
+			acceptance.TestAccPreCheckCaeEnvironmentIds(t, 1)
+			// Please make sure the authorized repository have the master branch.
+			acceptance.TestAccPreCheckCaeComponentRepoAuth(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComponent_step1(name),
+				Config: testAccComponent_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "metadata.0.name", name),
-					resource.TestCheckResourceAttr(rName, "environment_id", acceptance.HW_CAE_ENVIRONMENT_ID),
-					resource.TestCheckResourceAttr(rName, "application_id", acceptance.HW_CAE_APPLICATION_ID),
+					resource.TestCheckResourceAttrSet(rName, "environment_id"),
+					resource.TestCheckResourceAttrPair(rName, "application_id", "huaweicloud_cae_application.test", "id"),
 					resource.TestCheckResourceAttr(rName, "metadata.0.annotations.version", "1.0.0"),
 					resource.TestCheckResourceAttr(rName, "spec.0.replica", "2"),
 					resource.TestCheckResourceAttr(rName, "spec.0.runtime", "Docker"),
 					resource.TestCheckResourceAttr(rName, "spec.0.resource_limit.0.cpu", "1000m"),
 					resource.TestCheckResourceAttr(rName, "spec.0.resource_limit.0.memory", "4Gi"),
 					resource.TestCheckResourceAttr(rName, "spec.0.source.0.type", "image"),
-					resource.TestCheckResourceAttr(rName, "spec.0.source.0.url", acceptance.HW_CAE_IMAGE_URL),
+					resource.TestCheckResourceAttrSet(rName, "spec.0.source.0.url"),
 					// Check attributes.
 					// When the component is not deployed, the number of available instances under it is 0.
 					resource.TestCheckResourceAttr(rName, "available_replica", "0"),
@@ -70,7 +71,7 @@ func TestAccComponent_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccComponent_step2(updateName),
+				Config: testAccComponent_basic_step2(updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "metadata.0.name", updateName),
@@ -81,10 +82,10 @@ func TestAccComponent_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "spec.0.resource_limit.0.memory", "1Gi"),
 					resource.TestCheckResourceAttr(rName, "spec.0.source.0.type", "code"),
 					resource.TestCheckResourceAttr(rName, "spec.0.source.0.sub_type", "GitHub"),
-					resource.TestCheckResourceAttr(rName, "spec.0.source.0.url", acceptance.HW_CAE_CODE_URL),
+					resource.TestCheckResourceAttr(rName, "spec.0.source.0.url", acceptance.HW_GITHUB_REPO_URL),
 					resource.TestCheckResourceAttr(rName, "spec.0.source.0.code.0.%", "3"),
 					resource.TestCheckResourceAttr(rName, "spec.0.source.0.code.0.auth_name", acceptance.HW_CAE_CODE_AUTH_NAME),
-					resource.TestCheckResourceAttr(rName, "spec.0.source.0.code.0.branch", acceptance.HW_CAE_CODE_BRANCH),
+					resource.TestCheckResourceAttr(rName, "spec.0.source.0.code.0.branch", "master"),
 					resource.TestCheckResourceAttr(rName, "spec.0.source.0.code.0.namespace", acceptance.HW_CAE_CODE_NAMESPACE),
 					resource.TestCheckResourceAttr(rName, "spec.0.build.0.archive.0.artifact_namespace", acceptance.HW_CAE_ARTIFACT_NAMESPACE),
 					resource.TestCheckResourceAttr(rName, "spec.0.build.0.parameters.base_image", acceptance.HW_CAE_BUILD_BASE_IMAGE),
@@ -103,27 +104,47 @@ func TestAccComponent_basic(t *testing.T) {
 	})
 }
 
-func testAccComponent_step1(name string) string {
+func testAccComponent_basic_step1(name string) string {
 	return fmt.Sprintf(`
+locals {
+  environment_ids = split(",", "%[1]s")
+}
+
+# Query by environment ID under non-default enterprise project ID.
+data "huaweicloud_cae_environments" "test" {
+  environment_id = local.environment_ids[0]
+}
+
+resource "huaweicloud_cae_application" "test" {
+  environment_id = try(data.huaweicloud_cae_environments.test.environments[0].id, "NOT_FOUND")
+  name           = "%[2]s"
+}
+
+data "huaweicloud_swr_repositories" "test" {}
+
+locals {
+  swr_repositories = [for v in data.huaweicloud_swr_repositories.test.repositories : v if length(v.tags) > 0][0]
+}
+
 resource "huaweicloud_cae_component" "test" {
-  environment_id = "%s"
-  application_id = "%s"
-  
+  environment_id = try(data.huaweicloud_cae_environments.test.environments[0].id, "NOT_FOUND")
+  application_id = huaweicloud_cae_application.test.id
+
   metadata {
-    name = "%s"
+    name = "%[2]s"
     
     annotations = {
       version = "1.0.0"
     }
   }
-  
+
   spec {
     replica = 2
     runtime = "Docker"
 
     source {
       type = "image"
-      url  = "%s"
+      url  = format("%%s:%%s", local.swr_repositories.path, local.swr_repositories.tags[0])
     }
   
     resource_limit {
@@ -132,23 +153,43 @@ resource "huaweicloud_cae_component" "test" {
     }
   }
 }
-`, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID, name, acceptance.HW_CAE_IMAGE_URL)
+`, acceptance.HW_CAE_ENVIRONMENT_IDS, name)
 }
 
-func testAccComponent_step2(name string) string {
+func testAccComponent_basic_step2(name string) string {
 	return fmt.Sprintf(`
+locals {
+  environment_ids = split(",", "%[1]s")
+}
+
+# Query by environment ID under non-default enterprise project ID.
+data "huaweicloud_cae_environments" "test" {
+  environment_id = local.environment_ids[0]
+}
+
+resource "huaweicloud_cae_application" "test" {
+  environment_id = try(data.huaweicloud_cae_environments.test.environments[0].id, "NOT_FOUND")
+  name           = "%[2]s"
+}
+
+data "huaweicloud_swr_repositories" "test" {}
+
+locals {
+  swr_repositories = [for v in data.huaweicloud_swr_repositories.test.repositories : v if length(v.tags) > 0][0]
+}
+
 resource "huaweicloud_cae_component" "test" {
-  environment_id = "%s"
-  application_id = "%s"
-  
+  environment_id = try(data.huaweicloud_cae_environments.test.environments[0].id, "NOT_FOUND")
+  application_id = huaweicloud_cae_application.test.id
+
   metadata {
-    name = "%s"
-    
+    name = "%[2]s"
+
     annotations = {
       version = "1.0.0"
     }
   }
-  
+
   spec {
     replica = 1
     runtime = "Java17"
@@ -156,35 +197,35 @@ resource "huaweicloud_cae_component" "test" {
     source {
       type     = "code"
       sub_type = "GitHub"
-      url      = "%s"
-  
+      url      = "%[3]s"
+
       code {
-        auth_name = "%s"
-        branch    = "%s"
-        namespace = "%s"
+        auth_name = "%[4]s"
+        branch    = "master"
+        namespace = "%[5]s"
       }
     }
-  
+
     resource_limit {
       cpu    = "500m"
       memory = "1Gi"
     }
-  
+
     build {
       archive {
-        artifact_namespace = "%s"
+        artifact_namespace = "%[6]s"
       }
 
       parameters = {
-        base_image      = "%s"
+        base_image      = "%[7]s"
         dockerfile_path = "./Dockerfile"
         build_cmd       = "echo test"
       }
     }
   }
 }
-`, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID, name, acceptance.HW_CAE_CODE_URL,
-		acceptance.HW_CAE_CODE_AUTH_NAME, acceptance.HW_CAE_CODE_BRANCH, acceptance.HW_CAE_CODE_NAMESPACE,
+`, acceptance.HW_CAE_ENVIRONMENT_IDS, name, acceptance.HW_GITHUB_REPO_URL,
+		acceptance.HW_CAE_CODE_AUTH_NAME, acceptance.HW_CAE_CODE_NAMESPACE,
 		acceptance.HW_CAE_ARTIFACT_NAMESPACE, acceptance.HW_CAE_BUILD_BASE_IMAGE)
 }
 
@@ -196,15 +237,19 @@ func testAccComponentImportStateFunc(name string) resource.ImportStateIdFunc {
 		}
 
 		var (
-			environmentId = rs.Primary.Attributes["environment_id"]
-			applicationId = rs.Primary.Attributes["application_id"]
-			componentId   = rs.Primary.ID
+			environmentId       = rs.Primary.Attributes["environment_id"]
+			applicationId       = rs.Primary.Attributes["application_id"]
+			componentId         = rs.Primary.ID
+			enterpriseProjectId = rs.Primary.Attributes["enterprise_project_id"]
 		)
 		if environmentId == "" || applicationId == "" || componentId == "" {
 			return "", fmt.Errorf("some import IDs are missing, want '<environment_id>/<application_id>/<id>', but got '%s/%s/%s'",
 				environmentId, applicationId, componentId)
 		}
 
+		if enterpriseProjectId != "" {
+			return fmt.Sprintf("%s/%s/%s/%s", environmentId, applicationId, componentId, enterpriseProjectId), nil
+		}
 		return fmt.Sprintf("%s/%s/%s", environmentId, applicationId, componentId), nil
 	}
 }
@@ -213,23 +258,27 @@ func TestAccComponent_configurationsAndAction(t *testing.T) {
 	var (
 		obj interface{}
 
-		withConfiguration                  = "huaweicloud_cae_component.test.0"
-		withoutConfiguration               = "huaweicloud_cae_component.test.1"
-		withConfigurationUpdateDeploy      = "huaweicloud_cae_component.deploy_after_update.0"
+		withConfiguration   = "huaweicloud_cae_component.test.0"
+		rcWithConfiguration = acceptance.InitResourceCheck(withConfiguration, &obj, getComponentFunc)
+
+		withoutConfiguration   = "huaweicloud_cae_component.test.1"
+		rcWithoutConfiguration = acceptance.InitResourceCheck(withoutConfiguration, &obj, getComponentFunc)
+
+		withConfigurationUpdateDeploy   = "huaweicloud_cae_component.deploy_after_update.0"
+		rcWithConfigurationUpdateDeploy = acceptance.InitResourceCheck(withConfigurationUpdateDeploy, &obj, getComponentFunc)
+
 		withoutConfigurationUpdateDeploy   = "huaweicloud_cae_component.deploy_after_update.1"
-		rcWithConfiguration                = acceptance.InitResourceCheck(withConfiguration, &obj, getComponentFunc)
-		rcWithoutConfiguration             = acceptance.InitResourceCheck(withoutConfiguration, &obj, getComponentFunc)
-		rcWithConfigurationUpdateDeploy    = acceptance.InitResourceCheck(withConfigurationUpdateDeploy, &obj, getComponentFunc)
 		rcWithoutConfigurationUpdateDeploy = acceptance.InitResourceCheck(withoutConfigurationUpdateDeploy, &obj, getComponentFunc)
 
-		name = acceptance.RandomAccResourceNameWithDash()
+		name       = acceptance.RandomAccResourceNameWithDash()
+		baseConfig = testAccComponent_deploy_base(name)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCaeEnvironment(t)
-			acceptance.TestAccPreCheckCaeApplication(t)
+			acceptance.TestAccPreCheckCaeEnvironmentIds(t, 2)
+			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
@@ -240,12 +289,12 @@ func TestAccComponent_configurationsAndAction(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComponent_configurationsAndAction_step1(name),
+				Config: testAccComponent_configurationsAndAction_step1(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rcWithConfiguration.CheckResourceExists(),
 					resource.TestMatchResourceAttr(withConfiguration, "metadata.0.name", regexp.MustCompile(name)),
-					resource.TestCheckResourceAttr(withConfiguration, "environment_id", acceptance.HW_CAE_ENVIRONMENT_ID),
-					resource.TestCheckResourceAttr(withConfiguration, "application_id", acceptance.HW_CAE_APPLICATION_ID),
+					resource.TestCheckResourceAttrSet(withConfiguration, "environment_id"),
+					resource.TestCheckResourceAttrPair(withConfiguration, "application_id", "huaweicloud_cae_application.test", "id"),
 					resource.TestCheckResourceAttr(withConfiguration, "metadata.0.annotations.version", "1.0.0"),
 					resource.TestCheckResourceAttr(withConfiguration, "spec.0.replica", "1"),
 					resource.TestCheckResourceAttr(withConfiguration, "spec.0.runtime", "Docker"),
@@ -263,7 +312,7 @@ func TestAccComponent_configurationsAndAction(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccComponent_configurationsAndAction_step2(name),
+				Config: testAccComponent_configurationsAndAction_step2(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rcWithConfiguration.CheckResourceExists(),
 					resource.TestCheckResourceAttr(withConfiguration, "configurations.#", "1"),
@@ -279,7 +328,7 @@ func TestAccComponent_configurationsAndAction(t *testing.T) {
 			},
 			// Upgrade the component.
 			{
-				Config: testAccComponent_configurationsAndAction_step3(name),
+				Config: testAccComponent_configurationsAndAction_step3(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rcWithConfiguration.CheckResourceExists(),
 					resource.TestCheckResourceAttr(withConfiguration, "configurations.#", "1"),
@@ -304,7 +353,7 @@ func TestAccComponent_configurationsAndAction(t *testing.T) {
 			},
 			// Upgrade the component again to verify that the action has not changed.
 			{
-				Config: testAccComponent_configurationsAndAction_step4(name),
+				Config: testAccComponent_configurationsAndAction_step4(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rcWithConfiguration.CheckResourceExists(),
 					resource.TestCheckResourceAttr(withConfiguration, "metadata.0.annotations.version", "2.0.0"),
@@ -375,8 +424,8 @@ func TestAccComponent_configurationsAndAction(t *testing.T) {
 	})
 }
 
-func testAccComponent_deploy_base() string {
-	return `
+func testAccComponent_deploy_base(name string) string {
+	return fmt.Sprintf(`
 data "huaweicloud_swr_repositories" "test" {}
 
 locals {
@@ -428,22 +477,37 @@ locals {
     }
   ]
 }
-`
+
+locals {
+  environment_ids = split(",", "%[1]s")
 }
 
-func testAccComponent_configurationsAndAction_step1(name string) string {
+# Query by environment ID under non-default enterprise project ID.
+data "huaweicloud_cae_environments" "test" {
+  environment_id = local.environment_ids[0]
+}
+
+resource "huaweicloud_cae_application" "test" {
+  environment_id = try(data.huaweicloud_cae_environments.test.environments[0].id, "NOT_FOUND")
+  name           = "%[2]s"
+}
+`, acceptance.HW_CAE_ENVIRONMENT_IDS, name)
+}
+
+func testAccComponent_configurationsAndAction_step1(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 # Deploy components directly after creation, and the first component specifies 'configurations', the second component does not specify
 # 'configurations'.
 resource "huaweicloud_cae_component" "test" {
-  count          = 2
-  environment_id = "%[2]s"
-  application_id = "%[3]s"
+  count = 2
+
+  environment_id = try(data.huaweicloud_cae_environments.test.environments[0].id, "NOT_FOUND")
+  application_id = huaweicloud_cae_application.test.id
 
   metadata {
-    name = "%[4]s${count.index}"
+    name = format("%[2]s-%%d", count.index)
 
     annotations = {
       version = "1.0.0"
@@ -478,12 +542,13 @@ resource "huaweicloud_cae_component" "test" {
 
 # The components are not deployed when created.
 resource "huaweicloud_cae_component" "deploy_after_update" {
-  count          = 2
-  environment_id = "%[2]s"
-  application_id = "%[3]s"
+  count = 2
+
+  environment_id = try(data.huaweicloud_cae_environments.test.environments[0].id, "NOT_FOUND")
+  application_id = huaweicloud_cae_application.test.id
 
   metadata {
-    name = "%[4]s-update-${count.index}"
+    name = format("%[2]s-update-%%d", count.index)
 
     annotations = {
       version = "1.0.0"
@@ -505,10 +570,10 @@ resource "huaweicloud_cae_component" "deploy_after_update" {
     }
   }
 }
-`, testAccComponent_deploy_base(), acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID, name)
+`, baseConfig, name)
 }
 
-func testAccComponent_configurationsAndAction_step2(name string) string {
+func testAccComponent_configurationsAndAction_step2(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -522,12 +587,13 @@ locals {
 
 # Modify the configurations of the component, and the action is 'configure'.
 resource "huaweicloud_cae_component" "test" {
-  count          = 2
-  environment_id = "%[2]s"
-  application_id = "%[3]s"
+  count = 2
+
+  environment_id = try(data.huaweicloud_cae_environments.test.environments[0].id, "NOT_FOUND")
+  application_id = huaweicloud_cae_application.test.id
 
   metadata {
-    name = "%[4]s${count.index}"
+    name = format("%[2]s-%%d", count.index)
 
     annotations = {
       version = "1.0.0"
@@ -562,12 +628,13 @@ resource "huaweicloud_cae_component" "test" {
 
 # Modify the configurations of the component, and the action is 'deploy'.
 resource "huaweicloud_cae_component" "deploy_after_update" {
-  count          = 2
-  environment_id = "%[2]s"
-  application_id = "%[3]s"
+  count = 2
+
+  environment_id = try(data.huaweicloud_cae_environments.test.environments[0].id, "NOT_FOUND")
+  application_id = huaweicloud_cae_application.test.id
 
   metadata {
-    name = "%[4]s-update-${count.index}"
+    name = format("%[2]s-update-%%d", count.index)
 
     annotations = {
       version = "1.0.0"
@@ -599,21 +666,22 @@ resource "huaweicloud_cae_component" "deploy_after_update" {
     }
   }
 }
-`, testAccComponent_deploy_base(), acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID, name)
+`, baseConfig, name)
 }
 
 // Upgrade the component, modify the configuration, version and other parameters, and the action is 'upgrade'.
-func testAccComponent_configurationsAndAction_step3(name string) string {
+func testAccComponent_configurationsAndAction_step3(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_cae_component" "test" {
-  count          = 2
-  environment_id = "%[2]s"
-  application_id = "%[3]s"
+  count = 2
+
+  environment_id = try(data.huaweicloud_cae_environments.test.environments[0].id, "NOT_FOUND")
+  application_id = huaweicloud_cae_application.test.id
 
   metadata {
-    name = "%[4]s${count.index}"
+    name = format("%[2]s-%%d", count.index)
 
     annotations = {
       version = "2.0.0"
@@ -647,12 +715,13 @@ resource "huaweicloud_cae_component" "test" {
 }
 
 resource "huaweicloud_cae_component" "deploy_after_update" {
-  count          = 2
-  environment_id = "%[2]s"
-  application_id = "%[3]s"
+  count  = 2
+
+  environment_id = try(data.huaweicloud_cae_environments.test.environments[0].id, "NOT_FOUND")
+  application_id = huaweicloud_cae_application.test.id
 
   metadata {
-    name = "%[4]s-update-${count.index}"
+    name = format("%[2]s-update-%%d", count.index)
 
     annotations = {
       version = "2.0.0"
@@ -684,21 +753,22 @@ resource "huaweicloud_cae_component" "deploy_after_update" {
     }
   }
 }
-`, testAccComponent_deploy_base(), acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID, name)
+`, baseConfig, name)
 }
 
-func testAccComponent_configurationsAndAction_step4(name string) string {
+func testAccComponent_configurationsAndAction_step4(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 # Verify that only 'resource_limit' is changed.
 resource "huaweicloud_cae_component" "test" {
-  count          = 2
-  environment_id = "%[2]s"
-  application_id = "%[3]s"
+  count = 2
+
+  environment_id = try(data.huaweicloud_cae_environments.test.environments[0].id, "NOT_FOUND")
+  application_id = huaweicloud_cae_application.test.id
 
   metadata {
-    name = "%[4]s${count.index}"
+    name = format("%[2]s-%%d", count.index)
 
     annotations = {
       version = "2.0.0"
@@ -733,12 +803,13 @@ resource "huaweicloud_cae_component" "test" {
 
 # Verify that only the 'version' is changed and that 'resource_limit' is ignored in the request body.
 resource "huaweicloud_cae_component" "deploy_after_update" {
-  count          = 2
-  environment_id = "%[2]s"
-  application_id = "%[3]s"
+  count = 2
+
+  environment_id = try(data.huaweicloud_cae_environments.test.environments[0].id, "NOT_FOUND")
+  application_id = huaweicloud_cae_application.test.id
 
   metadata {
-    name = "%[4]s-update-${count.index}"
+    name = format("%[2]s-update-%%d", count.index)
 
     annotations = {
       version = "3.0.0"
@@ -770,5 +841,113 @@ resource "huaweicloud_cae_component" "deploy_after_update" {
     }
   }
 }
-`, testAccComponent_deploy_base(), acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID, name)
+`, baseConfig, name)
+}
+
+func TestAccComponent_withEpsId(t *testing.T) {
+	var (
+		obj interface{}
+
+		rName = "huaweicloud_cae_component.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+		rc    = acceptance.InitResourceCheck(rName, &obj, getComponentFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please make sure the second environment is under the non-default enterprise project.
+			acceptance.TestAccPreCheckCaeEnvironmentIds(t, 2)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComponent_withEpsId_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "environment_id"),
+					resource.TestCheckResourceAttrPair(rName, "application_id", "huaweicloud_cae_application.test", "id"),
+					resource.TestCheckResourceAttr(rName, "metadata.0.name", name),
+					resource.TestCheckResourceAttr(rName, "metadata.0.annotations.version", "1.0.0"),
+					resource.TestCheckResourceAttr(rName, "spec.0.replica", "1"),
+					resource.TestCheckResourceAttr(rName, "spec.0.runtime", "Docker"),
+					resource.TestCheckResourceAttr(rName, "spec.0.source.0.type", "image"),
+					resource.TestCheckResourceAttrSet(rName, "spec.0.source.0.url"),
+					resource.TestCheckResourceAttr(rName, "spec.0.resource_limit.0.cpu", "500m"),
+					resource.TestCheckResourceAttr(rName, "spec.0.resource_limit.0.memory", "1Gi"),
+					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
+					// Check attributes.
+					// When the component is not deployed, the number of available instances under it is 0.
+					resource.TestCheckResourceAttr(rName, "available_replica", "0"),
+					resource.TestCheckResourceAttr(rName, "status", "created"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.annotations"},
+				ImportStateIdFunc:       testAccComponentImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccComponent_withEpsId_step1(name string) string {
+	return fmt.Sprintf(`
+locals {
+  environment_ids = split(",", "%[1]s")
+}
+
+# Query by environment ID under non-default enterprise project ID.
+data "huaweicloud_cae_environments" "test" {
+  environment_id        = local.environment_ids[1]
+  enterprise_project_id = "%[2]s"
+}
+
+resource "huaweicloud_cae_application" "test" {
+  environment_id        = try(data.huaweicloud_cae_environments.test.environments[0].id, "NOT_FOUND")
+  name                  = "%[3]s"
+  enterprise_project_id = "%[2]s"
+}
+
+data "huaweicloud_swr_repositories" "test" {}
+
+locals {
+  swr_repositories = [for v in data.huaweicloud_swr_repositories.test.repositories : v if length(v.tags) > 0][0]
+}
+
+resource "huaweicloud_cae_component" "test" {
+  environment_id        = try(data.huaweicloud_cae_environments.test.environments[0].id, "NOT_FOUND")
+  application_id        = huaweicloud_cae_application.test.id
+  enterprise_project_id = "%[2]s"
+
+  metadata {
+    name = "%[3]s"
+
+    annotations = {
+      version = "1.0.0"
+    }
+  }
+
+  spec {
+    replica = 1
+    runtime = "Docker"
+
+    source {
+      type = "image"
+      url  = format("%%s:%%s", local.swr_repositories.path, local.swr_repositories.tags[0])
+    }
+
+    resource_limit {
+      cpu    = "500m"
+      memory = "1Gi"
+    }
+  }
+}
+`, acceptance.HW_CAE_ENVIRONMENT_IDS, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new optional parameter `enterprise_project_id` for the component resource and data source:
- data.huaweicloud_cae_components
- huaweicloud_cae_component
- huaweicloud_cae_component_action
- huaweicloud_cae_component_deployment (deprecated)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. component resource and data source support enterprise project ID parameter.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cae -f TestAccDatasourceApplications_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccDatasourceApplications_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourceApplications_basic
=== PAUSE TestAccDatasourceApplications_basic
=== CONT  TestAccDatasourceApplications_basic
--- PASS: TestAccDatasourceApplications_basic (13.50s)
PASS
coverage: 11.4% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       13.596s coverage: 11.4% of statements in ./huaweicloud/services/cae
```
```
./scripts/coverage.sh -o cae -f TestAccApplication_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccApplication_basic -timeout 360m -parallel 10
=== RUN   TestAccApplication_basic
=== PAUSE TestAccApplication_basic
=== CONT  TestAccApplication_basic
--- PASS: TestAccApplication_basic (19.65s)
PASS
coverage: 9.4% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       19.756s coverage: 9.4% of statements in ./huaweicloud/services/cae
```
```
./scripts/coverage.sh -o cae -f TestAccDataSourceComponents_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccDataSourceComponents_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceComponents_basic
=== PAUSE TestAccDataSourceComponents_basic
=== CONT  TestAccDataSourceComponents_basic
--- PASS: TestAccDataSourceComponents_basic (34.16s)
PASS
coverage: 19.2% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       34.277s coverage: 19.2% of statements in ./huaweicloud/services/cae
```
```
./scripts/coverage.sh -o cae -f TestAccComponent_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cae" -v -coverprofile="./huaweicloud/services/acceptance/cae/cae_coverage.cov" -coverpkg="./huaweicloud/services/cae" -run TestAccComponent_ -timeout 360m -parallel 10
=== RUN   TestAccComponent_basic
=== PAUSE TestAccComponent_basic
=== RUN   TestAccComponent_configurationsAndAction
=== PAUSE TestAccComponent_configurationsAndAction
=== RUN   TestAccComponent_withEpsId
=== PAUSE TestAccComponent_withEpsId
=== CONT  TestAccComponent_basic
=== CONT  TestAccComponent_withEpsId
=== CONT  TestAccComponent_configurationsAndAction
--- PASS: TestAccComponent_withEpsId (34.99s)
--- PASS: TestAccComponent_basic (62.18s)
--- PASS: TestAccComponent_configurationsAndAction (888.35s)
PASS
coverage: 23.4% of statements in ./huaweicloud/services/cae
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       888.427s        coverage: 23.4% of statements in ./huaweicloud/services/cae
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
