### PR TITLE
feat(lts): add new data source to get context logs

### DIFF
--- a/docs/data-sources/lts_context_logs.md
+++ b/docs/data-sources/lts_context_logs.md
@@ -1,0 +1,98 @@
+---
+subcategory: "Log Tank Service (LTS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_lts_context_logs"
+description: |-
+  Use this data source to query context log list under the specified log stream within HuaweiCloud.
+---
+
+# huaweicloud_lts_context_logs
+
+Use this data source to query context log list under the specified log stream within HuaweiCloud.
+
+## Example Usage
+
+### Query logs by the specified line number
+
+```hcl
+var "log_group_id" {}
+var "log_stream_id" {}
+var "line_num" {}
+
+data "huaweicloud_lts_context_logs" "test" {
+  log_group_id  = var.log_group_id
+  log_stream_id = var.log_stream_id
+  line_num      = var.line_num
+}
+```
+
+### Query logs with custom time field
+
+```hcl
+var "log_group_id" {}
+var "log_stream_id" {}
+var "start_time" {}
+var "end_time" {}
+
+data "huaweicloud_lts_logs" "test" {
+  log_group_id  = var.log_group_id
+  log_stream_id = var.log_stream_id
+  start_time    = var.start_time
+  end_time      = var.end_time
+}
+
+data "huaweicloud_lts_context_logs" "test" {
+  log_group_id  = var.log_group_id
+  log_stream_id = var.log_stream_id
+  line_num      = try(data.huaweicloud_lts_logs.test.logs[0].line_num, null)
+  time          = try(data.huaweicloud_lts_logs.test.logs[0].labels.__time__, null)
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the context logs are located.  
+  If omitted, the provider-level region will be used.
+
+* `log_group_id` - (Required, String) Specifies the ID of the log group to which the logs belong.
+
+* `log_stream_id` - (Required, String) Specifies the ID of the log stream to which the logs belong.
+
+* `line_num` - (Optional, String) Specifies the sequence number of a log line.
+
+* `time` - (Optional, String) Specifies the time field of the custom time function, in millisecond timestamp.  
+
+  -> If the structured configuration of this log stream has enabled the custom time function,
+     this parameter is required.
+
+* `backwards_size` - (Optional, Int) Specifies the number of logs before the start log.  
+  The valid value ranges from `0` to `500`. Defaults to **100**.
+
+* `forwards_size` - (Optional, Int) Specifies the number of logs after the start log.  
+  The valid value ranges from `0` to `500`. Defaults to **100**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `logs` - The list of context logs that match the filter parameters.  
+  The [logs](#lts_context_logs_attr) structure is documented below.
+
+* `backwards_count` - The number of logs queried backward based on `line_num`.
+
+* `forwards_count` - The number of logs queried forward based on `line_num`.
+
+* `total_count` - The total number of logs, including the starting log specified in the request parameters.
+
+<a name="lts_context_logs_attr"></a>
+The `logs` block supports:
+
+  * `content` - The original log data.
+
+  * `line_num` - The log line sequence number.
+
+  * `labels` - The labels contained in this log entry.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1351,6 +1351,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_lts_alarms":                       lts.DataSourceAlarms(),
 			"huaweicloud_lts_aom_accesses":                 lts.DataSourceAOMAccesses(),
 			"huaweicloud_lts_cce_accesses":                 lts.DataSourceCceAccesses(),
+			"huaweicloud_lts_context_logs":                 lts.DataSourceContextLogs(),
 			"huaweicloud_lts_groups":                       lts.DataSourceLtsGroups(),
 			"huaweicloud_lts_host_accesses":                lts.DataSourceHostAccesses(),
 			"huaweicloud_lts_hosts":                        lts.DataSourceHosts(),

--- a/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_context_logs_test.go
+++ b/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_context_logs_test.go
@@ -1,0 +1,86 @@
+package lts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataContextLogs_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		dataSource = "data.huaweicloud_lts_context_logs.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckFgsAgency(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"null": {
+				Source:            "hashicorp/null",
+				VersionConstraint: "3.2.1",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataContextLogs_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "logs.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "logs.0.content"),
+					resource.TestCheckResourceAttrSet(dataSource, "logs.0.labels.%"),
+					resource.TestCheckResourceAttrSet(dataSource, "logs.0.line_num"),
+					resource.TestCheckOutput("is_filter_success", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataContextLogs_basic(name string) string {
+	currentTime := time.Now()
+	startTime := currentTime.Format(time.RFC3339)
+	endTime := currentTime.Add(1 * time.Hour).Format(time.RFC3339)
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_lts_logs" "test" {
+  depends_on = [null_resource.test]
+
+  log_group_id  = huaweicloud_lts_group.test.id
+  log_stream_id = huaweicloud_lts_stream.test.id
+  start_time    = "%[2]s"
+  end_time      = "%[3]s"
+}
+
+locals {
+  logs = data.huaweicloud_lts_logs.test.logs
+}
+
+data "huaweicloud_lts_context_logs" "test" {
+  log_group_id  = huaweicloud_lts_group.test.id
+  log_stream_id = huaweicloud_lts_stream.test.id
+
+  # Get the line number of the log in the middle of the log list. Verify 'forwards_count' and 'backwards_count'.
+  line_num = try(local.logs[floor(length(local.logs) / 2)].line_num, null)
+}
+
+output "is_filter_success" {
+  value = (
+    data.huaweicloud_lts_context_logs.test.forwards_count > 0 &&
+    data.huaweicloud_lts_context_logs.test.backwards_count > 0 &&
+    data.huaweicloud_lts_context_logs.test.total_count > 0
+  )
+}
+`, testAccDataLogs_base(name), startTime, endTime)
+}

