### PR TITLE
feat(dew): add a new one-time resource to verify signature

### DIFF
--- a/docs/resources/kms_verify_sign.md
+++ b/docs/resources/kms_verify_sign.md
@@ -1,0 +1,82 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_kms_verify_sign"
+description: |-
+  Manages a KMS verify resource within HuaweiCloud.
+---
+
+# huaweicloud_kms_verify_sign
+
+Manages a KMS verify resource within HuaweiCloud.
+
+-> The current resource is a one-time resource, and destroying this resource will not recover verify,
+  but will only remove the resource information from the tfstate file.
+
+-> 1. This resource only supports signature verification operations for asymmetric keys with `key_usage` set to **SIGN_VERIFY**.
+  <br/>2. When using SM2 keys for signature, only can be used to sign message digests.
+
+## Example Usage
+
+```hcl
+variable "key_id" {}
+variable "message" {}
+variable "signature" {}
+variable "signing_algorithm" {}
+
+resource "huaweicloud_kms_verify_sign" "test" {
+  key_id            = var.key_id
+  message           = var.message
+  signature         = var.signature
+  signing_algorithm = var.signing_algorithm
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `key_id` - (Required, String, NonUpdatable) Specifies the key ID.
+  The valid length is `36` bytes, meeting regular match **^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$**.
+  For example: **0d0466b0-e727-4d9c-b35d-f84bb474a37f**.
+
+* `message` - (Required, String, NonUpdatable) Specifies the message digest or message to be signed.
+  The message length must be less than `4,096` bytes and should be encoded using Base64.
+
+* `signature` - (Required, String, NonUpdatable) Specifies the signature value to be verified, encoded using Base64.
+
+* `signing_algorithm` - (Required, String, NonUpdatable) Specifies the signature algorithm.
+  The valid values are as follows:
+  + **SM2DSA_SM3**
+  + **RSASSA_PSS_SHA_256**
+  + **RSASSA_PSS_SHA_384**
+  + **RSASSA_PSS_SHA_512**
+  + **RSASSA_PKCS1_V1_5_SHA_256**
+  + **RSASSA_PKCS1_V1_5_SHA_384**
+  + **RSASSA_PKCS1_V1_5_SHA_512**
+  + **ECDSA_SHA_256**
+  + **ECDSA_SHA_384**
+  + **ECDSA_SHA_512**
+
+* `message_type` - (Optional, String, NonUpdatable) Specifies the type of the message.
+  The valid values are as follows, the default value is **DIGEST**.
+  + **DIGEST**: Message digest.
+  + **RAW**: Original message.
+
+* `sequence` - (Optional, String, NonUpdatable) Specifies the sequence number of the request message, `36` bytes.
+  For example: **919c82d4-8046-4722-9094-35c3c6524cff**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `signature_valid` - The validity of signature verification.
+  The valid values are as follows:
+  + **true**: The signature is legal.
+  + **false**: The signature is illegal.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2705,6 +2705,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_kms_data_encrypt_decrypt":      dew.ResourceKmsDataEncryptDecrypt(),
 			"huaweicloud_kms_sign":                      dew.ResourceKmsSign(),
+			"huaweicloud_kms_verify_sign":               dew.ResourceKmsVerifySign(),
 			"huaweicloud_kms_key":                       dew.ResourceKmsKey(),
 			"huaweicloud_kps_keypair":                   dew.ResourceKeypair(),
 			"huaweicloud_kms_grant":                     dew.ResourceKmsGrant(),

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_verify_sign_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_verify_sign_test.go
@@ -1,0 +1,50 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccKmsVerifySign_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare a KMS Key ID and one message based on Base64 encoding, then config it to the environment variable.
+			acceptance.TestAccPreCheckKmsKeyID(t)
+			acceptance.TestAccPreCheckKmsKeyMessage(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKmsVerifySign_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("huaweicloud_kms_verify_sign.test", "key_id", acceptance.HW_KMS_KEY_ID),
+					resource.TestCheckOutput("verify_validation", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKmsVerifySign_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_kms_verify_sign" "test" {
+  key_id            = "%[2]s"
+  message           = "%[3]s"
+  signature         = huaweicloud_kms_sign.test.signature
+  signing_algorithm = "RSASSA_PSS_SHA_256"
+  message_type      = "RAW"
+}
+
+output verify_validation {
+	value = huaweicloud_kms_verify_sign.test.signature_valid
+}
+`, testAccKmsSign_basic(), acceptance.HW_KMS_KEY_ID, acceptance.HW_KMS_KEY_MESSAGE)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_kms_verify_sign.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kms_verify_sign.go
@@ -1,0 +1,165 @@
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var verifySignNonUpdatableParams = []string{
+	"key_id",
+	"message",
+	"signature",
+	"signing_algorithm",
+	"message_type",
+	"sequence",
+}
+
+// @API DEW POST /v1.0/{project_id}/kms/verify
+func ResourceKmsVerifySign() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKmsVerifySignCreate,
+		ReadContext:   resourceKmsVerifySignRead,
+		UpdateContext: resourceKmsVerifySignUpdate,
+		DeleteContext: resourceKmsVerifySignDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(verifySignNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to create the resource.`,
+			},
+			"key_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the key ID.`,
+			},
+			"message": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the message digest or message.`,
+			},
+			"signature": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the signature value to be verified.`,
+			},
+			"signing_algorithm": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the signature algorithm.`,
+			},
+			"message_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the type of the message.`,
+			},
+			"sequence": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the sequence number of the request message.`,
+			},
+			"enable_force_new": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"signature_valid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The validity of signature verification.`,
+			},
+		},
+	}
+}
+
+func buildVerifySignBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"key_id":            d.Get("key_id"),
+		"message":           d.Get("message"),
+		"signature":         d.Get("signature"),
+		"signing_algorithm": d.Get("signing_algorithm"),
+		"message_type":      utils.ValueIgnoreEmpty(d.Get("message_type")),
+		"sequence":          utils.ValueIgnoreEmpty(d.Get("sequence")),
+	}
+
+	return bodyParams
+}
+
+func resourceKmsVerifySignCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1.0/{project_id}/kms/verify"
+		product = "kms"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildVerifySignBodyParams(d)),
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error running verifying signature : %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("signature_valid", utils.PathSearch("signature_valid", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceKmsVerifySignRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKmsVerifySignUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKmsVerifySignDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to verify signature.
+Deleting this resource will not recover verify, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New one-time resource to verify signature and names huaweicloud_kms_verify_sign
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccKmsVerify_basic -timeout 360m -parallel 10
=== RUN   TestAccKmsVerify_basic
=== PAUSE TestAccKmsVerify_basic
=== CONT  TestAccKmsVerify_basic
--- PASS: TestAccKmsVerify_basic (28.38s)
PASS
coverage: 4.8% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       28.429s coverage: 4.8% of statements in ./huaweicloud/services/dew
```
<img width="865" height="87" alt="image" src="https://github.com/user-attachments/assets/a4f547e5-2f20-4315-a153-1d75ab3f84b0" />

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
