### PR TITLE
fix(ELB): fix lb pool and member wait func

### DIFF
--- a/huaweicloud/services/lb/lb_v2_shared.go
+++ b/huaweicloud/services/lb/lb_v2_shared.go
@@ -156,13 +156,13 @@ func waitForLBV2viaPool(ctx context.Context, networkingClient *golangsdk.Service
 		return err
 	}
 
-	if pool.Loadbalancers != nil {
+	if len(pool.Loadbalancers) > 0 {
 		// each pool has an LB in Octavia lbaasv2 API
 		lbID := pool.Loadbalancers[0].ID
 		return waitForLBV2LoadBalancer(ctx, networkingClient, lbID, target, nil, timeout)
 	}
 
-	if pool.Listeners != nil {
+	if len(pool.Listeners) > 0 {
 		// each pool has a listener in Neutron lbaasv2 API
 		listenerID := pool.Listeners[0].ID
 		listener, err := listeners.Get(networkingClient, listenerID).Extract()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix lb pool and member wait func
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix lb pool and member wait func
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/lb/ TESTARGS='-run TestAccLBV2Pool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb/ -v -run TestAccLBV2Pool_basic -timeout 360m -parallel 4
=== RUN   TestAccLBV2Pool_basic
=== PAUSE TestAccLBV2Pool_basic
=== CONT  TestAccLBV2Pool_basic
--- PASS: TestAccLBV2Pool_basic (143.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        143.083s

make testacc TEST=./huaweicloud/services/acceptance/lb/ TESTARGS='-run TestAccLBV2Member_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb/ -v -run TestAccLBV2Member_basic -timeout 360m -parallel 4
=== RUN   TestAccLBV2Member_basic
=== PAUSE TestAccLBV2Member_basic
=== CONT  TestAccLBV2Member_basic
--- PASS: TestAccLBV2Member_basic (209.34s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        209.407s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
