### PR TITLE
refactor(apig): rename the plugin associate resource

### DIFF
--- a/docs/resources/apig_plugin_associate.md
+++ b/docs/resources/apig_plugin_associate.md
@@ -1,13 +1,14 @@
 ---
 subcategory: "API Gateway (Dedicated APIG)"
 layout: "huaweicloud"
-page_title: "HuaweiCloud: huaweicloud_apig_plugin_associate"
-description: ""
+page_title: "HuaweiCloud: huaweicloud_apig_plugin_batch_apis_associate"
+description: |-
+  Use this resource to bind the APIs to the specified plugin within HuaweiCloud.
 ---
 
-# huaweicloud_apig_plugin_associate
+# huaweicloud_apig_plugin_batch_apis_associate
 
-Use this resource to bind the APIs to the plugin within HuaweiCloud.
+Use this resource to bind the APIs to the specified plugin within HuaweiCloud.
 
 ~> Before binding the API(s), please make sure all APIs have been published, otherwise you will receive a service error.
 
@@ -20,16 +21,16 @@ Use this resource to bind the APIs to the plugin within HuaweiCloud.
 ```hcl
 variable "instance_id" {}
 variable "plugin_id" {}
-variable "publish_environment_id" {}
-variable "bind_api_ids" {
+variable "published_env_id" {}
+variable "published_api_ids" {
   type = list(string)
 }
 
-resource "huaweicloud_apig_plugin_associate" "test" {
+resource "huaweicloud_apig_plugin_batch_apis_associate" "test" {
   instance_id = var.instance_id
   plugin_id   = var.plugin_id
-  env_id      = var.publish_environment_id
-  api_ids     = var.bind_api_ids
+  env_id      = var.published_env_id
+  api_ids     = var.published_api_ids
 }
 ```
 
@@ -64,5 +65,5 @@ Associate resources can be imported using their related dedicated instance ID of
 `env_id`, separated by slashes, e.g.
 
 ```bash
-$ terraform import huaweicloud_apig_plugin_associate.test <instance_id>/<plugin_id>/<env_id>
+$ terraform import huaweicloud_apig_plugin_batch_apis_associate.test <instance_id>/<plugin_id>/<env_id>
 ```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2080,7 +2080,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_instance_routes":                apig.ResourceInstanceRoutes(),
 			"huaweicloud_apig_instance":                       apig.ResourceApigInstanceV2(),
 			"huaweicloud_apig_orchestration_rule":             apig.ResourceOrchestrationRule(),
-			"huaweicloud_apig_plugin_associate":               apig.ResourcePluginAssociate(),
+			"huaweicloud_apig_plugin_batch_apis_associate":    apig.ResourcePluginBatchApisAssociate(),
 			"huaweicloud_apig_plugin":                         apig.ResourcePlugin(),
 			"huaweicloud_apig_response":                       apig.ResourceApigResponseV2(),
 			"huaweicloud_apig_signature_associate":            apig.ResourceSignatureAssociate(),
@@ -3288,6 +3288,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_lts_struct_template": lts.ResourceLtsStruct(),
 
 			// Legacy
+			"huaweicloud_apig_plugin_associate": apig.ResourcePluginBatchApisAssociate(),
+
 			"huaweicloud_networking_eip_associate": eip.ResourceEIPAssociate(),
 			"huaweicloud_dds_instance_recovery":    dds.ResourceDDSInstanceRestore(),
 

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_plugin_batch_apis_associate_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_plugin_batch_apis_associate_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getPluginAssociateFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getPluginBatchApisAssociateFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := cfg.ApigV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
@@ -26,15 +26,15 @@ func getPluginAssociateFunc(cfg *config.Config, state *terraform.ResourceState) 
 		utils.ParseStateAttributeToListWithSeparator(state.Primary.Attributes["api_ids_origin"], ","))
 }
 
