### PR TITLE
fix(apig/certificates): fix some incorrect attribute values

### DIFF
--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_instance_associated_ssl_certificates.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_instance_associated_ssl_certificates.go
@@ -232,9 +232,9 @@ func flattenAssociatedCertificates(certificates []interface{}) []interface{} {
 	result := make([]interface{}, 0, len(certificates))
 	for _, certificate := range certificates {
 		result = append(result, map[string]interface{}{
-			"id":                     utils.PathSearch("sign_id", certificate, nil),
-			"name":                   utils.PathSearch("sign_name", certificate, nil),
-			"type":                   utils.PathSearch("sign_type", certificate, nil),
+			"id":                     utils.PathSearch("id", certificate, nil),
+			"name":                   utils.PathSearch("name", certificate, nil),
+			"type":                   utils.PathSearch("type", certificate, nil),
 			"instance_id":            utils.PathSearch("instance_id", certificate, nil),
 			"project_id":             utils.PathSearch("project_id", certificate, nil),
 			"common_name":            utils.PathSearch("common_name", certificate, nil),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixed the issue of incorrect value ​​of some attributes in ReadContext.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccDataSourceInstanceAssociatedSSLCertificates_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataSourceInstanceAssociatedSSLCertificates_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceInstanceAssociatedSSLCertificates_basic
=== PAUSE TestAccDataSourceInstanceAssociatedSSLCertificates_basic
=== CONT  TestAccDataSourceInstanceAssociatedSSLCertificates_basic
--- PASS: TestAccDataSourceInstanceAssociatedSSLCertificates_basic (31.41s)
PASS
coverage: 2.9% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      31.542s coverage: 2.9% of statements in ./huaweicloud/services/apig
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
