### PR TITLE
feat(dew): add a data source to query the list of KMS regions supported by cross…

### DIFF
--- a/docs/data-sources/kms_key_regions.md
+++ b/docs/data-sources/kms_key_regions.md
@@ -1,0 +1,32 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_kms_key_regions"
+description: |-
+  Use this data source to query the list of KMS regions supported by cross-regional keys within HuaweiCloud.
+---
+
+# huaweicloud_kms_key_regions
+
+Use this data source to query the list of KMS regions supported by cross-regional keys within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_kms_key_regions" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `regions` - The list of KMS regions supported by cross-regional keys.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1327,6 +1327,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_aliases":               dew.DataSourceKmsAliases(),
 			"huaweicloud_kms_parameters_for_import": dew.DataSourceKmsParametersForImport(),
 			"huaweicloud_kms_key_tags":              dew.DataSourceKmsKeyTags(),
+			"huaweicloud_kms_key_regions":           dew.DataSourceKMSKeyRegions(),
 			"huaweicloud_kps_failed_tasks":          dew.DataSourceDewKpsFailedTasks(),
 			"huaweicloud_kps_running_tasks":         dew.DataSourceDewKpsRunningTasks(),
 			"huaweicloud_kps_keypairs":              dew.DataSourceKeypairs(),

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_kms_key_regions_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_kms_key_regions_test.go
@@ -1,0 +1,34 @@
+package dew
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccKMSKeyRegionsDataSource_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_kms_key_regions.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testKMSKeyRegions_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "regions.#"),
+				),
+			},
+		},
+	})
+}
+
+const testKMSKeyRegions_basic = `data "huaweicloud_kms_key_regions" "test" {}`

--- a/huaweicloud/services/dew/data_source_huaweicloud_kms_key_regions.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_kms_key_regions.go
@@ -1,0 +1,94 @@
+package dew
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW GET /v2/{project_id}/kms/regions
+func DataSourceKMSKeyRegions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceKMSKeyRegionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource.`,
+			},
+			"regions": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The list of regions supported by cross-regional keys.",
+			},
+		},
+	}
+}
+
+func dataSourceKMSKeyRegionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		mErr   *multierror.Error
+		offset = 0
+		result = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("kms", region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	httpUrl := "v2/{project_id}/kms/regions?limit=50"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		getListPath := fmt.Sprintf("%s&offset=%v", listPath, offset)
+		requestResp, err := client.Request("GET", getListPath, &opt)
+		if err != nil {
+			return diag.Errorf("error retrieving KMS key regions: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		regions := utils.PathSearch("regions", respBody, make([]interface{}, 0)).([]interface{})
+		if len(regions) == 0 {
+			break
+		}
+		result = append(result, regions...)
+		offset += len(regions)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("regions", result),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
…-regional keys

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports new data source to get kms regions supported by cross-regional keys and names huaweicloud_kms_key_regions.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccKMSKeyRegionsDataSource_basic -timeout 360m -parallel 10
=== RUN   TestAccKMSKeyRegionsDataSource_basic
=== PAUSE TestAccKMSKeyRegionsDataSource_basic
=== CONT  TestAccKMSKeyRegionsDataSource_basic
--- PASS: TestAccKMSKeyRegionsDataSource_basic (29.23s)
PASS
coverage: 4.0% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       29.309s coverage: 4.0% of statements in ./huaweicloud/services/dew
```
<img width="865" height="39" alt="image" src="https://github.com/user-attachments/assets/a10957f2-fc1e-42c4-92b6-4578a17cbed4" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
