### PR TITLE
refactor(sfsturbo): refactor sfs turbo resource in general code style

### DIFF
--- a/huaweicloud/services/acceptance/sfsturbo/resource_huaweicloud_sfs_turbo_test.go
+++ b/huaweicloud/services/acceptance/sfsturbo/resource_huaweicloud_sfs_turbo_test.go
@@ -8,34 +8,28 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/sfs_turbo/v1/shares"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/sfsturbo"
 )
 
 func getSfsTurboResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := cfg.SfsV1Client(acceptance.HW_REGION_NAME)
+	var (
+		region  = acceptance.HW_REGION_NAME
+		product = "sfs-turbo"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating SFS client: %s", err)
+		return nil, fmt.Errorf("error creating SFS Turbo client: %s", err)
 	}
 
-	resourceID := state.Primary.ID
-	share, err := shares.Get(client, resourceID).Extract()
-	if err != nil {
-		return nil, err
-	}
-
-	if share.ID == resourceID {
-		return &share, nil
-	}
-
-	return nil, fmt.Errorf("the sfs turbo %s does not exist", resourceID)
+	return sfsturbo.GetTurboDetail(client, state.Primary.ID)
 }
 
 func TestAccSFSTurbo_basic(t *testing.T) {
-	var turbo shares.Turbo
+	var turbo interface{}
 	rName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_sfs_turbo.test"
 
@@ -91,7 +85,7 @@ func TestAccSFSTurbo_basic(t *testing.T) {
 }
 
 func TestAccSFSTurbo_crypt(t *testing.T) {
-	var turbo shares.Turbo
+	var turbo interface{}
 	rName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_sfs_turbo.test"
 
@@ -126,7 +120,7 @@ func TestAccSFSTurbo_crypt(t *testing.T) {
 }
 
 func TestAccSFSTurbo_withEpsId(t *testing.T) {
-	var turbo shares.Turbo
+	var turbo interface{}
 	rName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_sfs_turbo.test"
 
@@ -156,7 +150,7 @@ func TestAccSFSTurbo_withEpsId(t *testing.T) {
 }
 
 func TestAccSFSTurbo_prePaid(t *testing.T) {
-	var turbo shares.Turbo
+	var turbo interface{}
 	rName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_sfs_turbo.test"
 
@@ -195,7 +189,7 @@ func TestAccSFSTurbo_prePaid(t *testing.T) {
 }
 
 func TestAccSFSTurbo_hpcShareType(t *testing.T) {
-	var turbo shares.Turbo
+	var turbo interface{}
 	rName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_sfs_turbo.test"
 
@@ -243,7 +237,7 @@ func TestAccSFSTurbo_hpcShareType(t *testing.T) {
 }
 
 func TestAccSFSTurbo_hpcCacheShareType(t *testing.T) {
-	var turbo shares.Turbo
+	var turbo interface{}
 	rName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_sfs_turbo.test"
 
@@ -300,7 +294,7 @@ func TestAccSFSTurbo_hpcCacheShareType(t *testing.T) {
 }
 
 func TestAccSFSTurbo_backupId(t *testing.T) {
-	var turbo shares.Turbo
+	var turbo interface{}
 	rName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_sfs_turbo.test"
 
@@ -341,7 +335,7 @@ func TestAccSFSTurbo_backupId(t *testing.T) {
 }
 
 func TestAccSFSTurbo_checkError(t *testing.T) {
-	var turbo shares.Turbo
+	var turbo interface{}
 	rName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_sfs_turbo.test"
 
@@ -380,7 +374,7 @@ func TestAccSFSTurbo_checkError(t *testing.T) {
 }
 
 func TestAccSFSTurbo_checkUpdateError(t *testing.T) {
-	var turbo shares.Turbo
+	var turbo interface{}
 	rName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_sfs_turbo.test"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

refactor sfs turbo resource in general code style

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o sfsturbo -f TestAccSFSTurbo_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/sfsturbo" -v -coverprofile="./huaweicloud/services/acceptance/sfsturbo/sfsturbo_coverage.cov" -coverpkg="./huaweicloud/services/sfsturbo" -run TestAccSFSTurbo_ -timeout 360m -parallel 10      
=== RUN   TestAccSFSTurbo_basic
=== PAUSE TestAccSFSTurbo_basic
=== RUN   TestAccSFSTurbo_crypt
=== PAUSE TestAccSFSTurbo_crypt
=== RUN   TestAccSFSTurbo_withEpsId
=== PAUSE TestAccSFSTurbo_withEpsId
=== RUN   TestAccSFSTurbo_prePaid
=== PAUSE TestAccSFSTurbo_prePaid
=== RUN   TestAccSFSTurbo_hpcShareType
=== PAUSE TestAccSFSTurbo_hpcShareType
=== RUN   TestAccSFSTurbo_hpcCacheShareType
=== PAUSE TestAccSFSTurbo_hpcCacheShareType
=== RUN   TestAccSFSTurbo_backupId
=== PAUSE TestAccSFSTurbo_backupId
=== RUN   TestAccSFSTurbo_checkError
=== PAUSE TestAccSFSTurbo_checkError
=== RUN   TestAccSFSTurbo_checkUpdateError
=== PAUSE TestAccSFSTurbo_checkUpdateError
=== CONT  TestAccSFSTurbo_basic
=== CONT  TestAccSFSTurbo_hpcCacheShareType
=== CONT  TestAccSFSTurbo_hpcShareType
=== CONT  TestAccSFSTurbo_checkError
=== CONT  TestAccSFSTurbo_checkUpdateError
=== CONT  TestAccSFSTurbo_withEpsId
=== CONT  TestAccSFSTurbo_crypt
=== CONT  TestAccSFSTurbo_backupId
=== CONT  TestAccSFSTurbo_prePaid
=== NAME  TestAccSFSTurbo_backupId
    acceptance.go:3817: HW_SFS_TURBO_BACKUP_ID must be set for the acceptance test
--- SKIP: TestAccSFSTurbo_backupId (0.07s)
=== NAME  TestAccSFSTurbo_hpcCacheShareType
    resource_huaweicloud_sfs_turbo_test.go:250: Step 1/4 error: Error running apply: exit status 1

        Error: error creating SFS Turbo: Bad request with: [POST https://sfs-turbo.cn-north-4.myhuaweicloud.com/v1/0970dd7a1300f5672ff2c003c60ae115/sfs-turbo/shares], request_id: 33ee43f44a77efea88fec45988799ef8, error message: {"errCode":"SFS.TURBO.0007","errMsg":"the file system type cannot be created"}

          with huaweicloud_sfs_turbo.test,
          on terraform_plugin_test.tf line 29, in resource "huaweicloud_sfs_turbo" "test":
          29: resource "huaweicloud_sfs_turbo" "test" {

--- FAIL: TestAccSFSTurbo_hpcCacheShareType (59.19s)
--- PASS: TestAccSFSTurbo_checkError (66.20s)
--- PASS: TestAccSFSTurbo_checkUpdateError (510.54s)
--- PASS: TestAccSFSTurbo_withEpsId (533.37s)
--- PASS: TestAccSFSTurbo_crypt (535.25s)
--- PASS: TestAccSFSTurbo_basic (669.42s)
--- PASS: TestAccSFSTurbo_hpcShareType (686.67s)
--- PASS: TestAccSFSTurbo_prePaid (954.57s)
FAIL
coverage: 17.4% of statements in ./huaweicloud/services/sfsturbo
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sfsturbo  954.682s
FAI
```
<img width="1281" height="83" alt="image" src="https://github.com/user-attachments/assets/a09b38a7-7d9b-47de-8175-0760096d665b" />


* [X] Documentation updated.
* [X] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
   <img width="820" height="176" alt="image" src="https://github.com/user-attachments/assets/948cb674-3f0a-4289-bc59-45592bc64748" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
