### PR TITLE
feat(SWR): support to create temporary login command

### DIFF
--- a/docs/resources/swr_temporary_login_command.md
+++ b/docs/resources/swr_temporary_login_command.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Software Repository for Container (SWR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_swr_temporary_login_command"
+description: |-
+  Manages a SWR temporary login command resource within HuaweiCloud.
+---
+
+# huaweicloud_swr_temporary_login_command
+
+Manages a SWR temporary login command resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_swr_temporary_login_command" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `enhanced` - (Optional, Bool, NonUpdatable) Specifies whether to create enhanced login command. Default to **false**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `auths` - Indicates the authentication information.
+  The [auths](#attrblock--auths) structure is documented below.
+
+* `x_swr_docker_login` - Indicates the docker login command.
+
+* `x_expire_at` - Indicates the expiration time of the login command.
+
+<a name="attrblock--auths"></a>
+The `auths` block supports:
+
+* `key` - Indicates the authentication information key.
+
+* `auth` - Indicates the base64-encoded authentication information.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3049,6 +3049,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_swr_image_trigger":            swr.ResourceSwrImageTrigger(),
 			"huaweicloud_swr_image_retention_policy":   swr.ResourceSwrImageRetentionPolicy(),
 			"huaweicloud_swr_image_auto_sync":          swr.ResourceSwrImageAutoSync(),
+			"huaweicloud_swr_temporary_login_command":  swr.ResourceSwrTemporaryLoginCommand(),
 
 			"huaweicloud_tms_resource_tags": tms.ResourceResourceTags(),
 			"huaweicloud_tms_tags":          tms.ResourceTmsTag(),

--- a/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_temporary_login_command_test.go
+++ b/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_temporary_login_command_test.go
@@ -1,0 +1,63 @@
+package swr
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccSwrTemporaryLoginCommand_basic(t *testing.T) {
+	rName := "huaweicloud_swr_temporary_login_command.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testSwrTemporaryLoginCommand_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rName, "x_swr_docker_login"),
+					resource.TestCheckResourceAttrSet(rName, "auths.#"),
+					resource.TestCheckResourceAttrSet(rName, "auths.0.key"),
+					resource.TestCheckResourceAttrSet(rName, "auths.0.auth"),
+				),
+			},
+		},
+	})
+}
+
+const testSwrTemporaryLoginCommand_basic = `resource "huaweicloud_swr_temporary_login_command" "test" {}`
+
+func TestAccSwrTemporaryLoginCommand_enhanced(t *testing.T) {
+	rName := "huaweicloud_swr_temporary_login_command.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testSwrTemporaryLoginCommand_enhanced,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rName, "x_swr_docker_login"),
+					resource.TestCheckResourceAttrSet(rName, "x_expire_at"),
+					resource.TestCheckResourceAttrSet(rName, "auths.#"),
+					resource.TestCheckResourceAttrSet(rName, "auths.0.key"),
+					resource.TestCheckResourceAttrSet(rName, "auths.0.auth"),
+				),
+			},
+		},
+	})
+}
+
+const testSwrTemporaryLoginCommand_enhanced = `
+resource "huaweicloud_swr_temporary_login_command" "test" {
+  enhanced = true
+}`

--- a/huaweicloud/services/swr/resource_huaweicloud_swr_temporary_login_command.go
+++ b/huaweicloud/services/swr/resource_huaweicloud_swr_temporary_login_command.go
@@ -1,0 +1,162 @@
+package swr
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var temporaryLoginCommandNonUpdatableParams = []string{
+	"enhanced",
+}
+
+// @API SWR POST /v2/manage/utils/secret
+// @API SWR POST /v2/manage/utils/authorizationtoken
+func ResourceSwrTemporaryLoginCommand() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSwrTemporaryLoginCommandCreate,
+		ReadContext:   resourceSwrTemporaryLoginCommandRead,
+		UpdateContext: resourceSwrTemporaryLoginCommandUpdate,
+		DeleteContext: resourceSwrTemporaryLoginCommandDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(temporaryLoginCommandNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"enhanced": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Specifies whether to create enhanced login command.`,
+			},
+			"x_swr_docker_login": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the docker login command.`,
+			},
+			"auths": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Indicates the authentication information.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the authentication information key.`,
+						},
+						"auth": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the base64-encoded authentication information.`,
+						},
+					},
+				},
+			},
+			"x_expire_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the expiration time of the login command.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceSwrTemporaryLoginCommandCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("swr", region)
+	if err != nil {
+		return diag.Errorf("error creating SWR client: %s", err)
+	}
+
+	createHttpUrl := "v2/manage/utils/secret"
+	if d.Get("enhanced").(bool) {
+		createHttpUrl = "v2/manage/utils/authorizationtoken"
+	}
+	createPath := client.Endpoint + createHttpUrl
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating SWR image auto sync: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	xSwrDockerLogin := createResp.Header.Get("X-Swr-Dockerlogin")
+	xSwrExpireAt := createResp.Header.Get("X-Swr-Expireat")
+
+	mErr := multierror.Append(nil,
+		d.Set("x_swr_docker_login", xSwrDockerLogin),
+		d.Set("x_expire_at", xSwrExpireAt),
+		d.Set("auths", flattenSwrTemporaryLoginCommandResponse(createRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSwrTemporaryLoginCommandResponse(resp interface{}) interface{} {
+	if auths, ok := utils.PathSearch("auths", resp, nil).(map[string]interface{}); ok && len(auths) > 0 {
+		result := make([]interface{}, 0, len(auths))
+		for k, v := range auths {
+			auth := v.(map[string]interface{})
+			m := map[string]interface{}{
+				"key":  k,
+				"auth": utils.PathSearch("auth", auth, nil),
+			}
+			result = append(result, m)
+		}
+
+		return result
+	}
+	return nil
+}
+
+func resourceSwrTemporaryLoginCommandRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceSwrTemporaryLoginCommandUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceSwrTemporaryLoginCommandDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting temporary login command resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to create temporary login command
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support to create temporary login command
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/swr' TESTARGS='-run TestAccSwrTemporaryLoginCommand_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swr -v -run TestAccSwrTemporaryLoginCommand_ -timeout 360m -parallel 4
=== RUN   TestAccSwrTemporaryLoginCommand_basic
=== PAUSE TestAccSwrTemporaryLoginCommand_basic
=== RUN   TestAccSwrTemporaryLoginCommand_enhanced
=== PAUSE TestAccSwrTemporaryLoginCommand_enhanced
=== CONT  TestAccSwrTemporaryLoginCommand_basic
=== CONT  TestAccSwrTemporaryLoginCommand_enhanced
--- PASS: TestAccSwrTemporaryLoginCommand_basic (14.27s)
--- PASS: TestAccSwrTemporaryLoginCommand_enhanced (14.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swr       14.457s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
