### PR TITLE
feat(fgs): add new data source to query async invocations

### DIFF
--- a/docs/data-sources/fgs_async_invocations.md
+++ b/docs/data-sources/fgs_async_invocations.md
@@ -1,0 +1,87 @@
+---
+subcategory: "FunctionGraph"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_fgs_async_invocations"
+description: |-
+  Use this data source to query async invocations of the specified function within HuaweiCloud.
+---
+
+# huaweicloud_fgs_async_invocations
+
+Use this data source to query async invocations of the specified function within HuaweiCloud.
+
+## Example Usage
+
+### Query all async invocations of the specified function
+
+```hcl
+variable "function_urn" {}
+
+data "huaweicloud_fgs_async_invocations" "test" {
+  function_urn = var.function_urn
+}
+```
+
+### Query all success async invocations in the specified time window
+
+```hcl
+variable "function_urn" {}
+
+data "huaweicloud_fgs_async_invocations" "test" {
+  function_urn     = var.function_urn
+  status           = "SUCCESS"
+  query_begin_time = "2025-01-01T00:00:00Z"
+  query_end_time   = "2025-01-31T23:59:59Z"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the async invocations are located.  
+  If omitted, the provider-level region will be used.
+
+* `function_urn` - (Required, String) Specifies the function URN to which the async invocations belong.
+
+* `request_id` - (Optional, String) Specifies the specified request ID of async invocation to be queried.
+
+* `status` - (Optional, String) Specifies the status of async invocations to be queried.  
+  The valid values are as follows:
+  + **WAIT**
+  + **RUNNING**
+  + **SUCCESS**
+  + **FAIL**
+  + **DISCARD**
+
+* `query_begin_time` - (Optional, String) Specifies the begin time to query async invocations, in RFC3339 format (UTC
+  time).  
+  For example, `1999-01-01T08:00:00Z`.
+
+* `query_end_time` - (Optional, String) Specifies the end time to query async invocations, in RFC3339 format (UTC
+  time).  
+  For example, `1999-01-01T08:00:00Z`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `invocations` - The list of async invocations that matched filter parameters.  
+  The [invocations](#fgs_async_invocations_attr) structure is documented below.
+
+<a name="fgs_async_invocations_attr"></a>
+The `invocations` block supports:
+
+* `request_id` - The request ID of the async invocation.
+
+* `status` - The status of the async invocation.
+
+* `error_code` - The error code of the async invocation.
+
+* `error_message` - The error message of the async invocation.
+
+* `start_time` - The start time of the async invocation, in RFC3339 format (UTC time).
+
+* `end_time` - The end time of the async invocation, in RFC3339 format (UTC time).

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1097,6 +1097,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_fgs_applications":                fgs.DataSourceApplications(),
 			"huaweicloud_fgs_application_templates":       fgs.DataSourceApplicationTemplates(),
+			"huaweicloud_fgs_async_invocations":           fgs.DataSourceAsyncInvocations(),
 			"huaweicloud_fgs_async_invoke_configurations": fgs.DataSourceAsyncInvokeConfigurations(),
 			"huaweicloud_fgs_dependencies":                fgs.DataSourceDependencies(),
 			"huaweicloud_fgs_dependency_versions":         fgs.DataSourceDependencieVersions(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -293,12 +293,11 @@ var (
 	HW_WORKSPACE_USER_NAMES                        = os.Getenv("HW_WORKSPACE_USER_NAMES")
 	HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID             = os.Getenv("HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID")
 
-	HW_FG_FUNCTION_NAME = os.Getenv("HW_EG_FUNCTION_NAME")
-
 	HW_FGS_AGENCY_NAME         = os.Getenv("HW_FGS_AGENCY_NAME")
 	HW_FGS_APP_AGENCY_NAME     = os.Getenv("HW_FGS_APP_AGENCY_NAME")
-	HW_FGS_GPU_TYPE            = os.Getenv("HW_FGS_GPU_TYPE")
 	HW_FGS_DEPENDENCY_OBS_LINK = os.Getenv("HW_FGS_DEPENDENCY_OBS_LINK")
+	HW_FGS_FUNCTION_NAME       = os.Getenv("HW_FGS_FUNCTION_NAME")
+	HW_FGS_GPU_TYPE            = os.Getenv("HW_FGS_GPU_TYPE")
 
 	HW_KMS_ENVIRONMENT         = os.Getenv("HW_KMS_ENVIRONMENT")
 	HW_KMS_HSM_CLUSTER_ID      = os.Getenv("HW_KMS_HSM_CLUSTER_ID")
@@ -1036,9 +1035,9 @@ func TestAccPreCheckMrsBootstrapScript(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckFgFunctionName(t *testing.T) {
-	if HW_FG_FUNCTION_NAME == "" {
-		t.Skip("HW_FG_FUNCTION_NAME must be set for FG acceptance tests")
+func TestAccPreCheckFgsFunctionName(t *testing.T) {
+	if HW_FGS_FUNCTION_NAME == "" {
+		t.Skip("HW_FGS_FUNCTION_NAME must be set for acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_event_subscription_target_test.go
+++ b/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_event_subscription_target_test.go
@@ -36,7 +36,7 @@ func TestAccEventSubscriptionTarget_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckProjectID(t)
-			acceptance.TestAccPreCheckFgFunctionName(t)
+			acceptance.TestAccPreCheckFgsFunctionName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
@@ -177,7 +177,7 @@ resource "huaweicloud_eg_event_subscription_target" "test" {
   }
 }
 `, testEventSubscriptionTarget_base(name), acceptance.HW_PROJECT_ID, acceptance.HW_REGION_NAME,
