### PR TITLE
feat(apig): add new resource for api offline by version action

### DIFF
--- a/docs/resources/apig_api_version_unpublish.md
+++ b/docs/resources/apig_api_version_unpublish.md
@@ -1,0 +1,46 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_api_version_unpublish"
+description: |-
+  Use this resource to unpublish API by version within HuaweiCloud.
+---
+
+# huaweicloud_apig_api_version_unpublish
+
+Use this resource to unpublish API by version within HuaweiCloud.
+
+-> This resource is only a one-time action resource for unpublish API by version. Deleting this resource
+   will not restore the API version, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "version_id" {}
+
+resource "huaweicloud_apig_api_version_unpublish" "test" {
+  instance_id = var.instance_id
+  version_id  = var.version_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the dedicated instance to which the API version
+belongs is located.  
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the dedicated instance to which the API version
+belongs.
+
+* `version_id` - (Required, String, NonUpdatable) Specifies the ID of the API version to be unpublish.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2024,6 +2024,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_api_check":                      apig.ResourceApiCheck(),
 			"huaweicloud_apig_api_debug":                      apig.ResourceApigApiDebug(),
 			"huaweicloud_apig_api_publishment":                apig.ResourceApigApiPublishment(),
+			"huaweicloud_apig_api_version_unpublish":          apig.ResourceApiVersionUnpublish(),
 			"huaweicloud_apig_appcode":                        apig.ResourceAppcode(),
 			"huaweicloud_apig_application":                    apig.ResourceApigApplicationV2(),
 			"huaweicloud_apig_application_acl":                apig.ResourceApplicationAcl(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_version_unpublish_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_version_unpublish_test.go
@@ -1,0 +1,85 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccApiVersionUnpublish_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		rcName = "huaweicloud_apig_api_version_unpublish.test"
+	)
+
+	// Avoid CheckDestroy because this resource is a one-time action resource.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApiVersionUnpublish_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rcName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccApiVersionUnpublish_basic(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+%[1]s
+
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[2]s"
+}
+
+resource "huaweicloud_apig_group" "test" {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  name        = "%[3]s"
+}
+
+resource "huaweicloud_apig_environment" "test" {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  name        = "%[3]s"
+}
+
+resource "huaweicloud_apig_api" "test" {
+  instance_id      = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  group_id         = huaweicloud_apig_group.test.id
+  name             = "%[3]s"
+  type             = "Private"
+  request_protocol = "HTTP"
+  request_method   = "GET"
+  request_path     = "/mock/test"
+
+  mock {
+    status_code = 200
+  }
+}
+
+resource "huaweicloud_apig_api_action" "test" {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  action      = "online"
+}
+
+resource "huaweicloud_apig_api_version_unpublish" "test" {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  version_id  = huaweicloud_apig_api_action.test.version_id
+}
+`, common.TestBaseNetwork(name), acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_api_version_unpublish.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_api_version_unpublish.go
@@ -1,0 +1,115 @@
+package apig
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var apiVersionUnpublishNonUpdatableParams = []string{"instance_id", "version_id"}
+
+// @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/apis/versions/{version_id}
+func ResourceApiVersionUnpublish() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceApiVersionUnpublishCreate,
+		ReadContext:   resourceApiVersionUnpublishRead,
+		UpdateContext: resourceApiVersionUnpublishUpdate,
+		DeleteContext: resourceApiVersionUnpublishDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(apiVersionUnpublishNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the dedicated instance to which the API version belongs is located.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the API version belongs.`,
+			},
+			"version_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the API version to be offline.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceApiVersionUnpublishCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/apis/versions/{version_id}"
+		instanceId = d.Get("instance_id").(string)
+		versionId  = d.Get("version_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceId)
+	deletePath = strings.ReplaceAll(deletePath, "{version_id}", versionId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error unpublishing API version(%s): %s", versionId, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceApiVersionUnpublishRead(ctx, d, meta)
+}
+
+func resourceApiVersionUnpublishRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceApiVersionUnpublishUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceApiVersionUnpublishDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for offline API by version. Deleting this resource
+will not restore the API version, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(apig): add new resource for api offline by version action

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccApigApiOfflineByVersion_basic -timeout 360m -parallel 10
=== RUN   TestAccApigApiOfflineByVersion_basic
=== PAUSE TestAccApigApiOfflineByVersion_basic
=== CONT  TestAccApigApiOfflineByVersion_basic
--- PASS: TestAccApigApiOfflineByVersion_basic (157.64s)
PASS
coverage: 6.5% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      157.753s        coverage: 6.5% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.
