### PR TITLE
feat(dew): add a datasource to query the list of CSMS secret tags

### DIFF
--- a/docs/data-sources/csms_secret_tags.md
+++ b/docs/data-sources/csms_secret_tags.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_csms_secret_tags"
+description: |-
+  Use this data source to query the list of CSMS secret tags within HuaweiCloud.
+---
+
+# huaweicloud_csms_secret_tags
+
+Use this data source to query the list of CSMS secret tags within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_csms_secret_tags" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tags` - The list of the secret tags.
+  The [tags](#csms_project_tags) structure is documented below.
+
+<a name="csms_project_tags"></a>
+The `tags` block supports:
+
+* `key` - The tag key.
+
+* `values` - The list of tag values.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -812,6 +812,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_csms_secret_versions":          dew.DataSourceDewCsmsSecretVersions(),
 			"huaweicloud_csms_secrets_by_tags":          dew.DataSourceCSMSSecretsByTags(),
 			"huaweicloud_csms_tasks":                    dew.DataSourceCsmsTasks(),
+			"huaweicloud_csms_secret_tags":              dew.DataSourceCsmsSecretTags(),
 			"huaweicloud_css_flavors":                   css.DataSourceCssFlavors(),
 			"huaweicloud_css_clusters":                  css.DataSourceCssClusters(),
 			"huaweicloud_css_logstash_pipelines":        css.DataSourceCssLogstashPipelines(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -138,6 +138,7 @@ var (
 	HW_KPS_ENABLE_FLAG      = os.Getenv("HW_KPS_ENABLE_FLAG")
 	HW_KPS_FAILED_TASK_ID   = os.Getenv("HW_KPS_FAILED_TASK_ID")
 	HW_CSMS_TASK_ID         = os.Getenv("HW_CSMS_TASK_ID")
+	HW_CSMS_SECRET_ID       = os.Getenv("HW_CSMS_SECRET_ID")
 
 	HW_DEST_REGION          = os.Getenv("HW_DEST_REGION")
 	HW_DEST_PROJECT_ID      = os.Getenv("HW_DEST_PROJECT_ID")
@@ -3829,6 +3830,13 @@ func TestAccPrecheckDewFlag(t *testing.T) {
 func TestAccPrecheckCsmsTask(t *testing.T) {
 	if HW_CSMS_TASK_ID == "" {
 		t.Skip("HW_CSMS_TASK_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCsmsSecretID(t *testing.T) {
+	if HW_CSMS_SECRET_ID == "" {
+		t.Skip("HW_CSMS_SECRET_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_csms_secret_tags_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_csms_secret_tags_test.go
@@ -1,0 +1,38 @@
+package dew
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCsmsSecretTags_basic(t *testing.T) {
+	var (
+		dataSourcename = "data.huaweicloud_csms_secret_tags.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourcename)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare an import CSMS secret with tags and config it to the environment variable.
+			acceptance.TestAccPreCheckCsmsSecretID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCsmsSecretTags_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourcename, "tags.#"),
+					resource.TestCheckResourceAttrSet(dataSourcename, "tags.0.key"),
+					resource.TestCheckResourceAttrSet(dataSourcename, "tags.0.values.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceCsmsSecretTags_basic = `data "huaweicloud_csms_secret_tags" "test" {}`

--- a/huaweicloud/services/dew/data_source_huaweicloud_csms_secret_tags.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_csms_secret_tags.go
@@ -1,0 +1,119 @@
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW GET /v1/{project_id}/csms/tags
+func DataSourceCsmsSecretTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCsmsSecretTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource.`,
+			},
+			"tags": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the secret tags.`,
+				Elem:        secretTagSchema(),
+			},
+		},
+	}
+}
+
+func secretTagSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The tag key.",
+			},
+			"values": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The list of tag values.",
+			},
+		},
+	}
+}
+
+func dataSourceCsmsSecretTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		mErr       *multierror.Error
+		getHttpUrl = "v1/{project_id}/csms/tags"
+		product    = "kms"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CSMS secret tags: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	tagsList := utils.PathSearch("tags", getRespBody, make([]interface{}, 0)).([]interface{})
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("tags", flattenCsmsSecretTags(tagsList)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCsmsSecretTags(tags []interface{}) []map[string]interface{} {
+	if len(tags) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(tags))
+	for _, tag := range tags {
+		result = append(result, map[string]interface{}{
+			"key":    utils.PathSearch("key", tag, nil),
+			"values": utils.PathSearch("values", tag, make([]interface{}, 0)),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New data source to query the list of CSMS secret tags and names huaweicloud_csms_secret_tags.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccDataSourceCsmsSecretTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCsmsSecretTags_basic
=== PAUSE TestAccDataSourceCsmsSecretTags_basic
=== CONT  TestAccDataSourceCsmsSecretTags_basic
--- PASS: TestAccDataSourceCsmsSecretTags_basic (25.76s)
PASS
coverage: 3.9% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       25.805s coverage: 3.9% of statements in ./huaweicloud/services/dew
```
<img width="865" height="47" alt="image" src="https://github.com/user-attachments/assets/442d7dc0-2187-4fd8-a53d-d8e724f9a98f" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
