### PR TITLE
feat(apig): add new resource to associate plugins to API

### DIFF
--- a/docs/resources/apig_api_batch_plugins_associate.md
+++ b/docs/resources/apig_api_batch_plugins_associate.md
@@ -1,0 +1,70 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_api_batch_plugins_associate"
+description: |-
+  Use this resource to bind the plugins to the API within HuaweiCloud.
+---
+
+# huaweicloud_apig_api_batch_plugins_associate
+
+Use this resource to bind the plugins to the API within HuaweiCloud.
+
+~> Before binding the plugins, please make sure the API has been published, otherwise you will receive a service error.
+
+-> If this resource was imported and no changes were deployed before deletion (a increase change must be triggered to
+   apply the `plugin_ids` configured in the script), terraform will delete all bound plugins for current configured API
+   in specified publish environment. Otherwise, terraform will only delete the bound plugins managed by the last change.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "published_api_id" {}
+variable "published_env_id" {}
+variable "plugin_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_apig_api_batch_plugins_associate" "test" {
+  instance_id = var.instance_id
+  api_id      = var.published_api_id
+  env_id      = var.published_env_id
+  plugin_ids  = var.plugin_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the API and plugins are located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the dedicated instance to which the API and
+  plugins belong.
+
+* `api_id` - (Required, String, NonUpdatable) Specifies the ID of the API to be bound with plugins.
+
+* `env_id` - (Required, String, NonUpdatable) Specifies the ID of the environment where the API is published.
+
+* `plugin_ids` - (Required, List) Specifies the list of plugin IDs to be bound to the API.
+
+  -> Only one plugin of each type can be bound to an API.
+     <br>For example, when two CORS plugins are bound to one API, the later-bound plugin will overwrite the previous
+     plugin of the same type, causing the list to always prompt changes.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, the format is `{instance_id}/{api_id}/{env_id}`.
+
+## Import
+
+All associated plugins for the specified API can be imported using the related instance ID, application ID and the
+published environment ID, separated by the slashes, e.g.
+
+```bash
+terraform import huaweicloud_apig_api_batch_plugins_associate.test <instance_id>/<api_id>/<env_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2057,6 +2057,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_api":                            apig.ResourceApigAPIV2(),
 			"huaweicloud_apig_api_action":                     apig.ResourceApigApiAction(),
 			"huaweicloud_apig_api_batch_action":               apig.ResourceApigApiBatchAction(),
+			"huaweicloud_apig_api_batch_plugins_associate":    apig.ResourceApiBatchPluginsAssociate(),
 			"huaweicloud_apig_api_check":                      apig.ResourceApiCheck(),
 			"huaweicloud_apig_api_debug":                      apig.ResourceApigApiDebug(),
 			"huaweicloud_apig_api_publishment":                apig.ResourceApigApiPublishment(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_batch_plugins_associate_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_batch_plugins_associate_test.go
@@ -1,0 +1,416 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getApiBatchPluginsAssociateFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient(acceptance.HW_REGION_NAME, "apig")
+	if err != nil {
+		return nil, fmt.Errorf("error creating APIG client: %s", err)
+	}
+
+	return apig.GetLocalBoundPluginIdsForApi(client, state.Primary.Attributes["instance_id"],
+		state.Primary.Attributes["api_id"], state.Primary.Attributes["env_id"],
+		utils.ParseStateAttributeToListWithSeparator(state.Primary.Attributes["plugin_ids_origin"], ","))
+}
+
+func TestAccApiBatchPluginsAssociate_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceNamePart1 = "huaweicloud_apig_api_batch_plugins_associate.part1"
+		resourceNamePart2 = "huaweicloud_apig_api_batch_plugins_associate.part2"
+		rcPart1           = acceptance.InitResourceCheck(resourceNamePart1, &obj, getApiBatchPluginsAssociateFunc)
+		rcPart2           = acceptance.InitResourceCheck(resourceNamePart2, &obj, getApiBatchPluginsAssociateFunc)
+		baseConfig        = testAccApiBatchPluginsAssociate_base()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+			acceptance.TestAccPreCheckApigChannelRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcPart1.CheckResourceDestroy(),
+			rcPart2.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApiBatchPluginsAssociate_basic_step1(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rcPart1.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceNamePart1, "plugin_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceNamePart1, "plugin_ids_origin.#", "2"),
+					rcPart2.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceNamePart2, "plugin_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceNamePart2, "plugin_ids_origin.#", "1"),
+				),
+			},
+			{
+				Config: testAccApiBatchPluginsAssociate_basic_step2(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rcPart1.CheckResourceExists(),
+					// After resources refreshed, the plugin_ids will be overridden as all plugins under the same
+					// environment are bound.
+					resource.TestCheckResourceAttr(resourceNamePart1, "plugin_ids.#", "3"),
+					resource.TestCheckResourceAttr(resourceNamePart1, "plugin_ids_origin.#", "2"),
+					rcPart2.CheckResourceExists(),
+					// After resources refreshed, the plugin_ids will be overridden as all plugins under the same
+					// environment are bound.
+					resource.TestCheckResourceAttr(resourceNamePart2, "plugin_ids.#", "3"),
+					resource.TestCheckResourceAttr(resourceNamePart2, "plugin_ids_origin.#", "1"),
+				),
+			},
+			{
+				Config: testAccApiBatchPluginsAssociate_basic_step3(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rcPart1.CheckResourceExists(),
+					// When multiple resources are used to manage the same function, plugin_ids will store the results
+					// modified by other resources, resulting in plugin_ids displaying all binding results except for the
+					// first change.
+					resource.TestMatchResourceAttr(resourceNamePart1, "plugin_ids.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(resourceNamePart1, "plugin_ids_origin.#", "1"),
+					rcPart2.CheckResourceExists(),
+					resource.TestMatchResourceAttr(resourceNamePart2, "plugin_ids.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(resourceNamePart2, "plugin_ids_origin.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceNamePart1,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"plugin_ids",
+				},
+			},
+			{
+				// After resource part1 is imported, then plugin_ids will be overridden as all plugins under the same
+				// environment are bound.
+				Config: testAccApiBatchPluginsAssociate_basic_step3(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rcPart1.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceNamePart1, "plugin_ids.#", "3"),
+					resource.TestCheckResourceAttr(resourceNamePart1, "plugin_ids_origin.#", "1"),
+					rcPart2.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceNamePart2, "plugin_ids.#", "3"),
+					resource.TestCheckResourceAttr(resourceNamePart2, "plugin_ids_origin.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccApiBatchPluginsAssociate_base() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  system_disk_type   = "SSD"
+
+  network {
+    uuid = "%[3]s"
+  }
+}
+
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[4]s"
+}
+
+locals {
+  instance_id = data.huaweicloud_apig_instances.test.instances[0].id
+}
+
+resource "huaweicloud_apig_group" "test" {
+  name        = "%[2]s"
+  instance_id = local.instance_id
+}
+
+resource "huaweicloud_apig_channel" "test" {
+  instance_id      = local.instance_id
+  name             = "%[2]s"
+  port             = 8000
+  balance_strategy = 2
+  member_type      = "ecs"
+  type             = 2
+
+  health_check {
+    protocol           = "HTTPS"
+    threshold_normal   = 10  # maximum value
+    threshold_abnormal = 10  # maximum value
+    interval           = 300 # maximum value
+    timeout            = 30  # maximum value
+    path               = "/"
+    method             = "HEAD"
+    port               = 8080
+    http_codes         = "201,202,303-404"
+  }
+
+  member {
+    id   = huaweicloud_compute_instance.test.id
+    name = huaweicloud_compute_instance.test.name
+  }
+}
+
+resource "huaweicloud_apig_api" "test" {
+  instance_id             = local.instance_id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[2]s"
+  type                    = "Public"
+  request_protocol        = "HTTP"
+  request_method          = "PATCH"
+  request_path            = "/user_info"
+  security_authentication = "APP"
+  matching                = "Exact"
+
+  web {
+    path             = "/getUserAge"
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 30000
+  }
+}
+
+resource "huaweicloud_apig_environment" "test" {
+  instance_id = local.instance_id
+  name        = "%[2]s"
+}
+
+resource "huaweicloud_apig_api_publishment" "test" {
+  instance_id = local.instance_id
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+}
+
+resource "huaweicloud_apig_application" "test" {
+  instance_id = local.instance_id
+  name        = "%[2]s"
+}
+
+resource "huaweicloud_apig_plugin" "http_response" {
+  instance_id = local.instance_id
+  name        = "%[2]s_http_response"
+  type        = "set_resp_headers"
+  content     = jsonencode(
+    {
+      response_headers = [{
+        name       = "X-Custom-Pwd"
+        value      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        value_type = "custom_value"
+        action     = "delete"
+      },
+      {
+        name       = "X-Custom-Log-PATH"
+        value      = "/tmp/debug.log"
+        value_type = "custom_value"
+        action     = "add"
+      },
+      {
+        name       = "Sys-Param-updated"
+        value      = "$context.cacheStatus"
+        value_type = "system_parameter"
+        action     = "append"
+      }]
+    }
+  )
+}
+
+resource "huaweicloud_apig_plugin" "cors" {
+  instance_id = local.instance_id
+  name        = "%[2]s_cors"
+  type        = "cors"
+  content     = jsonencode(
+    {
+      allow_origin      = "*.terraform.test.com"
+      allow_methods     = "POST,PATCH"
+      allow_headers     = "Content-Type,Accept,Accept-Ranges"
+      expose_headers    = "X-Request-Id,X-Apig-Auth-Type"
+      max_age           = 800
+      allow_credentials = false
+    }
+  )
+}
+
+resource "huaweicloud_apig_plugin" "third_auth" {
+  instance_id = local.instance_id
+  name        = "%[2]s_third_auth"
+  type        = "third_auth"
+  content     = jsonencode({
+    "auth_downgrade_enabled": true,
+    "auth_request": {
+      "method": "GET",
+      "path": "/test",
+      "protocol": "HTTPS",
+      "timeout": 5000,
+      "url_domain": "",
+      "vpc_channel_enabled": true,
+      "vpc_channel_info": {
+        "vpc_id": huaweicloud_apig_channel.test.id,
+        "vpc_proxy_host": "test"
+      }
+    },
+    "carry_body": {
+      "enabled": true,
+      "max_body_size": 1000
+    }
+    "carry_path_enabled": true,
+    "carry_resp_headers": [],
+    "custom_forbid_limit": 100,
+    "identities": {
+      "headers": [
+        {
+          "name": "X-Custom-Token"
+        }
+      ],
+      "queries": null
+    },
+    "match_auth": null,
+    "parameters": null,
+    "rules": null,
+    "return_resp_body_enabled": false,
+    "rule_enabled":  false,
+    "rule_type": "allow",
+    "simple_auth_mode_enabled": true
+  })
+}
+
+resource "huaweicloud_apig_plugin" "rate_limit" {
+  instance_id = local.instance_id
+  name        = "%[2]s_rate_limit"
+  type        = "rate_limit"
+  content     = jsonencode(
+    {
+      "scope": "basic",
+      "default_time_unit": "minute",
+      "default_interval": 2,
+      "api_limit": 35,
+      "app_limit": 15,
+      "user_limit": 25,
+      "ip_limit": 30,
+      "algorithm": "haht",
+      "specials": [
+        {
+          "type": "app",
+          "policies": [
+            {
+              "key": huaweicloud_apig_application.test.id,
+              "limit": 15
+            }
+          ]
+        },
+      ],
+      "parameters": [
+        {
+          "type": "system",
+          "name": "serverName",
+          "value": "serverName"
+        },
+      ],
+      "rules": [
+        {
+          "rule_name": "rule-0003",
+          "match_regex": "[\"serverName\",\"==\",\"terraform\"]",
+          "time_unit": "minute",
+          "interval": 1,
+          "limit": 15
+        },
+      ]
+    }
+  )
+}
+`, common.TestBaseComputeResources(name), name,
+		acceptance.HW_APIG_DEDICATED_INSTANCE_USED_SUBNET_ID,
+		acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
+}
+
+func testAccApiBatchPluginsAssociate_basic_step1(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_api_batch_plugins_associate" "part1" {
+  instance_id = local.instance_id
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  plugin_ids  = [
+    huaweicloud_apig_plugin.http_response.id,
+    huaweicloud_apig_plugin.third_auth.id,
+  ]
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+resource "huaweicloud_apig_api_batch_plugins_associate" "part2" {
+  instance_id = local.instance_id
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  plugin_ids  = [
+    huaweicloud_apig_plugin.cors.id,
+  ]
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+`, baseConfig)
+}
+
+func testAccApiBatchPluginsAssociate_basic_step2(baseConfig string) string {
+	// Refresh the plugin_ids for all api batch plugins associate resources.
+	return testAccApiBatchPluginsAssociate_basic_step1(baseConfig)
+}
+
+func testAccApiBatchPluginsAssociate_basic_step3(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_api_batch_plugins_associate" "part1" {
+  instance_id = local.instance_id
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  plugin_ids  = [
+    huaweicloud_apig_plugin.http_response.id,
+  ]
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+resource "huaweicloud_apig_api_batch_plugins_associate" "part2" {
+  instance_id = local.instance_id
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  plugin_ids  = [
+    huaweicloud_apig_plugin.cors.id,
+    huaweicloud_apig_plugin.rate_limit.id,
+  ]
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+`, baseConfig)
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_api_batch_plugins_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_api_batch_plugins_associate.go
@@ -1,0 +1,481 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	strSliceParamKeysForApiBatchPluginsAssociate = []string{
+		"plugin_ids",
+	}
+	apiBatchPluginsAssociateNonUpdatableParams = []string{
+		"instance_id",
+		"api_id",
+		"env_id",
+	}
+)
+
+// @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/apis/{api_id}/plugins/attach
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/apis/{api_id}/attached-plugins
+// @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}/apis/{api_id}/plugins/detach
+func ResourceApiBatchPluginsAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceApiBatchPluginsAssociateCreate,
+		ReadContext:   resourceApiBatchPluginsAssociateRead,
+		UpdateContext: resourceApiBatchPluginsAssociateUpdate,
+		DeleteContext: resourceApiBatchPluginsAssociateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceApiBatchPluginsAssociateImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(apiBatchPluginsAssociateNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the API and plugins are located.",
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the dedicated instance to which the API and plugins belong.",
+			},
+			"api_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the API to be bound with plugins.",
+			},
+			"env_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the environment where the API is published.",
+			},
+			"plugin_ids": {
+				Type:             schema.TypeSet,
+				Required:         true,
+				Description:      `The list of plugin IDs to be bound to the API.`,
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: utils.SuppressStrSliceDiffs(),
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+
+			// Internal attributes.
+			"plugin_ids_origin": {
+				Type:             schema.TypeList,
+				Optional:         true,
+				Computed:         true,
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: utils.SuppressDiffAll,
+				Description: utils.SchemaDesc(
+					`The script configuration value of this change is also the original value used for comparison with
+the new value next time the change is made. The corresponding parameter name is 'plugin_ids'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func bindPluginsToApi(client *golangsdk.ServiceClient, instanceId, apiId, envId string, pluginIds []interface{}) error {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/apis/{api_id}/plugins/attach"
+	bindPath := client.Endpoint + httpUrl
+	bindPath = strings.ReplaceAll(bindPath, "{project_id}", client.ProjectID)
+	bindPath = strings.ReplaceAll(bindPath, "{instance_id}", instanceId)
+	bindPath = strings.ReplaceAll(bindPath, "{api_id}", apiId)
+
+	bindOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"env_id":     envId,
+			"plugin_ids": pluginIds,
+		},
+	}
+
+	requestBody, err := client.Request("POST", bindPath, &bindOpt)
+	if err != nil {
+		return fmt.Errorf("error binding plugins to API (%s) under dedicated instance (%s): %s", apiId, instanceId, err)
+	}
+	respBody, err := utils.FlattenResponse(requestBody)
+	if err != nil {
+		return err
+	}
+
+	// Check for failed bindings
+	failedPluginRecords := utils.PathSearch("attached_plugins[?attached_plugins.status=='FAILED'].plugin_id", respBody,
+		make([]interface{}, 0)).([]interface{})
+	if len(failedPluginRecords) > 0 {
+		return fmt.Errorf("error binding plugins to API (%s) under dedicated instance (%s), the failed plugin IDs are: %s",
+			apiId, instanceId, failedPluginRecords)
+	}
+	return nil
+}
+
+func resourceApiBatchPluginsAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient(region, "apig")
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	var (
+		instanceId = d.Get("instance_id").(string)
+		apiId      = d.Get("api_id").(string)
+		envId      = d.Get("env_id").(string)
+		pluginIds  = d.Get("plugin_ids").(*schema.Set).List()
+		resourceId = fmt.Sprintf("%s/%s/%s", instanceId, apiId, envId)
+	)
+	// Lock the resource to prevent concurrent updates (error APIG.3500 will be returned if the etcd data synchronize
+	// failed)
+	config.MutexKV.Lock(resourceId)
+	defer config.MutexKV.Unlock(resourceId)
+
+	err = bindPluginsToApi(client, instanceId, apiId, envId, pluginIds)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(resourceId)
+
+	// If the request is successful, obtain the values of all slice parameters first and save them to the corresponding
+	// '_origin' attributes for subsequent determination and construction of the request body during next updates.
+	// And whether corresponding parameters are changed, the origin values must be refreshed.
+	err = utils.RefreshSliceParamOriginValues(d, strSliceParamKeysForApiBatchPluginsAssociate)
+	if err != nil {
+		// Don't fail the creation if origin refresh fails
+		log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+	}
+
+	return resourceApiBatchPluginsAssociateRead(ctx, d, meta)
+}
+
+func listApiBoundPluginsUnderEnv(client *golangsdk.ServiceClient, instanceId, apiId, envId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/apigw/instances/{instance_id}/apis/{api_id}/attached-plugins?env_id={env_id}&limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{api_id}", apiId)
+	listPath = strings.ReplaceAll(listPath, "{env_id}", envId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestBody, err := client.Request("GET", listPathWithOffset, &getOpt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestBody)
+		if err != nil {
+			return nil, err
+		}
+
+		boundPlugins := utils.PathSearch("plugins", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, boundPlugins...)
+		if len(boundPlugins) < limit {
+			break
+		}
+		offset += limit
+	}
+	if len(result) < 1 {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v2/{project_id}/apigw/instances/{instance_id}/apis/{api_id}/attached-plugins",
+				RequestId: "NONE",
+				Body:      []byte("all plugins are not bound to the API"),
+			},
+		}
+	}
+	return result, nil
+}
+
+func GetLocalBoundPluginIdsForApi(client *golangsdk.ServiceClient, instanceId, apiId, envId string,
+	originPluginIds []interface{}) ([]interface{}, error) {
+	boundPlugins, err := listApiBoundPluginsUnderEnv(client, instanceId, apiId, envId)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract plugin IDs from the bound plugins
+	boundPluginIds := utils.PathSearch("[*].plugin_id", boundPlugins, make([]interface{}, 0)).([]interface{})
+	if len(originPluginIds) > 0 && len(utils.FildSliceIntersection(boundPluginIds, originPluginIds)) < 1 {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v2/{project_id}/apigw/instances/{instance_id}/apis/{api_id}/attached-plugins",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("all locally managed plugins have been unbound: %v", originPluginIds)),
+			},
+		}
+	}
+	return boundPluginIds, nil
+}
+
+func resourceApiBatchPluginsAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient(region, "apig")
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	var (
+		instanceId      = d.Get("instance_id").(string)
+		apiId           = d.Get("api_id").(string)
+		envId           = d.Get("env_id").(string)
+		originPluginIds = d.Get("plugin_ids_origin").([]interface{})
+	)
+
+	boundPluginIds, err := GetLocalBoundPluginIdsForApi(client, instanceId, apiId, envId, originPluginIds)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error querying bound plugins from API (%s) under specified environment (%s)",
+			apiId, envId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("plugin_ids", boundPluginIds),
+	)
+
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving binding fields for specified API (%s): %s", apiId, err)
+	}
+
+	return nil
+}
+
+func unbindPluginsFromApi(client *golangsdk.ServiceClient, instanceId, apiId, envId string, pluginIds []string) error {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/apis/{api_id}/plugins/detach"
+	unbindPath := client.Endpoint + httpUrl
+	unbindPath = strings.ReplaceAll(unbindPath, "{project_id}", client.ProjectID)
+	unbindPath = strings.ReplaceAll(unbindPath, "{instance_id}", instanceId)
+	unbindPath = strings.ReplaceAll(unbindPath, "{api_id}", apiId)
+
+	unbindOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"env_id":     envId,
+			"plugin_ids": pluginIds,
+		},
+		OkCodes: []int{204},
+	}
+
+	_, err := client.Request("PUT", unbindPath, &unbindOpt)
+	if err != nil {
+		return fmt.Errorf("error unbinding plugins (%v) from API (%s) under specified environment (%s): %s", pluginIds, apiId, envId, err)
+	}
+	return nil
+}
+
+func unbindPluginsFromApis(client *golangsdk.ServiceClient, instanceId, apiId, envId string, pluginIds []interface{}) error {
+	notFoundErr := fmt.Sprintf("[DEBUG] All plugins have been unbound from API (%s) under dedicated instance (%s)", apiId, instanceId)
+
+	boundPlugins, err := listApiBoundPluginsUnderEnv(client, instanceId, apiId, envId)
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			log.Println(notFoundErr)
+			return nil
+		}
+		return fmt.Errorf("error querying bound plugins for API (%s) under dedicated instance (%s): %s", apiId, instanceId, err)
+	}
+
+	var (
+		mErr                     *multierror.Error
+		prepareToUnbindPluginIds = make([]string, 0)
+	)
+	for _, pluginId := range pluginIds {
+		boundPluginId := utils.PathSearch(fmt.Sprintf("[?plugin_id=='%s'].plugin_id|[0]", pluginId), boundPlugins, "").(string)
+		if boundPluginId == "" {
+			log.Printf("[DEBUG] Unable to find the bound plugin ID (%s), so skip this unbinding", pluginId)
+			continue
+		}
+		prepareToUnbindPluginIds = append(prepareToUnbindPluginIds, boundPluginId)
+	}
+
+	if len(prepareToUnbindPluginIds) < 1 {
+		log.Println(notFoundErr)
+		return nil
+	}
+
+	log.Printf("[DEBUG] Prepare to unbind plugin IDs (%v) from API (%s)", prepareToUnbindPluginIds, apiId)
+	err = unbindPluginsFromApi(client, instanceId, apiId, envId, prepareToUnbindPluginIds)
+	if err != nil {
+		mErr = multierror.Append(mErr, err)
+	}
+
+	return mErr.ErrorOrNil()
+}
+
+func resourceApiBatchPluginsAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient(region, "apig")
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	var (
+		resourceId = d.Id()
+		instanceId = d.Get("instance_id").(string)
+		apiId      = d.Get("api_id").(string)
+		envId      = d.Get("env_id").(string)
+
+		consolePluginIds, scriptPluginIds = d.GetChange("plugin_ids")
+
+		consolePluginIdsList = consolePluginIds.(*schema.Set).List()
+		scriptPluginIdsList  = scriptPluginIds.(*schema.Set).List()
+		originPluginIdsList  = d.Get("plugin_ids_origin").([]interface{})
+	)
+
+	// Lock the resource to prevent concurrent updates (error APIG.3500 will be returned if the etcd data synchronize
+	// failed)
+	config.MutexKV.Lock(resourceId)
+	defer config.MutexKV.Unlock(resourceId)
+
+	newPluginIds := utils.FindSliceElementsNotInAnother(scriptPluginIdsList, consolePluginIdsList)
+	rmPluginIds := utils.FindSliceElementsNotInAnother(originPluginIdsList, scriptPluginIdsList)
+
+	if len(rmPluginIds) > 0 {
+		log.Printf("[DEBUG] Prepare to unbind the specified plugin IDs: %v", rmPluginIds)
+		err := unbindPluginsFromApis(client, instanceId, apiId, envId, rmPluginIds)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if len(newPluginIds) > 0 {
+		log.Printf("[DEBUG] Prepare to bind the specified plugin IDs: %v", newPluginIds)
+		err = bindPluginsToApi(client, instanceId, apiId, envId, newPluginIds)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// If the request is successful, obtain the values of all slice parameters first and save them to the corresponding
+	// '_origin' attributes for subsequent determination and construction of the request body during next updates.
+	// And whether corresponding parameters are changed, the origin values must be refreshed.
+	err = utils.RefreshSliceParamOriginValues(d, strSliceParamKeysForApiBatchPluginsAssociate)
+	if err != nil {
+		// Don't fail the update if origin refresh fails
+		log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+	}
+
+	return resourceApiBatchPluginsAssociateRead(ctx, d, meta)
+}
+
+// getConfiguredPluginIdsForApi retrieves plugin IDs from configuration or origin
+func getConfiguredPluginIdsForApi(d *schema.ResourceData) []interface{} {
+	// Fallback to origin (last known configuration)
+	if origin, ok := d.Get("plugin_ids_origin").([]interface{}); ok && len(origin) > 0 {
+		log.Printf("[DEBUG] Found %d plugin ID(s) from the origin attribute: %v", len(origin), origin)
+		return origin
+	}
+
+	log.Printf("[DEBUG] Unable to find the plugin IDs from the origin attribute, so try to get from current state")
+	// After resource imported, the origin attribute is not set, so try to get from current state
+	current := d.Get("plugin_ids").(*schema.Set).List()
+	log.Printf("[DEBUG] Found %d plugin ID(s) from the current state: %v", len(current), current)
+
+	return current
+}
+
+func resourceApiBatchPluginsAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient(region, "apig")
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	var (
+		resourceId = d.Id()
+		instanceId = d.Get("instance_id").(string)
+		apiId      = d.Get("api_id").(string)
+		envId      = d.Get("env_id").(string)
+
+		rmPluginIds = getConfiguredPluginIdsForApi(d)
+	)
+
+	// Lock the resource to prevent concurrent updates (error APIG.3500 will be returned if the etcd data synchronize
+	// failed)
+	config.MutexKV.Lock(resourceId)
+	defer config.MutexKV.Unlock(resourceId)
+
+	if err := unbindPluginsFromApis(client, instanceId, apiId, envId, rmPluginIds); err != nil {
+		return diag.Errorf("error deleting configured plugin bindings: %s", err)
+	}
+
+	return nil
+}
+
+func resourceApiBatchPluginsAssociateImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<api_id>/<env_id>', "+
+			"but got '%s'", importedId)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("instance_id", parts[0]),
+		d.Set("api_id", parts[1]),
+		d.Set("env_id", parts[2]),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return []*schema.ResourceData{d}, fmt.Errorf("error saving associate resource field: %s", err)
+	}
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource to associate plugins to the specified API.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1121" height="707" alt="image" src="https://github.com/user-attachments/assets/2b08d2a4-397e-4eb8-bb96-d1887ced0d78" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to associate plugins to API
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccApiBatchPluginsAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccApiBatchPluginsAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccApiBatchPluginsAssociate_basic
=== PAUSE TestAccApiBatchPluginsAssociate_basic
=== CONT  TestAccApiBatchPluginsAssociate_basic
--- PASS: TestAccApiBatchPluginsAssociate_basic (210.84s)
PASS
coverage: 11.0% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      210.923s        coverage: 11.0% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1093" height="527" alt="image" src="https://github.com/user-attachments/assets/808b8937-a412-4296-9f4b-c025c7613838" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
