### PR TITLE
feat(lts/logs): add new data source to query logs

### DIFF
--- a/docs/data-sources/lts_logs.md
+++ b/docs/data-sources/lts_logs.md
@@ -1,0 +1,99 @@
+---
+subcategory: "Log Tank Service (LTS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_lts_logs"
+description: |-
+  Use this data source to query logs under specified log stream within HuaweiCloud.
+---
+
+# huaweicloud_lts_logs
+
+Use this data source to query log list under the specified log stream within HuaweiCloud.
+
+## Example Usage
+
+### Basic log query
+
+```hcl
+var "log_group_id" {}
+var "log_stream_id" {}
+var "start_time" {}
+var "end_time" {}
+
+data "huaweicloud_lts_logs" "test" {
+  log_group_id  = var.log_group_id
+  log_stream_id = var.log_stream_id
+  start_time    = var.start_time
+  end_time      = var.end_time
+}
+```
+
+### Query with custom time enabled
+
+```hcl
+var "log_group_id" {}
+var "log_stream_id" {}
+var "start_time" {}
+var "end_time" {}
+
+data "huaweicloud_lts_logs" "test" {
+  log_group_id           = var.log_group_id
+  log_stream_id          = var.log_stream_id
+  start_time             = var.start_time
+  end_time               = var.end_time
+  is_custom_time_enabled = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the LTS logs are located.  
+  If omitted, the provider-level region will be used.
+
+* `log_group_id` - (Required, String) Specifies the ID of the log group to which the logs belong.
+
+* `log_stream_id` - (Required, String) Specifies the ID of the log stream to which the logs belong.
+
+* `start_time` - (Required, String) Specifies the start time for querying log list, in RFC3339 format.
+
+* `end_time` - (Required, String) Specifies the end time for querying log list, in RFC3339 format.
+
+* `labels` - (Optional, Map) Specifies the labels in key/value format to be queried.
+
+* `keywords` - (Optional, String) Specifies the keywords for exact search.
+
+* `is_custom_time_enabled` - (Optional, Boolean) Specifies whether to enable the custom time function
+  for the log stream structured configuration.  
+  Defaults to **false**.
+
+  -> If the structured configuration of this log stream has enabled the custom time function, this parameter must
+     be set to **true**.
+
+* `highlight` - (Optional, Boolean) Specifies whether to highlight the keyword in the logs.  
+  Defaults to **true**.
+
+* `is_desc` - (Optional, Boolean) Specifies whether to sort the logs in descending order.  
+  Defaults to **false**.
+
+* `is_iterative` - (Optional, Boolean) Specifies whether to enable iterative query.  
+  Defaults to **false**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `logs` - The list of logs that match the filter parameters.  
+  The [logs](#lts_logs_attr) structure is documented below.
+
+<a name="lts_logs_attr"></a>
+The `logs` block supports:
+
+  * `content` - The content of the log.
+
+  * `line_num` - The line number of the log.
+
+  * `labels` - The labels associated with the log.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1356,6 +1356,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_lts_hosts":                        lts.DataSourceHosts(),
 			"huaweicloud_lts_host_groups":                  lts.DataSourceLtsHostGroups(),
 			"huaweicloud_lts_keyword_alarm_rules":          lts.DataSourceKeywordAlarmRules(),
+			"huaweicloud_lts_logs":                         lts.DataSourceLogs(),
 			"huaweicloud_lts_member_group_streams":         lts.DataSourceMemberGroupStreams(),
 			"huaweicloud_lts_notification_templates":       lts.DataSourceLtsNotificationTemplates(),
 			"huaweicloud_lts_search_criteria":              lts.DataSourceLtsSearchCriteria(),

--- a/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_log_test.go
+++ b/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_log_test.go
@@ -1,0 +1,264 @@
+package lts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataLogs_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		dataSource = "data.huaweicloud_lts_logs.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byLabels   = "data.huaweicloud_lts_logs.filter_by_labels"
+		dcByLabels = acceptance.InitDataSourceCheck(byLabels)
+
+		byIsDesc   = "data.huaweicloud_lts_logs.filter_by_is_desc"
+		dcByIsDesc = acceptance.InitDataSourceCheck(byIsDesc)
+
+		byKeywordsHighlight   = "data.huaweicloud_lts_logs.filter_by_keywords_highlight"
+		dcByKeywordsHighlight = acceptance.InitDataSourceCheck(byKeywordsHighlight)
+
+		randomId, _ = uuid.GenerateUUID()
+		currentTime = time.Now()
+		startTime   = currentTime.Format(time.RFC3339)
+		endTime     = currentTime.Add(1 * time.Hour).Format(time.RFC3339)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckFgsAgency(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"null": {
+				Source:            "hashicorp/null",
+				VersionConstraint: "3.2.1",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataLogs_logGroupNotFound(randomId, startTime, endTime),
+				ExpectError: regexp.MustCompile(`The log group does not existed`),
+			},
+			{
+				Config:      testAccDataLogs_logStreamNotFound(name, randomId, startTime, endTime),
+				ExpectError: regexp.MustCompile(`The log stream does not existed`),
+			},
+			{
+				Config: testAccDataLogs_basic(name, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "logs.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "logs.0.content"),
+					resource.TestCheckResourceAttrSet(dataSource, "logs.0.labels.%"),
+					resource.TestCheckResourceAttrSet(dataSource, "logs.0.line_num"),
+					dcByLabels.CheckResourceExists(),
+					resource.TestCheckOutput("is_labels_filter_useful", "true"),
+					dcByIsDesc.CheckResourceExists(),
+					resource.TestCheckOutput("is_desc_filter_useful", "true"),
+					dcByKeywordsHighlight.CheckResourceExists(),
+					resource.TestCheckOutput("is_keywords_highlight_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataLogs_logGroupNotFound(randomId, startTime, endTime string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_lts_logs" "test" {
+  log_group_id  = "%[1]s"
+  log_stream_id = "%[1]s"
+  start_time    = "%[2]s"
+  end_time      = "%[3]s"
+}
+`, randomId, startTime, endTime)
+}
+
+func testAccDataLogs_logStreamNotFound(randomId, name, startTime, endTime string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lts_group" "test" {
+  group_name  = "%[1]s"
+  ttl_in_days = 7
+}
+
+data "huaweicloud_lts_logs" "test" {
+  log_group_id  = huaweicloud_lts_group.test.id
+  log_stream_id = "%[2]s"
+  start_time    = "%[3]s"
+  end_time      = "%[4]s"
+}
+`, name, randomId, startTime, endTime)
+}
+
+func testAccDataLogs_base(name string) string {
+	return fmt.Sprintf(`
+variable "script_content" {
+  type    = string
+  default = <<EOT
+def main():
+    print("Hello, World!")
+
+if __name__ == "__main__":
+    main()
+EOT
+}
+
+resource "huaweicloud_lts_group" "test" {
+  group_name  = "%[1]s"
+  ttl_in_days = 7
+}
+
+resource "huaweicloud_lts_stream" "test" {
+  group_id    = huaweicloud_lts_group.test.id
+  stream_name = "%[1]s"
+}
+
+resource "huaweicloud_fgs_function" "test" {
+  name                  = "%[1]s"
+  memory_size           = 128
+  runtime               = "Python3.9"
+  timeout               = 3
+  app                   = "default"
+  handler               = "index.handler"
+  code_type             = "inline"
+  func_code             = base64encode(var.script_content)
+  functiongraph_version = "v2"
+  agency                = "%[2]s"
+  enable_lts_log        = true
+  log_group_id          = huaweicloud_lts_group.test.id
+  log_group_name        = huaweicloud_lts_group.test.group_name
+  log_stream_id         = huaweicloud_lts_stream.test.id
+  log_stream_name       = huaweicloud_lts_stream.test.stream_name
+}
+
+resource "huaweicloud_fgs_function_trigger" "test" {
+  function_urn = huaweicloud_fgs_function.test.urn
+  type         = "TIMER"
+  status       = "ACTIVE"
+
+  event_data = jsonencode({
+    name           = "%[1]s"
+    schedule_type  = "Rate"
+    sync_execution = false
+    schedule       = "1m"
+  })
+}
+
+# Waiting for the LTS log to be generated.
+resource "null_resource" "test" {
+  depends_on = [huaweicloud_fgs_function_trigger.test]
+
+  provisioner "local-exec" {
+    command = "sleep 180;"
+  }
+}
+`, name, acceptance.HW_FGS_AGENCY_NAME)
+}
+
+func testAccDataLogs_basic(name, startTime, endTime string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_lts_logs" "test" {
+  depends_on = [null_resource.test]
+
+  log_group_id  = huaweicloud_lts_group.test.id
+  log_stream_id = huaweicloud_lts_stream.test.id
+  start_time    = "%[2]s"
+  end_time      = "%[3]s"
+}
+
+# Filter by labels.
+data "huaweicloud_lts_logs" "filter_by_labels" {
+  depends_on = [null_resource.test]
+
+  log_group_id  = huaweicloud_lts_group.test.id
+  log_stream_id = huaweicloud_lts_stream.test.id
+  start_time    = "%[2]s"
+  end_time      = "%[3]s"
+
+  labels = {
+    function = huaweicloud_fgs_function.test.name
+  }
+}
+
+locals {
+  lables_filter_result = [for v in flatten(data.huaweicloud_lts_logs.filter_by_labels.logs[*].labels[*].function) :
+  strcontains(v, huaweicloud_fgs_function.test.name)]
+}
+
+output "is_labels_filter_useful" {
+  value = length(local.lables_filter_result) > 0 && alltrue(local.lables_filter_result)
+}
+
+# Filter by descending order.
+data "huaweicloud_lts_logs" "filter_by_is_desc" {
+  depends_on = [null_resource.test]
+
+  log_group_id  = huaweicloud_lts_group.test.id
+  log_stream_id = huaweicloud_lts_stream.test.id
+  start_time    = "%[2]s"
+  end_time      = "%[3]s"
+  is_desc       = true
+}
+
+# Filter by ascending order.
+data "huaweicloud_lts_logs" "filter_by_is_asc" {
+  depends_on = [null_resource.test]
+
+  log_group_id  = huaweicloud_lts_group.test.id
+  log_stream_id = huaweicloud_lts_stream.test.id
+  start_time    = "%[2]s"
+  end_time      = "%[3]s"
+  is_desc       = false
+}
+
+locals {
+  sort_desc_filter_result = data.huaweicloud_lts_logs.filter_by_is_desc.logs[*].line_num
+  sort_asc_filter_result  = data.huaweicloud_lts_logs.filter_by_is_asc.logs[*].line_num
+}
+
+output "is_desc_filter_useful" {
+  value = (
+    length(local.sort_desc_filter_result) == length(local.sort_asc_filter_result) &&
+    length(local.sort_asc_filter_result) > 0 &&
+    local.sort_desc_filter_result[0] == element(local.sort_asc_filter_result, -1)
+  )
+}
+
+# Filter by highlight.
+locals {
+  keywords = try(split(" ", data.huaweicloud_lts_logs.test.logs[0].content)[1], null)
+}
+
+data "huaweicloud_lts_logs" "filter_by_keywords_highlight" {
+  log_group_id  = huaweicloud_lts_group.test.id
+  log_stream_id = huaweicloud_lts_stream.test.id
+  start_time    = "%[2]s"
+  end_time      = "%[3]s"
+  keywords      = local.keywords
+  highlight     = true
+}
+
+locals {
+  keywords_highlight_flter_result = [for v in data.huaweicloud_lts_logs.filter_by_keywords_highlight.logs[*].content :
+  strcontains(v, format("<HighLightTag>%%s</HighLightTag>", local.keywords))]
+}
+
+output "is_keywords_highlight_filter_useful" {
+  value = length(local.keywords_highlight_flter_result) > 0 && alltrue(local.keywords_highlight_flter_result)
+}
+`, testAccDataLogs_base(name), startTime, endTime)
+}

