### PR TITLE
feat(apig): add new resource for query channel member groups

### DIFF
--- a/docs/data-sources/apig_channel_member_groups.md
+++ b/docs/data-sources/apig_channel_member_groups.md
@@ -1,0 +1,81 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_channel_member_groups"
+description: |-
+  Use this data source to get the list of member groups within HuaweiCloud.
+---
+
+# huaweicloud_apig_channel_member_groups
+
+Use this data source to get the list of member groups within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "vpc_channel_id" {}
+variable "member_group_name" {}
+
+data "huaweicloud_apig_channel_member_groups" "test" {
+  instance_id    = var.instance_id
+  vpc_channel_id = var.vpc_channel_id
+  name           = var.member_group_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the list of member groups are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the VPC channel belongs.
+
+* `vpc_channel_id` - (Required, String) Specifies the ID of the VPC channel to which the list of member groups belong.
+
+* `name` - (Optional, String) Specifies the name of the member group for fuzzy matching.
+
+* `precise_search` - (Optional, String) Specifies the list of parameter names for exact matching.  
+  When this parameter contains the field(s) to be queried, the corresponding field query will become an exact-match
+  query.  
+  The valid value is **member_group_name**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `member_groups` - The list of the member groups that matched filter parameters.  
+  The [member_groups](#apig_channel_member_groups) structure is documented below.
+
+<a name="apig_channel_member_groups"></a>
+The `member_groups` block supports:
+
+* `id` - The ID of the member group.
+
+* `name` - The name of the member group.
+
+* `description` - The description of the member group.
+
+* `weight` - The weight value of the member group.
+
+* `microservice_version` - The microservice version of the member group.
+
+* `microservice_port` - The microservice port of the member group.
+
+* `microservice_labels` - The microservice labels of the member group.  
+  The [microservice_labels](#apig_channel_member_groups_microservice_labels) structure is documented below.
+
+* `reference_vpc_channel_id` - The ID of the referenced load channel.
+
+* `create_time` - The creation time of the member group, in RFC3339 format.
+
+* `update_time` - The update time of the member group, in RFC3339 format.
+
+<a name="apig_channel_member_groups_microservice_labels"></a>
+The `microservice_labels` block supports:
+
+* `name` - The name of the microservice label.
+
+* `value` - The value of the microservice label.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -571,6 +571,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_application_acl":                    apig.DataSourceApplicationAcl(),
 			"huaweicloud_apig_application_quotas":                 apig.DataSourceApigApplicationQuotas(),
 			"huaweicloud_apig_channels":                           apig.DataSourceChannels(),
+			"huaweicloud_apig_channel_member_groups":              apig.DataSourceChannelMemberGroups(),
 			"huaweicloud_apig_custom_authorizers":                 apig.DataSourceCustomAuthorizers(),
 			"huaweicloud_apig_endpoint_connections":               apig.DataSourceApigEndpointConnections(),
 			"huaweicloud_apig_environment_variables":              apig.DataSourceApigEnvironmentVariables(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_channel_member_groups_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_channel_member_groups_test.go
@@ -1,0 +1,140 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceChannelMemberGroups_basic(t *testing.T) {
+	var (
+		rName = acceptance.RandomAccResourceName()
+
+		dataSource = "data.huaweicloud_apig_channel_member_groups.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byName   = "data.huaweicloud_apig_channel_member_groups.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byExactName   = "data.huaweicloud_apig_channel_member_groups.filter_by_exact_name"
+		dcByExactName = acceptance.InitDataSourceCheck(byExactName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceChannelMemberGroups_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "member_groups.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "member_groups.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "member_groups.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "member_groups.0.description"),
+					resource.TestCheckResourceAttrSet(dataSource, "member_groups.0.weight"),
+					resource.TestMatchResourceAttr(dataSource, "member_groups.0.create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(dataSource, "member_groups.0.update_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					dcByExactName.CheckResourceExists(),
+					resource.TestCheckOutput("exact_name_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceChannelMemberGroups_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[2]s"
+}
+
+resource "huaweicloud_apig_channel" "test" {
+  instance_id      = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  name             = "%[1]s"
+  port             = 80
+  balance_strategy = 1
+}
+
+resource "huaweicloud_apig_channel_member_group" "test" {
+  count = 2
+
+  instance_id    = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id = huaweicloud_apig_channel.test.id
+  name           = format("%[1]s_%%d", count.index)
+  description    = "terraform script test."
+  weight         = 50
+}`, name, acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
+}
+
+func testAccDataSourceChannelMemberGroups_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Query all
+data "huaweicloud_apig_channel_member_groups" "test" {
+  instance_id    = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id = huaweicloud_apig_channel.test.id
+
+  depends_on = [
+    huaweicloud_apig_channel_member_group.test,
+  ]
+}
+
+# Filter by name (fuzzy search)
+locals {
+  member_group_name_prefix = "%[2]s"
+}
+
+data "huaweicloud_apig_channel_member_groups" "filter_by_name" {
+  instance_id    = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id = huaweicloud_apig_channel.test.id
+  name           = local.member_group_name_prefix
+
+  depends_on = [
+    huaweicloud_apig_channel_member_group.test,
+  ]
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_apig_channel_member_groups.filter_by_name.member_groups[*].name : strcontains(v, "%[2]s")
+  ]
+}
+
+output "name_filter_is_useful" {
+  value = length(local.name_filter_result) >= 2 && alltrue(local.name_filter_result)
+}
+
+# Filter by name (exact search)
+locals {
+  member_group_name = try(data.huaweicloud_apig_channel_member_groups.test.member_groups[0].name, null)
+}
+
+data "huaweicloud_apig_channel_member_groups" "filter_by_exact_name" {
+  instance_id    = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id = huaweicloud_apig_channel.test.id
+  name           = local.member_group_name
+  precise_search = "member_group_name"
+
+  depends_on = [
+    huaweicloud_apig_channel_member_group.test,
+  ]
+}
+
+output "exact_name_filter_is_useful" {
+  value = length(data.huaweicloud_apig_channel_member_groups.filter_by_exact_name.member_groups) == 1
+}
+`, testAccDataSourceChannelMemberGroups_base(rName), rName)
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_channel_member_groups.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_channel_member_groups.go
@@ -1,0 +1,270 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/member-groups
+func DataSourceChannelMemberGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceChannelMemberGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the list of member groups are located.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the VPC channel belongs.`,
+			},
+			"vpc_channel_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the VPC channel to which the list of member groups belong.`,
+			},
+
+			// Optional parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the member group for fuzzy matching.`,
+			},
+			"precise_search": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The list of parameter names for exact matching.`,
+			},
+
+			// Attributes.
+			"member_groups": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        channelMemberGroupSchema(),
+				Description: `The list of the member groups that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func channelMemberGroupSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the member group.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the member group.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the member group.`,
+			},
+			"weight": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The weight value of the member group.`,
+			},
+			"microservice_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The microservice version of the member group.`,
+			},
+			"microservice_port": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The microservice port of the member group.`,
+			},
+			"microservice_labels": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        channelMemberGroupMicroserviceLabelSchema(),
+				Description: `The microservice labels of the member group.`,
+			},
+			"reference_vpc_channel_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the referenced load channel.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the member group, in RFC3339 format.`,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time of the member group, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func channelMemberGroupMicroserviceLabelSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the microservice label.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The value of the microservice label.`,
+			},
+		},
+	}
+}
+
+func buildChannelMemberGroupsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&member_group_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("precise_search"); ok {
+		res = fmt.Sprintf("%s&precise_search=%v", res, v)
+	}
+
+	return res
+}
+
+func listChannelMemberGroups(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl      = "v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/member-groups?limit={limit}"
+		instanceId   = d.Get("instance_id").(string)
+		vpcChannelId = d.Get("vpc_channel_id").(string)
+		limit        = 100
+		offset       = 0
+		result       = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{vpc_channel_id}", vpcChannelId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildChannelMemberGroupsQueryParams(d)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		memberGroups := utils.PathSearch("member_groups", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, memberGroups...)
+		if len(memberGroups) < limit {
+			break
+		}
+		offset += len(memberGroups)
+	}
+
+	return result, nil
+}
+
+func dataSourceChannelMemberGroupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	resp, err := listChannelMemberGroups(client, d)
+	if err != nil {
+		return diag.Errorf("error querying member groups: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("member_groups", flattenMemberGroups(resp)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenMemberGroups(memberGroups []interface{}) []interface{} {
+	if len(memberGroups) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(memberGroups))
+	for _, memberGroup := range memberGroups {
+		result = append(result, map[string]interface{}{
+			"id":                   utils.PathSearch("member_group_id", memberGroup, nil),
+			"name":                 utils.PathSearch("member_group_name", memberGroup, nil),
+			"description":          utils.PathSearch("member_group_remark", memberGroup, nil),
+			"weight":               utils.PathSearch("member_group_weight", memberGroup, nil),
+			"microservice_version": utils.PathSearch("microservice_version", memberGroup, nil),
+			"microservice_port":    utils.PathSearch("microservice_port", memberGroup, nil),
+			"microservice_labels": flattenMemberGroupsMicroserviceLabels(
+				utils.PathSearch("microservice_labels", memberGroup, make([]interface{}, 0)).([]interface{})),
+			"reference_vpc_channel_id": utils.PathSearch("reference_vpc_channel_id", memberGroup, nil),
+			"create_time":              utils.PathSearch("create_time", memberGroup, nil),
+			"update_time":              utils.PathSearch("update_time", memberGroup, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenMemberGroupsMicroserviceLabels(microserviceLabels []interface{}) []interface{} {
+	if len(microserviceLabels) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(microserviceLabels))
+	for _, microserviceLabel := range microserviceLabels {
+		result = append(result, map[string]interface{}{
+			"name":  utils.PathSearch("label_name", microserviceLabel, nil),
+			"value": utils.PathSearch("label_value", microserviceLabel, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(apig): add new resource for query channel member groups

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataSourceChannelMemberGroups_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceChannelMemberGroups_basic
=== PAUSE TestAccDataSourceChannelMemberGroups_basic
=== CONT  TestAccDataSourceChannelMemberGroups_basic
--- PASS: TestAccDataSourceChannelMemberGroups_basic (105.11s)
PASS
coverage: 5.3% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      105.245s        coverage: 5.3% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.