### PR TITLE
feat(apig): add new data source to query associable plugins for API

### DIFF
--- a/docs/data-sources/apig_api_associable_plugins.md
+++ b/docs/data-sources/apig_api_associable_plugins.md
@@ -1,0 +1,121 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_api_associable_plugins"
+description: |-
+  Use this data source to get the list of plugins that can be bound to the specified and published API within
+  HuaweiCloud.
+---
+
+# huaweicloud_apig_api_associable_plugins
+
+Use this data source to get the list of plugins that can be bound to the specified and published API within HuaweiCloud.
+
+## Example Usage
+
+### Query all plugins that can be bound to the specified API in an environment
+
+```hcl
+variable "instance_id" {}
+variable "api_id" {}
+variable "published_environment_id" {}
+
+data "huaweicloud_apig_api_associable_plugins" "test" {
+  instance_id = var.instance_id
+  api_id      = var.api_id
+  env_id      = var.published_environment_id
+}
+```
+
+### Query all plugins that can be bound to the specified API and filter by plugin type
+
+```hcl
+variable "instance_id" {}
+variable "api_id" {}
+variable "published_environment_id" {}
+
+data "huaweicloud_apig_api_associable_plugins" "test" {
+  instance_id = var.instance_id
+  api_id      = var.api_id
+  env_id      = var.published_environment_id
+  plugin_type = "cors"
+}
+```
+
+### Query all plugins that can be bound to the specified API and filter by plugin name
+
+```hcl
+variable "instance_id" {}
+variable "api_id" {}
+variable "published_environment_id" {}
+variable "plugin_name" {}
+
+data "huaweicloud_apig_api_associable_plugins" "test" {
+  instance_id = var.instance_id
+  api_id      = var.api_id
+  env_id      = var.published_environment_id
+  plugin_name = var.plugin_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the API and the associable plugins are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the API and the associable
+  plugins belong.
+
+* `api_id` - (Required, String) Specifies the ID of the API to be queried.
+
+* `env_id` - (Optional, String) Specifies the ID of the environment where the API is published.
+
+* `plugin_name` - (Optional, String) Specifies the name of the associable plugins to be queried.  
+  The fuzzy search is supported.
+
+* `plugin_type` - (Optional, String) Specifies the type of the associable plugins to be queried.  
+  The valid values are as follows:
+  + **cors** - Cross-Origin Resource Sharing
+  + **set_resp_headers** - HTTP Response Header Management
+  + **kafka_log** - Kafka Log Push
+  + **breaker** - Circuit Breaker
+  + **rate_limit** - Rate Limiting
+  + **third_auth** - Third-party Authentication
+  + **proxy_cache** - Response Cache
+  + **proxy_mirror** - Request Mirror
+  + **oidc_auth** - OIDC Authentication
+  + **jwt_auth** - JWT Authentication
+
+* `plugin_id` - (Optional, String) Specifies the ID of the specified associable plugin to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `plugins` - The list of plugins that can be bound to the specified API.
+  The [plugins](#apig_api_associable_plugins) structure is documented below.
+
+<a name="apig_api_associable_plugins"></a>
+The `plugins` block supports:
+
+* `id` - The ID of the associable plugin.
+
+* `name` - The name of the associable plugin.
+
+* `type` - The type of the associable plugin.
+
+* `scope` - The scope of the associable plugin.  
+  The valid values are as follows:
+  + **global** - Global scope
+
+* `content` - The content of the associable plugin configuration.
+
+* `description` - The description of the associable plugin.
+
+* `create_time` - The creation time of the associable plugin, in RFC3339 format.
+
+* `update_time` - The update time of the associable plugin, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -559,6 +559,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_api_associated_acl_policies":        apig.DataSourceApiAssociatedAclPolicies(),
 			"huaweicloud_apig_api_associated_applications":        apig.DataSourceApiAssociatedApplications(),
 			"huaweicloud_apig_api_associated_plugins":             apig.DataSourceApiAssociatedPlugins(),
+			"huaweicloud_apig_api_associable_plugins":             apig.DataSourceApiAssociablePlugins(),
 			"huaweicloud_apig_api_associated_signatures":          apig.DataSourceApiAssociatedSignatures(),
 			"huaweicloud_apig_api_associated_throttling_policies": apig.DataSourceApiAssociatedThrottlingPolicies(),
 			"huaweicloud_apig_api_basic_configurations":           apig.DataSourceApiBasicConfigurations(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_api_associable_plugins_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_api_associable_plugins_test.go
@@ -1,0 +1,373 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataApiAssociablePlugins_basic(t *testing.T) {
+	var (
+		rName = "data.huaweicloud_apig_api_associable_plugins.test"
+		dc    = acceptance.InitDataSourceCheck(rName)
+
+		byEnvId   = "data.huaweicloud_apig_api_associable_plugins.filter_by_env_id"
+		dcByEnvId = acceptance.InitDataSourceCheck(byEnvId)
+
+		byPluginName   = "data.huaweicloud_apig_api_associable_plugins.filter_by_plugin_name"
+		dcByPluginName = acceptance.InitDataSourceCheck(byPluginName)
+
+		byNotFoundPluginName   = "data.huaweicloud_apig_api_associable_plugins.filter_by_not_found_plugin_name"
+		dcByNotFoundPluginName = acceptance.InitDataSourceCheck(byNotFoundPluginName)
+
+		byPluginType   = "data.huaweicloud_apig_api_associable_plugins.filter_by_plugin_type"
+		dcByPluginType = acceptance.InitDataSourceCheck(byPluginType)
+
+		byPluginId   = "data.huaweicloud_apig_api_associable_plugins.filter_by_plugin_id"
+		dcByPluginId = acceptance.InitDataSourceCheck(byPluginId)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+			acceptance.TestAccPreCheckApigChannelRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataApiAssociablePlugins_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(rName, "plugins.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(rName, "plugins.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "plugins.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "plugins.0.type"),
+					resource.TestCheckResourceAttrSet(rName, "plugins.0.scope"),
+					resource.TestCheckResourceAttrSet(rName, "plugins.0.content"),
+					resource.TestCheckResourceAttrSet(rName, "plugins.0.description"),
+					resource.TestCheckResourceAttrSet(rName, "plugins.0.create_time"),
+					resource.TestCheckResourceAttrSet(rName, "plugins.0.update_time"),
+					dcByEnvId.CheckResourceExists(),
+					resource.TestCheckOutput("is_env_id_filter_useful", "true"),
+					dcByPluginName.CheckResourceExists(),
+					resource.TestCheckOutput("is_plugin_name_filter_useful", "true"),
+					dcByNotFoundPluginName.CheckResourceExists(),
+					resource.TestCheckOutput("is_not_found_plugin_name_useful", "true"),
+					dcByPluginType.CheckResourceExists(),
+					resource.TestCheckOutput("is_plugin_type_filter_useful", "true"),
+					dcByPluginId.CheckResourceExists(),
+					resource.TestCheckOutput("is_plugin_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataApiAssociablePlugins_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[2]s"
+}
+
+locals {
+  instance_id = data.huaweicloud_apig_instances.test.instances[0].id
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[3]s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  system_disk_type   = "SSD"
+
+  network {
+    uuid = "%[4]s"
+  }
+}
+
+resource "huaweicloud_apig_group" "test" {
+  name        = "%[3]s"
+  instance_id = local.instance_id
+}
+
+resource "huaweicloud_apig_channel" "test" {
+  instance_id      = local.instance_id
+  name             = "%[3]s"
+  port             = 8000
+  balance_strategy = 2
+  member_type      = "ecs"
+  type             = 2
+
+  health_check {
+    protocol           = "HTTPS"
+    threshold_normal   = 10  # maximum value
+    threshold_abnormal = 10  # maximum value
+    interval           = 300 # maximum value
+    timeout            = 30  # maximum value
+    path               = "/"
+    method             = "HEAD"
+    port               = 8080
+    http_codes         = "201,202,303-404"
+  }
+
+  member {
+    id   = huaweicloud_compute_instance.test.id
+    name = huaweicloud_compute_instance.test.name
+  }
+}
+
+resource "huaweicloud_apig_api" "test" {
+  instance_id             = local.instance_id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[3]s"
+  type                    = "Public"
+  request_protocol        = "HTTP"
+  request_method          = "GET"
+  request_path            = "/user_info/{user_age}"
+  security_authentication = "APP"
+  matching                = "Exact"
+  success_response        = "Success response"
+  failure_response        = "Failed response"
+  description             = "Created by script"
+
+  request_params {
+    name     = "user_age"
+    type     = "NUMBER"
+    location = "PATH"
+    required = true
+    maximum  = 200
+    minimum  = 0
+  }
+
+  backend_params {
+    type     = "REQUEST"
+    name     = "userAge"
+    location = "PATH"
+    value    = "user_age"
+  }
+
+  web {
+    path             = "/getUserAge/{userAge}"
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 30000
+  }
+
+  web_policy {
+    name             = "%[3]s_web"
+    request_protocol = "HTTP"
+    request_method   = "GET"
+    effective_mode   = "ANY"
+    path             = "/getUserAge/{userAge}"
+    timeout          = 30000
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+
+    backend_params {
+      type     = "REQUEST"
+      name     = "userAge"
+      location = "PATH"
+      value    = "user_age"
+    }
+
+    conditions {
+      source     = "param"
+      param_name = "user_age"
+      type       = "Equal"
+      value      = "28"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      request_params,
+    ]
+  }
+}
+
+resource "huaweicloud_apig_environment" "test" {
+  instance_id = local.instance_id
+  name        = "%[3]s"
+}
+
+resource "huaweicloud_apig_api_publishment" "test" {
+  instance_id = local.instance_id
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+}
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = local.instance_id
+  name        = "%[3]s_cors"
+  type        = "cors"
+  description = "Created by terraform script"
+  content     = jsonencode({
+    allow_origin      = "*"
+    allow_methods     = "GET,PUT,DELETE,HEAD,PATCH"
+    allow_headers     = "Content-Type,Accept,Cache-Control"
+    expose_headers    = "X-Request-Id,X-Apig-Latency"
+    max_age           = 12700
+    allow_credentials = true
+  })
+}
+`, common.TestBaseComputeResources(name),
+		acceptance.HW_APIG_DEDICATED_INSTANCE_ID,
+		name,
+		acceptance.HW_APIG_DEDICATED_INSTANCE_USED_SUBNET_ID)
+}
+
+func testAccDataApiAssociablePlugins_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_api_associable_plugins" "test" {
+  instance_id = local.instance_id
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+# Filter by environment ID
+locals {
+  env_id = huaweicloud_apig_environment.test.id
+}
+
+data "huaweicloud_apig_api_associable_plugins" "filter_by_env_id" {
+  instance_id = local.instance_id
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = local.env_id
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+locals {
+  env_id_filter_result = [
+    for v in data.huaweicloud_apig_api_associable_plugins.filter_by_env_id.plugins : v != null
+  ]
+}
+
+output "is_env_id_filter_useful" {
+  value = length(local.env_id_filter_result) > 0
+}
+
+# Filter by plugin name (fuzzy search)
+locals {
+  plugin_name = "%[2]s"
+}
+
+data "huaweicloud_apig_api_associable_plugins" "filter_by_plugin_name" {
+  instance_id = local.instance_id
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  plugin_name = local.plugin_name
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+locals {
+  plugin_name_filter_result = [
+    for v in data.huaweicloud_apig_api_associable_plugins.filter_by_plugin_name.plugins : strcontains(v.name, local.plugin_name)
+  ]
+}
+
+output "is_plugin_name_filter_useful" {
+  value = length(local.plugin_name_filter_result) > 0 && alltrue(local.plugin_name_filter_result)
+}
+
+# Filter by not found plugin name
+locals {
+  not_found_plugin_name = "not_found_plugin"
+}
+
+data "huaweicloud_apig_api_associable_plugins" "filter_by_not_found_plugin_name" {
+  instance_id = local.instance_id
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  plugin_name = local.not_found_plugin_name
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+locals {
+  not_found_plugin_name_filter_result = [
+    for v in data.huaweicloud_apig_api_associable_plugins.filter_by_not_found_plugin_name.plugins : strcontains(v.name, local.not_found_plugin_name)
+  ]
+}
+
+output "is_not_found_plugin_name_useful" {
+  value = length(local.not_found_plugin_name_filter_result) == 0
+}
+
+# Filter by plugin type
+locals {
+  plugin_type = "cors"
+}
+
+data "huaweicloud_apig_api_associable_plugins" "filter_by_plugin_type" {
+  instance_id = local.instance_id
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  plugin_type = local.plugin_type
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+locals {
+  plugin_type_filter_result = [
+    for v in data.huaweicloud_apig_api_associable_plugins.filter_by_plugin_type.plugins : v.type == local.plugin_type
+  ]
+}
+
+output "is_plugin_type_filter_useful" {
+  value = length(local.plugin_type_filter_result) > 0 && alltrue(local.plugin_type_filter_result)
+}
+
+# Filter by plugin ID
+locals {
+  plugin_id = huaweicloud_apig_plugin.test.id
+}
+
+data "huaweicloud_apig_api_associable_plugins" "filter_by_plugin_id" {
+  instance_id = local.instance_id
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  plugin_id   = local.plugin_id
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+locals {
+  plugin_id_filter_result = [
+    for v in data.huaweicloud_apig_api_associable_plugins.filter_by_plugin_id.plugins : v.id == local.plugin_id
+  ]
+}
+
+output "is_plugin_id_filter_useful" {
+  value = length(local.plugin_id_filter_result) > 0 && alltrue(local.plugin_id_filter_result)
+}
+`, testAccDataApiAssociablePlugins_base(name), name)
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_api_associable_plugins.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_api_associable_plugins.go
@@ -1,0 +1,230 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/apis/{api_id}/attachable-plugins
+func DataSourceApiAssociablePlugins() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceApiAssociablePluginsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the API and the associable plugins are located.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the API and the associable plugins belong.`,
+			},
+			"api_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the API to be queried.`,
+			},
+
+			// Optional parameters.
+			"env_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the environment where the API is published.`,
+			},
+			"plugin_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the associable plugins to be queried.`,
+			},
+			"plugin_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type of the associable plugins to be queried.`,
+			},
+			"plugin_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the specified associable plugin to be queried.`,
+			},
+
+			// Attributes.
+			"plugins": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of plugins that can be bound to the specified API.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the associable plugin.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the associable plugin.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the associable plugin.`,
+						},
+						"scope": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The scope of the associable plugin.`,
+						},
+						"content": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The content of the associable plugin configuration.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the associable plugin.`,
+						},
+						"create_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the associable plugin, in RFC3339 format.`,
+						},
+						"update_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The update time of the associable plugin, in RFC3339 format.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildApiAssociablePluginsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("env_id"); ok {
+		res = fmt.Sprintf("%s&env_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("plugin_name"); ok {
+		res = fmt.Sprintf("%s&plugin_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("plugin_type"); ok {
+		res = fmt.Sprintf("%s&plugin_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("plugin_id"); ok {
+		res = fmt.Sprintf("%s&plugin_id=%v", res, v)
+	}
+
+	return res
+}
+
+func listApiAssociablePlugins(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/apigw/instances/{instance_id}/apis/{api_id}/attachable-plugins?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", d.Get("instance_id").(string))
+	listPath = strings.ReplaceAll(listPath, "{api_id}", d.Get("api_id").(string))
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildApiAssociablePluginsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		plugins := utils.PathSearch("plugins", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, plugins...)
+		if len(plugins) < limit {
+			break
+		}
+		offset += len(plugins)
+	}
+
+	return result, nil
+}
+
+func dataSourceApiAssociablePluginsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	apiId := d.Get("api_id").(string)
+	resp, err := listApiAssociablePlugins(client, d)
+	if err != nil {
+		return diag.Errorf("error error querying associable plugins for specified API (%s): %s", apiId, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("plugins", flattenApiAssociablePlugins(resp)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenApiAssociablePlugins(plugins []interface{}) []map[string]interface{} {
+	if len(plugins) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(plugins))
+	for _, plugin := range plugins {
+		result = append(result, map[string]interface{}{
+			"id":          utils.PathSearch("plugin_id", plugin, nil),
+			"name":        utils.PathSearch("plugin_name", plugin, nil),
+			"type":        utils.PathSearch("plugin_type", plugin, nil),
+			"scope":       utils.PathSearch("plugin_scope", plugin, nil),
+			"content":     utils.PathSearch("plugin_content", plugin, nil),
+			"description": utils.PathSearch("remark", plugin, nil),
+			"create_time": utils.PathSearch("create_time", plugin, nil),
+			"update_time": utils.PathSearch("update_time", plugin, nil),
+		})
+	}
+
+	return result
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_plugin_associable_apis.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_plugin_associable_apis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -175,7 +176,7 @@ func buildPluginAssociableApisQueryParams(d *schema.ResourceData) string {
 
 func listPluginAssociableApis(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
 	var (
-		httpUrl = "v2/{project_id}/apigw/instances/{instance_id}/plugins/{plugin_id}/attachable-apis?limit=100"
+		httpUrl = "v2/{project_id}/apigw/instances/{instance_id}/plugins/{plugin_id}/attachable-apis?limit={limit}"
 		limit   = 100
 		offset  = 0
 		result  = make([]interface{}, 0)
@@ -185,6 +186,7 @@ func listPluginAssociableApis(client *golangsdk.ServiceClient, d *schema.Resourc
 	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
 	listPath = strings.ReplaceAll(listPath, "{instance_id}", d.Get("instance_id").(string))
 	listPath = strings.ReplaceAll(listPath, "{plugin_id}", d.Get("plugin_id").(string))
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
 	listPath += buildPluginAssociableApisQueryParams(d)
 
 	opt := golangsdk.RequestOpts{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new data source to query the associable plugins for API in a specified environment.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query associable plugins for API
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccDataApiAssociablePlugins_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataApiAssociablePlugins_basic -timeout 360m -parallel 10
=== RUN   TestAccDataApiAssociablePlugins_basic
=== PAUSE TestAccDataApiAssociablePlugins_basic
=== CONT  TestAccDataApiAssociablePlugins_basic
--- PASS: TestAccDataApiAssociablePlugins_basic (149.99s)
PASS
coverage: 11.4% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      150.075s        coverage: 11.4% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
