### PR TITLE
feat(secmaster): new datasource to query table histograms

### DIFF
--- a/docs/data-sources/secmaster_table_histograms.md
+++ b/docs/data-sources/secmaster_table_histograms.md
@@ -1,0 +1,59 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_table_histograms"
+description: |-
+  Use this data source to get the histogram data of a specified table from HuaweiCloud SecMaster.
+---
+
+# huaweicloud_secmaster_table_histograms
+
+Use this data source to get the histogram data of a specified table from HuaweiCloud SecMaster.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "table_id" {}
+
+data "huaweicloud_secmaster_table_histograms" "test" {
+  workspace_id = var.workspace_id
+  table_id     = var.table_id
+  query        = "*"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID.
+
+* `table_id` - (Required, String) Specifies the ID of the table to get histogram data.
+
+* `query` - (Required, String) Specifies the search query string.
+
+* `from` - (Optional, Int) Specifies the start timestamp in milliseconds.
+
+* `to` - (Optional, Int) Specifies the end timestamp in milliseconds.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `histograms` - The list of histogram data.
+  The [histogram](#histogram_struct) structure is documented below.
+
+<a name="histogram_struct"></a>
+The `histogram` block supports:
+
+* `count` - The count of logs in the time range.
+
+* `from` - The start timestamp of the time range.
+
+* `to` - The end timestamp of the time range.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1552,6 +1552,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_playbooks":                    secmaster.DataSourceSecmasterPlaybooks(),
 			"huaweicloud_secmaster_security_reports":             secmaster.DataSourceSecurityReports(),
 			"huaweicloud_secmaster_table_consumption":            secmaster.DataSourceTableConsumption(),
+			"huaweicloud_secmaster_table_histograms":             secmaster.DataSourceTableHistograms(),
 			"huaweicloud_secmaster_alert_rules":                  secmaster.DataSourceSecmasterAlertRules(),
 			"huaweicloud_secmaster_alert_rule_templates":         secmaster.DataSourceSecmasterAlertRuleTemplates(),
 			"huaweicloud_secmaster_playbook_versions":            secmaster.DataSourceSecmasterPlaybookVersions(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_table_histograms_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_table_histograms_test.go
@@ -1,0 +1,39 @@
+package secmaster
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceTableHistograms_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testDataSourceSecmasterTableHistograms_basic(),
+				ExpectError: regexp.MustCompile(`版本未升级，请使用老版本.`),
+			},
+		},
+	})
+}
+
+// Due to the lack of a test environment, only expected failure scenarios can be tested at present.
+// The value of `table_id` in the test script is mock data.
+func testDataSourceSecmasterTableHistograms_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_table_histograms" "test" {
+  workspace_id = "%s"
+  table_id     = "7251f007-f723-477f-949d-5b0f697238bf"
+  query        = "*"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_table_histograms.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_table_histograms.go
@@ -1,0 +1,156 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Secmaster POST /v2/{project_id}/workspaces/{workspace_id}/siem/tables/{table_id}/histograms
+func DataSourceTableHistograms() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTableHistogramsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"table_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"query": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"from": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"to": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"histograms": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"from": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"to": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildTableHistogramsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	rst := map[string]interface{}{
+		"query": d.Get("query"),
+	}
+
+	if v, ok := d.GetOk("from"); ok {
+		rst["from"] = v
+	}
+
+	if v, ok := d.GetOk("to"); ok {
+		rst["to"] = v
+	}
+
+	return rst
+}
+
+func dataSourceTableHistogramsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v2/{project_id}/workspaces/{workspace_id}/siem/tables/{table_id}/histograms"
+		workspaceID = d.Get("workspace_id").(string)
+		tableID     = d.Get("table_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", workspaceID)
+	requestPath = strings.ReplaceAll(requestPath, "{table_id}", tableID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildTableHistogramsBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving SecMaster table histograms: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("histograms", flattenHistograms(respBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenHistograms(respBody interface{}) []interface{} {
+	if respBody == nil {
+		return nil
+	}
+
+	respArray := utils.PathSearch("histograms", respBody, make([]interface{}, 0)).([]interface{})
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"count": utils.PathSearch("count", v, nil),
+			"from":  utils.PathSearch("from", v, nil),
+			"to":    utils.PathSearch("to", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query table histograms.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccDataSourceTableHistograms_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourceTableHistograms_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceTableHistograms_basic
=== PAUSE TestAccDataSourceTableHistograms_basic
=== CONT  TestAccDataSourceTableHistograms_basic
--- PASS: TestAccDataSourceTableHistograms_basic (1.61s)
PASS
coverage: 3.6% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 1.686s  coverage: 3.6% of statements in ./huaweicloud/services/secmaster
```
<img width="1370" height="81" alt="image" src="https://github.com/user-attachments/assets/95d0cffc-8239-4086-9337-e0e97cb8fdd1" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
