### PR TITLE
feat(rabbitmq): add 'arguments' field for exchange resource and data source

### DIFF
--- a/docs/data-sources/dms_rabbitmq_exchanges.md
+++ b/docs/data-sources/dms_rabbitmq_exchanges.md
@@ -59,3 +59,5 @@ The `exchanges` block supports:
 * `internal` - Indicates whether the exchange is internal.
 
 * `default` - Indicates whether the exchange is default.
+
+* `arguments` - The argument configuration of the exchange, in JSON format.

--- a/docs/resources/dms_rabbitmq_exchange.md
+++ b/docs/resources/dms_rabbitmq_exchange.md
@@ -12,6 +12,8 @@ Manages a DMS RabbitMQ exchange resource within HuaweiCloud.
 
 ## Example Usage
 
+### Create a RabbitMQ `3.x.x` exchange
+
 ```hcl
 variable "instance_id" {}
 variable "vhost" {}
@@ -25,6 +27,26 @@ resource "huaweicloud_dms_rabbitmq_exchange" "test" {
   auto_delete = false
   durable     = true
   internal    = false
+}
+```
+
+### Create a RabbitMQ `AMQP-0-9-1` exchange with arguments
+
+```hcl
+variable "instance_id" {}
+variable "vhost_name" {}
+variable "exchange_name" {}
+
+resource "huaweicloud_dms_rabbitmq_exchange" "test" {
+  instance_id = var.instance_id
+  vhost       = var.vhost_name
+  name        = var.exchange_name
+  type        = "x-delayed-message"
+  auto_delete = true
+
+  arguments   = jsonencode({
+    "x-delayed-type" = "header"
+  })
 }
 ```
 
@@ -44,16 +66,31 @@ The following arguments are supported:
 
 * `name` - (Required, String, ForceNew) Specifies the exchange name. Changing this creates a new resource.
 
-* `type` - (Required, String, ForceNew) Specifies the exchange type. Valid values are **direct**, **fanout**, **topic**
-  and **headers**. Changing this creates a new resource.
+* `type` - (Required, String, ForceNew) Specifies the routing type of the exchange.  
+  Changing this creates a new resource.  
+  The valid values are as follows:
+  + **direct**
+  + **fanout**
+  + **topic**
+  + **headers**
+  + **x-delayed-message**
+  + **x-consistent-hash**
+
+  Currently, only RabbitMQ `AMQP-0-9-1` exchange supports **x-delayed-message** and **x-consistent-hash**.
 
 * `auto_delete` - (Required, Bool, ForceNew) Specifies whether to enable auto delete. Changing this creates a new resource.
 
 * `durable` - (Optional, Bool, ForceNew) Specifies whether to enable durable. Defaults to **false**.
-  Changing this creates a new resource.
+  Changing this creates a new resource.  
+  This parameter is only valid for RabbitMQ `3.x.x` exchange. It is enabled by default for RabbitMQ `AMQP-0-9-1` exchange.
 
 * `internal` - (Optional, Bool, ForceNew) Specifies whether the exchange is internal. Defaults to **false**.
-  Changing this creates a new resource.
+  Changing this creates a new resource.  
+  This parameter is only valid for RabbitMQ `3.x.x` exchange.
+
+* `arguments` - (Optional, String, ForceNew) Specifies the argument configuration of the exchange, in JSON format.  
+  Changing this creates a new resource.  
+  Currently, this parameter is available only when `type` is set to **x-delayed-message**.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/rabbitmq/data_source_huaweicloud_dms_rabbitmq_exchanges_test.go
+++ b/huaweicloud/services/acceptance/rabbitmq/data_source_huaweicloud_dms_rabbitmq_exchanges_test.go
@@ -10,9 +10,15 @@ import (
 )
 
 func TestAccDataSourceDmsRabbitmqExchanges_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_dms_rabbitmq_exchanges.test"
