### PR TITLE
chore(kafka/instance): replace creation api and add new field

### DIFF
--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -139,8 +139,11 @@ The following arguments are supported:
 
   -> The number of specified IP addresses must be less than or equal to the number of new brokers.
 
-* `access_user` - (Optional, String, ForceNew) Specifies the username of SASL_SSL user. A username consists of 4
+* `access_user` - (Optional, String) Specifies the username of SASL_SSL user. A username consists of 4
   to 64 characters and supports only letters, digits, and hyphens (-). Changing this creates a new instance resource.
+
+  -> This parameter can be modified only when SSL is enabled for the first time using the `port_protocol` parameter.
+     This parameter cannot be modified after encrypted access is enabled.
 
 * `password` - (Optional, String) Specifies the password of SASL_SSL user. A password must meet the following
   complexity requirements: Must be 8 to 32 characters long. Must contain at least 2 of the following character types:
@@ -155,12 +158,18 @@ The following arguments are supported:
   
   Defaults to **SASL_SSL**. Changing this creates a new instance resource.
 
-* `enabled_mechanisms` - (Optional, List, ForceNew) Specifies the authentication mechanisms to use after SASL is
+  -> If `port_protocol` is used to set the private network access security protocol and the public network access
+  security protocol, this parameter is invalid.
+
+* `enabled_mechanisms` - (Optional, List) Specifies the authentication mechanisms to use after SASL is
   enabled. Value options:
   + **PLAIN**: Simple username and password verification.
   + **SCRAM-SHA-512**: User credential verification, which is more secure than **PLAIN**.
   
   Defaults to [**PLAIN**]. Changing this creates a new instance resource.
+
+  -> This parameter can be modified only when SSL is enabled for the first time using the `port_protocol` parameter.
+     This parameter cannot be modified after encrypted access is enabled.
 
 * `description` - (Optional, String) Specifies the description of the DMS Kafka instance. It is a character string
   containing not more than 1,024 characters.
@@ -213,8 +222,10 @@ The following arguments are supported:
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the Kafka instance.
 
-* `ssl_enable` - (Optional, Bool, ForceNew) Specifies whether the Kafka SASL_SSL is enabled.
-  Changing this creates a new resource.
+* `ssl_enable` - (Optional, Bool, ForceNew) Specifies whether the Kafka SASL_SSL is enabled.  
+  Defaults to **false**.  
+  Changing this creates a new resource.  
+  When both `port_protocol` and `ssl_enable` parameters are set, `port_protocol` takes precedence.
 
 * `vpc_client_plain` - (Optional, Bool, ForceNew) Specifies whether the intra-VPC plaintext access is enabled.
   Defaults to **false**. Changing this creates a new resource.