-		acceptance.HW_FG_FUNCTION_NAME)
+		acceptance.HW_FGS_FUNCTION_NAME)
 }
 
 func testEventSubscriptionTarget_basic_update(name string) string {

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_async_invocations_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_async_invocations_test.go
@@ -1,0 +1,232 @@
+package fgs
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this test, please make sure the function includes at least one failed async invocation and one
+// success async invocation.
+func TestAccDataAsyncInvocations_basic(t *testing.T) {
+	var (
+		all                 = "data.huaweicloud_fgs_async_invocations.all"
+		dcForAllInvocations = acceptance.InitDataSourceCheck(all)
+
+		byRequestId           = "data.huaweicloud_fgs_async_invocations.filter_by_request_id"
+		dcByRequestId         = acceptance.InitDataSourceCheck(byRequestId)
+		byNotFoundRequestId   = "data.huaweicloud_fgs_async_invocations.filter_by_not_found_request_id"
+		dcByNotFoundRequestId = acceptance.InitDataSourceCheck(byNotFoundRequestId)
+
+		bySuccessStatus   = "data.huaweicloud_fgs_async_invocations.filter_by_success_status"
+		dcBySuccessStatus = acceptance.InitDataSourceCheck(bySuccessStatus)
+		byFailStatus      = "data.huaweicloud_fgs_async_invocations.filter_by_fail_status"
+		dcByFailStatus    = acceptance.InitDataSourceCheck(byFailStatus)
+
+		byBeginTime   = "data.huaweicloud_fgs_async_invocations.filter_by_begin_time"
+		dcByBeginTime = acceptance.InitDataSourceCheck(byBeginTime)
+		byEndTime     = "data.huaweicloud_fgs_async_invocations.filter_by_end_time"
+		dcByEndTime   = acceptance.InitDataSourceCheck(byEndTime)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckFgsFunctionName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataAsyncInvocations_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// Without filter parameters.
+					dcForAllInvocations.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "invocations.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					// Filter by request ID.
+					dcByRequestId.CheckResourceExists(),
+					resource.TestCheckOutput("is_request_id_filter_useful", "true"),
+					dcByNotFoundRequestId.CheckResourceExists(),
+					resource.TestCheckOutput("request_id_not_found_validation_pass", "true"),
+					// Filter by status.
+					dcBySuccessStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_success_status_filter_useful", "true"),
+					dcByFailStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_fail_status_filter_useful", "true"),
+					// Filter by time range.
+					dcByBeginTime.CheckResourceExists(),
+					resource.TestCheckOutput("is_begin_time_filter_useful", "true"),
+					dcByEndTime.CheckResourceExists(),
+					resource.TestCheckOutput("is_end_time_filter_useful", "true"),
+					// Check the attributes.
+					resource.TestCheckResourceAttrSet(byRequestId, "invocations.0.request_id"),
+					resource.TestCheckResourceAttrSet(byRequestId, "invocations.0.status"),
+					resource.TestCheckResourceAttrSet(byRequestId, "invocations.0.start_time"),
+					resource.TestCheckResourceAttrSet(byRequestId, "invocations.0.end_time"),
+					resource.TestCheckResourceAttrSet(byFailStatus, "invocations.0.error_code"),
+					resource.TestCheckResourceAttrSet(byFailStatus, "invocations.0.error_message"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataAsyncInvocations_basic() string {
+	randRequestId, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_fgs_functions" "test" {
+  name = "%[1]s"
+}
+
+locals {
+  function_urn = try(data.huaweicloud_fgs_functions.test.functions[0].urn, "NOT_FOUND")
+}
+
+data "huaweicloud_fgs_async_invocations" "all" {
+  function_urn = local.function_urn
+}
+
+locals {
+  request_id = try(data.huaweicloud_fgs_async_invocations.all.invocations[0].request_id, "NOT_FOUND")
+}
+
+# Filter by request ID
+data "huaweicloud_fgs_async_invocations" "filter_by_request_id" {
+  depends_on = [
+    data.huaweicloud_fgs_async_invocations.all,
+  ]
+
+  function_urn = local.function_urn
+  request_id   = local.request_id
+}
+
+locals {
+  request_id_filter_result = [
+    for v in data.huaweicloud_fgs_async_invocations.filter_by_request_id.invocations[*].request_id : v == local.request_id
+  ]
+}
+
+output "is_request_id_filter_useful" {
+  value = length(local.request_id_filter_result) > 0 && alltrue(local.request_id_filter_result)
+}
+
+# Filter by not found request ID
+data "huaweicloud_fgs_async_invocations" "filter_by_not_found_request_id" {
+  depends_on = [
+    data.huaweicloud_fgs_async_invocations.all,
+  ]
+
+  function_urn = local.function_urn
+  request_id   = "%[2]s"
+}
+
+output "request_id_not_found_validation_pass" {
+  value = length(data.huaweicloud_fgs_async_invocations.filter_by_not_found_request_id.invocations) == 0
+}
+
+# Filter by status
+locals {
+  success_status = "SUCCESS"
+  fail_status    = "FAIL"
+}
+
+data "huaweicloud_fgs_async_invocations" "filter_by_success_status" {
+  depends_on = [
+    data.huaweicloud_fgs_async_invocations.all,
+  ]
+
+  function_urn = local.function_urn
+  status       = local.success_status
+}
+
+locals {
+  success_status_filter_result = [
+    for v in data.huaweicloud_fgs_async_invocations.filter_by_success_status.invocations : alltrue([
+      v.status == local.success_status,
+      v.error_code == "",
+      v.error_message == "",
+    ])
+  ]
+}
+
+output "is_success_status_filter_useful" {
+  value = length(local.success_status_filter_result) > 0 && alltrue(local.success_status_filter_result)
+}
+
+data "huaweicloud_fgs_async_invocations" "filter_by_fail_status" {
+  depends_on = [
+    data.huaweicloud_fgs_async_invocations.all,
+  ]
+
+  function_urn = local.function_urn
+  status       = local.fail_status
+}
+
+locals {
+  fail_status_filter_result = [
+    for v in data.huaweicloud_fgs_async_invocations.filter_by_fail_status.invocations : alltrue([
+      v.status == local.fail_status,
+      v.error_code != "",
+      v.error_message != "",
+    ])
+  ]
+}
+
+output "is_fail_status_filter_useful" {
+  value = length(local.fail_status_filter_result) > 0 && alltrue(local.fail_status_filter_result)
+}
+
+# Filter by begin time
+locals {
+  begin_time = try(data.huaweicloud_fgs_async_invocations.all.invocations[0].start_time, "NOT_FOUND")
+}
+
+data "huaweicloud_fgs_async_invocations" "filter_by_begin_time" {
+  depends_on = [
+    data.huaweicloud_fgs_async_invocations.all,
+  ]
+
+  function_urn     = local.function_urn
+  query_begin_time = local.begin_time
+}
+
+locals {
+  begin_time_filter_result = [
+    for v in data.huaweicloud_fgs_async_invocations.filter_by_begin_time.invocations : timecmp(v.start_time, local.begin_time) <= 0
+  ]
+}
+
+output "is_begin_time_filter_useful" {
+  value = length(local.begin_time_filter_result) > 0 && alltrue(local.begin_time_filter_result)
+}
+
+# Filter by end time
+locals {
+  end_time = try(data.huaweicloud_fgs_async_invocations.all.invocations[0].end_time, "NOT_FOUND")
+}
+
+data "huaweicloud_fgs_async_invocations" "filter_by_end_time" {
+  depends_on = [
+    data.huaweicloud_fgs_async_invocations.all,
+  ]
+
+  function_urn   = local.function_urn
+  query_end_time = local.end_time
+}
+
+locals {
+  end_time_filter_result = [
+    for v in data.huaweicloud_fgs_async_invocations.filter_by_end_time.invocations : timecmp(v.end_time, local.end_time) >= 0
+  ]
+}
+
+output "is_end_time_filter_useful" {
+  value = length(local.end_time_filter_result) > 0 && alltrue(local.end_time_filter_result)
+}
+`, acceptance.HW_FGS_FUNCTION_NAME, randRequestId)
+}

--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_async_invocations.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_async_invocations.go
@@ -1,0 +1,221 @@
+package fgs
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API FunctionGraph GET /v2/{project_id}/fgs/functions/{function_urn}/async-invocations
+func DataSourceAsyncInvocations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAsyncInvocationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the async invocations are located.`,
+			},
+
+			// Required parameters.
+			"function_urn": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The function URN to which the async invocations belong.`,
+			},
+
+			// Optional parameters.
+			"request_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The specified request ID of async invocation to be queried.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The status of async invocations to be queried.`,
+			},
+			"query_begin_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The begin time to query async invocations, in RFC3339 format (UTC time).`,
+			},
+			"query_end_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The end time to query async invocations, in RFC3339 format (UTC time).`,
+			},
+
+			// Attributes.
+			"invocations": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of async invocations that matched filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"request_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The request ID of the async invocation.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the async invocation.`,
+						},
+						"error_code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The error code of the async invocation.`,
+						},
+						"error_message": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The error message of the async invocation.`,
+						},
+						"start_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The start time of the async invocation, in RFC3339 format (UTC time).`,
+						},
+						"end_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The end time of the async invocation, in RFC3339 format (UTC time).`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAsyncInvocationsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("request_id"); ok {
+		res = fmt.Sprintf("%s&request_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+	if v, ok := d.GetOk("query_begin_time"); ok {
+		res = fmt.Sprintf("%s&query_begin_time=%v", res,
+			utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(v.(string))/1000, true, "2006-01-02T15:04:05"))
+	}
+	if v, ok := d.GetOk("query_end_time"); ok {
+		res = fmt.Sprintf("%s&query_end_time=%v", res,
+			utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(v.(string))/1000, true, "2006-01-02T15:04:05"))
+	}
+
+	return res
+}
+
+func listAsyncInvocations(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/fgs/functions/{function_urn}/async-invocations?limit={limit}"
+		limit   = 100
+		marker  = "0"
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{function_urn}", d.Get("function_urn").(string))
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildAsyncInvocationsQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithMarker := fmt.Sprintf("%s&marker=%v", listPath, marker)
+		requestResp, err := client.Request("GET", listPathWithMarker, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		invocations := utils.PathSearch("invocations", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, invocations...)
+		if len(invocations) < limit {
+			break
+		}
+		// In this API, marker has the same meaning as offset.
+		nextMarker := utils.PathSearch("next_marker", respBody, "0").(string)
+		if nextMarker == marker || nextMarker == "0" {
+			// Make sure the next marker value is correct, not the previous marker or zero (in the last page).
+			break
+		}
+		marker = nextMarker
+	}
+
+	return result, nil
+}
+
+func flattenAsyncInvocations(invocations []interface{}) []map[string]interface{} {
+	if len(invocations) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(invocations))
+	for _, invocation := range invocations {
+		result = append(result, map[string]interface{}{
+			"request_id":    utils.PathSearch("request_id", invocation, nil),
+			"status":        utils.PathSearch("status", invocation, nil),
+			"error_message": utils.PathSearch("error_message", invocation, nil),
+			"error_code":    utils.PathSearch("error_code", invocation, nil),
+			"start_time": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("start_time",
+				invocation, nil).(string), "2006-01-02T15:04:05")/1000, true, "2006-01-02T15:04:05Z"),
+			"end_time": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("end_time",
+				invocation, nil).(string), "2006-01-02T15:04:05")/1000, true, "2006-01-02T15:04:05Z"),
+		})
+	}
+
+	return result
+}
+
+func dataSourceAsyncInvocationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	invocations, err := listAsyncInvocations(client, d)
+	if err != nil {
+		return diag.Errorf("error querying FunctionGraph async invocations: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("invocations", flattenAsyncInvocations(invocations)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source that used to query the async invocations of the specified FunctionGraph function.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query async invocations.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccDataAsyncInvocations_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataAsyncInvocations_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAsyncInvocations_basic
=== PAUSE TestAccDataAsyncInvocations_basic
=== CONT  TestAccDataAsyncInvocations_basic
--- PASS: TestAccDataAsyncInvocations_basic (15.95s)
PASS
coverage: 6.9% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       16.027s coverage: 6.9% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
