### PR TITLE
feat(apig): add new resource associate the certificates with the domain

### DIFF
--- a/docs/resources/apig_domain_certificate_associate.md
+++ b/docs/resources/apig_domain_certificate_associate.md
@@ -1,0 +1,65 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_domain_certificate_associate"
+description: |-
+  Use this resource to associate an SSL certificate to the specified domain within HuaweiCloud.
+---
+
+# huaweicloud_apig_domain_certificate_associate
+
+Use this resource to associate an SSL certificate to the specified domain within HuaweiCloud.
+
+-> For instance with custom inbound ports, the same domain name is bound to a certificate at the same time.
+   Enabling or disabling client verification takes effect for different ports of the same domain name.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "group_id" {}
+variable "domain_id" {}
+variable "certificate_id" {}
+
+resource "huaweicloud_apig_domain_certificate_associate" "test" {
+  instance_id    = var.instance_id
+  group_id       = var.group_id
+  domain_id      = var.domain_id
+  certificate_id = var.certificate_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the domain and certificates are located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the dedicated instance to which
+  the domain belongs.
+
+* `group_id` - (Required, String, NonUpdatable) Specifies the ID of the API group to which the domain belongs.
+
+* `domain_id` - (Required, String, NonUpdatable) Specifies the ID of the domain.
+
+* `certificate_id` - (Required, String, NonUpdatable) Specifies the ID of the certificate to associate with
+  the domain.
+
+* `verified_client_certificate_enabled` - (Optional, Bool) Specifies whether to enable client
+  certificate verification.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID,the format is `<instance_id>/<group_id>/<domain_id>/<certificate_id>`.
+
+## Import
+
+This resource can be imported using its `id` (consists of `instance_id`, `group_id`, `domain_id` and
+`certificate_id`, separated by the slashes (/)), e.g.
+
+```shell
+$ terraform import huaweicloud_apig_domain_certificate_associate.test <instance_id>/<group_id>/<domain_id>/<certificate_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2095,6 +2095,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_channel_member":                      apig.ResourceChannelMember(),
 			"huaweicloud_apig_channel_member_group":                apig.ResourceChannelMemberGroup(),
 			"huaweicloud_apig_custom_authorizer":                   apig.ResourceApigCustomAuthorizerV2(),
+			"huaweicloud_apig_domain_certificate_associate":        apig.ResourceDomainCertificateAssociate(),
 			"huaweicloud_apig_endpoint_connection_management":      apig.ResourceEndpointConnectionManagement(),
 			"huaweicloud_apig_environment":                         apig.ResourceApigEnvironmentV2(),
 			"huaweicloud_apig_environment_variable":                apig.ResourceEnvironmentVariable(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_domain_certificate_associate_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_domain_certificate_associate_test.go
@@ -1,0 +1,144 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
+)
+
+func getDomainCertificateAssociateFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("apig", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating APIG client: %s", err)
+	}
+
+	return apig.GetDomainAssociatedCertificateByCertificateId(
+		client,
+		state.Primary.Attributes["instance_id"],
+		state.Primary.Attributes["group_id"],
+		state.Primary.Attributes["domain_id"],
+		state.Primary.Attributes["certificate_id"],
+	)
+}
+
+func TestAccDomainCertificateAssociate_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		associatedCertificates interface{}
+
+		resourceName = "huaweicloud_apig_domain_certificate_associate.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &associatedCertificates, getDomainCertificateAssociateFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+			acceptance.TestAccPreCheckCertificateBase(t)
+			acceptance.TestAccPreCheckCertificateRootCA(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainCertificateAssociate_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttrPair(resourceName, "group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "certificate_id", "huaweicloud_apig_certificate.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "verified_client_certificate_enabled", "true"),
+				),
+			},
+			{
+				Config: testAccDomainCertificateAssociate_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "verified_client_certificate_enabled", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDomainCertificateAssociate_base(name string) string {
+	return fmt.Sprintf(` 
+resource "huaweicloud_apig_certificate" "test" {
+  instance_id     = "%[1]s"
+  type            = "instance"
+  name            = "%[2]s"
+  content         = "%[3]s"
+  private_key     = "%[4]s"
+  trusted_root_ca = "%[5]s"
+}
+
+data "huaweicloud_apig_instance_ssl_certificates" "test" {
+  instance_id = "%[1]s"
+  name        = huaweicloud_apig_certificate.test.name
+
+  depends_on = [huaweicloud_apig_certificate.test]
+}
+
+locals {
+  domain_name = try([for v in data.huaweicloud_apig_instance_ssl_certificates.test.certificates : v.common_name
+  if v.id == huaweicloud_apig_certificate.test.id][0], null)
+}
+
+resource "huaweicloud_apig_group" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+}
+
+resource "huaweicloud_apig_group_domain_associate" "test" {
+  instance_id = "%[1]s"
+  group_id    = huaweicloud_apig_group.test.id
+  url_domain  = local.domain_name
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID,
+		name,
+		acceptance.HW_CERTIFICATE_CONTENT,
+		acceptance.HW_CERTIFICATE_PRIVATE_KEY,
+		acceptance.HW_CERTIFICATE_ROOT_CA,
+	)
+}
+
+func testAccDomainCertificateAssociate_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_domain_certificate_associate" "test" {
+  instance_id    = "%[2]s"
+  group_id       = huaweicloud_apig_group.test.id
+  domain_id      = huaweicloud_apig_group_domain_associate.test.domain_id
+  certificate_id = huaweicloud_apig_certificate.test.id
+
+  verified_client_certificate_enabled = true
+}
+`, testAccDomainCertificateAssociate_base(name), acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
+}
+
+func testAccDomainCertificateAssociate_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_domain_certificate_associate" "test" {
+  instance_id    = "%[2]s"
+  group_id       = huaweicloud_apig_group.test.id
+  domain_id      = huaweicloud_apig_group_domain_associate.test.domain_id
+  certificate_id = huaweicloud_apig_certificate.test.id
+}
+`, testAccDomainCertificateAssociate_base(name), acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_domain_certificate_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_domain_certificate_associate.go
@@ -1,0 +1,300 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var domainCertificateAssociateNonUpdatableParams = []string{
+	"instance_id",
+	"group_id",
+	"domain_id",
+	"certificate_id",
+}
+
+// @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/api-groups/{group_id}/domains/{domain_id}/certificates/attach
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/api-groups/{group_id}
+// @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/api-groups/{group_id}/domains/{domain_id}/certificates/detach
+func ResourceDomainCertificateAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDomainCertificateAssociateCreate,
+		ReadContext:   resourceDomainCertificateAssociateRead,
+		UpdateContext: resourceDomainCertificateAssociateUpdate,
+		DeleteContext: resourceDomainCertificateAssociateDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(domainCertificateAssociateNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDomainCertificateAssociateImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the domain and certificates are located.",
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the dedicated instance to which the domain belongs.",
+			},
+			"group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the API group to which the domain belongs.",
+			},
+			"domain_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the domain.",
+			},
+			"certificate_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the certificate to associate with the domain.",
+			},
+			"verified_client_certificate_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Whether to enable client certificate verification.",
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildAssociateCertificateToDomainBodyParams(certificateId string, verififyEnabled bool) map[string]interface{} {
+	return map[string]interface{}{
+		"certificate_ids":                     []string{certificateId},
+		"verified_client_certificate_enabled": verififyEnabled,
+	}
+}
+
+func associateCertificateToDomain(client *golangsdk.ServiceClient, instanceId, groupId, domainId, certificateId string,
+	verififyEnabled bool) error {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/api-groups/{group_id}/domains/{domain_id}/certificates/attach"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createPath = strings.ReplaceAll(createPath, "{group_id}", groupId)
+	createPath = strings.ReplaceAll(createPath, "{domain_id}", domainId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		OkCodes:  []int{204},
+		JSONBody: buildAssociateCertificateToDomainBodyParams(certificateId, verififyEnabled),
+	}
+
+	_, err := client.Request("POST", createPath, &opt)
+	return err
+}
+
+func resourceDomainCertificateAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		instanceId    = d.Get("instance_id").(string)
+		groupId       = d.Get("group_id").(string)
+		domainId      = d.Get("domain_id").(string)
+		certificateId = d.Get("certificate_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	err = associateCertificateToDomain(client, instanceId, groupId, domainId, certificateId, d.Get("verified_client_certificate_enabled").(bool))
+	if err != nil {
+		return diag.Errorf("error associating certificate  to domain (%s): %s", domainId, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s/%s/%s", instanceId, groupId, domainId, certificateId))
+	return resourceDomainCertificateAssociateRead(ctx, d, meta)
+}
+
+func getCertificateDomainInfoByDomainId(client *golangsdk.ServiceClient, instanceId, groupId, domainId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/api-groups/{group_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getPath = strings.ReplaceAll(getPath, "{group_id}", groupId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch(fmt.Sprintf("url_domains[?id=='%s']|[0]", domainId), respBody, nil), nil
+}
+
+func GetDomainAssociatedCertificateByCertificateId(client *golangsdk.ServiceClient, instanceId, groupId, domainId,
+	certificateId string) (interface{}, error) {
+	domainInfos, err := getCertificateDomainInfoByDomainId(client, instanceId, groupId, domainId)
+	if err != nil {
+		return nil, err
+	}
+
+	if utils.PathSearch(fmt.Sprintf("ssl_infos[?ssl_id=='%s']|[0]", certificateId), domainInfos, nil) == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return domainInfos, nil
+}
+
+func resourceDomainCertificateAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		instanceId    = d.Get("instance_id").(string)
+		groupId       = d.Get("group_id").(string)
+		domainId      = d.Get("domain_id").(string)
+		certificateId = d.Get("certificate_id").(string)
+	)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	certificates, err := GetDomainAssociatedCertificateByCertificateId(client, instanceId, groupId, domainId, certificateId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("unable to query the certificate associated with the domain (%s)", domainId))
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("certificate_id", utils.PathSearch(fmt.Sprintf("ssl_infos[?ssl_id=='%s']|[0].ssl_id", certificateId), certificates, nil)),
+		d.Set("verified_client_certificate_enabled", utils.PathSearch("verified_client_certificate_enabled", certificates, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDomainCertificateAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		groupId       = d.Get("group_id").(string)
+		domainId      = d.Get("domain_id").(string)
+		certificateId = d.Get("certificate_id").(string)
+	)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	if d.HasChanges("verified_client_certificate_enabled") {
+		err = associateCertificateToDomain(
+			client,
+			d.Get("instance_id").(string),
+			groupId,
+			domainId,
+			certificateId,
+			d.Get("verified_client_certificate_enabled").(bool),
+		)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("error updating client authentication of the domain (%s) associated with the certificate (%s): %s",
+				domainId, certificateId, err))
+		}
+	}
+
+	return resourceDomainCertificateAssociateRead(ctx, d, meta)
+}
+
+func disassociateCertificateFromDomain(client *golangsdk.ServiceClient, instanceId, groupId, domainId, certificateId string,
+	verifiedClientCertificateEnabled bool) error {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/api-groups/{group_id}/domains/{domain_id}/certificates/detach"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createPath = strings.ReplaceAll(createPath, "{group_id}", groupId)
+	createPath = strings.ReplaceAll(createPath, "{domain_id}", domainId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		OkCodes:  []int{204},
+		JSONBody: buildAssociateCertificateToDomainBodyParams(certificateId, verifiedClientCertificateEnabled),
+	}
+
+	_, err := client.Request("POST", createPath, &opt)
+	return err
+}
+
+func resourceDomainCertificateAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		domainId = d.Get("domain_id").(string)
+	)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	err = disassociateCertificateFromDomain(
+		client,
+		d.Get("instance_id").(string),
+		d.Get("group_id").(string),
+		domainId,
+		d.Get("certificate_id").(string),
+		d.Get("verified_client_certificate_enabled").(bool),
+	)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error disassociating certificates from domain (%s)", domainId))
+	}
+	return nil
+}
+
+func resourceDomainCertificateAssociateImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<group_id>/<domain_id>/<certificate_id>', "+
+			"but got '%s'", importedId)
+	}
+
+	mErr := multierror.Append(
+		d.Set("instance_id", parts[0]),
+		d.Set("group_id", parts[1]),
+		d.Set("domain_id", parts[2]),
+		d.Set("certificate_id", parts[3]),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource (`huaweicloud_apig_domain_certificate_associate`) associate the certificates with the domain

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new resource.
2. add corresponding documation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o apig -f TestAccDomainCertificateAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDomainCertificateAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccDomainCertificateAssociate_basic
=== PAUSE TestAccDomainCertificateAssociate_basic
=== CONT  TestAccDomainCertificateAssociate_basic
--- PASS: TestAccDomainCertificateAssociate_basic (60.75s)
PASS
coverage: 6.0% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      60.929s coverage: 6.0% of statements in ./huaweicloud/services/apig
```
<img width="998" height="509" alt="image" src="https://github.com/user-attachments/assets/bd313952-266b-438e-b935-72fe794592c2" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found 
    
      <img width="1233" height="868" alt="image" src="https://github.com/user-attachments/assets/fbed9e42-d791-4a02-862e-28c8bd445d69" />
    ab. Related resources (parent resources) not found  

     + The APIG instance does not exist.
     <img width="1239" height="745" alt="image" src="https://github.com/user-attachments/assets/472ff17f-a172-4e4a-9d94-94fd9e82a046" />

    + API group does not exist.
    <img width="1228" height="729" alt="image" src="https://github.com/user-attachments/assets/bd76f6ff-ea92-444d-b721-70cb4cfc8396" />

    + Domain does not exist.
    <img width="1181" height="678" alt="image" src="https://github.com/user-attachments/assets/45481525-984e-476a-bcb5-afdc6896eab9" />  

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found  
   
    <img width="1171" height="833" alt="image" src="https://github.com/user-attachments/assets/6dc3edb8-b3db-475f-b476-880b40b91b9e" />

    bb. Related resources (parent resources) not found
    +  The APIG instance does not exist.
    <img width="1224" height="877" alt="image" src="https://github.com/user-attachments/assets/dd122a31-842e-4e8b-ac58-30a2e0fa7a80" />

    + API group does not exist.
    <img width="1145" height="887" alt="image" src="https://github.com/user-attachments/assets/fc2eed2e-3833-4601-b88e-351b45d7497b" />

    + Domain does not exist.
    <img width="1222" height="795" alt="image" src="https://github.com/user-attachments/assets/6247ca51-aa2f-47ea-bc4e-5f3d3e84d2b4" />
