### PR TITLE
fix(dms/rocketmq): fix the incorrect definition

### DIFF
--- a/docs/data-sources/dms_rocketmq_message_traces.md
+++ b/docs/data-sources/dms_rocketmq_message_traces.md
@@ -16,7 +16,7 @@ Use this data source to get the list of RocketMQ message traces.
 variable "instance_id" {}
 variable "message_id" {}
 
-data "huaweicloud_dms_rocketmq_traces" "test" {
+data "huaweicloud_dms_rocketmq_message_traces" "test" {
   instance_id = var.instance_id
   message_id  = var.message_id
 }

--- a/huaweicloud/services/rocketmq/data_source_huaweicloud_dms_rocketmq_message_traces.go
+++ b/huaweicloud/services/rocketmq/data_source_huaweicloud_dms_rocketmq_message_traces.go
@@ -183,7 +183,7 @@ func dataSourceDmsRocketmqMessageTracesRead(_ context.Context, d *schema.Resourc
 	return nil
 }
 
-// @API RorcketMQ GET /v2/{engine}/{project_id}/instances/{instance_id}/trace
+// @API RocketMQ GET /v2/{engine}/{project_id}/instances/{instance_id}/trace
 func (w *RocketmqMessageTracesDSWrapper) ListMessageTrace() (*gjson.Result, error) {
 	client, err := w.NewClient(w.Config, "dmsv2")
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

There are two incorrect places for the data source `huaweicloud_dms_rocketmq_message_traces`:
- the resource type is incorrect in the markdown file example
- the product name of the API reference is incorrect in the data source content

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the incorrect definition
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
