### PR TITLE
feat(dew): add a new one-time resource to cancel key deletion

### DIFF
--- a/docs/resources/kms_cancel_key_deletion.md
+++ b/docs/resources/kms_cancel_key_deletion.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_kms_cancel_key_deletion"
+description: |-
+  Manages a KMS cancel key deletion resource within HuaweiCloud.
+---
+
+# huaweicloud_kms_cancel_key_deletion
+
+Manages a KMS cancel key deletion resource within HuaweiCloud.
+
+-> The current resource is a one-time resource, and destroying this resource will not recover the cancellation of key deletion,
+  but will only remove the resource information from the tfstate file.
+
+-> This resource only supports canceling key deletion for keys with `key_state` set to **4** (pending deletion).
+
+## Example Usage
+
+```hcl
+variable "key_id" {}
+
+resource "huaweicloud_kms_cancel_key_deletion" "test" {
+  key_id = var.key_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `key_id` - (Required, String, NonUpdatable) Specifies the key ID.
+  The valid length is `36` bytes, meeting regular match **^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$**.
+  For example: **0d0466b0-e727-4d9c-b35d-f84bb474a37f**.
+
+* `sequence` - (Optional, String, NonUpdatable) Specifies the sequence number of the request message, `36` bytes.
+  For example: **919c82d4-8046-4722-9094-35c3c6524cff**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `key_state` - The current status of the KMS key.
+  The valid values are as follows:
+  + **2**: Enabled.
+  + **3**: Disabled.
+  + **4**: Pending deletion.
+  + **5**: Pending import.
+  + **7**: Frozen.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2687,6 +2687,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_encrypt_datakey":           dew.ResourceKmsEncryptDatakey(),
 			"huaweicloud_kms_decrypt_datakey":           dew.ResourceKmsDecryptDatakey(),
 			"huaweicloud_kms_datakey_without_plaintext": dew.ResourceKmsDatakeyWithoutPlaintext(),
+			"huaweicloud_kms_cancel_key_deletion":       dew.ResourceKmsCancelKeyDeletion(),
 
 			"huaweicloud_kps_keypair_disassociate": dew.ResourceKpsKeypairDisassociate(),
 			"huaweicloud_kps_keypair_associate":    dew.ResourceKpsKeypairAssociate(),

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_cancel_key_deletion_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_cancel_key_deletion_test.go
@@ -1,0 +1,39 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccKmsCancelKeyDeletion_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare a KMS Key ID in the scheduled deletion state, then config it to the environment variable.
+			acceptance.TestAccPreCheckKmsKeyID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKmsCancelKeyDeletion_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("huaweicloud_kms_cancel_key_deletion.test", "key_id", acceptance.HW_KMS_KEY_ID),
+					resource.TestCheckResourceAttrSet("huaweicloud_kms_cancel_key_deletion.test", "key_state"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKmsCancelKeyDeletion_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kms_cancel_key_deletion" "test" {
+  key_id = "%s"
+}
+`, acceptance.HW_KMS_KEY_ID)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_kms_cancel_key_deletion.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kms_cancel_key_deletion.go
@@ -1,0 +1,137 @@
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var cancelKeyDeletionNonUpdatableParams = []string{
+	"key_id",
+	"sequence",
+}
+
+// @API DEW POST /v1.0/{project_id}/kms/cancel-key-deletion
+func ResourceKmsCancelKeyDeletion() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKmsCancelKeyDeletionCreate,
+		ReadContext:   resourceKmsCancelKeyDeletionRead,
+		UpdateContext: resourceKmsCancelKeyDeletionUpdate,
+		DeleteContext: resourceKmsCancelKeyDeletionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(cancelKeyDeletionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to create the resource.`,
+			},
+			"key_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the key ID.`,
+			},
+			"sequence": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the sequence number of the request message.`,
+			},
+			"enable_force_new": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"key_state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current status of the KMS key.`,
+			},
+		},
+	}
+}
+
+func buildCancelKeyDeletionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"key_id":   d.Get("key_id"),
+		"sequence": utils.ValueIgnoreEmpty(d.Get("sequence")),
+	}
+
+	return bodyParams
+}
+
+func resourceKmsCancelKeyDeletionCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1.0/{project_id}/kms/cancel-key-deletion"
+		product = "kms"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCancelKeyDeletionBodyParams(d)),
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error canceling the deletion of key: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("key_state", utils.PathSearch("key_state", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceKmsCancelKeyDeletionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKmsCancelKeyDeletionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKmsCancelKeyDeletionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to cancel key deletion.
+Deleting this resource will not recover the cancellation of the key deletion, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New one-time resource to cancel key deletion and names huaweicloud_kms_cancel_key_deletion
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccKmsCancelKeyDeletion_basic -timeout 360m -parallel 10
=== RUN   TestAccKmsCancelKeyDeletion_basic
=== PAUSE TestAccKmsCancelKeyDeletion_basic
=== CONT  TestAccKmsCancelKeyDeletion_basic
--- PASS: TestAccKmsCancelKeyDeletion_basic (27.09s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       27.170s coverage: 3.8% of statements in ./huaweicloud/services/dew
```
<img width="865" height="77" alt="image" src="https://github.com/user-attachments/assets/332fbfe8-bd60-47ac-8434-0a9b0880a807" />

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