--- a/huaweicloud/services/lts/data_source_huaweicloud_lts_logs.go
+++ b/huaweicloud/services/lts/data_source_huaweicloud_lts_logs.go
@@ -1,0 +1,220 @@
+package lts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API LTS POST /v2/{project_id}/groups/{log_group_id}/streams/{log_stream_id}/content/query
+func DataSourceLogs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceLogsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the LTS logs are located.`,
+			},
+			"log_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the log group to which the logs belong.`,
+			},
+			"log_stream_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the log stream to which the logs belong.`,
+			},
+			"start_time": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The start time for querying log list, in RFC3339 format.`,
+			},
+			"end_time": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The end time for querying log list, in RFC3339 format.`,
+			},
+			"labels": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The labels in key/value format to be queried.`,
+			},
+			"keywords": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The keywords for exact search.`,
+			},
+			"is_custom_time_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to enable the custom time function for the log stream structured configuration.`,
+			},
+			"highlight": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to highlight the keyword in the logs.`,
+			},
+			"is_desc": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to sort the logs in descending order.`,
+			},
+			"is_iterative": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to enable iterative query.`,
+			},
+			"logs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"content": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The content of the log.`,
+						},
+						"labels": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The labels associated with the log.`,
+						},
+						"line_num": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The line number of the log.`,
+						},
+					},
+				},
+				Description: `The list of logs that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func dataSourceLogsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("lts", region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+
+	logs, err := queryLogs(client, d)
+	if err != nil {
+		return diag.Errorf("error querying LTS logs: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("logs", flattenLogs(logs)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func queryLogs(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl    = "v2/{project_id}/groups/{log_group_id}/streams/{log_stream_id}/content/query"
+		result     = make([]interface{}, 0)
+		limit      = 500
+		lineNum    = ""
+		customTime = ""
+	)
+
+	queryPath := client.Endpoint + httpUrl
+	queryPath = strings.ReplaceAll(queryPath, "{project_id}", client.ProjectID)
+	queryPath = strings.ReplaceAll(queryPath, "{log_group_id}", d.Get("log_group_id").(string))
+	queryPath = strings.ReplaceAll(queryPath, "{log_stream_id}", d.Get("log_stream_id").(string))
+	queryOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	for {
+		queryOpt.JSONBody = utils.RemoveNil(buildLogsRequestBody(d, limit, lineNum, customTime))
+		resp, err := client.Request("POST", queryPath, &queryOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		logs := utils.PathSearch("logs", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, logs...)
+		if len(logs) < limit {
+			break
+		}
+		lineNum = utils.PathSearch("[-1].line_num", logs, "").(string)
+		if d.Get("is_custom_time_enabled").(bool) {
+			customTime = utils.PathSearch("[-1].labels.__time__", logs, "").(string)
+		}
+	}
+
+	return result, nil
+}
+
+func buildLogsRequestBody(d *schema.ResourceData, limit int, lineNum, customTime string) map[string]interface{} {
+	return map[string]interface{}{
+		"start_time":   fmt.Sprintf("%d", utils.ConvertTimeStrToNanoTimestamp(d.Get("start_time").(string))),
+		"end_time":     fmt.Sprintf("%d", utils.ConvertTimeStrToNanoTimestamp(d.Get("end_time").(string))),
+		"labels":       utils.ValueIgnoreEmpty(d.Get("labels")),
+		"keywords":     utils.ValueIgnoreEmpty(d.Get("keywords")),
+		"highlight":    utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "highlight"),
+		"is_desc":      d.Get("is_desc"),
+		"is_iterative": d.Get("is_iterative"),
+		"is_count":     true,
+		"limit":        limit,
+		"line_num":     utils.ValueIgnoreEmpty(lineNum),
+		// search_type: The type of the pagination query.
+		// + `init`: Initial query (default).
+		// + `forwards`: Query the next page.
+		// + `backwards`: Query the previous page.
+		"search_type": utils.ValueIgnoreEmpty(d.Get("search_type")),
+		// If the structured configuration of this log stream has enabled the custom time function,
+		// `__time__` parameter is required for paging.
+		"__time__": utils.ValueIgnoreEmpty(customTime),
+	}
+}
+
+func flattenLogs(logs []interface{}) []interface{} {
+	if len(logs) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(logs))
+	for _, v := range logs {
+		rst = append(rst, map[string]interface{}{
+			"content":  utils.PathSearch("content", v, nil),
+			"line_num": utils.PathSearch("line_num", v, nil),
+			"labels":   utils.PathSearch("labels", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add bew data source (**huaweicloud_lts_logs**) to query logs under the specified log stream.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source.
2. add corresponding documation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lts -f TestAccDataLogs_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccDataLogs_basic -timeout 360m -parallel 10
=== RUN   TestAccDataLogs_basic
=== PAUSE TestAccDataLogs_basic
=== CONT  TestAccDataLogs_basic
--- PASS: TestAccDataLogs_basic (231.73s)
PASS
coverage: 7.5% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       232.022s        coverage: 7.5% of statements in ./huaweicloud/services/lts
```
<img width="985" height="279" alt="image" src="https://github.com/user-attachments/assets/70174b89-7d76-45d0-ad36-68af18a4bde0" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
