### PR TITLE
feat(secmaster): add datasource to get list of collector channel groups

### DIFF
--- a/docs/data-sources/secmaster_collector_channel_groups.md
+++ b/docs/data-sources/secmaster_collector_channel_groups.md
@@ -1,0 +1,49 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_collector_channel_groups"
+description: |-
+  Use this data source to get the list of collector channel groups.
+---
+
+# huaweicloud_secmaster_collector_channel_groups
+
+Use this data source to get the list of collector channel groups.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_secmaster_collector_channel_groups" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID to which the collector channel groups belong.
+
+* `name` - (Optional, String) Specifies the name of the collector channel group.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `groups` - The list of report details.
+
+  The [groups](#groups_struct) structure is documented below.
+
+<a name="groups_struct"></a>
+The `groups` block supports:
+
+* `group_id` - The ID of the collector channel group.
+
+* `name` - The name of the collector channel group.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1606,6 +1606,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_upgradation_version":          secmaster.DataSourceUpgradationVersion(),
 			"huaweicloud_secmaster_vpc_endpoint_services":        secmaster.DataSourceSecmasterVpcEndpointServices(),
 			"huaweicloud_secmaster_catalogues_search":            secmaster.DataSourceSecmasterCataloguesSearch(),
+			"huaweicloud_secmaster_collector_channel_groups":     secmaster.DataSourceCollectorChannelGroups(),
 			"huaweicloud_secmaster_collector_logstash_parsers":   secmaster.DataSourceCollectorLogstashParsers(),
 			"huaweicloud_secmaster_installation_scripts":         secmaster.DataSourceSecmasterInstallationScripts(),
 			"huaweicloud_secmaster_retrieve_scripts":             secmaster.DataSourceRetrieveScripts(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_collector_channel_groups_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_collector_channel_groups_test.go
@@ -1,0 +1,60 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCollectorChannelGroups_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_secmaster_collector_channel_groups.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Before running test, prepare a collector channel group.
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCollectorChannelGroups_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.group_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "groups.0.name"),
+
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceCollectorChannelGroups_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_collector_channel_groups" "test" {
+  workspace_id = "%[1]s"
+}
+
+locals {
+  name = data.huaweicloud_secmaster_collector_channel_groups.test.groups[0].name
+}
+
+data "huaweicloud_secmaster_collector_channel_groups" "filter_by_name" {
+  workspace_id = "%[1]s"
+  name         = local.name
+}
+
+output "is_name_filter_useful" {
+  value = length(data.huaweicloud_secmaster_collector_channel_groups.filter_by_name.groups) > 0 && alltrue(
+    [for v in data.huaweicloud_secmaster_collector_channel_groups.filter_by_name.groups[*].name : v == local.name]
+  )
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_collector_channel_groups.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_collector_channel_groups.go
@@ -1,0 +1,128 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SecMaster GET /v1/{project_id}/workspaces/{workspace_id}/collector/channels/groups
+func DataSourceCollectorChannelGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCollectorChannelGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildCollectorChannelGroupsQueryParams(d *schema.ResourceData) string {
+	queryParams := ""
+
+	if v, ok := d.GetOk("name"); ok {
+		queryParams = fmt.Sprintf("%s?name=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceCollectorChannelGroupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		httpUrl     = "v1/{project_id}/workspaces/{workspace_id}/collector/channels/groups"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{workspace_id}", workspaceId)
+	getPath += buildCollectorChannelGroupsQueryParams(d)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving collector channel groups: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("groups", flattenCollectorChannelGroups(getRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCollectorChannelGroups(rawGroups interface{}) []interface{} {
+	if groups, ok := rawGroups.([]interface{}); ok {
+		rst := make([]interface{}, 0, len(groups))
+		for _, v := range groups {
+			rst = append(rst, map[string]interface{}{
+				"group_id": utils.PathSearch("group_id", v, nil),
+				"name":     utils.PathSearch("name", v, nil),
+			})
+		}
+		return rst
+	}
+
+	return make([]interface{}, 0)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add datasource to get list of collector channel groups.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/secmaster" TESTARGS="-run TestAccDataSourceCollectorChannelGroups_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/secmaster -v -run TestAccDataSourceCollectorChannelGroups_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCollectorChannelGroups_basic
=== PAUSE TestAccDataSourceCollectorChannelGroups_basic
=== CONT  TestAccDataSourceCollectorChannelGroups_basic
--- PASS: TestAccDataSourceCollectorChannelGroups_basic (13.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 13.594s
```
<img width="1175" height="26" alt="image" src="https://github.com/user-attachments/assets/a1a516c2-23f1-40e1-b2aa-92b667e9bc6c" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