--- a/huaweicloud/services/lts/data_source_huaweicloud_lts_context_logs.go
+++ b/huaweicloud/services/lts/data_source_huaweicloud_lts_context_logs.go
@@ -1,0 +1,181 @@
+package lts
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API LTS POST /v2/{project_id}/groups/{log_group_id}/streams/{log_stream_id}/context
+func DataSourceContextLogs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceContextLogsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the context logs are located.`,
+			},
+			"log_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the log group to which the logs belong.`,
+			},
+			"log_stream_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the log stream to which the logs belong.`,
+			},
+			"line_num": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The sequence number of a log line.`,
+			},
+			"time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The time field of the custom time function, in millisecond timestamp.`,
+			},
+			"backwards_size": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The number of logs before the start log.`,
+			},
+			"forwards_size": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The number of logs after the start log.`,
+			},
+			"logs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"content": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The original log data.`,
+						},
+						"line_num": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The log line sequence number.`,
+						},
+						"labels": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The labels contained in this log entry.`,
+						},
+					},
+				},
+				Description: `The context log information.`,
+			},
+			"backwards_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of logs queried backward based on 'line_num'.`,
+			},
+			"forwards_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of logs queried forward based on 'line_num'.`,
+			},
+			"total_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The total number of logs, including the starting log specified in the request parameters.`,
+			},
+		},
+	}
+}
+
+func dataSourceContextLogsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v2/{project_id}/groups/{log_group_id}/streams/{log_stream_id}/context"
+		logStreamId = d.Get("log_stream_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("lts", region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{log_group_id}", d.Get("log_group_id").(string))
+	getPath = strings.ReplaceAll(getPath, "{log_stream_id}", logStreamId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildQueryContextLogsBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error querying context logs under log stream (%s): %s", logStreamId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("logs", flattenContextLogs(utils.PathSearch("logs", respBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("backwards_count", utils.PathSearch("backwards_count", respBody, nil)),
+		d.Set("forwards_count", utils.PathSearch("forwards_count", respBody, nil)),
+		d.Set("total_count", utils.PathSearch("total_count", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildQueryContextLogsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"line_num":      utils.ValueIgnoreEmpty(d.Get("line_num").(string)),
+		"__time__":      utils.ValueIgnoreEmpty(d.Get("time").(string)),
+		"backwardsSize": utils.ValueIgnoreEmpty(d.Get("backwards_size").(int)),
+		"forwardsSize":  utils.ValueIgnoreEmpty(d.Get("forwards_size").(int)),
+	}
+}
+
+func flattenContextLogs(contextLogs []interface{}) []interface{} {
+	if len(contextLogs) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(contextLogs))
+	for _, v := range contextLogs {
+		result = append(result, map[string]interface{}{
+			"content":  utils.PathSearch("content", v, nil),
+			"line_num": utils.PathSearch("line_num", v, nil),
+			"labels":   utils.PathSearch("labels", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source (`huaweicloud_lts_context_logs`) to get context logs under the specified log stream.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source.
2. add corresponding documation and acceptance test.

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lts -f TestAccDataContextLogs_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lts" -v -coverprofile="./huaweicloud/services/acceptance/lts/lts_coverage.cov" -coverpkg="./huaweicloud/services/lts" -run TestAccDataContextLogs_basic -timeout 360m -parallel 10
=== RUN   TestAccDataContextLogs_basic
=== PAUSE TestAccDataContextLogs_basic
=== CONT  TestAccDataContextLogs_basic
--- PASS: TestAccDataContextLogs_basic (219.58s)
PASS
coverage: 8.0% of statements in ./huaweicloud/services/lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       219.687s        coverage: 8.0% of statements in ./huaweicloud/services/lts
```
<img width="957" height="167" alt="image" src="https://github.com/user-attachments/assets/ad7a5589-0ebd-429c-af72-8145d573e07e" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
