### PR TITLE
feat(rocketmq): add new data source to get topic list

### DIFF
--- a/docs/data-sources/dms_rocketmq_consumer_group_topics.md
+++ b/docs/data-sources/dms_rocketmq_consumer_group_topics.md
@@ -1,0 +1,96 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_rocketmq_consumer_group_topics"
+description: |-
+  Use this data source to get topic list under the specified consumer group within HuaweiCloud.
+---
+
+# huaweicloud_dms_rocketmq_consumer_group_topics
+
+Use this data source to get topic list under the specified consumer group within HuaweiCloud.
+
+## Example Usage
+
+### Query all topics under the specified consumer group
+
+```hcl
+var "instance_id" {}
+var "group_name" {}
+
+data "huaweicloud_dms_rocketmq_consumer_group_topics" "test" {
+  instance_id = var.instance_id
+  group       = var.group_name
+}
+```
+
+### Query the specified topic detail
+
+```hcl
+var "instance_id" {}
+var "group_name" {}
+var "topic_name" {}
+
+data "huaweicloud_dms_rocketmq_consumer_group_topics" "test" {
+  instance_id = var.instance_id
+  group       = var.group_name
+  topic       = var.topic_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the RocketMQ instance and consumer group are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the RocketMQ instance.
+
+* `group` - (Required, String) Specifies the name of the consumer group.
+
+* `topic` - (Optional, String) Specifies the name of the topic to be queried.  
+  If omitted, queries the topic list. If specified, queries the topic detail.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `topics` - The list of topics consumed by the consumer group.
+
+  -> Available if the filter parameter `topic` is **null** or omitted.
+
+* `lag` - The number of consumption accumulations.
+
+* `max_offset` - The total number of messages.
+
+* `consumer_offset` - The number of consumed messages.
+
+* `brokers` - The brokers associated with the topic.  
+  The [brokers](#rocketmq_consumer_group_topics_brokers_attr) structure is documented below.
+
+  -> The `lag`, `max_offset`, `consumer_offset` and `brokers` are available only when the
+     filter parameter `topic` is specified.
+
+<a name="rocketmq_consumer_group_topics_brokers_attr"></a>
+The `brokers` block supports:
+
+  * `broker_name` - The name of the broker.
+
+  * `queues` - The queue details of the associated broker.  
+    The [queues](#rocketmq_consumer_group_topics_queues_attr) structure is documented below.
+
+<a name="rocketmq_consumer_group_topics_queues_attr"></a>
+The `queues` block supports:
+
+  * `id` - The ID of the queue.
+
+  * `lag` - The number of consumption accumulations.
+
+  * `broker_offset` - The total number of messages.
+
+  * `consumer_offset` - The number of consumed messages.
+
+  * `last_message_time` - The storage time of the latest consumed message, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1010,6 +1010,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rocketmq_background_tasks":            rocketmq.DataSourceBackgroundTasks(),
 			"huaweicloud_dms_rocketmq_broker":                      rocketmq.DataSourceDmsRocketMQBroker(),
 			"huaweicloud_dms_rocketmq_consumer_group_access_users": rocketmq.DataSourceDmsRocketmqConsumerGroupAccessUsers(),
+			"huaweicloud_dms_rocketmq_consumer_group_topics":       rocketmq.DataSourceConsumerGroupTopics(),
 			"huaweicloud_dms_rocketmq_consumer_groups":             rocketmq.DataSourceDmsRocketMQConsumerGroups(),
 			"huaweicloud_dms_rocketmq_consumers":                   rocketmq.DataSourceDmsRocketmqConsumers(),
 			"huaweicloud_dms_rocketmq_dead_letter_messages":        rocketmq.DataSourceDeadLetterMessages(),

--- a/huaweicloud/services/acceptance/rocketmq/data_source_huaweicloud_dms_rocketmq_consumer_group_topics_test.go
+++ b/huaweicloud/services/acceptance/rocketmq/data_source_huaweicloud_dms_rocketmq_consumer_group_topics_test.go
@@ -1,0 +1,101 @@
+package rocketmq
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this test, make sure that the subscribed topic exists under the consumer group and
+// that messages have been sent to the topic.
+func TestAccDataConsumerGroupTopics_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dms_rocketmq_consumer_group_topics.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byTopic   = "data.huaweicloud_dms_rocketmq_consumer_group_topics.filter_by_topic"
+		dcByTopic = acceptance.InitDataSourceCheck(byTopic)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSRocketMQInstanceID(t)
+			acceptance.TestAccPreCheckDMSRocketMQGroupName(t)
+			acceptance.TestAccPreCheckDMSRocketMQTopicName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataConsumerGroupTopics_instanceNotFound(),
+				ExpectError: regexp.MustCompile(`This DMS instance does not exist`),
+			},
+			{
+				Config:      testAccDataConsumerGroupTopics_groupNotFound(),
+				ExpectError: regexp.MustCompile(`Group does not exist`),
+			},
+			{
+				Config: testAccDataConsumerGroupTopics_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "topics.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByTopic.CheckResourceExists(),
+					resource.TestCheckOutput("is_topic_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataConsumerGroupTopics_instanceNotFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dms_rocketmq_consumer_group_topics" "test" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+}
+`, randomId, acceptance.HW_DMS_ROCKETMQ_GROUP_NAME)
+}
+
+func testAccDataConsumerGroupTopics_groupNotFound() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dms_rocketmq_consumer_group_topics" "test" {
+  instance_id = "%[1]s"
+  group       = "non_found_consumer_group"
+}
+`, acceptance.HW_DMS_ROCKETMQ_INSTANCE_ID)
+}
+
+func testAccDataConsumerGroupTopics_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dms_rocketmq_consumer_group_topics" "test" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+}
+
+data "huaweicloud_dms_rocketmq_consumer_group_topics" "filter_by_topic" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+  topic       = "%[3]s"
+}
+
+locals {
+  filter_result = data.huaweicloud_dms_rocketmq_consumer_group_topics.filter_by_topic
+}
+
+output "is_topic_filter_useful" {
+  value = (
+    local.filter_result.max_offset > 0 &&
+    local.filter_result.consumer_offset > 0 &&
+    length(local.filter_result.brokers) > 0 &&
+    length(local.filter_result.brokers[0].broker_name) != "" &&
+    length(local.filter_result.brokers[0].queues) > 0
+  )
+}
+`, acceptance.HW_DMS_ROCKETMQ_INSTANCE_ID, acceptance.HW_DMS_ROCKETMQ_GROUP_NAME, acceptance.HW_DMS_ROCKETMQ_TOPIC_NAME)
+}

