### PR TITLE
feat(apig): add new resource for manage channel member

### DIFF
--- a/docs/resources/apig_channel_member.md
+++ b/docs/resources/apig_channel_member.md
@@ -1,0 +1,120 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_channel_member"
+description: |-
+  Use this resource to manage a channel member within HuaweiCloud.
+---
+
+# huaweicloud_apig_channel_member
+
+Use this resource to manage a channel member within HuaweiCloud.
+
+## Example Usage
+
+### Create APIG channel member by IP address
+
+```hcl
+variable "instance_id" {}
+variable "vpc_channel_id" {}
+variable "member_ip_address" {}
+variable "port" {}
+
+resource "huaweicloud_apig_channel_member" "test" {
+  instance_id       = var.instance_id
+  vpc_channel_id    = var.vpc_channel_id
+  member_ip_address = var.member_ip_address
+  port              = var.port
+  weight            = 10
+}
+```
+
+### Create APIG channel member by ECS instance ID
+
+```hcl
+variable "instance_id" {}
+variable "vpc_channel_id" {}
+variable "ecs_id" {}
+variable "ecs_name" {}
+variable "port" {}
+
+resource "huaweicloud_apig_channel_member" "test" {
+  instance_id    = var.instance_id
+  vpc_channel_id = var.vpc_channel_id
+  ecs_id         = var.ecs_id
+  ecs_name       = var.ecs_name
+  port           = var.port
+  weight         = 10
+  is_backup      = false
+  status         = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the channel member is located.  
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the dedicated instance to which the channel
+  member belongs.
+
+* `vpc_channel_id` - (Required, String, NonUpdatable) Specifies the ID of the VPC channel.
+
+* `weight` - (Optional, Int) Specifies the weight value of the channel member.  
+  This weight value is automatically used for weight allocation, and the valid value is range from `0` to `10,000`.
+  The greater the weight of a channel member, the more requests will be dispatched to it.
+
+* `port` - (Optional, Int) Specifies the port number of the channel member.  
+  The valid value is range from `0` to `65,535`.
+
+* `is_backup` - (Optional, Bool) Specifies whether this member is the backup member.  
+  When enabled, the corresponding backend service is a backup node and only works when all non-backup nodes fail.  
+  The default value is `false`.
+
+* `member_group_name` - (Optional, String) Specifies the name of the channel member group.  
+  This is used to select a channel member group for easy unified modification of the corresponding server group backend
+  attributes.
+
+* `status` - (Optional, Int) Specifies the status of the channel member.  
+  The valid values are as follow:
+  + **1**: Available
+  + **2**: Unavailable
+
+* `member_ip_address` - (Optional, String) Specifies the IP address of the channel member.  
+  The member_ip_address contain a maximum of `255` characters.
+
+  -> Required if the type of vpc channel is **ip**.
+
+* `ecs_id` - (Optional, String) Specifies the ID of the ECS instance.  
+  Only the English letters, numbers, underscores(_) and hyphens(-) are allowed and the valid value is range
+  from `0` to `255`.
+
+* `ecs_name` - (Optional, String) Specifies the name of the ECS instance.  
+  Only the Chinese characters, English letters, numbers, underscores(_), hyphens(-) and dots(.) are allowed
+  and the valid value is range from `0` to `255`.
+
+-> Parameter `ecs_id` and `ecs_name` are required if the type of vpc channel is **ecs**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `create_time` - The creation time of the channel member, in RFC3339 format.
+
+* `member_group_id` - The ID of the member group.
+
+* `health_status` - The health status of the channel member.
+
+## Import
+
+Channel members can be imported using their `id`, the ID of the related dedicated instance and the ID of the related VPC
+channel, separated by slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_apig_channel_member.test <instance_id>/<vpc_channel_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2067,6 +2067,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_application_quota_associate":    apig.ResourceApplicationQuotaAssociate(),
 			"huaweicloud_apig_certificate":                    apig.ResourceCertificate(),
 			"huaweicloud_apig_channel":                        apig.ResourceChannel(),
+			"huaweicloud_apig_channel_member":                 apig.ResourceChannelMember(),
 			"huaweicloud_apig_channel_member_group":           apig.ResourceChannelMemberGroup(),
 			"huaweicloud_apig_custom_authorizer":              apig.ResourceApigCustomAuthorizerV2(),
 			"huaweicloud_apig_endpoint_connection_management": apig.ResourceEndpointConnectionManagement(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_channel_member_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_channel_member_test.go
@@ -1,0 +1,231 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
+)
+
+func getChannelMemberFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		instanceId   = state.Primary.Attributes["instance_id"]
+		vpcChannelId = state.Primary.Attributes["vpc_channel_id"]
+		memberId     = state.Primary.ID
+	)
+
+	client, err := cfg.NewServiceClient("apig", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating APIG client: %s", err)
+	}
+
+	return apig.GetChannelMemberById(client, instanceId, vpcChannelId, memberId)
+}
+
+func TestAccChannelMember_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		ipMember     interface{}
+		ipMemberName = "huaweicloud_apig_channel_member.ip_member"
+		rcIpMember   = acceptance.InitResourceCheck(ipMemberName, &ipMember, getChannelMemberFunc)
+
+		ecsMember     interface{}
+		ecsMemberName = "huaweicloud_apig_channel_member.ecs_member"
+		rcEcsMember   = acceptance.InitResourceCheck(ecsMemberName, &ecsMember, getChannelMemberFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSubnetId(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcIpMember.CheckResourceDestroy(),
+			rcEcsMember.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccChannelMember_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rcIpMember.CheckResourceExists(),
+					resource.TestCheckResourceAttr(ipMemberName, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttrSet(ipMemberName, "vpc_channel_id"),
+					resource.TestCheckResourceAttr(ipMemberName, "weight", "20"),
+					resource.TestCheckResourceAttr(ipMemberName, "port", "80"),
+					resource.TestCheckResourceAttr(ipMemberName, "is_backup", "false"),
+					resource.TestCheckResourceAttr(ipMemberName, "status", "1"),
+					resource.TestCheckResourceAttrSet(ipMemberName, "ecs_id"),
+					resource.TestCheckResourceAttrSet(ipMemberName, "ecs_name"),
+					resource.TestMatchResourceAttr(ipMemberName, "create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(ipMemberName, "member_group_id"),
+					rcEcsMember.CheckResourceExists(),
+					resource.TestCheckResourceAttr(ecsMemberName, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttrSet(ecsMemberName, "vpc_channel_id"),
+					resource.TestCheckResourceAttr(ecsMemberName, "weight", "20"),
+					resource.TestCheckResourceAttr(ecsMemberName, "port", "80"),
+					resource.TestCheckResourceAttr(ecsMemberName, "is_backup", "false"),
+					resource.TestCheckResourceAttr(ecsMemberName, "status", "1"),
+					resource.TestCheckResourceAttrSet(ecsMemberName, "ecs_id"),
+					resource.TestCheckResourceAttrSet(ecsMemberName, "ecs_name"),
+					resource.TestMatchResourceAttr(ecsMemberName, "create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(ecsMemberName, "member_group_id"),
+				),
+			},
+			{
+				ResourceName:      ipMemberName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccChannelMemberImportStateFunc(ipMemberName),
+			},
+			{
+				ResourceName:      ecsMemberName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccChannelMemberImportStateFunc(ecsMemberName),
+			},
+		},
+	})
+}
+
+func testAccChannelMemberImportStateFunc(rsName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rsName]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", rsName, rs)
+		}
+		if rs.Primary.Attributes["instance_id"] == "" || rs.Primary.Attributes["vpc_channel_id"] == "" || rs.Primary.ID == "" {
+			return "", fmt.Errorf("resource not found: %s/%s/%s", rs.Primary.Attributes["instance_id"],
+				rs.Primary.Attributes["vpc_channel_id"], rs.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["vpc_channel_id"], rs.Primary.ID), nil
+	}
+}
+
+func testAccChannelMember_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[2]s"
+}
+
+resource "huaweicloud_apig_channel" "ip_channel" {
+  instance_id      = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  name             = format("%[1]s_%%s", "ip")
+  port             = 80
+  balance_strategy = 1
+  member_type      = "ip"
+  type             = "builtin"
+}
+
+resource "huaweicloud_apig_channel" "ecs_channel" {
+  instance_id      = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  name             = format("%[1]s_%%s", "ecs")
+  port             = 80
+  balance_strategy = 1
+  member_type      = "ecs"
+  type             = "builtin"
+}
+
+resource "huaweicloud_apig_channel_member_group" "ip_channel_member_group" {
+  instance_id    = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id = huaweicloud_apig_channel.ip_channel.id
+  name           = format("%[1]s_%%s", "ip")
+  weight         = 20
+  description    = "ip channel member group."
+}
+
+resource "huaweicloud_apig_channel_member_group" "ecs_channel_member_group" {
+  instance_id    = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id = huaweicloud_apig_channel.ecs_channel.id
+  name           = format("%[1]s_%%s", "ecs")
+  weight         = 20
+  description    = "ecs channel member group."
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  id = "%[3]s"
+}
+
+data "huaweicloud_images_image" "test" {
+  name        = "Ubuntu 18.04 server 64bit"
+  most_recent = true
+}
+
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name                = "%[1]s"
+  description         = "terraform test"
+  image_id            = data.huaweicloud_images_image.test.id
+  flavor_id           = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids  = [data.huaweicloud_networking_secgroup.test.id]
+  stop_before_destroy = true
+  agency_name         = "test111"
+  agent_list          = "hss"
+
+  user_data = <<EOF
+#! /bin/bash
+echo user_test > /home/user.txt
+EOF
+
+  network {
+    uuid              = data.huaweicloud_vpc_subnet.test.id
+    source_dest_check = false
+  }
+
+  system_disk_type = "SAS"
+  system_disk_size = 50
+
+  data_disks {
+    type = "SAS"
+    size = "10"
+  }
+}
+`, name, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, acceptance.HW_SUBNET_ID)
+}
+
+func testAccChannelMember_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_channel_member" "ip_member" {
+  instance_id       = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id    = huaweicloud_apig_channel.ip_channel.id
+  weight            = 20
+  port              = 80
+  member_group_name = huaweicloud_apig_channel_member_group.ip_channel_member_group.name
+  member_ip_address = huaweicloud_compute_instance.test.access_ip_v4
+}
+
+resource "huaweicloud_apig_channel_member" "ecs_member" {
+  instance_id       = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id    = huaweicloud_apig_channel.ecs_channel.id
+  weight            = 20
+  port              = 80
+  member_group_name = huaweicloud_apig_channel_member_group.ecs_channel_member_group.name
+  ecs_id            = huaweicloud_compute_instance.test.id
+  ecs_name          = huaweicloud_compute_instance.test.name
+}
+`, testAccChannelMember_base(name))
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_channel_member.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_channel_member.go
@@ -1,0 +1,406 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var channelMemberNonUpdatableParams = []string{"instance_id", "vpc_channel_id"}
+
+// @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/members
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/members
+// @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/members
+// @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/members/{member_id}
+func ResourceChannelMember() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceChannelMemberCreate,
+		ReadContext:   resourceChannelMemberRead,
+		UpdateContext: resourceChannelMemberUpdate,
+		DeleteContext: resourceChannelMemberDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(channelMemberNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceChannelMemberImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the channel member is located.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the channel member belongs.`,
+			},
+			"vpc_channel_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the VPC channel.`,
+			},
+
+			// Optional parameters.
+			"weight": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(0, 10_000),
+				Description:  `The weight value of the channel member.`,
+			},
+			"port": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(0, 65_535),
+				Description:  `The port number of the channel member.`,
+			},
+			"is_backup": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether this member is the backup member.`,
+			},
+			"member_group_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The name of the channel member group.`,
+			},
+			"status": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `The status of the channel member.`,
+			},
+			"member_ip_address": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The IP address of channel member.`,
+			},
+			"ecs_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The ID of the ECS channel member.`,
+			},
+			"ecs_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The name of the ECS channel member.`,
+			},
+
+			// Attributes.
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the channel member, in RFC3339 format.`,
+			},
+			"member_group_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the member group.`,
+			},
+			"health_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The health status of the channel member.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildChannelMemberBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"members": []map[string]interface{}{
+			{
+				"weight":            utils.ValueIgnoreEmpty(d.Get("weight")),
+				"port":              utils.ValueIgnoreEmpty(d.Get("port")),
+				"is_backup":         utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "is_backup"),
+				"member_group_name": utils.ValueIgnoreEmpty(d.Get("member_group_name")),
+				"status":            utils.ValueIgnoreEmpty(d.Get("status")),
+				"host":              utils.ValueIgnoreEmpty(d.Get("member_ip_address")),
+				"ecs_id":            utils.ValueIgnoreEmpty(d.Get("ecs_id")),
+				"ecs_name":          utils.ValueIgnoreEmpty(d.Get("ecs_name")),
+			},
+		},
+	}
+}
+
+func createChannelMember(client *golangsdk.ServiceClient, instanceId, vpcChannelId string, d *schema.ResourceData) (interface{}, error) {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/members"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createPath = strings.ReplaceAll(createPath, "{vpc_channel_id}", vpcChannelId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(utils.RemoveNil(buildChannelMemberBodyParams(d))),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceChannelMemberCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		instanceId   = d.Get("instance_id").(string)
+		vpcChannelId = d.Get("vpc_channel_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	respBody, err := createChannelMember(client, instanceId, vpcChannelId, d)
+	if err != nil {
+		return diag.Errorf("error creating channel member: %s", err)
+	}
+
+	memberId := utils.PathSearch("members[0].id", respBody, "").(string)
+	if memberId == "" {
+		return diag.Errorf("unable to find the member ID from the API response")
+	}
+	d.SetId(memberId)
+
+	return resourceChannelMemberRead(ctx, d, meta)
+}
+
+func listChannelMembers(client *golangsdk.ServiceClient, instanceId, vpcChannelId string) ([]interface{}, error) {
+	var (
+		result  = make([]interface{}, 0)
+		httpUrl = "v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/members?limit={limit}"
+		limit   = 100
+		offset  = 0
+	)
+
+	listPathWithLimit := client.Endpoint + httpUrl
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{project_id}", client.ProjectID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{instance_id}", instanceId)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{vpc_channel_id}", vpcChannelId)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{limit}", strconv.Itoa(limit))
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPathWithLimit + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		members := utils.PathSearch("members", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, members...)
+		if len(members) < limit {
+			break
+		}
+		offset += len(members)
+	}
+
+	return result, nil
+}
+
+func GetChannelMemberById(client *golangsdk.ServiceClient, instanceId, vpcChannelId, memberId string) (interface{}, error) {
+	members, err := listChannelMembers(client, instanceId, vpcChannelId)
+	if err != nil {
+		return nil, err
+	}
+
+	member := utils.PathSearch(fmt.Sprintf("[?id=='%s']|[0]", memberId), members, nil)
+	if member == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return member, nil
+}
+
+func resourceChannelMemberRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		instanceId   = d.Get("instance_id").(string)
+		vpcChannelId = d.Get("vpc_channel_id").(string)
+		memberId     = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	member, err := GetChannelMemberById(client, instanceId, vpcChannelId, memberId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error querying channel member detail")
+	}
+
+	mErr := multierror.Append(
+		d.Set("weight", utils.PathSearch("weight", member, nil)),
+		d.Set("port", utils.PathSearch("port", member, nil)),
+		d.Set("is_backup", utils.PathSearch("is_backup", member, nil)),
+		d.Set("member_group_name", utils.PathSearch("member_group_name", member, nil)),
+		d.Set("status", utils.PathSearch("status", member, nil)),
+		d.Set("member_ip_address", utils.PathSearch("host", member, nil)),
+		d.Set("ecs_id", utils.PathSearch("ecs_id", member, nil)),
+		d.Set("ecs_name", utils.PathSearch("ecs_name", member, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", member, nil)),
+		d.Set("member_group_id", utils.PathSearch("member_group_id", member, nil)),
+		d.Set("health_status", utils.PathSearch("health_status", member, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdateChannelMemberBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"member_group_name": utils.ValueIgnoreEmpty(d.Get("member_group_name")),
+		"members": []map[string]interface{}{
+			{
+				"port":              utils.ValueIgnoreEmpty(d.Get("port")),
+				"weight":            utils.ValueIgnoreEmpty(d.Get("weight")),
+				"is_backup":         utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "is_backup"),
+				"member_group_name": utils.ValueIgnoreEmpty(d.Get("member_group_name")),
+				"status":            utils.ValueIgnoreEmpty(d.Get("status")),
+				"host":              utils.ValueIgnoreEmpty(d.Get("member_ip_address")),
+				"ecs_id":            utils.ValueIgnoreEmpty(d.Get("ecs_id")),
+				"ecs_name":          utils.ValueIgnoreEmpty(d.Get("ecs_name")),
+			},
+		},
+	}
+}
+
+func updateChannelMember(client *golangsdk.ServiceClient, instanceId, vpcChannelId string, d *schema.ResourceData) error {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/members"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", instanceId)
+	updatePath = strings.ReplaceAll(updatePath, "{vpc_channel_id}", vpcChannelId)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildUpdateChannelMemberBodyParams(d)),
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
+func resourceChannelMemberUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		instanceId   = d.Get("instance_id").(string)
+		vpcChannelId = d.Get("vpc_channel_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	err = updateChannelMember(client, instanceId, vpcChannelId, d)
+	if err != nil {
+		return diag.Errorf("error updating channel member (%s): %s", d.Id(), err)
+	}
+
+	return resourceChannelMemberRead(ctx, d, meta)
+}
+
+func deleteChannelMember(client *golangsdk.ServiceClient, instanceId, vpcChannelId, memberId string) error {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/members/{member_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceId)
+	deletePath = strings.ReplaceAll(deletePath, "{vpc_channel_id}", vpcChannelId)
+	deletePath = strings.ReplaceAll(deletePath, "{member_id}", memberId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpt)
+	return err
+}
+
+func resourceChannelMemberDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		instanceId   = d.Get("instance_id").(string)
+		vpcChannelId = d.Get("vpc_channel_id").(string)
+		memberId     = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	err = deleteChannelMember(client, instanceId, vpcChannelId, memberId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting channel member (%s)",
+			memberId))
+	}
+
+	return nil
+}
+
+func resourceChannelMemberImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.SplitN(importedId, "/", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf(`invalid format specified for import ID, want '<instance_id>/<vpc_channel_id>/<id>',
+		 but got '%s'`, importedId)
+	}
+
+	d.SetId(parts[2])
+	mErr := multierror.Append(
+		d.Set("instance_id", parts[0]),
+		d.Set("vpc_channel_id", parts[1]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(apig): add new resource for manage channel member

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
Even when a health check is configured for the channel, the health_check attribute of the member still remains null.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccChannelMember_basic -timeout 360m -parallel 10
=== RUN   TestAccChannelMember_basic
=== PAUSE TestAccChannelMember_basic
=== CONT  TestAccChannelMember_basic
--- PASS: TestAccChannelMember_basic (338.10s)
PASS
coverage: 5.8% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      338.220s        coverage: 5.8% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.