-func TestAccPluginAssociate_basic(t *testing.T) {
+func TestAccPluginBatchApisAssociate_basic(t *testing.T) {
 	var (
 		obj interface{}
 
-		resourceNamePart1 = "huaweicloud_apig_plugin_associate.part1"
-		resourceNamePart2 = "huaweicloud_apig_plugin_associate.part2"
-		rcPart1           = acceptance.InitResourceCheck(resourceNamePart1, &obj, getPluginAssociateFunc)
-		rcPart2           = acceptance.InitResourceCheck(resourceNamePart2, &obj, getPluginAssociateFunc)
-		baseConfig        = testAccPluginAssociate_base()
+		resourceNamePart1 = "huaweicloud_apig_plugin_batch_apis_associate.part1"
+		resourceNamePart2 = "huaweicloud_apig_plugin_batch_apis_associate.part2"
+		rcPart1           = acceptance.InitResourceCheck(resourceNamePart1, &obj, getPluginBatchApisAssociateFunc)
+		rcPart2           = acceptance.InitResourceCheck(resourceNamePart2, &obj, getPluginBatchApisAssociateFunc)
+		baseConfig        = testAccPluginBatchApisAssociate_base()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -50,7 +50,7 @@ func TestAccPluginAssociate_basic(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPluginAssociate_basic_step1(baseConfig),
+				Config: testAccPluginBatchApisAssociate_basic_step1(baseConfig),
 				Check: resource.ComposeTestCheckFunc(
 					rcPart1.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceNamePart1, "api_ids.#", "2"),
@@ -61,7 +61,7 @@ func TestAccPluginAssociate_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccPluginAssociate_basic_step2(baseConfig),
+				Config: testAccPluginBatchApisAssociate_basic_step2(baseConfig),
 				Check: resource.ComposeTestCheckFunc(
 					rcPart1.CheckResourceExists(),
 					// After resources refreshed, the api_ids will be overridden as all APIs under the same
@@ -76,7 +76,7 @@ func TestAccPluginAssociate_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccPluginAssociate_basic_step3(baseConfig),
+				Config: testAccPluginBatchApisAssociate_basic_step3(baseConfig),
 				Check: resource.ComposeTestCheckFunc(
 					rcPart1.CheckResourceExists(),
 					// When multiple resources are used to manage the same function, api_ids will store the results
@@ -100,7 +100,7 @@ func TestAccPluginAssociate_basic(t *testing.T) {
 			{
 				// After resource part1 is imported, then api_ids will be overridden as all APIs under the same
 				// environment are bound.
-				Config: testAccPluginAssociate_basic_step3(baseConfig),
+				Config: testAccPluginBatchApisAssociate_basic_step3(baseConfig),
 				Check: resource.ComposeTestCheckFunc(
 					rcPart1.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceNamePart1, "api_ids.#", "3"),
@@ -114,7 +114,7 @@ func TestAccPluginAssociate_basic(t *testing.T) {
 	})
 }
 
-func testAccPluginAssociate_base() string {
+func testAccPluginBatchApisAssociate_base() string {
 	name := acceptance.RandomAccResourceName()
 
 	return fmt.Sprintf(`
@@ -227,11 +227,11 @@ resource "huaweicloud_apig_plugin" "test" {
 		acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
 }
 
-func testAccPluginAssociate_basic_step1(baseConfig string) string {
+func testAccPluginBatchApisAssociate_basic_step1(baseConfig string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_apig_plugin_associate" "part1" {
+resource "huaweicloud_apig_plugin_batch_apis_associate" "part1" {
   depends_on = [huaweicloud_apig_api_publishment.test]
 
   instance_id = local.instance_id
@@ -240,7 +240,7 @@ resource "huaweicloud_apig_plugin_associate" "part1" {
   api_ids     = slice(huaweicloud_apig_api.test[*].id, 0, 2)
 }
 
-resource "huaweicloud_apig_plugin_associate" "part2" {
+resource "huaweicloud_apig_plugin_batch_apis_associate" "part2" {
   depends_on = [huaweicloud_apig_api_publishment.test]
 
   instance_id = local.instance_id
@@ -251,16 +251,16 @@ resource "huaweicloud_apig_plugin_associate" "part2" {
 `, baseConfig)
 }
 
-func testAccPluginAssociate_basic_step2(baseConfig string) string {
+func testAccPluginBatchApisAssociate_basic_step2(baseConfig string) string {
 	// Refresh the api_ids for all plugin associate resources.
-	return testAccPluginAssociate_basic_step1(baseConfig)
+	return testAccPluginBatchApisAssociate_basic_step1(baseConfig)
 }
 
-func testAccPluginAssociate_basic_step3(baseConfig string) string {
+func testAccPluginBatchApisAssociate_basic_step3(baseConfig string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_apig_plugin_associate" "part1" {
+resource "huaweicloud_apig_plugin_batch_apis_associate" "part1" {
   depends_on = [huaweicloud_apig_api_publishment.test]
 
   instance_id = local.instance_id
@@ -269,7 +269,7 @@ resource "huaweicloud_apig_plugin_associate" "part1" {
   api_ids     = slice(huaweicloud_apig_api.test[*].id, 0, 1)
 }
 
-resource "huaweicloud_apig_plugin_associate" "part2" {
+resource "huaweicloud_apig_plugin_batch_apis_associate" "part2" {
   depends_on = [huaweicloud_apig_api_publishment.test]
 
   instance_id = local.instance_id

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_plugin_batch_apis_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_plugin_batch_apis_associate.go
@@ -18,21 +18,21 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-var strSliceParamKeysForPluginAssociate = []string{"api_ids"}
+var strSliceParamKeysForPluginBatchApisAssociate = []string{"api_ids"}
 
-// ResourcePluginAssociate defines the provider resource of the APIG plugin binding.
+// ResourcePluginBatchApisAssociate defines the provider resource of the APIG plugin binding.
 // @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}/plugins/{plugin_id}/detach
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/plugins/{plugin_id}/attached-apis
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/plugins/{plugin_id}/attach
-func ResourcePluginAssociate() *schema.Resource {
+func ResourcePluginBatchApisAssociate() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourcePluginAssociateCreate,
-		ReadContext:   resourcePluginAssociateRead,
-		UpdateContext: resourcePluginAssociateUpdate,
-		DeleteContext: resourcePluginAssociateDelete,
+		CreateContext: resourcePluginBatchApisAssociateCreate,
+		ReadContext:   resourcePluginBatchApisAssociateRead,
+		UpdateContext: resourcePluginBatchApisAssociateUpdate,
+		DeleteContext: resourcePluginBatchApisAssociateDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: resourcePluginAssociateImportState,
+			StateContext: resourcePluginBatchApisAssociateImportState,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -122,7 +122,7 @@ func bindPluginToApis(client *golangsdk.ServiceClient, instanceId, pluginId, env
 	return nil
 }
 
-func resourcePluginAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePluginBatchApisAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg    = meta.(*config.Config)
 		region = cfg.GetRegion(d)
@@ -153,13 +153,13 @@ func resourcePluginAssociateCreate(ctx context.Context, d *schema.ResourceData, 
 	// If the request is successful, obtain the values of all slice parameters first and save them to the corresponding
 	// '_origin' attributes for subsequent determination and construction of the request body during next updates.
 	// And whether corresponding parameters are changed, the origin values must be refreshed.
-	err = utils.RefreshSliceParamOriginValues(d, strSliceParamKeysForPluginAssociate)
+	err = utils.RefreshSliceParamOriginValues(d, strSliceParamKeysForPluginBatchApisAssociate)
 	if err != nil {
 		// Don't fail the creation if origin refresh fails
 		log.Printf("[WARN] Unable to refresh the origin values: %s", err)
 	}
 
-	return resourcePluginAssociateRead(ctx, d, meta)
+	return resourcePluginBatchApisAssociateRead(ctx, d, meta)
 }
 
 func listPluginBoundApisUnderEnv(client *golangsdk.ServiceClient, instanceId, pluginId, envId string) ([]interface{}, error) {
@@ -237,7 +237,7 @@ func GetLocalBoundApiIdsForPlugin(client *golangsdk.ServiceClient, instanceId, p
 	return boundApiIds, nil
 }
 
-func resourcePluginAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePluginBatchApisAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg    = meta.(*config.Config)
 		region = cfg.GetRegion(d)
@@ -336,7 +336,7 @@ func unbindPluginFromApis(client *golangsdk.ServiceClient, instanceId, pluginId,
 	return mErr.ErrorOrNil()
 }
 
-func resourcePluginAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePluginBatchApisAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
@@ -383,16 +383,16 @@ func resourcePluginAssociateUpdate(ctx context.Context, d *schema.ResourceData, 
 	// If the request is successful, obtain the values of all slice parameters first and save them to the corresponding
 	// '_origin' attributes for subsequent determination and construction of the request body during next updates.
 	// And whether corresponding parameters are changed, the origin values must be refreshed.
-	err = utils.RefreshSliceParamOriginValues(d, strSliceParamKeysForPluginAssociate)
+	err = utils.RefreshSliceParamOriginValues(d, strSliceParamKeysForPluginBatchApisAssociate)
 	if err != nil {
 		// Don't fail the update if origin refresh fails
 		log.Printf("[WARN] Unable to refresh the origin values: %s", err)
 	}
 
-	return resourcePluginAssociateRead(ctx, d, meta)
+	return resourcePluginBatchApisAssociateRead(ctx, d, meta)
 }
 
-func resourcePluginAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePluginBatchApisAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
@@ -420,7 +420,7 @@ func resourcePluginAssociateDelete(_ context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func resourcePluginAssociateImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+func resourcePluginBatchApisAssociateImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
 	error) {
 	importedId := d.Id()
 	parts := strings.Split(importedId, "/")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Rename the plugin associate resource from `huaweicloud_apig_plugin_associate` to `huaweicloud_apig_plugin_batch_apis_associate`.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. rename the plugin associate resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccPluginBatchApisAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccPluginBatchApisAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccPluginBatchApisAssociate_basic
=== PAUSE TestAccPluginBatchApisAssociate_basic
=== CONT  TestAccPluginBatchApisAssociate_basic
--- PASS: TestAccPluginBatchApisAssociate_basic (251.58s)
PASS
coverage: 10.7% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      251.694s        coverage: 10.7% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
