### PR TITLE
feat(waf): support `waf_rules_threat_intelligence` data source

### DIFF
--- a/docs/data-sources/waf_rules_threat_intelligence.md
+++ b/docs/data-sources/waf_rules_threat_intelligence.md
@@ -1,0 +1,73 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_rules_threat_intelligence"
+description: |-
+  Use this data source to get a list of threat intelligence rules.
+---
+
+# huaweicloud_waf_rules_threat_intelligence
+
+Use this data source to get a list of threat intelligence rules.
+
+## Example Usage
+
+```hcl
+variable "policy_id" {}
+
+data "huaweicloud_waf_rules_threat_intelligence" "test" {
+  policy_id = var.policy_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `policy_id` - (Required, String) Specifies the protection policy ID.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  This parameter is only valid for enterprise users.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `items` - The list of threat intelligence rules.
+
+  The [items](#items_struct) structure is documented below.
+
+<a name="items_struct"></a>
+The `items` block supports:
+
+* `name` - The name of the threat intelligence rule.
+
+* `id` - The ID of the threat intelligence rule.
+
+* `policyid` - The protection policy ID.
+
+* `type` - The reputation type.
+
+* `description` - The description of the threat intelligence rule.
+
+* `tags` - The list of IDC data center tags for the reputation type.
+
+* `status` - The status of the threat intelligence rule. The value can be `0` (disabled) or `1` (enabled).
+
+* `action` - The protective action taken when the rule is triggered.
+
+  The [action](#rules_action_struct) structure is documented below.
+
+<a name="rules_action_struct"></a>
+The `action` block supports:
+
+* `category` - The action category.  
+  The valid values are as follows:
+  + **pass**: Pass.
+  + **block**: Block.
+  + **log**: Only record.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1826,6 +1826,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_rules_information_leakage_prevention": waf.DataSourceWafRulesInformationLeakagePrevention(),
 			"huaweicloud_waf_rules_known_attack_source":            waf.DataSourceWafRulesKnownAttackSource(),
 			"huaweicloud_waf_rules_precise_protection":             waf.DataSourceWafRulesPreciseProtection(),
+			"huaweicloud_waf_rules_threat_intelligence":            waf.DataSourceRulesThreatIntelligence(),
 			"huaweicloud_waf_rules_web_tamper_protection":          waf.DataSourceWafRulesWebTamperProtection(),
 			"huaweicloud_waf_security_report_subscriptions":        waf.DataSourceSecurityReportSubscriptions(),
 			"huaweicloud_waf_source_ips":                           waf.DataSourceWafSourceIps(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_rules_threat_intelligence_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_rules_threat_intelligence_test.go
@@ -1,0 +1,59 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running the test case, please ensure that there is at least one WAF instance in the current region.
+// Due to testing environment limitations, this test case can only test the scenario with empty `items`.
+func TestAccDataSourceRulesThreatIntelligence_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_waf_rules_threat_intelligence.test"
+		rName          = acceptance.RandomAccResourceName()
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceRulesThreatIntelligence_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceRulesThreatIntelligence_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_policy" "test" {
+  name                  = "%[1]s"
+  level                 = 1
+  enterprise_project_id = "0"
+}
+`, name)
+}
+
+func testDataSourceRulesThreatIntelligence_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_waf_rules_threat_intelligence" "test" {
+  policy_id             = huaweicloud_waf_policy.test.id
+  enterprise_project_id = "0"
+}
+
+`, testDataSourceRulesThreatIntelligence_base(name), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_rules_threat_intelligence.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_rules_threat_intelligence.go
@@ -1,0 +1,197 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/waf/policy/{policy_id}/ip-reputation
+func DataSourceRulesThreatIntelligence() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRulesThreatIntelligenceRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policyid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"status": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"action": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"category": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildThreatIntelligenceQueryParams(cfg *config.Config, d *schema.ResourceData) string {
+	epsId := cfg.GetEnterpriseProjectID(d)
+	rst := "?limit=200"
+
+	if epsId != "" {
+		rst += fmt.Sprintf("&enterprise_project_id=%v", epsId)
+	}
+
+	return rst
+}
+
+func dataSourceRulesThreatIntelligenceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		policyId = d.Get("policy_id").(string)
+		httpUrl  = "v1/{project_id}/waf/policy/{policy_id}/ip-reputation"
+		offset   = 0
+		result   = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{policy_id}", policyId)
+	listPath += buildThreatIntelligenceQueryParams(cfg, d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", listPath, offset)
+		resp, err := client.Request("GET", currentPath, &listOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving WAF threat intelligence rules: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		itemsResp := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		if len(itemsResp) == 0 {
+			break
+		}
+
+		result = append(result, itemsResp...)
+		offset += len(itemsResp)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("items", flattenThreatIntelligenceRules(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenThreatIntelligenceRules(rawRules []interface{}) []interface{} {
+	if len(rawRules) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(rawRules))
+	for _, v := range rawRules {
+		rst = append(rst, map[string]interface{}{
+			"name":        utils.PathSearch("name", v, nil),
+			"id":          utils.PathSearch("id", v, nil),
+			"policyid":    utils.PathSearch("policyid", v, nil),
+			"type":        utils.PathSearch("type", v, nil),
+			"description": utils.PathSearch("description", v, nil),
+			"tags":        utils.ExpandToStringList(utils.PathSearch("tags", v, make([]interface{}, 0)).([]interface{})),
+			"status":      utils.PathSearch("status", v, nil),
+			"action":      flattenThreatIntelligenceAction(utils.PathSearch("action", v, nil)),
+		})
+	}
+
+	return rst
+}
+
+func flattenThreatIntelligenceAction(rawAction interface{}) []interface{} {
+	if rawAction == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"category": utils.PathSearch("category", rawAction, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `waf_rules_threat_intelligence` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `waf_rules_threat_intelligence` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccDataSourceRulesThreatIntelligence_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceRulesThreatIntelligence_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRulesThreatIntelligence_basic
=== PAUSE TestAccDataSourceRulesThreatIntelligence_basic
=== CONT  TestAccDataSourceRulesThreatIntelligence_basic
--- PASS: TestAccDataSourceRulesThreatIntelligence_basic (15.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       15.928s

```
<img width="922" height="47" alt="image" src="https://github.com/user-attachments/assets/79263b51-4235-447a-9e8b-d50e38817bf2" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
