### PR TITLE
feat(eg): add new data source to query event subscriptions

### DIFF
--- a/docs/data-sources/eg_event_subscriptions.md
+++ b/docs/data-sources/eg_event_subscriptions.md
@@ -1,0 +1,156 @@
+---
+subcategory: "EventGrid (EG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_eg_event_subscriptions"
+description: |-
+  Use this data source to get the list of EG event subscriptions within HuaweiCloud.
+---
+
+# huaweicloud_eg_event_subscriptions
+
+Use this data source to get the list of EG event subscriptions within HuaweiCloud.
+
+## Example Usage
+
+### Query all subscriptions
+
+```hcl
+data "huaweicloud_eg_event_subscriptions" "test" {}
+```
+
+### Query subscriptions by name
+
+```hcl
+variable "subscription_name" {}
+
+data "huaweicloud_eg_event_subscriptions" "test" {
+  name = var.subscription_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the subscriptions are located.  
+  If omitted, the provider-level region will be used.
+
+* `channel_id` - (Optional, String) Specifies the ID of the event channel to filter subscriptions.
+
+* `name` - (Optional, String) Specifies the exact name of the subscription to be queried.
+
+* `fuzzy_name` - (Optional, String) Specifies the name of the subscription to be queried for fuzzy matching.
+
+* `connection_id` - (Optional, String) Specifies the ID of the target connection to filter subscriptions.
+
+* `sort` - (Optional, String) Specifies the sorting method for query results.  
+  The format is `field:order`, where `field` is the field name and `order` is `ASC` or `DESC`. e.g. `created_time:DESC`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `subscriptions` - The list of the subscriptions that matched filter parameters.  
+  The [subscriptions](#eg_subscriptions_attr) structure is documented below.
+
+<a name="eg_subscriptions_attr"></a>
+The `subscriptions` block supports:
+
+* `id` - The ID of the subscription.
+
+* `name` - The name of the subscription.
+
+* `description` - The description of the subscription.
+
+* `type` - The type of the subscription.
+  + **EVENT**
+  + **SCHEDULED**
+
+* `status` - The status of the subscription.
+  + **CREATED**
+  + **ENABLED**
+  + **DISABLED**
+  + **FROZEN**
+  + **ERROR**
+
+* `channel_id` - The ID of the event channel.
+
+* `channel_name` - The name of the event channel.
+
+* `used` - The associated resources of the subscription.  
+  The [used](#eg_subscriptions_used) structure is documented below.
+
+* `sources` - The list of subscription sources.  
+  The [sources](#eg_subscriptions_sources) structure is documented below.
+
+* `targets` - The list of subscription targets.  
+  The [targets](#eg_subscriptions_targets) structure is documented below.
+
+* `created_time` - The creation time of the subscription, in RFC3339 format.
+
+* `updated_time` - The update time of the subscription, in RFC3339 format.
+
+<a name="eg_subscriptions_used"></a>
+The `used` block supports:
+
+* `resource_id` - The ID of the associated resource.
+
+* `owner` - The management tenant account to which the associated resource belongs.
+
+* `description` - The description of the associated resource.
+
+<a name="eg_subscriptions_sources"></a>
+The `sources` block supports:
+
+* `id` - The ID of the subscription source.
+
+* `name` - The name of the subscription source.
+
+* `provider_type` - The provider type of the subscription source.
+  + **OFFICIAL**
+  + **CUSTOM**
+  + **PARTNER**
+
+* `detail` - The parameter list of the subscription source, in JSON format.
+
+* `filter` - The matching filter rules of the subscription source, in JSON format.
+
+* `created_time` - The creation time of the subscription source, in RFC3339 format.
+
+* `updated_time` - The update time of the subscription source, in RFC3339 format.
+
+<a name="eg_subscriptions_targets"></a>
+The `targets` block supports:
+
+* `id` - The ID of the subscription target.
+
+* `name` - The name of the subscription target.
+
+* `provider_type` - The provider type of the subscription target.
+  + **OFFICIAL**
+  + **CUSTOM**
+  + **PARTNER**
+
+* `connection_id` - The target connection ID used by the subscription target.
+
+* `detail` - The parameter list of the subscription target, in JSON format.
+
+* `kafka_detail` - The Kafka target parameter list of the subscription, in JSON format.
+
+* `smn_detail` - The SMN target parameter list of the subscription, in JSON format.
+
+* `eg_detail` - The EG channel target parameter list of the subscription, in JSON format.
+
+* `apigw_detail` - The APIGW target parameter list of the subscription, in JSON format.
+
+* `retry_times` - The number of retry times.
+
+* `transform` - The transform rules of the subscription target, in JSON format.
+
+* `dead_letter_queue` - The dead letter queue parameters of the subscription, in JSON format.
+
+* `created_time` - The creation time of the subscription target, in RFC3339 format.
+
+* `updated_time` - The update time of the subscription target, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1065,6 +1065,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_eg_event_channels":        eg.DataSourceEventChannels(),
 			"huaweicloud_eg_event_sources":         eg.DataSourceEventSources(),
 			"huaweicloud_eg_event_streams":         eg.DataSourceEventStreams(),
+			"huaweicloud_eg_event_subscriptions":   eg.DataSourceEventSubscriptions(),
 			"huaweicloud_eg_event_target_catalogs": eg.DataSourceEventTargetCatalogs(),
 			"huaweicloud_eg_quotas":                eg.DataSourceQuotas(),
 			"huaweicloud_eg_traced_events":         eg.DataSourceTracedEvents(),

--- a/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_event_subscriptions_test.go
+++ b/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_event_subscriptions_test.go
@@ -1,0 +1,295 @@
+package eg
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataEventSubscriptions_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_eg_event_subscriptions.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byChannelId   = "data.huaweicloud_eg_event_subscriptions.filter_by_channel_id"
+		dcByChannelId = acceptance.InitDataSourceCheck(byChannelId)
+
+		byName   = "data.huaweicloud_eg_event_subscriptions.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byFuzzyName   = "data.huaweicloud_eg_event_subscriptions.filter_by_fuzzy_name"
+		dcByFuzzyName = acceptance.InitDataSourceCheck(byFuzzyName)
+
+		byConnectionId   = "data.huaweicloud_eg_event_subscriptions.filter_by_connection_id"
+		dcByConnectionId = acceptance.InitDataSourceCheck(byConnectionId)
+
+		byNotFoundName   = "data.huaweicloud_eg_event_subscriptions.filter_by_not_found_name"
+		dcByNotFoundName = acceptance.InitDataSourceCheck(byNotFoundName)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataEventSubscriptions_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "subscriptions.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckOutput("is_query_result_contains_subscriptions", "true"),
+
+					// Test filter by channel_id
+					dcByChannelId.CheckResourceExists(),
+					resource.TestCheckOutput("is_channel_id_filter_useful", "true"),
+					resource.TestCheckResourceAttrPair(byChannelId, "subscriptions.0.channel_id", "huaweicloud_eg_custom_event_channel.test", "id"),
+
+					// Test filter by name
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckResourceAttr(byName, "subscriptions.0.name", fmt.Sprintf("%s-suffix", name)),
+					resource.TestCheckResourceAttr(byName, "subscriptions.0.description", "Created by acceptance test"),
+					resource.TestCheckResourceAttr(byName, "subscriptions.0.type", "EVENT"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.status"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.channel_name"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.created_time"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.updated_time"),
+
+					// Test sources structure
+					resource.TestCheckResourceAttr(byName, "subscriptions.0.sources.#", "1"),
+					resource.TestCheckResourceAttr(byName, "subscriptions.0.sources.0.provider_type", "CUSTOM"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.sources.0.name"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.sources.0.filter"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.sources.0.created_time"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.sources.0.updated_time"),
+
+					// Test targets structure
+					resource.TestCheckResourceAttr(byName, "subscriptions.0.targets.#", "2"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.0.id"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.0.name"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.0.provider_type"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.0.smn_detail"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.0.transform"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.0.created_time"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.0.updated_time"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.1.id"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.1.name"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.1.provider_type"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.1.connection_id"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.1.detail"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.1.transform"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.1.created_time"),
+					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.1.updated_time"),
+
+					// Test filter by not found name
+					dcByNotFoundName.CheckResourceExists(),
+					resource.TestCheckOutput("is_not_found_name_filter_useful", "true"),
+
+					// Test filter by fuzzy name
+					dcByFuzzyName.CheckResourceExists(),
+					resource.TestCheckOutput("is_fuzzy_name_filter_useful", "true"),
+
+					// Test filter by connection_id
+					dcByConnectionId.CheckResourceExists(),
+					resource.TestCheckOutput("is_connection_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataEventSubscriptions_base(name string) string {
+	randSmnTargetId, _ := uuid.GenerateUUID()
+	randHTTPSTargetId, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_eg_custom_event_channel" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_eg_custom_event_source" "test" {
+  channel_id = huaweicloud_eg_custom_event_channel.test.id
+  name       = "%[1]s"
+}
+
+resource "huaweicloud_smn_topic" "test" {
+  name = "%[1]s"
+}
+
+data "huaweicloud_eg_connections" "test" {
+  name = "default"
+}
+
+resource "huaweicloud_eg_event_subscription" "test" {
+  channel_id  = huaweicloud_eg_custom_event_channel.test.id
+  name        = "%[1]s-suffix"
+  description = "Created by acceptance test"
+
+  sources {
+    provider_type = "CUSTOM"
+    name          = huaweicloud_eg_custom_event_source.test.name
+    filter_rule   = jsonencode({
+      "source": [{
+        "op":"StringIn",
+        "values":[huaweicloud_eg_custom_event_source.test.name]
+      }]
+    })
+  }
+
+  targets {
+    id            = "%[2]s"
+    provider_type = "OFFICIAL"
+    name          = "HC.SMN"
+    detail_name   = "smn_detail"
+    detail        = jsonencode({
+      "subject_transform": {
+        "type": "CONSTANT",
+        "value": "TEST_CONSTANT"
+      },
+      "urn": huaweicloud_smn_topic.test.topic_urn,
+      "agency_name": "EG_TARGET_AGENCY",
+    })
+    transform = jsonencode({
+      type  = "ORIGINAL"
+      value = ""
+    })
+  }
+  targets {
+    id            = "%[3]s"
+    provider_type = "CUSTOM"
+    name          = "HTTPS"
+    connection_id = try(data.huaweicloud_eg_connections.test.connections[0].id, "NOT_FOUND")
+    detail_name   = "detail"
+    detail        = jsonencode({
+      "url": "https://test.com/example",
+    })
+    transform = jsonencode({
+      type  = "VARIABLE"
+      value = "{\"name\":\"$.data.name\"}",
+      template = "My name is $${name}"
+    })
+  }
+
+  lifecycle {
+    ignore_changes = [sources, targets]
+  }
+}
+`, name, randSmnTargetId, randHTTPSTargetId)
+}
+
+func testAccDataEventSubscriptions_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Query all subscriptions
+data "huaweicloud_eg_event_subscriptions" "test" {
+  depends_on = [huaweicloud_eg_event_subscription.test]
+}
+
+output "is_query_result_contains_subscriptions" {
+  value = length(data.huaweicloud_eg_event_subscriptions.test.subscriptions) > 0
+}
+
+# Filter by channel ID
+locals {
+  channel_id = huaweicloud_eg_custom_event_channel.test.id
+}
+
+data "huaweicloud_eg_event_subscriptions" "filter_by_channel_id" {
+  depends_on = [huaweicloud_eg_event_subscription.test]
+
+  channel_id = local.channel_id
+}
+
+locals {
+  channel_id_filter_result = [
+    for v in data.huaweicloud_eg_event_subscriptions.filter_by_channel_id.subscriptions[*].channel_id : v == local.channel_id
+  ]
+}
+
+output "is_channel_id_filter_useful" {
+  value = length(local.channel_id_filter_result) > 0 && alltrue(local.channel_id_filter_result)
+}
+
+# Filter by name (exact match)
+locals {
+  subscription_name = "%[2]s-suffix"
+}
+
+data "huaweicloud_eg_event_subscriptions" "filter_by_name" {
+  depends_on = [huaweicloud_eg_event_subscription.test]
+
+  name = local.subscription_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_eg_event_subscriptions.filter_by_name.subscriptions[*].name : v == local.subscription_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by fuzzy name (fuzzy match)
+locals {
+  subscription_name_prefix = "%[2]s"
+}
+
+data "huaweicloud_eg_event_subscriptions" "filter_by_fuzzy_name" {
+  depends_on = [huaweicloud_eg_event_subscription.test]
+
+  fuzzy_name = local.subscription_name_prefix
+}
+
+locals {
+  fuzzy_name_filter_result = [
+    for v in data.huaweicloud_eg_event_subscriptions.filter_by_fuzzy_name.subscriptions[*].name : strcontains(v, local.subscription_name_prefix)
+  ]
+}
+
+output "is_fuzzy_name_filter_useful" {
+  value = length(local.fuzzy_name_filter_result) > 0 && alltrue(local.fuzzy_name_filter_result)
+}
+
+# Filter by not found name
+data "huaweicloud_eg_event_subscriptions" "filter_by_not_found_name" {
+  name = "not_found"
+}
+
+output "is_not_found_name_filter_useful" {
+  value = length(data.huaweicloud_eg_event_subscriptions.filter_by_not_found_name.subscriptions) < 1
+}
+
+# Filter by connection ID
+locals {
+  connection_id = try(data.huaweicloud_eg_connections.test.connections[0].id, "NOT_FOUND")
+}
+
+data "huaweicloud_eg_event_subscriptions" "filter_by_connection_id" {
+  depends_on = [huaweicloud_eg_event_subscription.test]
+
+  connection_id = local.connection_id
+}
+
+locals {
+  connection_id_filter_result = [
+    for v in data.huaweicloud_eg_event_subscriptions.filter_by_connection_id.subscriptions[*].targets : 
+      length([for t in v : t.connection_id == local.connection_id]) > 0
+  ]
+}
+
+output "is_connection_id_filter_useful" {
+  value = length(local.connection_id_filter_result) > 0 && alltrue(local.connection_id_filter_result)
+}
+`, testAccDataEventSubscriptions_base(name), name)
+}

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_event_subscriptions.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_event_subscriptions.go
@@ -1,0 +1,449 @@
+package eg
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EG GET /v1/{project_id}/subscriptions
+func DataSourceEventSubscriptions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEventSubscriptionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the subscriptions are located.`,
+			},
+
+			// Optional parameters.
+			"channel_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the event channel to filter subscriptions.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The exact name of the subscription to be queried.`,
+			},
+			"fuzzy_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the subscription to be queried for fuzzy matching.`,
+			},
+			"connection_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the target connection to filter subscriptions.`,
+			},
+			"sort": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The sorting method for query results.`,
+			},
+
+			// Attributes.
+			"subscriptions": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the subscriptions that matched filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the subscription.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the subscription.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the subscription.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the subscription.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the subscription.`,
+						},
+						"channel_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the event channel.`,
+						},
+						"channel_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the event channel.`,
+						},
+						"used": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The associated resources of the subscription.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"resource_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the associated resource.`,
+									},
+									"owner": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The management tenant account to which the associated resource belongs.`,
+									},
+									"description": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The description of the associated resource.`,
+									},
+								},
+							},
+						},
+						"sources": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of subscription sources.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the subscription source.`,
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the subscription source.`,
+									},
+									"provider_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The provider type of the subscription source.`,
+									},
+									"detail": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The parameter list of the subscription source, in JSON format.`,
+									},
+									"filter": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The matching filter rules of the subscription source, in JSON format.`,
+									},
+									"created_time": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The creation time of the subscription source, in RFC3339 format.`,
+									},
+									"updated_time": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The update time of the subscription source, in RFC3339 format.`,
+									},
+								},
+							},
+						},
+						"targets": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of subscription targets.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the subscription target.`,
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the subscription target.`,
+									},
+									"provider_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The provider type of the subscription target.`,
+									},
+									"connection_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The target connection ID used by the subscription target.`,
+									},
+									"detail": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The parameter list of the subscription target, in JSON format.`,
+									},
+									"kafka_detail": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The Kafka target parameter list of the subscription, in JSON format.`,
+									},
+									"smn_detail": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The SMN target parameter list of the subscription, in JSON format.`,
+									},
+									"eg_detail": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The EG channel target parameter list of the subscription, in JSON format.`,
+									},
+									"apigw_detail": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The APIGW target parameter list of the subscription, in JSON format.`,
+									},
+									"retry_times": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The number of retry times.`,
+									},
+									"transform": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The transform rules of the subscription target, in JSON format.`,
+									},
+									"dead_letter_queue": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The dead letter queue parameters of the subscription, in JSON format.`,
+									},
+									"created_time": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The creation time of the subscription target, in RFC3339 format.`,
+									},
+									"updated_time": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The update time of the subscription target, in RFC3339 format.`,
+									},
+								},
+							},
+						},
+						"created_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the subscription, in RFC3339 format.`,
+						},
+						"updated_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The update time of the subscription, in RFC3339 format.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceEventSubscriptionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("eg", region)
+	if err != nil {
+		return diag.Errorf("error creating EG client: %s", err)
+	}
+
+	subscriptions, err := listEventSubscriptions(client, d)
+	if err != nil {
+		return diag.Errorf("error querying event subscriptions: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("subscriptions", flattenEventSubscriptions(subscriptions)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func listEventSubscriptions(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/subscriptions?limit={limit}"
+		limit   = 1000
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildEventSubscriptionsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		subscriptions := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, subscriptions...)
+		if len(subscriptions) < limit {
+			break
+		}
+
+		offset += len(subscriptions)
+	}
+
+	return result, nil
+}
+
+func buildEventSubscriptionsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("channel_id"); ok {
+		res = fmt.Sprintf("%s&channel_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("fuzzy_name"); ok {
+		res = fmt.Sprintf("%s&fuzzy_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("connection_id"); ok {
+		res = fmt.Sprintf("%s&connection_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("sort"); ok {
+		res = fmt.Sprintf("%s&sort=%v", res, v)
+	}
+
+	return res
+}
+
+func flattenSubscriptionUsed(usedList []interface{}) []map[string]interface{} {
+	if len(usedList) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(usedList))
+	for _, used := range usedList {
+		result = append(result, map[string]interface{}{
+			"resource_id": utils.PathSearch("resource_id", used, nil),
+			"owner":       utils.PathSearch("owner", used, nil),
+			"description": utils.PathSearch("description", used, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenSubscriptionSources(sources []interface{}) []map[string]interface{} {
+	if len(sources) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(sources))
+	for _, source := range sources {
+		result = append(result, map[string]interface{}{
+			"id":            utils.PathSearch("id", source, nil),
+			"name":          utils.PathSearch("name", source, nil),
+			"provider_type": utils.PathSearch("provider_type", source, nil),
+			"detail":        utils.JsonToString(utils.PathSearch("detail", source, nil)),
+			"filter":        utils.JsonToString(utils.PathSearch("filter", source, nil)),
+			"created_time":  utils.PathSearch("created_time", source, nil),
+			"updated_time":  utils.PathSearch("updated_time", source, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenSubscriptionTargets(targets []interface{}) []map[string]interface{} {
+	if len(targets) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(targets))
+	for _, target := range targets {
+		result = append(result, map[string]interface{}{
+			"id":                utils.PathSearch("id", target, nil),
+			"name":              utils.PathSearch("name", target, nil),
+			"provider_type":     utils.PathSearch("provider_type", target, nil),
+			"connection_id":     utils.PathSearch("connection_id", target, nil),
+			"detail":            utils.JsonToString(utils.PathSearch("detail", target, nil)),
+			"kafka_detail":      utils.JsonToString(utils.PathSearch("kafka_detail", target, nil)),
+			"smn_detail":        utils.JsonToString(utils.PathSearch("smn_detail", target, nil)),
+			"eg_detail":         utils.JsonToString(utils.PathSearch("eg_detail", target, nil)),
+			"apigw_detail":      utils.JsonToString(utils.PathSearch("apigw_detail", target, nil)),
+			"retry_times":       utils.PathSearch("retry_times", target, nil),
+			"transform":         utils.JsonToString(utils.PathSearch("transform", target, nil)),
+			"dead_letter_queue": utils.JsonToString(utils.PathSearch("dead_letter_queue", target, nil)),
+			"created_time":      utils.PathSearch("created_time", target, nil),
+			"updated_time":      utils.PathSearch("updated_time", target, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenEventSubscriptions(subscriptions []interface{}) []map[string]interface{} {
+	if len(subscriptions) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(subscriptions))
+	for _, subscription := range subscriptions {
+		result = append(result, map[string]interface{}{
+			"id":           utils.PathSearch("id", subscription, nil),
+			"name":         utils.PathSearch("name", subscription, nil),
+			"description":  utils.PathSearch("description", subscription, nil),
+			"type":         utils.PathSearch("type", subscription, nil),
+			"status":       utils.PathSearch("status", subscription, nil),
+			"channel_id":   utils.PathSearch("channel_id", subscription, nil),
+			"channel_name": utils.PathSearch("channel_name", subscription, nil),
+			"used":         flattenSubscriptionUsed(utils.PathSearch("used", subscription, make([]interface{}, 0)).([]interface{})),
+			"sources":      flattenSubscriptionSources(utils.PathSearch("sources", subscription, make([]interface{}, 0)).([]interface{})),
+			"targets":      flattenSubscriptionTargets(utils.PathSearch("targets", subscription, make([]interface{}, 0)).([]interface{})),
+			"created_time": utils.PathSearch("created_time", subscription, nil),
+			"updated_time": utils.PathSearch("updated_time", subscription, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source to query EG event subscriptions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="975" height="619" alt="image" src="https://github.com/user-attachments/assets/1cab6202-b27c-466c-a369-3026192571b3" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query event subscriptions.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o eg -f TestAccDataEventSubscriptions_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eg" -v -coverprofile="./huaweicloud/services/acceptance/eg/eg_coverage.cov" -coverpkg="./huaweicloud/services/eg" -run TestAccDataEventSubscriptions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataEventSubscriptions_basic
--- PASS: TestAccDataEventSubscriptions_basic (20.20s)
PASS
coverage: 20.2% of statements in ./huaweicloud/services/eg
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        20.268s coverage: 20.2% of statements in ./huaweicloud/services/eg
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
