### PR TITLE
fix(dms): fix maintain time input is inconsistent with query format

### DIFF
--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_instance_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_instance_test.go
@@ -51,6 +51,8 @@ func TestAccKafkaInstance_prePaid(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
 				),
 			},
 			{
@@ -62,6 +64,8 @@ func TestAccKafkaInstance_prePaid(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform_update"),
 					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "02:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "06:00:00"),
 				),
 			},
 			{
@@ -119,6 +123,8 @@ func TestAccKafkaInstance_newFormat(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cross_vpc_accesses.2.advertised_ip", "192.168.0.53"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "log.retention.hours"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "48"),
+					resource.TestCheckResourceAttrSet(resourceName, "maintain_begin"),
+					resource.TestCheckResourceAttrSet(resourceName, "maintain_end"),
 				),
 			},
 			{
@@ -140,6 +146,8 @@ func TestAccKafkaInstance_newFormat(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cross_vpc_accesses.3.advertised_ip", "192.168.0.63"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "auto.create.groups.enable"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "false"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
 				),
 			},
 		},
@@ -306,6 +314,8 @@ resource "huaweicloud_dms_kafka_instance" "test" {
   password           = "Kafkatest@123"
   security_protocol  = "SASL_PLAINTEXT"
   enabled_mechanisms = ["SCRAM-SHA-512"]
+  maintain_begin     = "06:00:00"
+  maintain_end       = "10:00:00"
 
   cross_vpc_accesses {
     advertised_ip = "192.168.0.61"
@@ -360,6 +370,8 @@ resource "huaweicloud_dms_kafka_instance" "test" {
 
   manager_user     = "kafka-user"
   manager_password = "Kafkatest@123"
+  maintain_begin   = "06:00"
+  maintain_end     = "10:00"
 
   charging_mode = "prePaid"
   period_unit   = "month"
@@ -407,6 +419,8 @@ resource "huaweicloud_dms_kafka_instance" "test" {
 
   manager_user     = "kafka-user"
   manager_password = "Kafkatest@123"
+  maintain_begin   = "02:00"
+  maintain_end     = "06:00"
 
   charging_mode = "prePaid"
   period_unit   = "month"

--- a/huaweicloud/services/acceptance/rabbitmq/resource_huaweicloud_dms_rabbitmq_instance_test.go
+++ b/huaweicloud/services/acceptance/rabbitmq/resource_huaweicloud_dms_rabbitmq_instance_test.go
@@ -47,6 +47,8 @@ func TestAccDmsRabbitmqInstances_newFormat_cluster(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "rabbitmq test"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttrSet(resourceName, "maintain_begin"),
+					resource.TestCheckResourceAttrSet(resourceName, "maintain_end"),
 					resource.TestMatchResourceAttr(resourceName, "created_at",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
@@ -59,6 +61,8 @@ func TestAccDmsRabbitmqInstances_newFormat_cluster(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "rabbitmq test update"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform_update"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
 				),
 			},
 			{
@@ -97,6 +101,8 @@ func TestAccDmsRabbitmqInstances_newFormat_single(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "rabbitmq test"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
 				),
 			},
 			{
@@ -107,6 +113,8 @@ func TestAccDmsRabbitmqInstances_newFormat_single(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "rabbitmq test update"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform_update"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "02:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "06:00:00"),
 				),
 			},
 			{
@@ -396,7 +404,9 @@ resource "huaweicloud_dms_rabbitmq_instance" "test" {
   broker_num        = 5
   access_user       = "user"
   password          = "Rabbitmqtest@123"
-
+  maintain_begin    = "06:00:00"
+  maintain_end      = "10:00:00"
+  
   tags = {
     key1  = "value"
     owner = "terraform_update"
@@ -437,6 +447,8 @@ resource "huaweicloud_dms_rabbitmq_instance" "test" {
   access_user       = "user"
   password          = "Rabbitmqtest@123"
   broker_num        = 1
+  maintain_begin    = "06:00"
+  maintain_end      = "10:00"
 
   tags = {
     key   = "value"
@@ -479,6 +491,8 @@ resource "huaweicloud_dms_rabbitmq_instance" "test" {
   access_user       = "user"
   password          = "Rabbitmqtest@123"
   broker_num        = 1
+  maintain_begin    = "02:00"
+  maintain_end      = "06:00"
 
   tags = {
     key1  = "value"

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance.go
@@ -177,15 +177,24 @@ func ResourceDmsKafkaInstance() *schema.Resource {
 				},
 				Description: "schema: Internal",
 			},
+			// The API return format is "HH:mm:ss" for `maintain_begin` and `maintain_end`.
 			"maintain_begin": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				DiffSuppressFunc: func(_, o, n string, _ *schema.ResourceData) bool {
+					log.Printf("[DEBUG] maintain_begin DiffSuppressFunc: %s, %s", o, n)
+					log.Printf("[DEBUG] maintain_begin: %v", regexp.MustCompile(fmt.Sprintf("^%s", n)).MatchString(o))
+					return regexp.MustCompile(fmt.Sprintf("^%s", n)).MatchString(o)
+				},
 			},
 			"maintain_end": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				DiffSuppressFunc: func(_, o, n string, _ *schema.ResourceData) bool {
+					return regexp.MustCompile(fmt.Sprintf("^%s", n)).MatchString(o)
+				},
 			},
 			"public_ip_ids": {
 				Type:     schema.TypeSet,

--- a/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_instance.go
+++ b/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_instance.go
@@ -135,15 +135,22 @@ func ResourceDmsRabbitmqInstance() *schema.Resource {
 				Computed:     true,
 				RequiredWith: []string{"flavor_id"},
 			},
+			// The API return format is "HH:mm:ss" for `maintain_begin` and `maintain_end`.
 			"maintain_begin": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				DiffSuppressFunc: func(_, o, n string, _ *schema.ResourceData) bool {
+					return regexp.MustCompile(fmt.Sprintf("^%s", n)).MatchString(o)
+				},
 			},
 			"maintain_end": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				DiffSuppressFunc: func(_, o, n string, _ *schema.ResourceData) bool {
+					return regexp.MustCompile(fmt.Sprintf("^%s", n)).MatchString(o)
+				},
 			},
 			"ssl_enable": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fixed the issue where the `maintain_begin` and `maintain_end` parameter input format was inconsistent with the query format. The input format was `HH:mm`, but the query API returned the format as `HH:mm:ss`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccKafkaInstance_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccKafkaInstance_ -timeout 360m -parallel 10
=== RUN   TestAccKafkaInstance_prePaid
=== PAUSE TestAccKafkaInstance_prePaid
=== RUN   TestAccKafkaInstance_newFormat
=== PAUSE TestAccKafkaInstance_newFormat
=== RUN   TestAccKafkaInstance_publicIp
=== PAUSE TestAccKafkaInstance_publicIp
=== CONT  TestAccKafkaInstance_prePaid
=== CONT  TestAccKafkaInstance_publicIp
=== CONT  TestAccKafkaInstance_newFormat
--- PASS: TestAccKafkaInstance_prePaid (854.18s)
--- PASS: TestAccKafkaInstance_publicIp (1463.47s)
--- PASS: TestAccKafkaInstance_newFormat (2547.12s)
PASS
coverage: 21.9% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     2547.234s       coverage: 21.9% of statements in ./huaweicloud/services/kafka
```
```
 ./scripts/coverage.sh -o rabbitmq -f TestAccDmsRabbitmqInstances_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rabbitmq" -v -coverprofile="./huaweicloud/services/acceptance/rabbitmq/rabbitmq_coverage.cov" -coverpkg="./huaweicloud/services/rabbitmq" -run TestAccDmsRabbitmqInstances_ -timeout 360m -parallel 10
=== RUN   TestAccDmsRabbitmqInstances_newFormat_cluster
=== PAUSE TestAccDmsRabbitmqInstances_newFormat_cluster
=== RUN   TestAccDmsRabbitmqInstances_newFormat_single
=== PAUSE TestAccDmsRabbitmqInstances_newFormat_single
=== RUN   TestAccDmsRabbitmqInstances_prePaid
=== PAUSE TestAccDmsRabbitmqInstances_prePaid
=== RUN   TestAccDmsRabbitmqInstances_compatible
=== PAUSE TestAccDmsRabbitmqInstances_compatible
=== RUN   TestAccDmsRabbitmqInstances_publicID
=== PAUSE TestAccDmsRabbitmqInstances_publicID
=== RUN   TestAccDmsRabbitmqInstances_amqp_single
=== PAUSE TestAccDmsRabbitmqInstances_amqp_single
=== CONT  TestAccDmsRabbitmqInstances_newFormat_cluster
=== CONT  TestAccDmsRabbitmqInstances_compatible
=== CONT  TestAccDmsRabbitmqInstances_prePaid
=== CONT  TestAccDmsRabbitmqInstances_newFormat_single
=== CONT  TestAccDmsRabbitmqInstances_amqp_single
=== CONT  TestAccDmsRabbitmqInstances_publicID
--- PASS: TestAccDmsRabbitmqInstances_compatible (585.21s)
--- PASS: TestAccDmsRabbitmqInstances_amqp_single (647.06s)
--- PASS: TestAccDmsRabbitmqInstances_publicID (706.30s)
--- PASS: TestAccDmsRabbitmqInstances_prePaid (819.09s)
--- PASS: TestAccDmsRabbitmqInstances_newFormat_single (1023.86s)
--- PASS: TestAccDmsRabbitmqInstances_newFormat_cluster (2369.85s)
PASS
coverage: 17.7% of statements in ./huaweicloud/services/rabbitmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rabbitmq  2369.939s       coverage: 17.7% of statements in ./huaweicloud/services/rabbitmq
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
