### PR TITLE
feat(Config): add config policy assignment example

### DIFF
--- a/examples/rms/policy-assignment/README.md
+++ b/examples/rms/policy-assignment/README.md
@@ -1,0 +1,104 @@
+# Create a RMS policy assignment example
+
+This example provides best practice code for using Terraform to create an RMS (Resource Management Service)
+policy assignment in HuaweiCloud to check if ECS instances have required tags.
+
+## Prerequisites
+
+* A HuaweiCloud account
+* Terraform installed
+* HuaweiCloud access key and secret key (AK/SK)
+
+## Variables Introduction
+
+The following variables need to be configured:
+
+### Authentication Variables
+
+* `region_name` - The region where the resources are located
+* `access_key` - The access key of the IAM user
+* `secret_key` - The secret key of the IAM user
+
+### Resource Variables
+
+#### Required Variables
+
+* `vpc_name` - The name of the VPC
+* `subnet_name` - The name of the subnet
+* `security_group_name` - The name of the security group
+* `ecs_instance_name` - The name of the ECS instance
+* `availability_zone` - The availability zone where the ECS instance is located
+* `policy_assignment_name` - The name of the policy assignment
+
+#### Optional Variables
+
+* `vpc_cidr` - The CIDR block of the VPC (default: "192.168.0.0/16")
+* `subnet_cidr` - The CIDR block of the subnet (default: "")
+* `subnet_gateway_ip` - The gateway IP of the subnet (default: "")
+* `ecs_image_name` - The name of the image used to create the ECS instance (default: "Ubuntu 20.04 server 64bit")
+* `ecs_flavor_name` - The flavor name of the ECS instance (default: "s6.small.1")
+* `ecs_tags` - The tags of the ECS instance (default: { "Owner" = "terraform", "Env" = "test" })
+* `policy_assignment_description` - The description of the policy assignment (default: "Check if ECS instances have
+  required tags")
+* `policy_definition_id` - The ID of the policy definition
+* `policy_assignment_policy_filter` - The configuration used to filter resources
+  - `region` - The name of the region to which the filtered resources belong
+  - `resource_provider` - The service name to which the filtered resources belong
+  - `resource_type` - The resource type of the filtered resources
+  - `resource_id` - The resource ID used to filter a specified resource
+  - `tag_key` - The tag name used to filter resources
+  - `tag_value` - The tag value used to filter resources
+* `policy_assignment_parameters` - The rule definition of the policy assignment
+* `policy_assignment_tags` - The tags of the policy assignment (default: { "Owner" = "terraform", "Env" = "test" })
+
+## Usage
+
+* Copy this example script to your `main.tf`.
+
+* Create a `terraform.tfvars` file and fill in the required variables:
+
+  ```hcl
+  vpc_name              = "your_vpc_name"
+  subnet_name           = "your_subnet_name"
+  security_group_name   = "your_security_group_name"
+  ecs_instance_name     = "your_ecs_instance_name"
+  availability_zone     = "your_availability_zone"
+  policy_assignment_name = "your_policy_assignment_name"
+  ```
+
+* Initialize Terraform:
+
+  ```bash
+  $ terraform init
+  ```
+
+* Review the Terraform plan:
+
+  ```bash
+  $ terraform plan
+  ```
+
+* Apply the configuration:
+
+  ```bash
+  $ terraform apply
+  ```
+
+* To clean up the resources:
+
+  ```bash
+  $ terraform destroy
+  ```
+
+## Note
+
+* Make sure to keep your credentials secure and never commit them to version control
+* The policy assignment will check if ECS instances have the required tags specified in `policy_parameters`
+* All resources will be created in the specified region
+
+## Requirements
+
+| Name | Version |
+| ---- | ---- |
+| terraform | >= 1.9.0 |
+| huaweicloud | >= 1.77.6 |

--- a/examples/rms/policy-assignment/main.tf
+++ b/examples/rms/policy-assignment/main.tf
@@ -1,0 +1,63 @@
+# Create VPC for testing policy assignment
+resource "huaweicloud_vpc" "test" {
+  name = var.vpc_name
+  cidr = var.vpc_cidr
+}
+
+# Create subnet for VPC
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id     = huaweicloud_vpc.test.id
+  name       = var.subnet_name
+  cidr       = var.subnet_cidr == "" ? cidrsubnet(huaweicloud_vpc.test.cidr, 8, 0) : var.subnet_cidr
+  gateway_ip = var.subnet_gateway_ip == "" ? cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 8, 0), 1) : var.subnet_gateway_ip
+}
+
+# Create security group
+resource "huaweicloud_networking_secgroup" "test" {
+  name                 = var.security_group_name
+  delete_default_rules = true
+}
+
+# Create ECS instance for policy assignment testing
+resource "huaweicloud_compute_instance" "test" {
+  name               = var.ecs_instance_name
+  image_name         = var.ecs_image_name
+  flavor_name        = var.ecs_flavor_name
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = var.availability_zone
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+
+  tags = var.ecs_tags
+}
+
+# Create a policy assignment to check if ECS instances have specific tags
+resource "huaweicloud_rms_policy_assignment" "test" {
+  name                 = var.policy_assignment_name
+  description          = var.policy_assignment_description
+  policy_definition_id = var.policy_definition_id
+
+  dynamic "policy_filter" {
+    for_each = var.policy_assignment_policy_filter
+
+    content {
+      region            = policy_filter.value.region
+      resource_provider = policy_filter.value.resource_provider
+      resource_type     = policy_filter.value.resource_type
+      resource_id       = policy_filter.value.resource_id
+      tag_key           = policy_filter.value.tag_key
+      tag_value         = policy_filter.value.tag_value
+    }
+  }
+
+  parameters = var.policy_assignment_parameters
+
+  tags = var.policy_assignment_tags
+}
+
+# Evaluate the policy assignment
+resource "huaweicloud_rms_policy_assignment_evaluate" "test" {
+  policy_assignment_id = huaweicloud_rms_policy_assignment.test.id
+}