-	rName := acceptance.RandomAccResourceName()
-	dc := acceptance.InitDataSourceCheck(dataSource)
+	var (
+		rName = acceptance.RandomAccResourceName()
+
+		dataSource = "data.huaweicloud_dms_rabbitmq_exchanges.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		withArguments   = "data.huaweicloud_dms_rabbitmq_exchanges.with_arguments"
+		dcWithArguments = acceptance.InitDataSourceCheck(withArguments)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -31,15 +37,66 @@ func TestAccDataSourceDmsRabbitmqExchanges_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSource, "exchanges.0.durable"),
 					resource.TestCheckResourceAttrSet(dataSource, "exchanges.0.internal"),
 					resource.TestCheckResourceAttrSet(dataSource, "exchanges.0.default"),
+					dcWithArguments.CheckResourceExists(),
+					resource.TestCheckOutput("arguments_is_set_and_valid", "true"),
 				),
 			},
 		},
 	})
 }
 
+func testDataSourceDataSourceExchanges_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_dms_rabbitmq_flavors" "with_arguments" {
+  type = "single.professional"
+}
+
+locals {
+  flavor_with_arguments = data.huaweicloud_dms_rabbitmq_flavors.with_arguments.flavors[0]
+}
+
+resource "huaweicloud_dms_rabbitmq_instance" "with_arguments" {
+  name              = "%[2]s_with_arguments"
+  vpc_id            = huaweicloud_vpc.test.id
+  network_id        = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+
+  flavor_id         = local.flavor_with_arguments.id
+  engine_version    = "AMQP-0-9-1"
+  storage_space     = local.flavor_with_arguments.properties[0].min_storage_per_node
+  storage_spec_code = local.flavor_with_arguments.ios[0].storage_spec_code
+}
+
+resource "huaweicloud_dms_rabbitmq_vhost" "with_arguments" {
+  instance_id = huaweicloud_dms_rabbitmq_instance.with_arguments.id
+  name        = "%[2]s_with_arguments"
+}
+
+resource "huaweicloud_dms_rabbitmq_exchange" "with_arguments" {
+  depends_on = [huaweicloud_dms_rabbitmq_vhost.with_arguments]
+
+  instance_id = huaweicloud_dms_rabbitmq_instance.with_arguments.id
+  vhost       = huaweicloud_dms_rabbitmq_vhost.with_arguments.name
+  name        = "%[2]s_with_arguments"
+  type        = "x-delayed-message"
+  auto_delete = false
+
+  arguments   = jsonencode({
+    "x-delayed-type" = "header"
+  })
+}
+`, testRabbitmqExchange_basic(name), name)
+}
+
 func testDataSourceDataSourceDmsRabbitmqExchanges_basic(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 data "huaweicloud_dms_rabbitmq_exchanges" "test" {
   depends_on = [huaweicloud_dms_rabbitmq_exchange.test]
@@ -47,5 +104,17 @@ data "huaweicloud_dms_rabbitmq_exchanges" "test" {
   instance_id = huaweicloud_dms_rabbitmq_instance.test.id
   vhost       = huaweicloud_dms_rabbitmq_vhost.test.name
 }
-`, testRabbitmqExchange_basic(name))
+
+data "huaweicloud_dms_rabbitmq_exchanges" "with_arguments" {
+  depends_on = [huaweicloud_dms_rabbitmq_exchange.with_arguments]
+
+  instance_id = huaweicloud_dms_rabbitmq_instance.with_arguments.id
+  vhost       = huaweicloud_dms_rabbitmq_vhost.with_arguments.name
+}
+
+output "arguments_is_set_and_valid" {
+  value = length([for v in data.huaweicloud_dms_rabbitmq_exchanges.with_arguments.exchanges : v
+  if v.arguments == huaweicloud_dms_rabbitmq_exchange.with_arguments.arguments]) > 0
+}
+`, testDataSourceDataSourceExchanges_base(name))
 }

--- a/huaweicloud/services/rabbitmq/data_source_huaweicloud_dms_rabbitmq_exchanges.go
+++ b/huaweicloud/services/rabbitmq/data_source_huaweicloud_dms_rabbitmq_exchanges.go
@@ -65,6 +65,11 @@ func DataSourceDmsRabbitmqExchanges() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
+						"arguments": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The argument configuration of the exchange, in JSON format.`,
+						},
 					},
 				},
 			},
