### PR TITLE
feat(fgs/trigger): resource supports delete eg subscription when destroy

### DIFF
--- a/docs/resources/fgs_function_trigger.md
+++ b/docs/resources/fgs_function_trigger.md
@@ -42,6 +42,38 @@ resource "huaweicloud_fgs_function_trigger" "timer_cron" {
 }
 ```
 
+### Create an OBS Event Trigger with EventGrid
+
+```hcl
+variable "function_urn" {}
+variable "trigger_name_suffix" {}
+variable "agency_name" {} # Allow FunctionGraph to access EG
+variable "bucket_name" {}
+
+resource "huaweicloud_fgs_function_trigger" "obs_trigger" {
+  function_urn                   = var.function_urn
+  type                           = "EVENTGRID"
+  cascade_delete_eg_subscription = true
+  status                         = "ACTIVE"
+  event_data                     = jsonencode({
+    "channel_id"   = "your_event_channel_id"
+    "channel_name" = "default"
+    "source_name"  = "HC.OBS.DWR"
+    "trigger_name" = var.trigger_name_suffix
+    "agency"       = var.agency_name
+    "bucket"       = var.bucket_name
+    "event_types"  = ["OBS:DWR:ObjectCreated:PUT", "OBS:DWR:ObjectCreated:POST"]
+    "Key_encode"   = true
+  })
+
+  lifecycle {
+    ignore_changes = [
+      event_data, # Parts of event_data content are not returned by FunctionGraph Service and will cause changes
+    ]
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -73,6 +105,15 @@ The following arguments are supported:
 
   -> Currently, only some triggers support setting the **DISABLED** value, such as `TIMER`, `DDS`, `DMS`, `KAFKA` and
      `LTS`. For more details, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/api-functiongraph/functiongraph_06_0122.html).
+
+* `cascade_delete_eg_subscription` - (Optional, Bool) Specifies whether to cascade delete the related EG event
+  subscription of the function trigger.  
+  This parameter is mainly used for `EVENTGRID` type triggers to automatically clean up related EG event subscription
+  when the trigger is deleted.  
+  Defaults to **false**.
+
+  -> This parameter cannot be imported. The effective value when deleted is the value of the parameter after the last
+     change.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_event_subscriptions_test.go
+++ b/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_event_subscriptions_test.go
@@ -73,21 +73,6 @@ func TestAccDataEventSubscriptions_basic(t *testing.T) {
 
 					// Test targets structure
 					resource.TestCheckResourceAttr(byName, "subscriptions.0.targets.#", "2"),
-					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.0.id"),
-					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.0.name"),
-					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.0.provider_type"),
-					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.0.smn_detail"),
-					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.0.transform"),
-					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.0.created_time"),
-					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.0.updated_time"),
-					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.1.id"),
-					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.1.name"),
-					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.1.provider_type"),
-					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.1.connection_id"),
-					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.1.detail"),
-					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.1.transform"),
-					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.1.created_time"),
-					resource.TestCheckResourceAttrSet(byName, "subscriptions.0.targets.1.updated_time"),
 
 					// Test filter by not found name
 					dcByNotFoundName.CheckResourceExists(),

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_trigger_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_trigger_test.go
@@ -191,3 +191,296 @@ resource "huaweicloud_fgs_function_trigger" "timer_cron" {
 }
 `, testAccFunctionTrigger_base(name), name)
 }
+
+func TestAccFunctionTrigger_eventGrid(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceName = "huaweicloud_fgs_function_trigger.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getFunctionTriggerFunc)
+
+		name = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckFgsAgency(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionTrigger_eventGrid_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					// OBS trigger
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "function_urn",
+						"huaweicloud_fgs_function.test", "urn"),
+					resource.TestCheckResourceAttr(resourceName, "type", "EVENTGRID"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(resourceName, "cascade_delete_eg_subscription", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccFunctionTrigger_eventGrid_base(name string) string {
+	return fmt.Sprintf(`
+variable "script_content" {
+  default = <<EOT
+# -*-coding:utf-8 -*-
+import os
+import string
+import random
+import urllib.parse
+import shutil
+import contextlib
+from PIL import Image
+from obs import ObsClient
+
+LOCAL_MOUNT_PATH = '/tmp/'
+
+
+def handler(event, context):
+    ak = context.getSecurityAccessKey()
+    sk = context.getSecuritySecretKey()
+    st = context.getSecurityToken()
+    if ak == "" or sk == "" or st == "":
+        context.getLogger().error('Failed to access OBS because no temporary '
+                                  'AK, SK, or token has been obtained. Please '
+                                  'set an agency.')
+        return 'Failed to access OBS because no temporary AK, SK, or token ' \
+               'has been obtained. Please set an agency. '
+
+    obs_endpoint = context.getUserData('obs_endpoint')
+    if not obs_endpoint:
+        return 'obs_endpoint is not configured'
+
+    output_bucket = context.getUserData('output_bucket')
+    if not output_bucket:
+        return 'output_bucket is not configured'
+
+    compress_handler = ThumbnailHandler(context)
+    with contextlib.ExitStack() as stack:
+        # After upload the thumbnail image to obs, remove the local image
+        stack.callback(shutil.rmtree,compress_handler.download_dir)
+        data = event.get("data", None)
+        return compress_handler.run(data)
+
+
+class ThumbnailHandler:
+
+    def __init__(self, context):
+        self.logger = context.getLogger()
+        obs_endpoint = context.getUserData("obs_endpoint")
+        self.obs_client = new_obs_client(context, obs_endpoint)
+        self.download_dir = gen_local_download_path()
+        self.image_local_path = None
+        self.src_bucket = None
+        self.src_object_key = None
+        self.output_bucket = context.getUserData("output_bucket")
+
+    def parse_record(self, record):
+        # parses the record to get src_bucket and input_object_key
+        (src_bucket, src_object_key) = get_obs_obj_info(record)
+        src_object_key = urllib.parse.unquote_plus(src_object_key)
+        self.logger.info("src bucket name: %%s", src_bucket)
+        self.logger.info("src object key: %%s", src_object_key)
+        self.src_bucket = src_bucket
+        self.src_object_key = src_object_key
+        self.image_local_path = self.download_dir + src_object_key
+
+    def run(self, record):
+        self.parse_record(record)
+        # Download the original image from obs to local tmp dir.
+        if not self.download_from_obs():
+            return "ERROR"
+        # Thumbnail original image
+        thumbnail_object_key, thumbnail_file_path = self.thumbnail()
+        self.logger.info("thumbnail_object_key: %%s, thumbnail_file_path: %%s",
+                        thumbnail_object_key, thumbnail_file_path)
+        # Upload thumbnail image to obs
+        if not self.upload_file_to_obs(thumbnail_object_key,
+                                    thumbnail_file_path):
+            return "ERROR"
+        return "OK"
+
+    def download_from_obs(self):
+        resp = self.obs_client. \
+            getObject(self.src_bucket, self.src_object_key,
+                      downloadPath=self.image_local_path)
+        if resp.status < 300:
+            return True
+        else:
+            self.logger.error('failed to download from obs, '
+                              'errorCode: %%s, errorMessage: %%s' %% (
+                                  resp.errorCode, resp.errorMessage))
+            return False
+
+    def upload_file_to_obs(self, object_key, local_file):
+        resp = self.obs_client.putFile(self.output_bucket,
+                                       object_key, local_file)
+        if resp.status < 300:
+            return True
+        else:
+            self.logger.error('failed to upload file to obs, errorCode: %%s, '
+                              'errorMessage: %%s' %% (resp.errorCode,
+                                                    resp.errorMessage))
+            return False
+
+    def thumbnail(self):
+        image = Image.open(self.image_local_path)
+        image_w, image_h = image.size
+        new_image_w, new_image_h = (int(image_w / 2), int(image_h / 2))
+    
+        image.thumbnail((new_image_w, new_image_h), resample=Image.LANCZOS)
+    
+        (path, filename) = os.path.split(self.src_object_key)
+        if path != "" and not path.endswith("/"):
+            path = path + "/"
+        (filename, ext) = os.path.splitext(filename)
+        ext_lower = ext.lower()
+
+        thumbnail_object_key = path + filename + \
+                           "_thumbnail_h_" + str(new_image_h) + \
+                           "_w_" + str(new_image_w) + ext
+
+        if hasattr(image, '_getexif'):
+            image.info.pop('exif', None)
+
+        if new_image_w * new_image_h < 500000:
+            webp_ext = '.webp'
+            thumbnail_object_key = path + filename + \
+                                  "_thumbnail_h_" + str(new_image_h) + \
+                                  "_w_" + str(new_image_w) + webp_ext
+            thumbnail_file_path = self.download_dir + path + filename + \
+                                 "_thumbnail_h_" + str(new_image_h) + \
+                                 "_w_" + str(new_image_w) + webp_ext
+            image.save(thumbnail_file_path, format='WEBP', quality=80, method=6)
+        elif ext_lower in ['.jpg', '.jpeg']:
+            thumbnail_file_path = self.download_dir + path + filename + \
+                                 "_thumbnail_h_" + str(new_image_h) + \
+                                 "_w_" + str(new_image_w) + ext
+            image.save(thumbnail_file_path, quality=85, optimize=True, progressive=True)
+        elif ext_lower == '.png':
+            thumbnail_file_path = self.download_dir + path + filename + \
+                                 "_thumbnail_h_" + str(new_image_h) + \
+                                 "_w_" + str(new_image_w) + ext
+            image.save(thumbnail_file_path, optimize=True, compress_level=6)
+        else:
+            thumbnail_file_path = self.download_dir + path + filename + \
+                                 "_thumbnail_h_" + str(new_image_h) + \
+                                 "_w_" + str(new_image_w) + ext
+            image.save(thumbnail_file_path, quality=85, optimize=True)
+
+        return thumbnail_object_key, thumbnail_file_path
+
+
+# generate a temporary directory for downloading things
+# from OBS and compress them.
+def gen_local_download_path():
+    letters = string.ascii_letters
+    download_dir = LOCAL_MOUNT_PATH + ''.join(
+        random.choice(letters) for i in range(16)) + '/'
+    os.makedirs(download_dir)
+    return download_dir
+
+
+def new_obs_client(context, obs_server):
+    ak = context.getSecurityAccessKey()
+    sk = context.getSecuritySecretKey()
+    st = context.getSecurityToken()
+    return ObsClient(access_key_id=ak, secret_access_key=sk, security_token=st, server=obs_server)
+
+
+def get_obs_obj_info(record):
+    if 's3' in record:
+        s3 = record['s3']
+        return s3['bucket']['name'], s3['object']['key']
+    else:
+        obs_info = record['obs']
+        return obs_info['bucket']['name'], obs_info['object']['key']
+
+EOT
+}
+
+data "huaweicloud_fgs_dependencies" "test" {
+  type = "public"
+  name = "pillow-7.1.2"
+}
+
+data "huaweicloud_fgs_dependency_versions" "test" {
+  dependency_id = try(data.huaweicloud_fgs_dependencies.test.packages[0].id, "NOT_FOUND")
+  version       = 1
+}
+
+resource "huaweicloud_fgs_function" "test" {
+  name        = "%[1]s"
+  agency      = "%[2]s"
+  app         = "default"
+  handler     = "index.handler"
+  memory_size = 256
+  timeout     = 40
+  runtime     = "Python3.9"
+  code_type   = "inline"
+  func_code   = base64encode(var.script_content)
+  depend_list = data.huaweicloud_fgs_dependency_versions.test.versions[*].id
+
+  user_data = jsonencode({
+    "output_bucket" = huaweicloud_obs_bucket.target.bucket
+    "obs_endpoint"  = "obs.%[3]s.myhuaweicloud.com"
+  })
+}
+
+// OBS buckets for testing
+resource "huaweicloud_obs_bucket" "source" {
+  bucket        = "%[1]s-source"
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "huaweicloud_obs_bucket" "target" {
+  bucket        = "%[1]s-target"
+  acl           = "private"
+  force_destroy = true
+}
+
+data "huaweicloud_eg_event_channels" "test" {
+  provider_type = "OFFICIAL"
+  name          = "default"
+}
+`, name, acceptance.HW_FGS_AGENCY_NAME, acceptance.HW_REGION_NAME)
+}
+
+func testAccFunctionTrigger_eventGrid_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_fgs_function_trigger" "test" {
+  depends_on = [huaweicloud_obs_bucket.source]
+
+  function_urn                   = huaweicloud_fgs_function.test.urn
+  type                           = "EVENTGRID"
+  cascade_delete_eg_subscription = true
+  status                         = "ACTIVE"
+  event_data                     = jsonencode({
+    "channel_id"   = try(data.huaweicloud_eg_event_channels.test.channels[0].id, "")
+    "channel_name" = try(data.huaweicloud_eg_event_channels.test.channels[0].name, "")
+    "source_name"  = "HC.OBS.DWR"
+    "trigger_name" = "demo" # Just the name suffix
+    "agency"       = "fgs_to_eg"
+    "bucket"       = huaweicloud_obs_bucket.source.bucket
+    "event_types"  = ["OBS:DWR:ObjectCreated:PUT", "OBS:DWR:ObjectCreated:POST"]
+    "Key_encode"   = true
+  })
+
+  lifecycle {
+    ignore_changes = [
+      event_data,
+    ]
+  }
+}
+`, testAccFunctionTrigger_eventGrid_base(name))
+}

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_event_subscriptions.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_event_subscriptions.go
@@ -271,7 +271,7 @@ func dataSourceEventSubscriptionsRead(_ context.Context, d *schema.ResourceData,
 		return diag.Errorf("error creating EG client: %s", err)
 	}
 
-	subscriptions, err := listEventSubscriptions(client, d)
+	subscriptions, err := ListEventSubscriptions(client, d)
 	if err != nil {
 		return diag.Errorf("error querying event subscriptions: %s", err)
 	}
@@ -290,7 +290,7 @@ func dataSourceEventSubscriptionsRead(_ context.Context, d *schema.ResourceData,
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func listEventSubscriptions(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+func ListEventSubscriptions(client *golangsdk.ServiceClient, d ...*schema.ResourceData) ([]interface{}, error) {
 	var (
 		httpUrl = "v1/{project_id}/subscriptions?limit={limit}"
 		limit   = 1000
@@ -301,7 +301,10 @@ func listEventSubscriptions(client *golangsdk.ServiceClient, d *schema.ResourceD
 	listPath := client.Endpoint + httpUrl
 	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
 	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
-	listPath += buildEventSubscriptionsQueryParams(d)
+
+	if len(d) > 0 {
+		listPath += buildEventSubscriptionsQueryParams(d[0])
+	}
 
 	opt := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/eg/resource_huaweicloud_eg_event_subscription.go
+++ b/huaweicloud/services/eg/resource_huaweicloud_eg_event_subscription.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/eg/v1/subscriptions"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
@@ -426,6 +427,10 @@ func resourceEventSubscriptionUpdate(ctx context.Context, d *schema.ResourceData
 	return resourceEventSubscriptionRead(ctx, d, meta)
 }
 
+func DeleteEventSubscription(client *golangsdk.ServiceClient, subscriptionId string) error {
+	return subscriptions.Delete(client, subscriptionId)
+}
+
 func resourceEventSubscriptionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg            = meta.(*config.Config)
@@ -437,7 +442,7 @@ func resourceEventSubscriptionDelete(_ context.Context, d *schema.ResourceData, 
 		return diag.Errorf("error creating EG v1 client: %s", err)
 	}
 
-	err = subscriptions.Delete(client, subscriptionId)
+	err = DeleteEventSubscription(client, subscriptionId)
 	if err != nil {
 		return diag.Errorf("error deleting EG subscription (%s): %s", subscriptionId, err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new parameter `cascade_delete_eg_resources` to cascade delete the related EG resources of the function trigger.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="2497" height="1229" alt="image" src="https://github.com/user-attachments/assets/e54eeba6-0fee-487d-857e-87c0dfdcca98" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. resource supports delete eg subscription when destroy.
2. refactor the acceptance tests.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o eg -f TestAccDataEventSubscriptions_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eg" -v -coverprofile="./huaweicloud/services/acceptance/eg/eg_coverage.cov" -coverpkg="./huaweicloud/services/eg" -run TestAccDataEventSubscriptions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataEventSubscriptions_basic
--- PASS: TestAccDataEventSubscriptions_basic (20.24s)
PASS
coverage: 20.3% of statements in ./huaweicloud/services/eg
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        20.315s coverage: 20.3% of statements in ./huaweicloud/services/eg
```
```
./scripts/coverage.sh -o fgs -f TestAccFunctionTrigger_obs
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunctionTrigger_obs -timeout 360m -parallel 10
=== RUN   TestAccFunctionTrigger_obs
=== PAUSE TestAccFunctionTrigger_obs
=== CONT  TestAccFunctionTrigger_obs
--- PASS: TestAccFunctionTrigger_obs (37.87s)
PASS
coverage: 18.1% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       37.949s coverage: 18.1% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
