### PR TITLE
feat(dew): add a new one-time resource to sign data

### DIFF
--- a/docs/resources/kms-sign.md
+++ b/docs/resources/kms-sign.md
@@ -1,0 +1,75 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_kms_sign"
+description: |-
+  Manages a KMS sign resource within HuaweiCloud.
+---
+
+# huaweicloud_kms_sign
+
+Manages a KMS sign resource within HuaweiCloud.
+
+-> The current resource is a one-time resource, and destroying this resource will not recover sign,
+  but will only remove the resource information from the tfstate file.
+
+-> 1. This resource only supports signature operations for asymmetric keys with `key_usage` set to **SIGN_VERIFY**.
+  <br/>2. When using SM2 keys for signature, only can be used to sign message digests.
+
+## Example Usage
+
+```hcl
+variable "key_id" {}
+variable "message" {}
+variable "signing_algorithm" {}
+
+resource "huaweicloud_kms_sign" "test" {
+  key_id            = var.key_id
+  message           = var.message
+  signing_algorithm = var.signing_algorithm
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `key_id` - (Required, String, NonUpdatable) Specifies the key ID.
+  The valid length is `36` bytes, meeting regular match **^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$**.
+  For example: **0d0466b0-e727-4d9c-b35d-f84bb474a37f**.
+
+* `message` - (Required, String, NonUpdatable) Specifies the message digest or message to be signed.
+  The message length must be less than `4,096` bytes and should be encoded using Base64.
+
+* `signing_algorithm` - (Required, String, NonUpdatable) Specifies the signature algorithm.
+  The valid values are as follows:
+  + **SM2DSA_SM3**
+  + **RSASSA_PSS_SHA_256**
+  + **RSASSA_PSS_SHA_384**
+  + **RSASSA_PSS_SHA_512**
+  + **RSASSA_PKCS1_V1_5_SHA_256**
+  + **RSASSA_PKCS1_V1_5_SHA_384**
+  + **RSASSA_PKCS1_V1_5_SHA_512**
+  + **ECDSA_SHA_256**
+  + **ECDSA_SHA_384**
+  + **ECDSA_SHA_512**
+
+* `message_type` - (Optional, String, NonUpdatable) Specifies the type of the message.
+  The valid values are as follows, the default value is **DIGEST**.
+  + **DIGEST**: Message digest.
+  + **RAW**: Original message.
+
+* `sequence` - (Optional, String, NonUpdatable) Specifies the sequence number of the request message, `36` bytes.
+  For example: **919c82d4-8046-4722-9094-35c3c6524cff**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `signature` - The signature value, encoded using Base64.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2655,6 +2655,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_device_policy":            iotda.ResourceDevicePolicy(),
 
 			"huaweicloud_kms_data_encrypt_decrypt":      dew.ResourceKmsDataEncryptDecrypt(),
+			"huaweicloud_kms_sign":                      dew.ResourceKmsSign(),
 			"huaweicloud_kms_key":                       dew.ResourceKmsKey(),
 			"huaweicloud_kps_keypair":                   dew.ResourceKeypair(),
 			"huaweicloud_kms_grant":                     dew.ResourceKmsGrant(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -311,6 +311,7 @@ var (
 	HW_KMS_KEY_PLAINTEXT_LEN   = os.Getenv("HW_KMS_KEY_PLAINTEXT_LEN")
 	HW_KMS_KEY_CIPHER_TEXT     = os.Getenv("HW_KMS_KEY_CIPHER_TEXT")
 	HW_KMS_KEY_CIPHER_TEXT_LEN = os.Getenv("HW_KMS_KEY_CIPHER_TEXT_LEN")
+	HW_KMS_KEY_MESSAGE         = os.Getenv("HW_KMS_KEY_MESSAGE")
 
 	HW_MULTI_ACCOUNT_ENVIRONMENT            = os.Getenv("HW_MULTI_ACCOUNT_ENVIRONMENT")
 	HW_ORGANIZATIONS_OPEN                   = os.Getenv("HW_ORGANIZATIONS_OPEN")
@@ -1951,6 +1952,13 @@ func TestAccPreCheckKmsKeyPlaintext(t *testing.T) {
 func TestAccPreCheckKmsKeyCiphertext(t *testing.T) {
 	if HW_KMS_KEY_CIPHER_TEXT == "" || HW_KMS_KEY_CIPHER_TEXT_LEN == "" {
 		t.Skip("HW_KMS_KEY_CIPHER_TEXT, HW_KMS_KEY_CIPHER_TEXT_LEN must be set for acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckKmsKeyMessage(t *testing.T) {
+	if HW_KMS_KEY_MESSAGE == "" {
+		t.Skip("HW_KMS_KEY_MESSAGE must be set for acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_sign_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_sign_test.go
@@ -1,0 +1,43 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccKmsSign_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare a KMS Key ID and one message based on Base64 encoding, then config it to the environment variable.
+			acceptance.TestAccPreCheckKmsKeyID(t)
+			acceptance.TestAccPreCheckKmsKeyMessage(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKmsSign_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("huaweicloud_kms_sign.test", "key_id", acceptance.HW_KMS_KEY_ID),
+					resource.TestCheckResourceAttrSet("huaweicloud_kms_sign.test", "signature"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKmsSign_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kms_sign" "test" {
+  key_id            = "%[1]s"
+  message           = "%[2]s"
+  signing_algorithm = "RSASSA_PSS_SHA_256"
+  message_type      = "RAW"
+}
+`, acceptance.HW_KMS_KEY_ID, acceptance.HW_KMS_KEY_MESSAGE)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_kms_sign.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kms_sign.go
@@ -1,0 +1,158 @@
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var signNonUpdatableParams = []string{
+	"key_id",
+	"message",
+	"signing_algorithm",
+	"message_type",
+	"sequence",
+}
+
+// @API DEW POST /v1.0/{project_id}/kms/sign
+func ResourceKmsSign() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKmsSignCreate,
+		ReadContext:   resourceKmsSignRead,
+		UpdateContext: resourceKmsSignUpdate,
+		DeleteContext: resourceKmsSignDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(signNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to create the resource.`,
+			},
+			"key_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the key ID.`,
+			},
+			"message": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the message digest or message.`,
+			},
+			"signing_algorithm": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the signature algorithm.`,
+			},
+			"message_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the type of the message.`,
+			},
+			"sequence": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the sequence number of the request message.`,
+			},
+			"enable_force_new": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"signature": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The signature value.`,
+			},
+		},
+	}
+}
+
+func buildSignBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"key_id":            d.Get("key_id"),
+		"message":           d.Get("message"),
+		"signing_algorithm": d.Get("signing_algorithm"),
+		"message_type":      utils.ValueIgnoreEmpty(d.Get("message_type")),
+		"sequence":          utils.ValueIgnoreEmpty(d.Get("sequence")),
+	}
+
+	return bodyParams
+}
+
+func resourceKmsSignCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1.0/{project_id}/kms/sign"
+		product = "kms"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildSignBodyParams(d)),
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error running sign : %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("signature", utils.PathSearch("signature", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceKmsSignRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKmsSignUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKmsSignDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to sign message.
+Deleting this resource will not recover sign, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New one-time resource to sign data and names huaweicloud_kms_sign
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccKmsSign_basic -timeout 360m -parallel 10
=== RUN   TestAccKmsSign_basic
=== PAUSE TestAccKmsSign_basic
=== CONT  TestAccKmsSign_basic
--- PASS: TestAccKmsSign_basic (26.89s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       26.951s coverage: 3.8% of statements in ./huaweicloud/services/dew
```
<img width="865" height="33" alt="image" src="https://github.com/user-attachments/assets/b859136b-311d-44fb-8125-23b87e082257" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
