### PR TITLE
feat(secmaster): new datasource to query collector logstash parsers

### DIFF
--- a/docs/data-sources/secmaster_collector_logstash_parsers.md
+++ b/docs/data-sources/secmaster_collector_logstash_parsers.md
@@ -1,0 +1,60 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_collector_logstash_parsers"
+description: |-
+  Use this data source to query the SecMaster collector logstash parsers within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_collector_logstash_parsers
+
+Use this data source to query the SecMaster collector logstash parsers within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_secmaster_collector_logstash_parsers" "example" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the collector logstash parsers.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to query collector logstash parsers.
+
+* `query_type` - (Optional, String) Specifies the query type. The value can be **QUICK** or **GENERAL**.
+
+* `title` - (Optional, String) Specifies the title of the parser to query.
+
+* `description` - (Optional, String) Specifies the description of the parser to query.
+
+* `sort_key` - (Optional, String) Specifies the field to sort the results by.
+
+* `sort_dir` - (Optional, String) Specifies the sorting direction. The value can be **asc** or **desc**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `records` - Indicates the list of collector logstash parsers.
+  The [records](#secmaster_collector_logstash_parser) structure is documented below.
+
+<a name="secmaster_collector_logstash_parser"></a>
+The `records` block supports:
+
+* `parser_id` - The ID of the parser.
+
+* `title` - The title of the parser.
+
+* `description` - The description of the parser.
+
+* `channel_refer_count` - The number of channels that reference this parser.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1572,6 +1572,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_upgradation_version":          secmaster.DataSourceUpgradationVersion(),
 			"huaweicloud_secmaster_vpc_endpoint_services":        secmaster.DataSourceSecmasterVpcEndpointServices(),
 			"huaweicloud_secmaster_catalogues_search":            secmaster.DataSourceSecmasterCataloguesSearch(),
+			"huaweicloud_secmaster_collector_logstash_parsers":   secmaster.DataSourceCollectorLogstashParsers(),
 			"huaweicloud_secmaster_installation_scripts":         secmaster.DataSourceSecmasterInstallationScripts(),
 			"huaweicloud_secmasterv2_alert_rule_template_detail": secmaster.DataSourceAlertRuleTemplateDetailV2(),
 			"huaweicloud_secmasterv2_alert_rule_templates":       secmaster.DataSourceAlertRuleTemplatesV2(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_collector_logstash_parsers_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_collector_logstash_parsers_test.go
@@ -1,0 +1,40 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCollectorLogstashParsers_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_secmaster_collector_logstash_parsers.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCollectorLogstashParsers_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "records.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCollectorLogstashParsers_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_collector_logstash_parsers" "test" {
+  workspace_id = "%[1]s"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_collector_logstash_parsers.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_collector_logstash_parsers.go
@@ -1,0 +1,197 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Secmaster GET /v1/{project_id}/workspaces/{workspace_id}/collector/logstash/parsers
+func DataSourceCollectorLogstashParsers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCollectorLogstashParsersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"query_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"title": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// This field is `Int` value in API document. To be safe, we set it to `String` value.
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"records": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"parser_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"title": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"channel_refer_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildCollectorLogstashParsersQueryParams(d *schema.ResourceData, offset int) string {
+	rst := ""
+	if v, ok := d.GetOk("query_type"); ok {
+		rst += fmt.Sprintf("&query_type=%v", v)
+	}
+
+	if v, ok := d.GetOk("title"); ok {
+		rst += fmt.Sprintf("&title=%v", v)
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		rst += fmt.Sprintf("&description=%v", v)
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		rst += fmt.Sprintf("&sort_key=%v", v)
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%v", v)
+	}
+
+	if offset > 0 {
+		rst += fmt.Sprintf("&offset=%d", offset)
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func dataSourceCollectorLogstashParsersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/workspaces/{workspace_id}/collector/logstash/parsers"
+		offset  = 0
+		allData = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", d.Get("workspace_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		requestPathWithQueryParams := requestPath + buildCollectorLogstashParsersQueryParams(d, offset)
+		resp, err := client.Request("GET", requestPathWithQueryParams, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving SecMaster collector logstash parsers: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		data := utils.PathSearch("records", respBody, make([]interface{}, 0)).([]interface{})
+		if len(data) == 0 {
+			break
+		}
+
+		allData = append(allData, data...)
+		count := utils.PathSearch("count", respBody, 0).(int)
+		if len(allData) >= count {
+			break
+		}
+
+		offset += len(data)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("records", flattenCollectorLogstashParsers(allData)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCollectorLogstashParsers(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"parser_id":           utils.PathSearch("parser_id", v, nil),
+			"title":               utils.PathSearch("title", v, nil),
+			"description":         utils.PathSearch("description", v, nil),
+			"channel_refer_count": utils.PathSearch("channel_refer_count", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query collector logstash parsers.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccDataSourceCollectorLogstashParsers_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourceCollectorLogstashParsers_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCollectorLogstashParsers_basic
=== PAUSE TestAccDataSourceCollectorLogstashParsers_basic
=== CONT  TestAccDataSourceCollectorLogstashParsers_basic
--- PASS: TestAccDataSourceCollectorLogstashParsers_basic (10.52s)
PASS
coverage: 4.1% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 10.630s coverage: 4.1% of statements in ./huaweicloud/services/secmaster
```
<img width="1377" height="81" alt="image" src="https://github.com/user-attachments/assets/0effa050-56a6-4135-8ea0-dfb9dcd5f188" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
