### PR TITLE
feat(sfsturbo): resource support new field

### DIFF
--- a/docs/resources/sfs_turbo.md
+++ b/docs/resources/sfs_turbo.md
@@ -145,6 +145,12 @@ The following arguments are supported:
 * `dedicated_storage_id` - (Optional, String, ForceNew) Specifies the ID of the dedicated distributed storage used
   when creating a dedicated file system.
 
+* `auto_create_security_group_rules` - (Optional, String) Specifies whether to automatically create security
+  group rules. **true** means automatically create security group rules.
+  **false** means not automatically create security group rules. Defaults to **true**.
+  This field cannot be edited individually. Editing this field alone will not make any changes to the resource.
+  Editing this field will only take effect when the `security_group_id` field is changed.
+
 * `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the file system. Changing this
   will create a new resource.
 
@@ -210,7 +216,8 @@ $ terraform import huaweicloud_sfs_turbo.test <id>
 
 Note that the imported state may not be identical to your resource definition, due to payment attributes missing from
 the API response.
-The missing attributes include: `charging_mode`, `period_unit`, `period`, `auto_renew`.
+The missing attributes include: `charging_mode`, `period_unit`, `period`, `auto_renew`,
+`auto_create_security_group_rules`, `dedicated_flavor`, `dedicated_storage_id`.
 It is generally recommended running `terraform plan` after importing an instance.
 You can ignore changes as below.
 
@@ -221,6 +228,7 @@ resource "huaweicloud_sfs_turbo" "test" {
   lifecycle {
     ignore_changes = [
       charging_mode, period_unit, period, auto_renew,
+      auto_create_security_group_rules, dedicated_flavor, dedicated_storage_id,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/sfsturbo/resource_huaweicloud_sfs_turbo_test.go
+++ b/huaweicloud/services/acceptance/sfsturbo/resource_huaweicloud_sfs_turbo_test.go
@@ -58,6 +58,7 @@ func TestAccSFSTurbo_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", "200"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "auto_create_security_group_rules", "false"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",
 						"huaweicloud_networking_secgroup.test", "id"),
 				),
@@ -66,6 +67,9 @@ func TestAccSFSTurbo_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"auto_create_security_group_rules",
+				},
 			},
 			{
 				Config: testAccSFSTurbo_update(rName),
@@ -75,6 +79,7 @@ func TestAccSFSTurbo_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "size", "600"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
+					resource.TestCheckResourceAttr(resourceName, "auto_create_security_group_rules", "true"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",
 						"huaweicloud_networking_secgroup.test_update", "id"),
 					resource.TestCheckResourceAttr(resourceName, "status", "232"),
@@ -416,13 +421,14 @@ func testAccSFSTurbo_basic(rName string) string {
 data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_sfs_turbo" "test" {
-  name              = "%s"
-  size              = 500
-  share_proto       = "NFS"
-  vpc_id            = huaweicloud_vpc.test.id
-  subnet_id         = huaweicloud_vpc_subnet.test.id
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name                             = "%s"
+  size                             = 500
+  share_proto                      = "NFS"
+  vpc_id                           = huaweicloud_vpc.test.id
+  subnet_id                        = huaweicloud_vpc_subnet.test.id
+  security_group_id                = huaweicloud_networking_secgroup.test.id
+  auto_create_security_group_rules = "false"
+  availability_zone                = data.huaweicloud_availability_zones.test.names[0]
 
   tags = {
     foo = "bar"
@@ -444,13 +450,14 @@ resource "huaweicloud_networking_secgroup" "test_update" {
 data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_sfs_turbo" "test" {
-  name              = "%[2]s_update"
-  size              = 600
-  share_proto       = "NFS"
-  vpc_id            = huaweicloud_vpc.test.id
-  subnet_id         = huaweicloud_vpc_subnet.test.id
-  security_group_id = huaweicloud_networking_secgroup.test_update.id
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name                             = "%[2]s_update"
+  size                             = 600
+  share_proto                      = "NFS"
+  vpc_id                           = huaweicloud_vpc.test.id
+  subnet_id                        = huaweicloud_vpc_subnet.test.id
+  security_group_id                = huaweicloud_networking_secgroup.test_update.id
+  auto_create_security_group_rules = "true"
+  availability_zone                = data.huaweicloud_availability_zones.test.names[0]
 
   tags = {
     foo = "bar_update"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Resource support new field `auto_create_security_group_rules`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o sfsturbo -f TestAccSFSTurbo_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/sfsturbo" -v -coverprofile="./huaweicloud/services/acceptance/sfsturbo/sfsturbo_coverage.cov" -coverpkg="./huaweicloud/services/sfsturbo" -run TestAccSFSTurbo_basic -timeout 360m -parallel 10
=== RUN   TestAccSFSTurbo_basic
=== PAUSE TestAccSFSTurbo_basic
=== CONT  TestAccSFSTurbo_basic
--- PASS: TestAccSFSTurbo_basic (748.08s)
PASS
coverage: 14.0% of statements in ./huaweicloud/services/sfsturbo
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sfsturbo  748.167s        coverage: 14.0% of statements in ./huaweicloud/services/sfsturbo
```
<img width="1291" height="177" alt="image" src="https://github.com/user-attachments/assets/d9fc0fc6-59fa-40f3-9e05-94cc7a86b395" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
