### PR TITLE
feat(secmaster): new datasource to query table consumption

### DIFF
--- a/.github/workflows/doc-lint.yml
+++ b/.github/workflows/doc-lint.yml
@@ -38,7 +38,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           locale: "US"
           ignore: |
-            analyses,cancelled,classis,cancelling,catalogue,catalogues,defence,
+            analyses,cancelled,classis,cancelling,catalogue,catalogues,defence,subscirption,
           pattern: |
             *.md
             *.tf

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,6 +72,7 @@ linters-settings:
       - cancelling
       - catalogue
       - catalogues
+      - subscirption
       - defence
   gci:
     # Section configuration to compare against.

--- a/docs/data-sources/secmaster_table_consumption.md
+++ b/docs/data-sources/secmaster_table_consumption.md
@@ -1,0 +1,56 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_table_consumption"
+description: |-
+  Use this data source to get the data consumption configuration of a specified table from HuaweiCloud SecMaster.
+---
+
+# huaweicloud_secmaster_table_consumption
+
+Use this data source to get the data consumption configuration of a specified table from HuaweiCloud SecMaster.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "table_id" {}
+
+data "huaweicloud_secmaster_table_consumption" "example" {
+  workspace_id = var.workspace_id
+  table_id     = var.table_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID.
+
+* `table_id` - (Required, String) Specifies the ID of the table to get consumption configuration.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `table_name` - The name of the table.
+
+* `dataspace_id` - The data space ID.
+
+* `pipe_id` - The pipeline ID.
+
+* `pipe_name` - The name of the pipeline.
+
+* `status` - The status of the consumption configuration. Possible values are **ENABLED** or **DISABLED**.
+
+* `type` - The network type. Possible values are **INTERNET** or **INTRANET**.
+
+* `access_point` - The access point domain information (format: `{dataspace}.{endpoint}`).
+
+* `subscirption` - The subscription name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1551,6 +1551,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_baseline_check_results":       secmaster.DataSourceSecmasterBaselineCheckResults(),
 			"huaweicloud_secmaster_playbooks":                    secmaster.DataSourceSecmasterPlaybooks(),
 			"huaweicloud_secmaster_security_reports":             secmaster.DataSourceSecurityReports(),
+			"huaweicloud_secmaster_table_consumption":            secmaster.DataSourceTableConsumption(),
 			"huaweicloud_secmaster_alert_rules":                  secmaster.DataSourceSecmasterAlertRules(),
 			"huaweicloud_secmaster_alert_rule_templates":         secmaster.DataSourceSecmasterAlertRuleTemplates(),
 			"huaweicloud_secmaster_playbook_versions":            secmaster.DataSourceSecmasterPlaybookVersions(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_table_consumption_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_table_consumption_test.go
@@ -1,0 +1,38 @@
+package secmaster
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceTableConsumption_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testDataSourceSecmasterTableConsumption_basic(),
+				ExpectError: regexp.MustCompile(`版本未升级，请使用老版本.`),
+			},
+		},
+	})
+}
+
+// Due to the lack of a test environment, only expected failure scenarios can be tested at present.
+// The value of `table_id` in the test script is mock data.
+func testDataSourceSecmasterTableConsumption_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_table_consumption" "test" {
+  workspace_id = "%s"
+  table_id     = "7251f007-f723-477f-949d-5b0f697238bf"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_table_consumption.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_table_consumption.go
@@ -1,0 +1,129 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Secmaster GET /v2/{project_id}/workspaces/{workspace_id}/siem/tables/{table_id}/consumption
+func DataSourceTableConsumption() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTableConsumptionRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"table_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"table_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dataspace_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"pipe_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"pipe_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"access_point": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			// This field is misspelled in the API documentation. It is consistent here with the API documentation.
+			"subscirption": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTableConsumptionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v2/{project_id}/workspaces/{workspace_id}/siem/tables/{table_id}/consumption"
+		workspaceID = d.Get("workspace_id").(string)
+		tableID     = d.Get("table_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", workspaceID)
+	requestPath = strings.ReplaceAll(requestPath, "{table_id}", tableID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving SecMaster table consumption configuration: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("table_name", utils.PathSearch("table_name", respBody, nil)),
+		d.Set("dataspace_id", utils.PathSearch("dataspace_id", respBody, nil)),
+		d.Set("pipe_id", utils.PathSearch("pipe_id", respBody, nil)),
+		d.Set("pipe_name", utils.PathSearch("pipe_name", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("type", utils.PathSearch("type", respBody, nil)),
+		d.Set("access_point", utils.PathSearch("access_point", respBody, nil)),
+		d.Set("subscirption", utils.PathSearch("subscirption", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query table consumption.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccDataSourceTableConsumption_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourceTableConsumption_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceTableConsumption_basic
=== PAUSE TestAccDataSourceTableConsumption_basic
=== CONT  TestAccDataSourceTableConsumption_basic
--- PASS: TestAccDataSourceTableConsumption_basic (2.65s)
PASS
coverage: 3.5% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 2.749s  coverage: 3.5% of statements in ./huaweicloud/services/secmaster
```
<img width="1373" height="81" alt="image" src="https://github.com/user-attachments/assets/9682dabf-14d4-4a9b-aa42-3d933d0d5ec2" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
