### PR TITLE
feat(apig): add new resource for channel member group

### DIFF
--- a/docs/resources/apig_channel_member_group.md
+++ b/docs/resources/apig_channel_member_group.md
@@ -1,0 +1,115 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_channel_member_group"
+description: |-
+  Use this resource to manage a member group within HuaweiCloud.
+---
+
+# huaweicloud_apig_channel_member_group
+
+Use this resource to manage a member group within HuaweiCloud.
+
+## Example Usage
+
+### Basic usage
+
+```hcl
+variable "instance_id" {}
+variable "vpc_channel_id" {}
+variable "member_group_name" {}
+
+resource "huaweicloud_apig_channel_member_group" "test" {
+  instance_id    = var.instance_id
+  vpc_channel_id = var.vpc_channel_id
+  name           = var.member_group_name
+  weight         = 10
+}
+```
+
+### Create APIG channel member group for microservice
+
+```hcl
+variable "instance_id" {}
+variable "vpc_channel_id" {}
+variable "member_group_name" {}
+
+resource "huaweicloud_apig_channel_member_group" "test" {
+  instance_id          = var.instance_id
+  vpc_channel_id       = var.vpc_channel_id
+  name                 = var.member_group_name
+  weight               = 10
+  microservice_version = "v1.0"
+  microservice_port    = 8080
+
+  microservice_labels {
+    label_name  = "terraform_test"
+    label_value = "true"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the member group is located.  
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the dedicated instance to which the member group
+  belongs.
+
+* `vpc_channel_id` - (Required, String, NonUpdatable) Specifies the ID of the VPC channel.
+
+* `name` - (Required, String) Specifies the name of the member group.  
+  Only the Chinese characters, English letters, numbers, underscores(_), hyphens(-) and dots(.) are allowed and the
+  valid value is range from `3` to `64`.
+  Only start with English letters and Chinese characters.
+
+* `description` - (Optional, String) Specifies the description of the member group.  
+  The description contain a maximum of `255` characters.
+
+* `weight` - (Optional, Int) Specifies the weight value of the member group.  
+  This weight value is automatically used for weight allocation, and the valid value is range from `0` to `100`.
+
+* `microservice_version` - (Optional, String) Specifies the version of the member group.  
+  Only supported when VPC channel type is microservice.
+  The microservice version contain a maximum of `255` characters.
+
+* `microservice_port` - (Optional, Int) Specifies the port number of the member group.  
+  Only supported when VPC channel type is microservice.
+  When the port number is `0`, all addresses under the backend server group follow the original load balancing
+  configuration.
+
+* `microservice_labels` - (Optional, List) Specifies the microservice labels of the member group.  
+  Only supported when VPC channel type is microservice.
+  The [microservice_labels](#apig_channel_member_group_microservice_labels) structure is documented below.
+
+* `reference_vpc_channel_id` - (Optional, String) Specifies the ID of the reference load balance channel.
+
+<a name="apig_channel_member_group_microservice_labels"></a>
+The `microservice_labels` block supports:
+
+* `name` - (Required, String) The name of the microservice label.
+
+* `value` - (Required, String) The value of the microservice label.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `create_time` - The creation time of the member group, in RFC3339 format.
+
+* `update_time` - The update time of the member group, in RFC3339 format.
+
+## Import
+
+Member groups can be imported using their `id`, the ID of the related dedicated instance and the ID of the related VPC
+channel, separated by slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_apig_channel_member_groups.test <instance_id>/<vpc_channel_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2055,6 +2055,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_application_quota_associate":    apig.ResourceApplicationQuotaAssociate(),
 			"huaweicloud_apig_certificate":                    apig.ResourceCertificate(),
 			"huaweicloud_apig_channel":                        apig.ResourceChannel(),
+			"huaweicloud_apig_channel_member_group":           apig.ResourceChannelMemberGroup(),
 			"huaweicloud_apig_custom_authorizer":              apig.ResourceApigCustomAuthorizerV2(),
 			"huaweicloud_apig_endpoint_connection_management": apig.ResourceEndpointConnectionManagement(),
 			"huaweicloud_apig_environment":                    apig.ResourceApigEnvironmentV2(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_channel_member_group_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_channel_member_group_test.go
@@ -1,0 +1,135 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
+)
+
+func getChannelMemberGroupsFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		instanceId    = state.Primary.Attributes["instance_id"]
+		vpcChannelId  = state.Primary.Attributes["vpc_channel_id"]
+		memberGroupId = state.Primary.ID
+	)
+
+	client, err := cfg.NewServiceClient("apig", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating APIG client: %s", err)
+	}
+
+	return apig.GetChannelMemberGroupById(client, instanceId, vpcChannelId, memberGroupId)
+}
+
+func TestAccChannelMemberGroups_basic(t *testing.T) {
+	var (
+		memberGroup interface{}
+
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		memberGroupName = "huaweicloud_apig_channel_member_group.test"
+		rcMemberGroup   = acceptance.InitResourceCheck(memberGroupName, &memberGroup, getChannelMemberGroupsFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcMemberGroup.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccChannelMemberGroups_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rcMemberGroup.CheckResourceExists(),
+					resource.TestCheckResourceAttr(memberGroupName, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(memberGroupName, "name", name),
+					resource.TestCheckResourceAttrSet(memberGroupName, "vpc_channel_id"),
+					resource.TestCheckResourceAttrSet(memberGroupName, "create_time"),
+					resource.TestCheckResourceAttrSet(memberGroupName, "update_time"),
+				),
+			},
+			{
+				Config: testAccChannelMemberGroups_basic_step2(name, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rcMemberGroup.CheckResourceExists(),
+					resource.TestCheckResourceAttr(memberGroupName, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttr(memberGroupName, "name", updateName),
+					resource.TestCheckResourceAttrSet(memberGroupName, "vpc_channel_id"),
+					resource.TestCheckResourceAttrSet(memberGroupName, "description"),
+					resource.TestCheckResourceAttrSet(memberGroupName, "weight"),
+					resource.TestCheckResourceAttrSet(memberGroupName, "create_time"),
+					resource.TestCheckResourceAttrSet(memberGroupName, "update_time"),
+				),
+			},
+			{
+				ResourceName:      memberGroupName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccChannelMemberGroupsImportStateFunc(memberGroupName),
+			},
+		},
+	})
+}
+
+func testAccChannelMemberGroupsImportStateFunc(rsName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rsName]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", rsName, rs)
+		}
+		if rs.Primary.Attributes["instance_id"] == "" || rs.Primary.Attributes["vpc_channel_id"] == "" || rs.Primary.ID == "" {
+			return "", fmt.Errorf("resource not found: %s/%s/%s", rs.Primary.Attributes["instance_id"],
+				rs.Primary.Attributes["vpc_channel_id"], rs.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["vpc_channel_id"], rs.Primary.ID), nil
+	}
+}
+
+func testAccChannelMemberGroups_basic_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[2]s"
+}
+
+resource "huaweicloud_apig_channel" "test" {
+  instance_id      = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  name             = "%[1]s"
+  port             = 80
+  balance_strategy = 1
+}`, name, acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
+}
+
+func testAccChannelMemberGroups_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_channel_member_group" "test" {
+  instance_id    = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id = huaweicloud_apig_channel.test.id
+  name           = "%[2]s"
+}`, testAccChannelMemberGroups_basic_base(name), name)
+}
+
+func testAccChannelMemberGroups_basic_step2(name, updateName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_channel_member_group" "test" {
+  instance_id    = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id = huaweicloud_apig_channel.test.id
+  name           = "%[2]s"
+  description    = "terraform script test."
+  weight         = 20
+}`, testAccChannelMemberGroups_basic_base(name), updateName)
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_channel_member_group.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_channel_member_group.go
@@ -1,0 +1,394 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var channelMemberGroupNonUpdatableParams = []string{"instance_id", "vpc_channel_id"}
+
+// @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/member-groups
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/member-groups/{member_group_id}
+// @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/member-groups/{member_group_id}
+// @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/member-groups/{member_group_id}
+func ResourceChannelMemberGroup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceChannelMemberGroupCreate,
+		ReadContext:   resourceChannelMemberGroupRead,
+		UpdateContext: resourceChannelMemberGroupUpdate,
+		DeleteContext: resourceChannelMemberGroupDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(channelMemberGroupNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceChannelMemberGroupImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the member group is located.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the member group belongs.`,
+			},
+			"vpc_channel_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the VPC channel.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the member group.`,
+			},
+
+			// Optional parameters.
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the member group.`,
+			},
+			"weight": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 100),
+				Description:  `The weight value of the member group.`,
+			},
+			"microservice_version": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The version of the member group.`,
+			},
+			"microservice_port": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The port number of the member group.`,
+			},
+			"microservice_labels": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        channelMemberGroupMicroserviceLabelsSchema(),
+				Description: `The microservice labels of the member group.`,
+			},
+			"reference_vpc_channel_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the reference load balance channel.`,
+			},
+
+			// Attributes.
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the member group, in RFC3339 format.`,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time of the member group, in RFC3339 format.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func channelMemberGroupMicroserviceLabelsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the microservice label.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The value of the microservice label.`,
+			},
+		},
+	}
+}
+
+func buildChannelMemberGroupMicroserviceLabels(labels []interface{}) []map[string]interface{} {
+	if len(labels) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(labels))
+	for _, label := range labels {
+		result = append(result, map[string]interface{}{
+			"label_name":  utils.PathSearch("name", label, ""),
+			"label_value": utils.PathSearch("value", label, ""),
+		})
+	}
+
+	return result
+}
+
+func buildCreateChannelMemberGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"member_groups": []map[string]interface{}{
+			{
+				"member_group_name":        d.Get("name"),
+				"member_group_remark":      utils.ValueIgnoreEmpty(d.Get("description")),
+				"member_group_weight":      utils.ValueIgnoreEmpty(d.Get("weight")),
+				"microservice_version":     utils.ValueIgnoreEmpty(d.Get("microservice_version")),
+				"microservice_port":        utils.ValueIgnoreEmpty(d.Get("microservice_port")),
+				"microservice_labels":      buildChannelMemberGroupMicroserviceLabels(d.Get("microservice_labels").([]interface{})),
+				"reference_vpc_channel_id": utils.ValueIgnoreEmpty(d.Get("reference_vpc_channel_id")),
+			},
+		},
+	}
+}
+
+func createChannelMemberGroup(client *golangsdk.ServiceClient, instanceId, vpcChannelId string, d *schema.ResourceData) (interface{}, error) {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/member-groups"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createPath = strings.ReplaceAll(createPath, "{vpc_channel_id}", vpcChannelId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateChannelMemberGroupBodyParams(d)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceChannelMemberGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		instanceId   = d.Get("instance_id").(string)
+		vpcChannelId = d.Get("vpc_channel_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	respBody, err := createChannelMemberGroup(client, instanceId, vpcChannelId, d)
+	if err != nil {
+		return diag.Errorf("error creating member group: %s", err)
+	}
+
+	memberGroupId := utils.PathSearch("member_groups[0].member_group_id", respBody, "").(string)
+	if memberGroupId == "" {
+		return diag.Errorf("unable to find the member group ID from the API response")
+	}
+	d.SetId(memberGroupId)
+
+	return resourceChannelMemberGroupRead(ctx, d, meta)
+}
+
+func flattenChannelMemberGroupMicroserviceLabels(labels []interface{}) []map[string]interface{} {
+	if len(labels) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(labels))
+	for _, label := range labels {
+		result = append(result, map[string]interface{}{
+			"name":  utils.PathSearch("label_name", label, ""),
+			"value": utils.PathSearch("label_value", label, ""),
+		})
+	}
+
+	return result
+}
+
+func GetChannelMemberGroupById(client *golangsdk.ServiceClient, instanceId, vpcChannelId, memberGroupId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/member-groups/{member_group_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getPath = strings.ReplaceAll(getPath, "{vpc_channel_id}", vpcChannelId)
+	getPath = strings.ReplaceAll(getPath, "{member_group_id}", memberGroupId)
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceChannelMemberGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		instanceId    = d.Get("instance_id").(string)
+		vpcChannelId  = d.Get("vpc_channel_id").(string)
+		memberGroupId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	memberGroup, err := GetChannelMemberGroupById(client, instanceId, vpcChannelId, memberGroupId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error querying member group detail")
+	}
+
+	mErr := multierror.Append(
+		d.Set("name", utils.PathSearch("member_group_name", memberGroup, nil)),
+		d.Set("description", utils.PathSearch("member_group_remark", memberGroup, nil)),
+		d.Set("weight", utils.PathSearch("member_group_weight", memberGroup, nil)),
+		d.Set("microservice_version", utils.PathSearch("microservice_version", memberGroup, nil)),
+		d.Set("microservice_port", utils.PathSearch("microservice_port", memberGroup, nil)),
+		d.Set("microservice_labels", flattenChannelMemberGroupMicroserviceLabels(
+			utils.PathSearch("microservice_labels", memberGroup, make([]interface{}, 0)).([]interface{}))),
+		d.Set("reference_vpc_channel_id", utils.PathSearch("reference_vpc_channel_id", memberGroup, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", memberGroup, nil)),
+		d.Set("update_time", utils.PathSearch("update_time", memberGroup, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdateChannelMemberGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"member_group_name":        d.Get("name"),
+		"member_group_remark":      utils.ValueIgnoreEmpty(d.Get("description")),
+		"member_group_weight":      utils.ValueIgnoreEmpty(d.Get("weight")),
+		"microservice_version":     utils.ValueIgnoreEmpty(d.Get("microservice_version")),
+		"microservice_port":        utils.ValueIgnoreEmpty(d.Get("microservice_port")),
+		"microservice_labels":      buildChannelMemberGroupMicroserviceLabels(d.Get("microservice_labels").([]interface{})),
+		"reference_vpc_channel_id": utils.ValueIgnoreEmpty(d.Get("reference_vpc_channel_id")),
+	}
+}
+
+func updateChannelMemberGroup(client *golangsdk.ServiceClient, instanceId, vpcChannelId, memberGroupId string, d *schema.ResourceData) error {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/member-groups/{member_group_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", instanceId)
+	updatePath = strings.ReplaceAll(updatePath, "{vpc_channel_id}", vpcChannelId)
+	updatePath = strings.ReplaceAll(updatePath, "{member_group_id}", memberGroupId)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildUpdateChannelMemberGroupBodyParams(d)),
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
+func resourceChannelMemberGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		instanceId    = d.Get("instance_id").(string)
+		vpcChannelId  = d.Get("vpc_channel_id").(string)
+		memberGroupId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	err = updateChannelMemberGroup(client, instanceId, vpcChannelId, memberGroupId, d)
+	if err != nil {
+		return diag.Errorf("error updating member group (%s): %s", memberGroupId, err)
+	}
+
+	return resourceChannelMemberGroupRead(ctx, d, meta)
+}
+
+func deleteChannelMemberGroup(client *golangsdk.ServiceClient, instanceId, vpcChannelId, memberGroupId string) error {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/member-groups/{member_group_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceId)
+	deletePath = strings.ReplaceAll(deletePath, "{vpc_channel_id}", vpcChannelId)
+	deletePath = strings.ReplaceAll(deletePath, "{member_group_id}", memberGroupId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpt)
+	return err
+}
+
+func resourceChannelMemberGroupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		instanceId    = d.Get("instance_id").(string)
+		vpcChannelId  = d.Get("vpc_channel_id").(string)
+		memberGroupId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	err = deleteChannelMemberGroup(client, instanceId, vpcChannelId, memberGroupId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting member group (%s)",
+			memberGroupId))
+	}
+
+	return nil
+}
+
+func resourceChannelMemberGroupImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.SplitN(importedId, "/", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf(`invalid format specified for import ID, want '<instance_id>/<vpc_channel_id>/<id>',
+		 but got '%s'`, importedId)
+	}
+
+	d.SetId(parts[2])
+	mErr := multierror.Append(
+		d.Set("instance_id", parts[0]),
+		d.Set("vpc_channel_id", parts[1]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(apig): add new resource for channel member group

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
when creating an APIG microservice load-balancing channel, it must be associated with a CCE Turbo cloud-native cluster; however, the cluster’s security group allows all inbound traffic, so the channel cannot be created.
The following three attributes are ignored during unit tests:
+ microservice_version
+ microservice_port
+ microservice_labels

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccChannelMemberGroups_basic -timeout 360m -parallel 10
=== RUN   TestAccChannelMemberGroups_basic
=== PAUSE TestAccChannelMemberGroups_basic
=== CONT  TestAccChannelMemberGroups_basic
    acceptance.go:1004: Before running APIG acceptance tests, please ensure the env 'HW_APIG_DEDICATED_INSTANCE_ID' has been configured
--- SKIP: TestAccChannelMemberGroups_basic (0.00s)
PASS
coverage: 1.4% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      0.116s  coverage: 1.4% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.