@@ -223,6 +234,9 @@ The following arguments are supported:
 
 * `cross_vpc_accesses` - (Optional, List) Specifies the cross-VPC access information.
   The [object](#dms_cross_vpc_accesses) structure is documented below.
+
+* `port_protocol` - (Optional, List) Specifies the port protocol information.  
+  The [object](#kafka_instance_port_protocol) structure is documented below.
 
 * `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the instance. Valid values are *prePaid*
   and *postPaid*, defaults to *postPaid*. Changing this creates a new resource.
@@ -248,6 +262,25 @@ The `parameters` block supports:
 * `name` - (Required, String) Specifies the parameter name. Static parameter needs to restart the instance to take effect.
 
 * `value` - (Required, String) Specifies the parameter value.
+
+<a name="kafka_instance_port_protocol"></a>
+The `port_protocol` block supports:
+
+* `private_plain_enable` - (Optional, Bool) Specifies whether the private plaintext access is enabled.
+
+  -> The private plaintext access and private SSL access cannot be disabled at the same time.
+
+* `private_sasl_ssl_enable` - (Optional, Bool) Specifies whether the private SASL SSL access is enabled.  
+  This parameter and `private_sasl_plaintext_enable` cannot be set to `true` at the same time.
+
+* `private_sasl_plaintext_enable` - (Optional, Bool) Specifies whether the private SASL plaintext access is enabled.
+
+* `public_plain_enable` - (Optional, Bool) Specifies whether the public plaintext access is enabled.
+
+* `public_sasl_ssl_enable` - (Optional, Bool) Specifies whether the public SASL SSL access is enabled.
+  This parameter and `public_sasl_plaintext_enable` cannot be set to **true** at the same time.
+
+* `public_sasl_plaintext_enable` - (Optional, Bool) Specifies whether the public SASL plaintext access is enabled.
 
 ## Attribute Reference
 
@@ -283,8 +316,9 @@ In addition to all arguments above, the following attributes are exported:
 * `pod_connect_address` - Indicates the connection address on the tenant side.
 * `public_bandwidth` - Indicates the public network access bandwidth.
 * `ssl_two_way_enable` - Indicates whether to enable two-way authentication.
-* `port_protocols` - Indicates instance connection address. The structure is documented below.
-  The [port_protocols](#attr_port_protocols) structure is documented below.
+
+* `port_protocol` - Indicates instance connection address. The structure is documented below.
+  The [port_protocol](#dms_instance_port_protocol_attr) structure is documented below.
 
 <a name="attr_cross_vpc_accesses"></a>
 The `cross_vpc_accesses` block supports:
@@ -293,26 +327,31 @@ The `cross_vpc_accesses` block supports:
 * `port` - The port number.
 * `port_id` - The port ID associated with the address.
 
-<a name="attr_port_protocols"></a>
+<a name="dms_instance_port_protocol_attr"></a>
 The `port_protocols` block supports:
 
-* `private_plain_enable` - Whether the private plain enabled.
 * `private_plain_address` - The private plain address.
+
 * `private_plain_domain_name` - The private plain domain name.
-* `private_sasl_ssl_enable` - Whether the private sasl ssl enabled.
+
 * `private_sasl_ssl_address` - The private sasl ssl address.
+
 * `private_sasl_ssl_domain_name` - The private sasl ssl domain name.
-* `private_sasl_plaintext_enable` - Whether the private sasl plaintext enabled.
+
 * `private_sasl_plaintext_address` - The private sasl plaintext address.
+
 * `private_sasl_plaintext_domain_name` - The private sasl plaintext domain name.
-* `public_plain_enable` - Whether the public plain enabled.
+
 * `public_plain_address` - The public plain address.
+
 * `public_plain_domain_name` - The public plain domain name.
-* `public_sasl_ssl_enable` - Whether the public sasl ssl enabled.
+
 * `public_sasl_ssl_address` - The public sasl ssl address.
+
 * `public_sasl_ssl_domain_name` - The public sasl ssl domain name.
-* `public_sasl_plaintext_enable` - Whether the public sasl plaintext enabled.
+
 * `public_sasl_plaintext_address` - The public sasl plaintext address.
+
 * `public_sasl_plaintext_domain_name` - The public sasl plaintext domain name.
 
 ## Timeouts
@@ -333,7 +372,7 @@ DMS Kafka instance can be imported using the instance id, e.g.
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include:
-`password`, `public_ip_ids`, `security_protocol`, `enabled_mechanisms` and `arch_type`.
+`password`, `security_protocol`, `enabled_mechanisms`, `arch_type` and `new_tenant_ips`.
 It is generally recommended running `terraform plan` after importing
 a DMS Kafka instance. You can then decide if changes should be applied to the instance, or the resource definition
 should be updated to align with the instance. Also you can ignore changes as below.
@@ -344,7 +383,7 @@ resource "huaweicloud_dms_kafka_instance" "instance_1" {
 
   lifecycle {
     ignore_changes = [
-      password,
+      password, security_protocol, enabled_mechanisms, arch_type, new_tenant_ips
     ]
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20250819081804-8cb1d13917c6
+	github.com/chnsz/golangsdk v0.0.0-20250829092604-a21a0532b48a
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20250819081804-8cb1d13917c6 h1:4UNQBG1jtjuaFW4cusbK2yMYm4yLAsvjt/NlPxpPpd0=
-github.com/chnsz/golangsdk v0.0.0-20250819081804-8cb1d13917c6/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
+github.com/chnsz/golangsdk v0.0.0-20250829092604-a21a0532b48a h1:ZLkxFP5RobhPnBNMmurJ+JeKn33vlFLNBYjEICd8RNE=
+github.com/chnsz/golangsdk v0.0.0-20250829092604-a21a0532b48a/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/requests.go
@@ -150,6 +150,12 @@ type CreateOps struct {
 
 	// Indicates the parameter related to the yearly/monthly billing mode.
 	BssParam BssParam `json:"bss_param,omitempty"`
+
+	// The access mode of the Kafka instance.
+	PortProtocol *PortProtocol `json:"port_protocol,omitempty"`
+
+	// The private IP addresses of the Kafka instance.
+	TenantIps []string `json:"tenant_ips,omitempty"`
 }
 
 type BssParam struct {
@@ -169,6 +175,39 @@ type BssParam struct {
 	IsAutoPay *bool `json:"is_auto_pay,omitempty"`
 }
 
+type PortProtocol struct {
+	// Whether to enable private plaintext access. Default to `false`.
+	// + true: Enable private plaintext access. Connection address: ip:9092, access protocol: PLAINTEXT.
+	// + false: Disable private plaintext access.
+	PrivatePlainEnable *bool `json:"private_plain_enable,omitempty"`
+
+	// Whether to enable private ciphertext access mode with the SASL_SSL security protocol. Default to `false`.
+	// `private_sasl_ssl_enable` and `private_sasl_plaintext_enable` cannot be set to `true` at the same time.
+	PrivateSaslSslEnable *bool `json:"private_sasl_ssl_enable,omitempty"`
+
+	// Whether to enable private SASL plaintext access. Default to `false`.
+	// Connection address: ip:9093, access protocol: SASL_PLAINTEXT.
+	// `private_sasl_plaintext_enable` and `private_sasl_ssl_enable` cannot be set to `true` at the same time.
+	PrivateSaslPlaintextEnable *bool `json:"private_sasl_plaintext_enable,omitempty"`
+
+	// Whether to enable public plaintext access. Default to `false`.
+	// Before enabling public plaintext access, you must enable public network access.
+	// Connection address: ip:9094, access protocol: PLAINTEXT.
+	PublicPlainEnable *bool `json:"public_plain_enable,omitempty"`
+
+	// Whether to enable public SASL SSL access. Default to `false`.
+	// Connection address: ip:9095, access protocol: SASL_SSL.
+	// `public_sasl_ssl_enable` and `public_sasl_plaintext_enable` cannot be set to `true` at the same time.
+	// When this parameter is set to `true`, the instance must be enabled for public network access.
+	PublicSaslSslEnable *bool `json:"public_sasl_ssl_enable,omitempty"`
+
+	// Whether to enable public SASL plaintext access. Default to `false`.
+	// Connection address: ip:9095, access protocol: SASL_PLAINTEXT.
+	// `public_sasl_plaintext_enable` and `public_sasl_ssl_enable` cannot be set to `true` at the same time.
+	// When this parameter is set to `true`, the instance must be enabled for public network access.
+	PublicSaslPlaintextEnable *bool `json:"public_sasl_plaintext_enable,omitempty"`
+}
+
 // ToInstanceCreateMap is used for type convert
 func (ops CreateOps) ToInstanceCreateMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(ops, "")
@@ -183,6 +222,20 @@ func Create(client *golangsdk.ServiceClient, ops CreateOpsBuilder) (r CreateResu
 	}
 
 	_, r.Err = client.Post(createURL(client), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}
+
+func CreateWithEngine(client *golangsdk.ServiceClient, ops CreateOpsBuilder, engine string) (r CreateResult) {
+	b, err := ops.ToInstanceCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(createURLWithEngine(engine, client), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{200},
 	})
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/urls.go
@@ -10,6 +10,10 @@ func createURL(client *golangsdk.ServiceClient) string {
 	return client.ServiceURL(client.ProjectID, resourcePath)
 }
 
+func createURLWithEngine(engine string, client *golangsdk.ServiceClient) string {
+	return client.ServiceURL(engine, client.ProjectID, resourcePath)
+}
+
 // deleteURL will build the url of deletion
 func deleteURL(client *golangsdk.ServiceClient, id string) string {
 	return client.ServiceURL(client.ProjectID, resourcePath, id)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20250819081804-8cb1d13917c6
+# github.com/chnsz/golangsdk v0.0.0-20250829092604-a21a0532b48a
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Use the new creation API instead of the old one and support the `port_protocol` parameter.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccKafkaInstance_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccKafkaInstance_ -timeout 360m -parallel 10
=== RUN   TestAccKafkaInstance_prePaid
=== PAUSE TestAccKafkaInstance_prePaid
=== RUN   TestAccKafkaInstance_newFormat
=== PAUSE TestAccKafkaInstance_newFormat
=== RUN   TestAccKafkaInstance_publicIp
=== PAUSE TestAccKafkaInstance_publicIp
=== CONT  TestAccKafkaInstance_prePaid
=== CONT  TestAccKafkaInstance_newFormat
=== CONT  TestAccKafkaInstance_publicIp
--- PASS: TestAccKafkaInstance_prePaid (841.82s)
--- PASS: TestAccKafkaInstance_publicIp (1458.95s)
--- PASS: TestAccKafkaInstance_newFormat (2335.72s)
PASS
coverage: 21.7% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     2335.806s       coverage: 21.7% of statements in ./huaweicloud/services/kafka
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