--- a/examples/rms/policy-assignment/providers.tf
+++ b/examples/rms/policy-assignment/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.77.6"
+    }
+  }
+}
+
+provider "huaweicloud" {
+  region     = var.region_name
+  access_key = var.access_key
+  secret_key = var.secret_key
+}

--- a/examples/rms/policy-assignment/terraform.tfvars
+++ b/examples/rms/policy-assignment/terraform.tfvars
@@ -1,0 +1,7 @@
+vpc_name               = "tf_test_vpc"
+subnet_name            = "tf_test_subnet"
+security_group_name    = "tf_test_security_group"
+ecs_instance_name      = "tf_test_ecs"
+availability_zone      = "cn-north-4a"
+policy_assignment_name = "tf_test_policy_assignment_name"
+policy_definition_id   = "tf_test_policy_definition_id"

--- a/examples/rms/policy-assignment/variables.tf
+++ b/examples/rms/policy-assignment/variables.tf
@@ -1,0 +1,134 @@
+# Variable definitions for authentication
+variable "region_name" {
+  description = "The region where the resources are located"
+  type        = string
+}
+
+variable "access_key" {
+  description = "The access key of the IAM user"
+  type        = string
+  sensitive   = true
+}
+
+variable "secret_key" {
+  description = "The secret key of the IAM user"
+  type        = string
+  sensitive   = true
+}
+
+# Variable definitions for network resources
+variable "vpc_name" {
+  description = "The name of the VPC"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "The CIDR block of the VPC"
+  type        = string
+  default     = "192.168.0.0/16"
+}
+
+variable "subnet_name" {
+  description = "The name of the subnet"
+  type        = string
+}
+
+variable "subnet_cidr" {
+  description = "The CIDR block of the subnet"
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "subnet_gateway_ip" {
+  description = "The gateway IP of the subnet"
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "security_group_name" {
+  description = "The name of the security group"
+  type        = string
+}
+
+# Variable definitions for ECS instance
+variable "ecs_instance_name" {
+  description = "The name of the ECS instance"
+  type        = string
+}
+
+variable "ecs_image_name" {
+  description = "The name of the image used to create the ECS instance"
+  type        = string
+  default     = "Ubuntu 20.04 server 64bit"
+}
+
+variable "ecs_flavor_name" {
+  description = "The flavor name of the ECS instance"
+  type        = string
+  default     = "s6.small.1"
+}
+
+variable "availability_zone" {
+  description = "The availability zone where the ECS instance is located"
+  type        = string
+}
+
+variable "ecs_tags" {
+  description = "The tags of the ECS instance"
+  type        = map(string)
+  default     = {
+    "Owner" = "terraform"
+    "Env"   = "test"
+  }
+}
+
+# Variable definitions for policy assignment
+variable "policy_assignment_name" {
+  description = "The name of the policy assignment"
+  type        = string
+}
+
+variable "policy_assignment_description" {
+  description = "The description of the policy assignment"
+  type        = string
+  default     = "Check if ECS instances have required tags"
+}
+
+variable "policy_definition_id" {
+  description = "The ID of the policy definition"
+  type        = string
+}
+
+variable "policy_assignment_policy_filter" {
+  description = "The configuration used to filter resources"
+
+  type = list(object({
+    region  = string
+    resource_provider = string
+    resource_type = string
+    resource_id = string
+    tag_key = string
+    tag_value = string
+  }))
+
+  default = []
+}
+
+variable "policy_assignment_parameters" {
+  description = "The parameters of the policy assignment"
+  type        = map(string)
+  default = {
+    "tagKeys" = "[\"Owner\",\"Env\"]"
+  }
+}
+
+variable "policy_assignment_tags" {
+  description = "The tags of the policy assignment"
+  type        = map(string)
+  default = {
+    "Owner" = "terraform"
+    "Env"   = "test"
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add config policy assignment example
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add config policy assignment example
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
