### PR TITLE
feat(secmaster): add new data source to get list of directories

### DIFF
--- a/docs/data-sources/secmaster_siem_directories.md
+++ b/docs/data-sources/secmaster_siem_directories.md
@@ -1,0 +1,66 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_siem_directories"
+description: |-
+  Use this data source to get the list of directories.
+---
+
+# huaweicloud_secmaster_siem_directories
+
+Use this data source to get the list of directories.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "category" {}
+
+data "huaweicloud_secmaster_siem_directories" "test" {
+  workspace_id = var.workspace_id
+  category     = var.category
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID.
+
+* `category` - (Required, String) Specifies the directory type.
+  The valid values are as follows:
+  + **TABLE**
+  + **PIPE**
+  + **RETRIEVE_SCRIPT**
+  + **ANALYSIS_SCRIPT**
+  + **DATA_TRANSFORMATION**
+  + **ALERT_RULE**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `workspaceid` - The workspace ID.
+
+* `project_id` - The project ID.
+
+* `directories` - The directory list.
+
+* `directory_i18ns` - The directory I18N list.
+
+  The [directory_i18ns](#directory_i18ns_struct) structure is documented below.
+
+<a name="directory_i18ns_struct"></a>
+The `directory_i18ns` block supports:
+
+* `directory` - The directory grouping.
+
+* `directory_en` - The en directory grouping.
+
+* `directory_fr` - The fr directory grouping.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1567,6 +1567,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_baseline_check_results":       secmaster.DataSourceSecmasterBaselineCheckResults(),
 			"huaweicloud_secmaster_playbooks":                    secmaster.DataSourceSecmasterPlaybooks(),
 			"huaweicloud_secmaster_security_reports":             secmaster.DataSourceSecurityReports(),
+			"huaweicloud_secmaster_siem_directories":             secmaster.DataSourceSiemDirectories(),
 			"huaweicloud_secmaster_table_consumption":            secmaster.DataSourceTableConsumption(),
 			"huaweicloud_secmaster_table_histograms":             secmaster.DataSourceTableHistograms(),
 			"huaweicloud_secmaster_alert_rules":                  secmaster.DataSourceSecmasterAlertRules(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_siem_directories_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_siem_directories_test.go
@@ -1,0 +1,46 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSiemdirectories_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_secmaster_siem_directories.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSiemdirectories_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "workspaceid"),
+					resource.TestCheckResourceAttrSet(dataSource, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "directories.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "directory_i18ns.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceSiemdirectories_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_siem_directories" "test" {
+  workspace_id = "%[1]s"
+  category     = "ALERT_RULE"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_siem_directories.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_siem_directories.go
@@ -1,0 +1,140 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Secmaster GET /v2/{project_id}/workspaces/{workspace_id}/siem/directories
+func DataSourceSiemDirectories() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSiemDirectoriesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"workspaceid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"directories": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"directory_i18ns": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"directory": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"directory_en": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"directory_fr": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceSiemDirectoriesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/workspaces/{workspace_id}/siem/directories"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{workspace_id}", d.Get("workspace_id").(string))
+	listPath = fmt.Sprintf("%s?category=%s", listPath, d.Get("category").(string))
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	listResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving directories: %s", err)
+	}
+
+	listRespBody, err := utils.FlattenResponse(listResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("workspaceid", utils.PathSearch("workspace_id", listRespBody, nil)),
+		d.Set("project_id", utils.PathSearch("project_id", listRespBody, nil)),
+		d.Set("directories", utils.PathSearch("directories", listRespBody, nil)),
+		d.Set("directory_i18ns", flattenSiemDirectories(
+			utils.PathSearch("directory_i18ns", listRespBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSiemDirectories(simeDirectories []interface{}) []interface{} {
+	if len(simeDirectories) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(simeDirectories))
+	for _, v := range simeDirectories {
+		rst = append(rst, map[string]interface{}{
+			"directory":    utils.PathSearch("directory", v, nil),
+			"directory_en": utils.PathSearch("directory_en", v, nil),
+			"directory_fr": utils.PathSearch("directory_fr", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get list of directories.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/secmaster" TESTARGS="-run TestAccDataSourceSiemdirectories_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/secmaster -v -run TestAccDataSourceSiemdirectories_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSiemdirectories_basic
=== PAUSE TestAccDataSourceSiemdirectories_basic
=== CONT  TestAccDataSourceSiemdirectories_basic
--- PASS: TestAccDataSourceSiemdirectories_basic (11.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 11.660s
```
<img width="1124" height="33" alt="image" src="https://github.com/user-attachments/assets/a0b95361-2e56-4f70-b1e1-b9155c1dcb2f" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
