### PR TITLE
fix(fgs/tags): fix the incorrect API reference

### DIFF
--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_resource_tags.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_resource_tags.go
@@ -15,7 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API FunctionGraph GET /v2/{project_id}/functions/tags
+// @API FunctionGraph GET /v2/{project_id}/{resource_type}/tags
 func DataSourceResourceTags() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceResourceTagsRead,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Incorrect API reference for the FunctionGraph resource tags querying.
Should be `GET /v2/{project_id}/{resource_type}/tags`, but specifies `GET /v2/{project_id}/function/tags`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the incorrect API reference for `data.huaweicloud_fgs_resource_tags`.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
