### PR TITLE
feat(apig): add new data source to query associable APIs for plugin

### DIFF
--- a/docs/data-sources/apig_plugin_associable_apis.md
+++ b/docs/data-sources/apig_plugin_associable_apis.md
@@ -1,0 +1,144 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_plugin_associable_apis"
+description: |-
+  Use this data source to get the list of published APIs that can be bound to the current plugin within HuaweiCloud.
+---
+
+# huaweicloud_apig_plugin_associable_apis
+
+Use this data source to get the list of published APIs that can be bound to the current plugin within HuaweiCloud.
+
+## Example Usage
+
+### Query all published APIs that can be bound to the specified plugin in an environment
+
+```hcl
+variable "instance_id" {}
+variable "plugin_id" {}
+variable "published_environment_id" {}
+
+data "huaweicloud_apig_plugin_associable_apis" "test" {
+  instance_id = var.instance_id
+  plugin_id   = var.plugin_id
+  env_id      = var.env_id
+}
+```
+
+### Query all published APIs that can be bound to the specified plugin and filter by group ID
+
+```hcl
+variable "instance_id" {}
+variable "plugin_id" {}
+variable "published_environment_id" {}
+variable "group_id" {}
+
+data "huaweicloud_apig_plugin_associable_apis" "test" {
+  instance_id = var.instance_id
+  plugin_id   = var.plugin_id
+  env_id      = var.published_environment_id
+  group_id    = var.group_id
+}
+```
+
+### Query all published APIs that can be bound to the specified plugin without any tags
+
+```hcl
+variable "instance_id" {}
+variable "plugin_id" {}
+variable "published_environment_id" {}
+
+data "huaweicloud_apig_plugin_associable_apis" "test" {
+  instance_id = var.instance_id
+  plugin_id   = var.plugin_id
+  env_id      = var.published_environment_id
+  tags        = "#no_tags#"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the plugin and the associable APIs are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the plugin and the associable
+  APIs belong.
+
+* `plugin_id` - (Required, String) Specifies the ID of the plugin to be queried.
+
+* `env_id` - (Required, String) Specifies the ID of the environment where the associable APIs are published.
+
+* `api_name` - (Optional, String) Specifies the name of the associable APIs to be queried.  
+  The fuzzy search is supported.
+
+* `api_id` - (Optional, String) Specifies the ID of the specified associable API to be queried.
+
+* `group_id` - (Optional, String) Specifies the ID of the API group to be queried to which the associable APIs belong.
+
+* `req_method` - (Optional, String) Specifies the request method of the associable APIs to be queried.  
+  The valid values are as follows:
+  + **GET**
+  + **POST**
+  + **PUT**
+  + **DELETE**
+  + **HEAD**
+  + **PATCH**
+  + **OPTIONS**
+  + **ANY**
+
+* `tags` - (Optional, String) Specifies the tags of the associable APIs to be queried.
+  The value `#no_tags#` means filtering APIs without tags.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `apis` - The list of APIs that can be bound to the specified plugin.
+  The [apis](#apig_plugin_associable_apis) structure is documented below.
+
+<a name="apig_plugin_associable_apis"></a>
+The `apis` block supports:
+
+* `id` - The ID of the associable API.
+
+* `name` - The name of the associable API.
+
+* `type` - The type of the associable API.  
+  The valid values are as follows:
+  + **1** - Public API
+  + **2** - Private API
+
+* `req_protocol` - The request protocol of the associable API.  
+  The valid values are as follows:
+  + **HTTP**
+  + **HTTPS**
+  + **BOTH** - Both **HTTP** and **HTTPS**
+
+* `req_method` - The request method of the associable API.
+
+* `req_uri` - The request path of the associable API.
+
+* `auth_type` - The authentication type of the associable API.  
+  The valid values are as follows:
+  + **NONE** - No authentication
+  + **APP** - APP authentication
+  + **IAM** - IAM authentication
+  + **AUTHORIZER** - Custom authentication
+
+* `match_mode` - The match mode of the associable API.  
+  The valid values are as follows:
+  + **SWA** - Prefix matching
+  + **NORMAL** - Normal matching (exact matching)
+
+* `description` - The description of the associable API.
+
+* `group_id` - The ID of the API group to which the associable API belongs.
+
+* `group_name` - The name of the API group to which the associable API belongs.
+
+* `tags` - The tag list bound to the associable API.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -586,6 +586,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_orchestration_rules":                apig.DataSourceOrchestrationRules(),
 			"huaweicloud_apig_orchestration_rule_associated_apis": apig.DataSourceOrchestrationRuleAssociatedApis(),
 			"huaweicloud_apig_plugins":                            apig.DataSourcePlugins(),
+			"huaweicloud_apig_plugin_associable_apis":             apig.DataSourcePluginAssociableApis(),
 			"huaweicloud_apig_quotas":                             apig.DataSourceQuotas(),
 			"huaweicloud_apig_signatures":                         apig.DataSourceSignatures(),
 			"huaweicloud_apig_throttling_policies":                apig.DataSourceThrottlingPolicies(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_plugin_associable_apis_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_plugin_associable_apis_test.go
@@ -1,0 +1,444 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataPluginAssociableApis_basic(t *testing.T) {
+	var (
+		rName = "data.huaweicloud_apig_plugin_associable_apis.test"
+		dc    = acceptance.InitDataSourceCheck(rName)
+
+		byApiName   = "data.huaweicloud_apig_plugin_associable_apis.filter_by_api_name"
+		dcByApiName = acceptance.InitDataSourceCheck(byApiName)
+
+		byApiId   = "data.huaweicloud_apig_plugin_associable_apis.filter_by_api_id"
+		dcByApiId = acceptance.InitDataSourceCheck(byApiId)
+
+		byGroupId   = "data.huaweicloud_apig_plugin_associable_apis.filter_by_group_id"
+		dcByGroupId = acceptance.InitDataSourceCheck(byGroupId)
+
+		byReqMethod   = "data.huaweicloud_apig_plugin_associable_apis.filter_by_req_method"
+		dcByReqMethod = acceptance.InitDataSourceCheck(byReqMethod)
+
+		byTags   = "data.huaweicloud_apig_plugin_associable_apis.filter_by_tags"
+		dcByTags = acceptance.InitDataSourceCheck(byTags)
+
+		byNoTags   = "data.huaweicloud_apig_plugin_associable_apis.filter_by_no_tags"
+		dcByNoTags = acceptance.InitDataSourceCheck(byNoTags)
+
+		byNotFoundApiName   = "data.huaweicloud_apig_plugin_associable_apis.filter_by_not_found_api_name"
+		dcByNotFoundApiName = acceptance.InitDataSourceCheck(byNotFoundApiName)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+			acceptance.TestAccPreCheckApigChannelRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataPluginAssociableApis_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(rName, "apis.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(rName, "apis.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "apis.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "apis.0.type"),
+					resource.TestCheckResourceAttrSet(rName, "apis.0.req_protocol"),
+					resource.TestCheckResourceAttrSet(rName, "apis.0.req_method"),
+					resource.TestCheckResourceAttrSet(rName, "apis.0.req_uri"),
+					resource.TestCheckResourceAttrSet(rName, "apis.0.auth_type"),
+					resource.TestCheckResourceAttrSet(rName, "apis.0.match_mode"),
+					resource.TestCheckResourceAttrSet(rName, "apis.0.group_id"),
+					resource.TestCheckResourceAttrSet(rName, "apis.0.group_name"),
+					dcByApiName.CheckResourceExists(),
+					resource.TestCheckOutput("is_api_name_filter_useful", "true"),
+					dcByNotFoundApiName.CheckResourceExists(),
+					resource.TestCheckOutput("is_not_found_api_name_useful", "true"),
+					dcByApiId.CheckResourceExists(),
+					resource.TestCheckOutput("is_api_id_filter_useful", "true"),
+					dcByGroupId.CheckResourceExists(),
+					resource.TestCheckOutput("is_group_id_filter_useful", "true"),
+					dcByReqMethod.CheckResourceExists(),
+					resource.TestCheckOutput("is_req_method_filter_useful", "true"),
+					dcByTags.CheckResourceExists(),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
+					dcByNoTags.CheckResourceExists(),
+					resource.TestCheckOutput("is_no_tags_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataPluginAssociableApis_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[2]s"
+}
+
+locals {
+  instance_id = data.huaweicloud_apig_instances.test.instances[0].id
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[3]s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  system_disk_type   = "SSD"
+
+  network {
+    uuid = "%[4]s"
+  }
+}
+
+resource "huaweicloud_apig_group" "test" {
+  name        = "%[3]s"
+  instance_id = local.instance_id
+}
+
+resource "huaweicloud_apig_channel" "test" {
+  instance_id      = local.instance_id
+  name             = "%[3]s"
+  port             = 8000
+  balance_strategy = 2
+  member_type      = "ecs"
+  type             = 2
+
+  health_check {
+    protocol           = "HTTPS"
+    threshold_normal   = 10  # maximum value
+    threshold_abnormal = 10  # maximum value
+    interval           = 300 # maximum value
+    timeout            = 30  # maximum value
+    path               = "/"
+    method             = "HEAD"
+    port               = 8080
+    http_codes         = "201,202,303-404"
+  }
+
+  member {
+    id   = huaweicloud_compute_instance.test.id
+    name = huaweicloud_compute_instance.test.name
+  }
+}
+
+resource "huaweicloud_apig_api" "test" {
+  count = 2
+
+  instance_id             = local.instance_id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = format("%[3]s_%%s", count.index)
+  type                    = "Public"
+  request_protocol        = "HTTP"
+  request_method          = "GET"
+  request_path            = "/user_info/{user_age}"
+  security_authentication = "APP"
+  matching                = "Exact"
+  success_response        = "Success response"
+  failure_response        = "Failed response"
+  description             = "Created by script"
+
+  request_params {
+    name     = "user_age"
+    type     = "NUMBER"
+    location = "PATH"
+    required = true
+    maximum  = 200
+    minimum  = 0
+  }
+
+  backend_params {
+    type     = "REQUEST"
+    name     = "userAge"
+    location = "PATH"
+    value    = "user_age"
+  }
+
+  web {
+    path             = "/getUserAge/{userAge}"
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 30000
+  }
+
+  web_policy {
+    name             = format("%[3]s_web_%%s", count.index)
+    request_protocol = "HTTP"
+    request_method   = "GET"
+    effective_mode   = "ANY"
+    path             = "/getUserAge/{userAge}"
+    timeout          = 30000
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+
+    backend_params {
+      type     = "REQUEST"
+      name     = "userAge"
+      location = "PATH"
+      value    = "user_age"
+    }
+
+    conditions {
+      source     = "param"
+      param_name = "user_age"
+      type       = "Equal"
+      value      = "28"
+    }
+  }
+
+  tags = count.index == 0 ? ["terraform", "test"] : null
+
+  lifecycle {
+    ignore_changes = [
+      request_params,
+    ]
+  }
+}
+
+resource "huaweicloud_apig_environment" "test" {
+  instance_id = local.instance_id
+  name        = "%[3]s"
+}
+
+resource "huaweicloud_apig_api_publishment" "test" {
+  count = 2
+
+  instance_id = local.instance_id
+  api_id      = huaweicloud_apig_api.test[count.index].id
+  env_id      = huaweicloud_apig_environment.test.id
+}
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = local.instance_id
+  name        = "%[3]s_cors"
+  type        = "cors"
+  description = "Created by terraform script"
+  content     = jsonencode({
+    allow_origin      = "*"
+    allow_methods     = "GET,PUT,DELETE,HEAD,PATCH"
+    allow_headers     = "Content-Type,Accept,Cache-Control"
+    expose_headers    = "X-Request-Id,X-Apig-Latency"
+    max_age           = 12700
+    allow_credentials = true
+  })
+}
+`, common.TestBaseComputeResources(name),
+		acceptance.HW_APIG_DEDICATED_INSTANCE_ID,
+		name,
+		acceptance.HW_APIG_DEDICATED_INSTANCE_USED_SUBNET_ID)
+}
+
+func testAccDataPluginAssociableApis_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_plugin_associable_apis" "test" {
+  instance_id = local.instance_id
+  plugin_id   = huaweicloud_apig_plugin.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+# Filter by API name (fuzzy search)
+locals {
+  api_name = "%[2]s"
+}
+
+data "huaweicloud_apig_plugin_associable_apis" "filter_by_api_name" {
+  instance_id = local.instance_id
+  plugin_id   = huaweicloud_apig_plugin.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  api_name    = local.api_name
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+locals {
+  api_name_filter_result = [
+    for v in data.huaweicloud_apig_plugin_associable_apis.filter_by_api_name.apis : strcontains(v.name, local.api_name)
+  ]
+}
+
+output "is_api_name_filter_useful" {
+  value = length(local.api_name_filter_result) >= 2 && alltrue(local.api_name_filter_result)
+}
+
+# Filter by not found API name
+locals {
+  not_found_api_name = "not_found_api"
+}
+
+data "huaweicloud_apig_plugin_associable_apis" "filter_by_not_found_api_name" {
+  instance_id = local.instance_id
+  plugin_id   = huaweicloud_apig_plugin.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  api_name    = local.not_found_api_name
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+locals {
+  not_found_api_name_filter_result = [
+    for v in data.huaweicloud_apig_plugin_associable_apis.filter_by_not_found_api_name.apis : strcontains(v.name, local.not_found_api_name)
+  ]
+}
+
+output "is_not_found_api_name_useful" {
+  value = length(local.not_found_api_name_filter_result) == 0
+}
+
+# Filter by API ID
+locals {
+  api_id = huaweicloud_apig_api.test[0].id
+}
+
+data "huaweicloud_apig_plugin_associable_apis" "filter_by_api_id" {
+  instance_id = local.instance_id
+  plugin_id   = huaweicloud_apig_plugin.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  api_id      = local.api_id
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+locals {
+  api_id_filter_result = [
+    for v in data.huaweicloud_apig_plugin_associable_apis.filter_by_api_id.apis : v.id == local.api_id
+  ]
+}
+
+output "is_api_id_filter_useful" {
+  value = length(local.api_id_filter_result) > 0 && alltrue(local.api_id_filter_result)
+}
+
+# Filter by group ID
+locals {
+  group_id = huaweicloud_apig_group.test.id
+}
+
+data "huaweicloud_apig_plugin_associable_apis" "filter_by_group_id" {
+  instance_id = local.instance_id
+  plugin_id   = huaweicloud_apig_plugin.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  group_id    = local.group_id
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+locals {
+  group_id_filter_result = [
+    for v in data.huaweicloud_apig_plugin_associable_apis.filter_by_group_id.apis : v.group_id == local.group_id
+  ]
+}
+
+output "is_group_id_filter_useful" {
+  value = length(local.group_id_filter_result) > 0 && alltrue(local.group_id_filter_result)
+}
+
+# Filter by request method
+locals {
+  req_method = huaweicloud_apig_api.test[0].request_method
+}
+
+data "huaweicloud_apig_plugin_associable_apis" "filter_by_req_method" {
+  instance_id = local.instance_id
+  plugin_id   = huaweicloud_apig_plugin.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  req_method  = local.req_method
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+locals {
+  req_method_filter_result = [
+    for v in data.huaweicloud_apig_plugin_associable_apis.filter_by_req_method.apis : v.req_method == local.req_method
+  ]
+}
+
+output "is_req_method_filter_useful" {
+  value = length(local.req_method_filter_result) > 0 && alltrue(local.req_method_filter_result)
+}
+
+# Filter by tags
+locals {
+  tags = "terraform"
+}
+
+data "huaweicloud_apig_plugin_associable_apis" "filter_by_tags" {
+  instance_id = local.instance_id
+  plugin_id   = huaweicloud_apig_plugin.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  tags        = local.tags
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+locals {
+  tags_filter_result = [
+    for v in data.huaweicloud_apig_plugin_associable_apis.filter_by_tags.apis : contains(v.tags, local.tags)
+  ]
+}
+
+output "is_tags_filter_useful" {
+  value = length(local.tags_filter_result) > 0 && alltrue(local.tags_filter_result)
+}
+
+# Filter by tags (no tags)
+locals {
+  no_tags = "#no_tags#"
+}
+
+data "huaweicloud_apig_plugin_associable_apis" "filter_by_no_tags" {
+  instance_id = local.instance_id
+  plugin_id   = huaweicloud_apig_plugin.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  tags        = local.no_tags
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+locals {
+  no_tags_filter_result = [
+    for v in data.huaweicloud_apig_plugin_associable_apis.filter_by_no_tags.apis : length(v.tags) == 0
+  ]
+}
+
+output "is_no_tags_filter_useful" {
+  value = length(local.no_tags_filter_result) > 0 && alltrue(local.no_tags_filter_result)
+}
+`, testAccDataPluginAssociableApis_base(name), name)
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_plugin_associable_apis.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_plugin_associable_apis.go
@@ -1,0 +1,269 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/plugins/{plugin_id}/attachable-apis
+func DataSourcePluginAssociableApis() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePluginAssociableApisRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the plugin and the associable APIs are located.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the plugin and the associable APIs belong.`,
+			},
+			"plugin_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the plugin to be queried.`,
+			},
+			"env_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the environment where the associable APIs are published.`,
+			},
+
+			// Optional parameters.
+			"api_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the associable APIs to be queried.`,
+			},
+			"api_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the specified associable API to be queried.`,
+			},
+			"group_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the API group to be queried to which the associable APIs belong.`,
+			},
+			"req_method": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The request method of the associable APIs to be queried.`,
+			},
+			"tags": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The tags of the associable APIs to be queried.`,
+			},
+
+			// Attributes.
+			"apis": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of APIs that can be bound to the specified plugin.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the associable API.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the associable API.`,
+						},
+						"type": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The type of the associable API.`,
+						},
+						"req_protocol": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The request protocol of the associable API.`,
+						},
+						"req_method": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The request method of the associable API.`,
+						},
+						"req_uri": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The request path of the associable API.`,
+						},
+						"auth_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The authentication type of the associable API.`,
+						},
+						"match_mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The match mode of the associable API.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the associable API.`,
+						},
+						"group_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the API group to which the associable API belongs.`,
+						},
+						"group_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the API group to which the associable API belongs.`,
+						},
+						"tags": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The tag list bound to the associable API.`,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildPluginAssociableApisQueryParams(d *schema.ResourceData) string {
+	res := "&env_id={env_id}"
+	res = strings.ReplaceAll(res, "{env_id}", d.Get("env_id").(string))
+
+	if v, ok := d.GetOk("api_name"); ok {
+		res = fmt.Sprintf("%s&api_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("api_id"); ok {
+		res = fmt.Sprintf("%s&api_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("group_id"); ok {
+		res = fmt.Sprintf("%s&group_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("req_method"); ok {
+		res = fmt.Sprintf("%s&req_method=%v", res, v)
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		encodedTags := url.QueryEscape(v.(string))
+		res = fmt.Sprintf("%s&tags=%v", res, encodedTags)
+	}
+
+	return res
+}
+
+func listPluginAssociableApis(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/apigw/instances/{instance_id}/plugins/{plugin_id}/attachable-apis?limit=100"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", d.Get("instance_id").(string))
+	listPath = strings.ReplaceAll(listPath, "{plugin_id}", d.Get("plugin_id").(string))
+	listPath += buildPluginAssociableApisQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		apis := utils.PathSearch("apis", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, apis...)
+		if len(apis) < limit {
+			break
+		}
+		offset += len(apis)
+	}
+
+	return result, nil
+}
+
+func flattenPluginAssociableApis(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"id":           utils.PathSearch("api_id", item, nil),
+			"name":         utils.PathSearch("api_name", item, nil),
+			"type":         utils.PathSearch("type", item, nil),
+			"req_protocol": utils.PathSearch("req_protocol", item, nil),
+			"req_method":   utils.PathSearch("req_method", item, nil),
+			"req_uri":      utils.PathSearch("req_uri", item, nil),
+			"auth_type":    utils.PathSearch("auth_type", item, nil),
+			"match_mode":   utils.PathSearch("match_mode", item, nil),
+			"description":  utils.PathSearch("remark", item, nil),
+			"group_id":     utils.PathSearch("group_id", item, nil),
+			"group_name":   utils.PathSearch("group_name", item, nil),
+			"tags":         utils.PathSearch("tags", item, make([]interface{}, 0)),
+		})
+	}
+
+	return result
+}
+
+func dataSourcePluginAssociableApisRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	pluginId := d.Get("plugin_id").(string)
+	resp, err := listPluginAssociableApis(client, d)
+	if err != nil {
+		return diag.Errorf("error querying associable APIs for specified plugin (%s): %s", pluginId, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("apis", flattenPluginAssociableApis(resp)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new data source to query the associable APIs for plugin in a specified environment.

The `#` character for tags parameter value **#no_tags#** is base on URL encode rule, but we don't know which encode rule is parameter `req_uri` uses.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

Some attributes in API documentation are not return:
<img width="2546" height="765" alt="image" src="https://github.com/user-attachments/assets/62c591fa-b7d9-4620-97d5-7ae1f3ebe660" />

- env_id
- env_name
- publish_id
- plugin_attach_id

And if the API has been associated, there will not include in this API return.
So attached_time is never be a not empty value
- attached_time


UT for resource coverage:
<img width="1009" height="850" alt="image" src="https://github.com/user-attachments/assets/8aa2e694-5d2f-4558-83f9-16eaf6f8c1e4" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query associable APIs for plugin
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccDataSourcePluginAssociableApis_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataSourcePluginAssociableApis_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourcePluginAssociableApis_basic
=== PAUSE TestAccDataSourcePluginAssociableApis_basic
=== CONT  TestAccDataSourcePluginAssociableApis_basic
--- PASS: TestAccDataSourcePluginAssociableApis_basic (154.76s)
PASS
coverage: 11.6% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      154.911s        coverage: 11.6% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