--- a/huaweicloud/services/rocketmq/data_source_huaweicloud_dms_rocketmq_consumer_group_topics.go
+++ b/huaweicloud/services/rocketmq/data_source_huaweicloud_dms_rocketmq_consumer_group_topics.go
@@ -1,0 +1,236 @@
+package rocketmq
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RocketMQ GET /v2/{project_id}/instances/{instance_id}/groups/{group}/topics
+func DataSourceConsumerGroupTopics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceConsumerGroupTopicsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the RocketMQ instance and consumer group are located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the RocketMQ instance.`,
+			},
+			"group": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the consumer group.`,
+			},
+			"topic": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the topic to be queried.`,
+			},
+			"topics": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of topics consumed by the consumer group.`,
+			},
+			"lag": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of consumption accumulations.`,
+			},
+			"max_offset": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The total number of messages.`,
+			},
+			"consumer_offset": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of consumed messages.`,
+			},
+			"brokers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"broker_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the broker.`,
+						},
+						"queues": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The queue details of the associated broker.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The ID of the queue.`,
+									},
+									"lag": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The number of consumption accumulations.`,
+									},
+									"broker_offset": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The total number of messages.`,
+									},
+									"consumer_offset": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The number of consumed messages.`,
+									},
+									"last_message_time": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The storage time of the latest consumed message, in RFC3339 format.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildConsumerGroupTopicsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if topic, ok := d.GetOk("topic"); ok {
+		res += fmt.Sprintf("&topic=%s", topic)
+	}
+	return res
+}
+
+func getConsumerGroupTopics(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, interface{}, error) {
+	var (
+		// The limit maximum value is 50, default is 10.
+		httpUrl  = "v2/{project_id}/instances/{instance_id}/groups/{group}/topics?limit=50"
+		offset   = 0
+		result   = make([]interface{}, 0)
+		respBody interface{}
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", d.Get("instance_id").(string))
+	listPath = strings.ReplaceAll(listPath, "{group}", d.Get("group").(string))
+	listPath += buildConsumerGroupTopicsQueryParams(d)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &getOpt)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		respBody, err = utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		topics := utils.PathSearch("topics", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, topics...)
+		// The `offset` cannot be greater than or equal to the total number of topics. Otherwise, the response is as follows:
+		// {"error_code": "DMS.40050010","error_msg": "Offset parameter is invalid."}
+		offset += len(topics)
+		totalCount := utils.PathSearch("total", respBody, float64(0))
+		if offset >= int(totalCount.(float64)) {
+			break
+		}
+	}
+	return result, respBody, nil
+}
+
+func dataSourceConsumerGroupTopicsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	topics, respBody, err := getConsumerGroupTopics(client, d)
+	if err != nil {
+		return diag.Errorf("error getting topics under consumer group: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("topics", topics),
+		d.Set("lag", utils.PathSearch("lag", respBody, nil)),
+		d.Set("max_offset", utils.PathSearch("max_offset", respBody, nil)),
+		d.Set("consumer_offset", utils.PathSearch("consumer_offset", respBody, nil)),
+		d.Set("brokers", flattenConsumerGroupTopicsBrokers(utils.PathSearch("brokers", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenConsumerGroupTopicsBrokers(brokers []interface{}) []interface{} {
+	if len(brokers) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(brokers))
+	for _, v := range brokers {
+		rst = append(rst, map[string]interface{}{
+			"broker_name": utils.PathSearch("broker_name", v, nil),
+			"queues":      flattenConsumerGroupTopicsBrokerQueues(utils.PathSearch("queues", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return rst
+}
+
+func flattenConsumerGroupTopicsBrokerQueues(queues []interface{}) []interface{} {
+	if len(queues) == 0 {
+		return nil
+	}
+	rst := make([]interface{}, 0, len(queues))
+	for _, v := range queues {
+		rst = append(rst, map[string]interface{}{
+			"id":                utils.PathSearch("id", v, nil),
+			"lag":               utils.PathSearch("lag", v, nil),
+			"broker_offset":     utils.PathSearch("broker_offset", v, nil),
+			"consumer_offset":   utils.PathSearch("consumer_offset", v, nil),
+			"last_message_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("last_message_time", v, float64(0)).(float64))/1000, false),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

Add new data source (`huaweicloud_dms_rocketmq_consumer_group_topics`) to get topics list under a specified consumer group.

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
2. add related documation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o rocketmq -f TestAccDataConsumerGroupTopics_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rocketmq" -v -coverprofile="./huaweicloud/services/acceptance/rocketmq/rocketmq_coverage.cov" -coverpkg="./huaweicloud/services/rocketmq" -run TestAccDataConsumerGroupTopics_basic -timeout 360m -parallel 10
=== RUN   TestAccDataConsumerGroupTopics_basic
=== PAUSE TestAccDataConsumerGroupTopics_basic
=== CONT  TestAccDataConsumerGroupTopics_basic
--- PASS: TestAccDataConsumerGroupTopics_basic (14.76s)
PASS
coverage: 6.6% of statements in ./huaweicloud/services/rocketmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rocketmq  14.847s coverage: 6.6% of statements in ./huaweicloud/services/rocketmq
```
<img width="1073" height="177" alt="image" src="https://github.com/user-attachments/assets/81ce9468-62ba-4386-82fc-c578dd26657d" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
