### PR TITLE
feat(VPN): support to reset connection

### DIFF
--- a/docs/resources/vpn_connection_reset.md
+++ b/docs/resources/vpn_connection_reset.md
@@ -1,0 +1,37 @@
+---
+subcategory: "Virtual Private Network (VPN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_vpn_connection_reset"
+description: |-
+  Manages a VPN gateway connection reset resource within HuaweiCloud.
+---
+
+# huaweicloud_vpn_connection_reset
+
+Manages a VPN gateway connection reset resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "connection_id" {}
+
+resource "huaweicloud_vpn_connection_reset" "test" {
+  connection_id = var.connection_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `connection_id` - (Required, String, NonUpdatable) Specifies the connection ID of a VPN gateway.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3038,6 +3038,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpn_customer_gateway":                  vpn.ResourceCustomerGateway(),
 			"huaweicloud_vpn_connection":                        vpn.ResourceConnection(),
 			"huaweicloud_vpn_connection_health_check":           vpn.ResourceConnectionHealthCheck(),
+			"huaweicloud_vpn_connection_reset":                  vpn.ResourceConnectionReset(),
 			"huaweicloud_vpn_user":                              vpn.ResourceUser(),
 			"huaweicloud_vpn_user_group":                        vpn.ResourceUserGroup(),
 			"huaweicloud_vpn_client_ca_certificate":             vpn.ResourceClientCACertificate(),

--- a/huaweicloud/services/acceptance/vpn/resource_huaweicloud_vpn_connection_reset_test.go
+++ b/huaweicloud/services/acceptance/vpn/resource_huaweicloud_vpn_connection_reset_test.go
@@ -1,0 +1,38 @@
+package vpn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGatewayConnectionReset_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	ipAddress := "172.16.1.2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testGatewayConnectionReset_basic(name, ipAddress),
+			},
+		},
+	})
+}
+
+func testGatewayConnectionReset_basic(name, ipAddress string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_vpn_connection_reset" "test" {
+  connection_id = huaweicloud_vpn_connection.test.id
+}
+`, testConnection_basic(name, ipAddress))
+}

--- a/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection_reset.go
+++ b/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection_reset.go
@@ -1,0 +1,102 @@
+package vpn
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var connectionResetNonUpdatableParams = []string{"connection_id"}
+
+// @API VPN POST /v5/{project_id}/vpn-connection/{vpn_connection_id}/reset
+// @API VPN GET /v5/{project_id}/vpn-connection/{vpn_connection_id}
+func ResourceConnectionReset() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceConnectionResetCreate,
+		ReadContext:   resourceConnectionResetRead,
+		UpdateContext: resourceConnectionResetUpdate,
+		DeleteContext: resourceConnectionResetDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(connectionResetNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"connection_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the connection ID of a VPN gateway.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceConnectionResetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vpn", region)
+	if err != nil {
+		return diag.Errorf("error creating VPN client: %s", err)
+	}
+
+	connectionId := d.Get("connection_id").(string)
+
+	createHttpUrl := "v5/{project_id}/vpn-connection/{vpn_connection_id}/reset"
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{vpn_connection_id}", connectionId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating VPN gateway connection reset: %s", err)
+	}
+
+	d.SetId(connectionId)
+
+	err = createConnectionWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for reseting VPN connection (%s) to complete: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceConnectionResetRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceConnectionResetUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceConnectionResetDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting VPN gateway connection reset resource is not supported. The resource is only " +
+		"removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to reset connection
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support to reset connection
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/vpn' TESTARGS='-run TestAccGatewayConnectionReset_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccGatewayConnectionReset_basic -timeout 360m -parallel 4
=== RUN   TestAccGatewayConnectionReset_basic
=== PAUSE TestAccGatewayConnectionReset_basic
=== CONT  TestAccGatewayConnectionReset_basic
--- PASS: TestAccGatewayConnectionReset_basic (643.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       643.348s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
