### PR TITLE
feat(apig): add new data source to query app authorize statistic

### DIFF
--- a/docs/data-sources/apig_application_authorize_statistic.md
+++ b/docs/data-sources/apig_application_authorize_statistic.md
@@ -1,0 +1,42 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_application_authorize_statistic"
+description: |-
+  Use this data source to get the application authorize statistics under the specified dedicated instance within
+  HuaweiCloud.
+---
+
+# huaweicloud_apig_application_authorize_statistic
+
+Use this data source to get the application authorize statistics under the specified dedicated instance within
+HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_apig_application_authorize_statistic" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the applications are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the applications belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `authed_nums` - The number of authorized applications.
+
+* `unauthed_nums` - The number of unauthorized applications.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -567,6 +567,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_api_history_versions":               apig.DataSourceApiHistoryVersions(),
 			"huaweicloud_apig_appcodes":                           apig.DataSourceAppcodes(),
 			"huaweicloud_apig_applications":                       apig.DataSourceApplications(),
+			"huaweicloud_apig_application_authorize_statistic":    apig.DataSourceApplicationAuthorizeStatistic(),
 			"huaweicloud_apig_availability_zones":                 apig.DataSourceAvailabilityZones(),
 			"huaweicloud_apig_application_acl":                    apig.DataSourceApplicationAcl(),
 			"huaweicloud_apig_application_quotas":                 apig.DataSourceApigApplicationQuotas(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_application_authorize_statistic_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_application_authorize_statistic_test.go
@@ -1,0 +1,205 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataApplicationAuthorizeStatistic_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_apig_application_authorize_statistic.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataApplicationAuthorizeStatistic_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "authed_nums", regexp.MustCompile(`^[1-9]+$`)),
+					resource.TestMatchResourceAttr(dataSourceName, "unauthed_nums", regexp.MustCompile(`^[1-9]+$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataApplicationAuthorizeStatistic_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[2]s"
+}
+
+locals {
+  instance_id = data.huaweicloud_apig_instances.test.instances[0].id
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[3]s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  system_disk_type   = "SSD"
+
+  network {
+    uuid = "%[4]s"
+  }
+}
+
+resource "huaweicloud_apig_group" "test" {
+  name        = "%[3]s"
+  instance_id = local.instance_id
+}
+
+resource "huaweicloud_apig_channel" "test" {
+  instance_id      = local.instance_id
+  name             = "%[3]s"
+  port             = 8000
+  balance_strategy = 2
+  member_type      = "ecs"
+  type             = 2
+
+  health_check {
+    protocol           = "HTTPS"
+    threshold_normal   = 10  # maximum value
+    threshold_abnormal = 10  # maximum value
+    interval           = 300 # maximum value
+    timeout            = 30  # maximum value
+    path               = "/"
+    method             = "HEAD"
+    port               = 8080
+    http_codes         = "201,202,303-404"
+  }
+
+  member {
+    id   = huaweicloud_compute_instance.test.id
+    name = huaweicloud_compute_instance.test.name
+  }
+}
+
+resource "huaweicloud_apig_api" "test" {
+  count = 2
+
+  instance_id             = local.instance_id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = format("%[3]s_%%s", count.index)
+  type                    = "Public"
+  request_protocol        = "HTTP"
+  request_method          = "GET"
+  request_path            = "/user_info/{user_age}"
+  security_authentication = "APP"
+  matching                = "Exact"
+  success_response        = "Success response"
+  failure_response        = "Failed response"
+
+  request_params {
+    name     = "user_age"
+    type     = "NUMBER"
+    location = "PATH"
+    required = true
+    maximum  = 200
+    minimum  = 0
+  }
+
+  backend_params {
+    type     = "REQUEST"
+    name     = "userAge"
+    location = "PATH"
+    value    = "user_age"
+  }
+
+  web {
+    path             = "/getUserAge/{userAge}"
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 30000
+  }
+
+  web_policy {
+    name             = format("%[3]s_web_%%s", count.index)
+    request_protocol = "HTTP"
+    request_method   = "GET"
+    effective_mode   = "ANY"
+    path             = "/getUserAge/{userAge}"
+    timeout          = 30000
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+
+    backend_params {
+      type     = "REQUEST"
+      name     = "userAge"
+      location = "PATH"
+      value    = "user_age"
+    }
+
+    conditions {
+      source     = "param"
+      param_name = "user_age"
+      type       = "Equal"
+      value      = "28"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      request_params,
+    ]
+  }
+}
+
+resource "huaweicloud_apig_environment" "test" {
+  instance_id = local.instance_id
+  name        = "%[3]s"
+}
+
+resource "huaweicloud_apig_api_publishment" "test" {
+  instance_id = local.instance_id
+  api_id      = huaweicloud_apig_api.test[0].id
+  env_id      = huaweicloud_apig_environment.test.id
+}
+
+resource "huaweicloud_apig_application" "test" {
+  instance_id = local.instance_id
+  name        = "%[2]s"
+}
+
+resource "huaweicloud_apig_application_authorization" "test" {
+  instance_id    = local.instance_id
+  application_id = huaweicloud_apig_application.test.id
+  env_id         = huaweicloud_apig_environment.test.id
+  api_ids        = slice(huaweicloud_apig_api.test[*].id, 0, 1)
+
+  depends_on = [
+    huaweicloud_apig_api_publishment.test,
+  ]
+}
+
+
+data "huaweicloud_apig_application_authorize_statistic" "test" {
+  instance_id = local.instance_id
+
+  depends_on = [
+    huaweicloud_apig_application_authorization.test,
+  ]
+}
+`, common.TestBaseComputeResources(name),
+		acceptance.HW_APIG_DEDICATED_INSTANCE_ID,
+		name,
+		acceptance.HW_APIG_DEDICATED_INSTANCE_USED_SUBNET_ID)
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_application_authorize_statistic.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_application_authorize_statistic.go
@@ -1,0 +1,103 @@
+package apig
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/resources/outline/apps
+func DataSourceApplicationAuthorizeStatistic() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceApplicationAuthorizeStatisticRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the applications are located.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the applications belong.`,
+			},
+
+			// Attributes.
+			"authed_nums": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of authorized applications.`,
+			},
+			"unauthed_nums": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of unauthorized applications.`,
+			},
+		},
+	}
+}
+
+func getApplicationAuthorizeStatistic(client *golangsdk.ServiceClient, instanceId string) (interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/apigw/instances/{instance_id}/resources/outline/apps"
+	)
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func dataSourceApplicationAuthorizeStatisticRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	resp, err := getApplicationAuthorizeStatistic(client, instanceId)
+	if err != nil {
+		return diag.Errorf("error querying application authorize statistics under a specified instance (%s): %s",
+			instanceId, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("authed_nums", utils.PathSearch("authed_nums", resp, nil)),
+		d.Set("unauthed_nums", utils.PathSearch("unauthed_nums", resp, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source to query application authorize statistic.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query app authorize statistic
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccDataApplicationAuthorizeStatistic_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataApplicationAuthorizeStatistic_basic -timeout 360m -parallel 10
=== RUN   TestAccDataApplicationAuthorizeStatistic_basic
=== PAUSE TestAccDataApplicationAuthorizeStatistic_basic
=== CONT  TestAccDataApplicationAuthorizeStatistic_basic
--- PASS: TestAccDataApplicationAuthorizeStatistic_basic (135.04s)
PASS
coverage: 12.2% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      135.134s        coverage: 12.2% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
