### PR TITLE
feat(organizations): add more params in data_source organizations_accounts

### DIFF
--- a/docs/data-sources/organizations_accounts.md
+++ b/docs/data-sources/organizations_accounts.md
@@ -28,6 +28,9 @@ The following arguments are supported:
 
 * `name` - (Optional, String) Specifies the name of the account.
 
+* `with_register_contact_info` - (Optional, Bool) Whether to return email addresses and mobile
+  numbers associated with the account.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -53,3 +56,9 @@ The `accounts` block supports:
 * `join_method` - How the account joined an organization.
 
 * `joined_at` - The time when the account joined an organization.
+
+* `mobile_phone` - The mobile phone number.
+
+* `intl_number_prefix` - The prefix of a mobile phone number.
+
+* `email` - The email address associated with the account.

--- a/huaweicloud/services/organizations/data_source_huaweicloud_organizations_accounts.go
+++ b/huaweicloud/services/organizations/data_source_huaweicloud_organizations_accounts.go
@@ -36,6 +36,11 @@ func DataSourceAccounts() *schema.Resource {
 				Optional:    true,
 				Description: `Specifies the name of the account.`,
 			},
+			"with_register_contact_info": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Whether to return email addresses and mobile numbers associated with the account.",
+			},
 			"accounts": {
 				Type:        schema.TypeList,
 				Elem:        organizationsAccountSchema(),
@@ -83,6 +88,21 @@ func organizationsAccountSchema() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: `Time when an account joined an organization.`,
+			},
+			"mobile_phone": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Mobile phone number.`,
+			},
+			"intl_number_prefix": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Prefix of a mobile phone number.`,
+			},
+			"email": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Email address associated with the account.`,
 			},
 		},
 	}
@@ -157,13 +177,16 @@ func flattenAccountsResp(resp interface{}, name string) []interface{} {
 	rst := make([]interface{}, 0, len(curArray))
 	for _, v := range curArray {
 		rst = append(rst, map[string]interface{}{
-			"id":          utils.PathSearch("id", v, nil),
-			"name":        utils.PathSearch("name", v, nil),
-			"urn":         utils.PathSearch("urn", v, nil),
-			"description": utils.PathSearch("description", v, nil),
-			"status":      utils.PathSearch("status", v, nil),
-			"join_method": utils.PathSearch("join_method", v, nil),
-			"joined_at":   utils.PathSearch("joined_at", v, nil),
+			"id":                 utils.PathSearch("id", v, nil),
+			"name":               utils.PathSearch("name", v, nil),
+			"urn":                utils.PathSearch("urn", v, nil),
+			"description":        utils.PathSearch("description", v, nil),
+			"status":             utils.PathSearch("status", v, nil),
+			"join_method":        utils.PathSearch("join_method", v, nil),
+			"joined_at":          utils.PathSearch("joined_at", v, nil),
+			"mobile_phone":       utils.PathSearch("mobile_phone", v, nil),
+			"intl_number_prefix": utils.PathSearch("intl_number_prefix", v, nil),
+			"email":              utils.PathSearch("email", v, nil),
 		})
 	}
 	return rst
@@ -172,6 +195,8 @@ func flattenAccountsResp(resp interface{}, name string) []interface{} {
 func buildListAccountsQueryParams(d *schema.ResourceData, marker string) string {
 	// the default value of limit is 200
 	res := "?limit=200"
+
+	res = fmt.Sprintf("%s&with_register_contact_info=%v", res, d.Get("with_register_contact_info"))
 
 	if marker != "" {
 		res = fmt.Sprintf("%s&marker=%v", res, marker)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/organizations' TESTARGS='-run TestAccDatasourceAccounts_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/organizations -v -run TestAccDatasourceAccounts_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceAccounts_basic
=== PAUSE TestAccDatasourceAccounts_basic
=== CONT  TestAccDatasourceAccounts_basic
--- PASS: TestAccDatasourceAccounts_basic (23.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     23.246s

make testacc TEST='./huaweicloud/services/acceptance/organizations' TESTARGS='-run TestAccDatasourceAccounts_name'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/organizations -v -run TestAccDatasourceAccounts_name -timeout 360m -parallel 4
=== RUN   TestAccDatasourceAccounts_name
=== PAUSE TestAccDatasourceAccounts_name
=== CONT  TestAccDatasourceAccounts_name
--- PASS: TestAccDatasourceAccounts_name (20.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     20.855s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
