### PR TITLE
feat(apig): add new data source for query api versions

### DIFF
--- a/docs/data-sources/apig_api_history_versions.md
+++ b/docs/data-sources/apig_api_history_versions.md
@@ -1,0 +1,81 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_api_history_versions"
+description: |-
+  Use this data source to get the list of API history versions within HuaweiCloud.
+---
+# huaweicloud_apig_api_history_versions
+
+Use this data source to get the list of API history versions within HuaweiCloud.
+
+## Example Usage
+
+### Query all history versions for the specified API
+
+```hcl
+variable "instance_id" {}
+variable "api_id" {}
+
+data "huaweicloud_apig_api_history_versions" "test" {
+  instance_id = var.instance_id
+  api_id      = var.api_id
+}
+```
+
+### Query all history versions for the specified API with environment filter
+
+```hcl
+variable "instance_id" {}
+variable "api_id" {}
+variable "environment_id" {}
+
+data "huaweicloud_apig_api_history_versions" "test" {
+  instance_id = var.instance_id
+  api_id      = var.api_id
+  env_id      = var.environment_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the API history versions are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the API belongs.
+
+* `api_id` - (Required, String) Specifies the ID of the API.
+
+* `env_id` - (Optional, String) Specifies the ID of the environment.
+
+* `env_name` - (Optional, String) Specifies the name of the environment.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `api_versions` - The list of the API history versions that matched filter parameters.  
+  The [api_versions](#apig_api_versions) structure is documented below.
+
+<a name="apig_api_versions"></a>
+The `api_versions` block supports:
+
+* `id` - The ID of the API history version.
+
+* `number` - The version number of the API.
+
+* `api_id` - The ID of the API.
+
+* `env_id` - The ID of the published environment.
+
+* `env_name` - The name of the published environment.
+
+* `remark` - The publish description.
+
+* `publish_time` - The publish time of the version, in RFC3339 format.
+
+* `status` - The status of the API version.  
+  + **1**: current version is online.
+  + **2**: this version is offline.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -562,6 +562,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_api_associated_throttling_policies": apig.DataSourceApiAssociatedThrottlingPolicies(),
 			"huaweicloud_apig_api_basic_configurations":           apig.DataSourceApiBasicConfigurations(),
 			"huaweicloud_apig_api":                                apig.DataSourceApi(),
+			"huaweicloud_apig_api_history_versions":               apig.DataSourceApiHistoryVersions(),
 			"huaweicloud_apig_appcodes":                           apig.DataSourceAppcodes(),
 			"huaweicloud_apig_applications":                       apig.DataSourceApplications(),
 			"huaweicloud_apig_availability_zones":                 apig.DataSourceAvailabilityZones(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_api_history_versions_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_api_history_versions_test.go
@@ -1,0 +1,183 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataSourceApiHistoryVersions_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		dcName = "data.huaweicloud_apig_api_history_versions.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+
+		dcFilterByEnvIdName = "data.huaweicloud_apig_api_history_versions.filter_by_env_id"
+		dcFilterByEnvId     = acceptance.InitDataSourceCheck(dcFilterByEnvIdName)
+
+		dcFilterByEnvNameName = "data.huaweicloud_apig_api_history_versions.filter_by_env_name"
+		dcFilterByEnvName     = acceptance.InitDataSourceCheck(dcFilterByEnvNameName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceApiHistoryVersions_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dcName, "api_versions.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dcName, "api_versions.0.id"),
+					resource.TestCheckResourceAttrSet(dcName, "api_versions.0.number"),
+					resource.TestCheckResourceAttrSet(dcName, "api_versions.0.api_id"),
+					resource.TestCheckResourceAttrSet(dcName, "api_versions.0.env_id"),
+					resource.TestCheckResourceAttrSet(dcName, "api_versions.0.env_name"),
+					resource.TestCheckResourceAttrSet(dcName, "api_versions.0.publish_time"),
+					resource.TestCheckResourceAttrSet(dcName, "api_versions.0.status"),
+					dcFilterByEnvId.CheckResourceExists(),
+					resource.TestCheckOutput("is_env_id_filter_useful", "true"),
+					dcFilterByEnvName.CheckResourceExists(),
+					resource.TestCheckOutput("is_env_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceApiHistoryVersions_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+%[1]s
+
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[2]s"
+}
+
+resource "huaweicloud_apig_group" "test" {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  name        = "%[3]s"
+}
+
+resource "huaweicloud_apig_environment" "test" {
+  count = 2
+
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  name        = format("%[3]s_%%d", count.index)
+}
+
+resource "huaweicloud_apig_api" "test" {
+  instance_id      = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  group_id         = huaweicloud_apig_group.test.id
+  name             = "%[3]s"
+  type             = "Private"
+  request_protocol = "HTTP"
+  request_method   = "GET"
+  request_path     = "/mock/test"
+  
+  mock {
+    status_code = 200
+  }
+}
+
+resource "huaweicloud_apig_api_action" "test_online_first" {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test[0].id
+  action      = "online"
+}
+
+resource "huaweicloud_apig_api_action" "test_offline_first" {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test[0].id
+  action      = "offline"
+  
+  depends_on = [huaweicloud_apig_api_action.test_online_first]
+}
+
+resource "huaweicloud_apig_api_action" "test_online_second" {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test[1].id
+  action      = "online"
+  
+  depends_on = [huaweicloud_apig_api_action.test_offline_first]
+}
+
+resource "huaweicloud_apig_api_action" "test_offline_second" {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test[1].id
+  action      = "offline"
+  
+  depends_on = [huaweicloud_apig_api_action.test_online_second]
+}
+`, common.TestBaseNetwork(name), acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+}
+
+func testAccDataSourceApiHistoryVersions_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Query all
+data "huaweicloud_apig_api_history_versions" "test" {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  api_id      = huaweicloud_apig_api.test.id
+
+  depends_on = [
+    huaweicloud_apig_api_action.test_online_first,
+    huaweicloud_apig_api_action.test_online_second,
+  ]
+}
+
+# Filter by api environment id
+data "huaweicloud_apig_api_history_versions" "filter_by_env_id" {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test[0].id
+
+  depends_on = [
+    huaweicloud_apig_api_action.test_online_first,
+    huaweicloud_apig_api_action.test_online_second,
+  ]
+}
+
+output "is_env_id_filter_useful" {
+  value = length(data.huaweicloud_apig_api_history_versions.filter_by_env_id.api_versions) > 0 && alltrue(
+    [for v in data.huaweicloud_apig_api_history_versions.filter_by_env_id.api_versions[*].env_id :
+v == huaweicloud_apig_environment.test[0].id]
+  )
+}
+
+# Filter by api environment name
+data "huaweicloud_apig_api_history_versions" "filter_by_env_name" {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  api_id      = huaweicloud_apig_api.test.id
+  env_name    = huaweicloud_apig_environment.test[1].name
+
+  depends_on = [
+    huaweicloud_apig_api_action.test_online_first,
+    huaweicloud_apig_api_action.test_online_second,
+	data.huaweicloud_apig_api_history_versions.filter_by_env_id
+  ]
+}
+
+output "is_env_name_filter_useful" {
+  value = length(data.huaweicloud_apig_api_history_versions.filter_by_env_name.api_versions) > 0 && alltrue(
+    [for v in data.huaweicloud_apig_api_history_versions.filter_by_env_name.api_versions[*].env_name :
+v == huaweicloud_apig_environment.test[1].name]
+  )
+}
+`, testAccDataSourceApiHistoryVersions_base(name))
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_api_history_versions.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_api_history_versions.go
@@ -1,0 +1,223 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/apis/publish/{api_id}
+func DataSourceApiHistoryVersions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceApiHistoryVersionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the API history versions are located.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the API belongs.`,
+			},
+			"api_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the API.`,
+			},
+
+			// Optional parameters.
+			"env_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the environment.`,
+			},
+			"env_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the environment.`,
+			},
+
+			// Attributes.
+			"api_versions": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the API history versions that matched filter parameters.`,
+				Elem:        apiHistoryVersionSchema(),
+			},
+		},
+	}
+}
+
+func apiHistoryVersionSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the API history version.`,
+			},
+			"number": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The version number of the API.`,
+			},
+			"api_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the API.`,
+			},
+			"env_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the published environment.`,
+			},
+			"env_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the published environment.`,
+			},
+			"remark": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The publish description.`,
+			},
+			"publish_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The publish time of the version, in RFC3339 format.`,
+			},
+			"status": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The status of the API version.`,
+			},
+		},
+	}
+}
+
+func buildApiHistoryVersionsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("env_id"); ok {
+		res = fmt.Sprintf("%s&env_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("env_name"); ok {
+		res = fmt.Sprintf("%s&env_name=%v", res, v)
+	}
+	return res
+}
+
+func listApiHistoryVersions(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		result     = make([]interface{}, 0)
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/apis/publish/{api_id}?limit={limit}"
+		instanceId = d.Get("instance_id").(string)
+		apiId      = d.Get("api_id").(string)
+		limit      = 100
+		offset     = 0
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{api_id}", apiId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildApiHistoryVersionsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		apiVersions := utils.PathSearch("api_versions", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, apiVersions...)
+		if len(apiVersions) < limit {
+			break
+		}
+		offset += len(apiVersions)
+	}
+
+	return result, nil
+}
+
+func flattenApiHistoryVersions(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"id":           utils.PathSearch("version_id", item, nil),
+			"number":       utils.PathSearch("version_no", item, nil),
+			"api_id":       utils.PathSearch("api_id", item, nil),
+			"env_id":       utils.PathSearch("env_id", item, nil),
+			"env_name":     utils.PathSearch("env_name", item, nil),
+			"remark":       utils.PathSearch("remark", item, nil),
+			"publish_time": utils.PathSearch("publish_time", item, nil),
+			"status":       utils.PathSearch("status", item, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceApiHistoryVersionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		apiId  = d.Get("api_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	resp, err := listApiHistoryVersions(client, d)
+	if err != nil {
+		return diag.Errorf("error querying history versions for specified API (%s): %s", apiId, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("api_versions", flattenApiHistoryVersions(resp)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(apig): add new data source for query api versions

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataSourceApiPublishVersions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceApiPublishVersions_basic
=== PAUSE TestAccDataSourceApiPublishVersions_basic
=== CONT  TestAccDataSourceApiPublishVersions_basic
--- PASS: TestAccDataSourceApiPublishVersions_basic (304.43s)
PASS
coverage: 6.9% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      304.544s        coverage: 6.9% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.