@@ -133,6 +138,8 @@ func getRabbitmqExchangesList(client *golangsdk.ServiceClient, d *schema.Resourc
 				"durable":     utils.PathSearch("durable", exchange, nil),
 				"internal":    utils.PathSearch("internal", exchange, nil),
 				"default":     utils.PathSearch("default", exchange, nil),
+				"arguments": flattenExchangeArguments(utils.PathSearch("arguments",
+					exchange, make(map[string]interface{})).(map[string]interface{})),
 			})
 		}
 

--- a/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_exchange.go
+++ b/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_exchange.go
@@ -213,7 +213,7 @@ func GetRabbitmqExchange(client *golangsdk.ServiceClient, instanceID, vhost, nam
 		currentPath := listPath + fmt.Sprintf("&offset=%d", offset)
 		listResp, err := client.Request("GET", currentPath, &listOpt)
 		if err != nil {
-			return nil, fmt.Errorf("error retrieving the exchanges list: %s", err)
+			return nil, err
 		}
 		listRespBody, err := utils.FlattenResponse(listResp)
 		if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Add **arguments** field for exchange resource and data source.
2. Fixed the issue where CheckDeletedDiag could not be triggered when the instance does not exist.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o rabbitmq -f TestAccRabbitmqExchange_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rabbitmq" -v -coverprofile="./huaweicloud/services/acceptance/rabbitmq/rabbitmq_coverage.cov" -coverpkg="./huaweicloud/services/rabbitmq" -run TestAccRabbitmqExchange_ -timeout 360m -parallel 10
=== RUN   TestAccRabbitmqExchange_basic
=== PAUSE TestAccRabbitmqExchange_basic
=== RUN   TestAccRabbitmqExchange_special_charcters
=== PAUSE TestAccRabbitmqExchange_special_charcters
=== RUN   TestAccRabbitmqExchange_bindings
=== PAUSE TestAccRabbitmqExchange_bindings
=== CONT  TestAccRabbitmqExchange_basic
=== CONT  TestAccRabbitmqExchange_bindings
=== CONT  TestAccRabbitmqExchange_special_charcters
--- PASS: TestAccRabbitmqExchange_basic (534.67s)
--- PASS: TestAccRabbitmqExchange_bindings (544.74s)
--- PASS: TestAccRabbitmqExchange_special_charcters (579.98s)
PASS
coverage: 30.9% of statements in ./huaweicloud/services/rabbitmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rabbitmq  580.053s        coverage: 30.9% of statements in ./huaweicloud/services/rabbitmq
```
```
./scripts/coverage.sh -o rabbitmq -f TestAccDataSourceDmsRabbitmqExchanges_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rabbitmq" -v -coverprofile="./huaweicloud/services/acceptance/rabbitmq/rabbitmq_coverage.cov" -coverpkg="./huaweicloud/services/rabbitmq" -run TestAccDataSourceDmsRabbitmqExchanges_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDmsRabbitmqExchanges_basic
=== PAUSE TestAccDataSourceDmsRabbitmqExchanges_basic
=== CONT  TestAccDataSourceDmsRabbitmqExchanges_basic
--- PASS: TestAccDataSourceDmsRabbitmqExchanges_basic (564.15s)
PASS
coverage: 21.5% of statements in ./huaweicloud/services/rabbitmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rabbitmq  564.226s        coverage: 21.5% of statements in ./huaweicloud/services/rabbitmq
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
  The RabbitMQ instance does not exist.
  <img width="1277" height="844" alt="image" src="https://github.com/user-attachments/assets/c3af4782-3c83-467a-9a41-8bf07a5acbd7" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
