### PR TITLE
feat(apig): add new data source for query application associated quotas

### DIFF
--- a/docs/data-sources/apig_application_associated_quota.md
+++ b/docs/data-sources/apig_application_associated_quota.md
@@ -1,0 +1,58 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_application_associated_quota"
+description: |-
+  Use this data source to query the application associated quota within HuaweiCloud.
+---
+
+# huaweicloud_apig_application_associated_quota
+
+Use this data source to query the application associated quota within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "app_id" {}
+
+data "huaweicloud_apig_application_associated_quota" "test" {
+  instance_id = var.instance_id
+  app_id      = var.app_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the application is located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the application belongs.
+
+* `app_id` - (Required, String) Specifies the ID of the application to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of data source.
+
+* `app_quota_id` - The ID of the application quota.
+
+* `name` - The name of the application quota.
+
+* `call_limits` - The maximum number of times the application quota can be called.
+
+* `time_unit` - The time unit of the quota limit.
+
+* `time_interval` - The time interval of the quota limit.
+
+* `remark` - The description of the application quota.
+
+* `reset_time` - The first quota reset time point, in RFC3339 format.
+
+* `create_time` - The creation time of the application quota, in RFC3339 format.
+
+* `bound_app_num` - The number of applications bound to the quota policy.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -569,6 +569,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_applications":                       apig.DataSourceApplications(),
 			"huaweicloud_apig_availability_zones":                 apig.DataSourceAvailabilityZones(),
 			"huaweicloud_apig_application_acl":                    apig.DataSourceApplicationAcl(),
+			"huaweicloud_apig_application_associated_quota":       apig.DataSourceApplicationAssociatedQuota(),
 			"huaweicloud_apig_application_quotas":                 apig.DataSourceApigApplicationQuotas(),
 			"huaweicloud_apig_channels":                           apig.DataSourceChannels(),
 			"huaweicloud_apig_custom_authorizers":                 apig.DataSourceCustomAuthorizers(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_application_associated_quota_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_application_associated_quota_test.go
@@ -1,0 +1,88 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataSourceApplicationAssociatedQuota_basic(t *testing.T) {
+	var (
+		dcName = "data.huaweicloud_apig_application_associated_quota.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+		rName  = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceApplicationAssociatedQuota_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dcName, "id"),
+					resource.TestCheckResourceAttrSet(dcName, "app_quota_id"),
+					resource.TestCheckResourceAttrSet(dcName, "name"),
+					resource.TestCheckResourceAttrSet(dcName, "call_limits"),
+					resource.TestCheckResourceAttrSet(dcName, "time_unit"),
+					resource.TestCheckResourceAttrSet(dcName, "time_interval"),
+					resource.TestCheckResourceAttrSet(dcName, "remark"),
+					resource.TestCheckResourceAttrSet(dcName, "bound_app_num"),
+					resource.TestMatchResourceAttr(dcName, "create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceApplicationAssociatedQuota_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[2]s"
+}
+
+resource "huaweicloud_apig_application" "test" {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  name        = "%[3]s"
+}
+
+resource "huaweicloud_apig_application_quota" "test" {
+  instance_id   = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  name          = "%[3]s"
+  time_unit     = "MINUTE"
+  call_limits   = 100
+  time_interval = 5
+  description   = "Created by terraform script for testing"
+}
+
+resource "huaweicloud_apig_application_quota_associate" "test" {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  quota_id    = huaweicloud_apig_application_quota.test.id
+
+  applications {
+    id = huaweicloud_apig_application.test.id
+  }
+}
+
+data "huaweicloud_apig_application_associated_quota" "test" {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  app_id      = huaweicloud_apig_application.test.id
+
+  depends_on = [
+    huaweicloud_apig_application_quota_associate.test,
+  ]
+}
+`, common.TestBaseNetwork(name), acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_application_associated_quota.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_application_associated_quota.go
@@ -1,0 +1,151 @@
+package apig
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/bound-quota
+func DataSourceApplicationAssociatedQuota() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceApplicationAssociatedQuotaRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the application is located.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the application belongs.`,
+			},
+			"app_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the application to be queried.`,
+			},
+
+			// Attributes.
+			"app_quota_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the application quota.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the application quota.`,
+			},
+			"call_limits": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The maximum number of times the application quota can be called.`,
+			},
+			"time_unit": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time unit of the quota limit.`,
+			},
+			"time_interval": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The time interval of the quota limit.`,
+			},
+			"remark": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the application quota.`,
+			},
+			"reset_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The first quota reset time point, in RFC3339 format.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the application quota, in RFC3339 format.`,
+			},
+			"bound_app_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of applications bound to the quota policy.`,
+			},
+		},
+	}
+}
+
+func getApplicationAssociatedQuota(client *golangsdk.ServiceClient, instanceId, appId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/bound-quota"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getPath = strings.ReplaceAll(getPath, "{app_id}", appId)
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func dataSourceApplicationAssociatedQuotaRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+		appId      = d.Get("app_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	quota, err := getApplicationAssociatedQuota(client, instanceId, appId)
+	if err != nil {
+		return diag.Errorf("error querying application associated quota: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("app_quota_id", utils.PathSearch("app_quota_id", quota, nil)),
+		d.Set("name", utils.PathSearch("name", quota, nil)),
+		d.Set("call_limits", utils.PathSearch("call_limits", quota, nil)),
+		d.Set("time_unit", utils.PathSearch("time_unit", quota, nil)),
+		d.Set("time_interval", utils.PathSearch("time_interval", quota, nil)),
+		d.Set("remark", utils.PathSearch("remark", quota, nil)),
+		d.Set("reset_time", utils.PathSearch("reset_time", quota, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", quota, nil)),
+		d.Set("bound_app_num", utils.PathSearch("bound_app_num", quota, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(apig): add new data source for query application associated quotas

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataSourceApplicationAssociatedQuotas_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceApplicationAssociatedQuotas_basic
=== PAUSE TestAccDataSourceApplicationAssociatedQuotas_basic
=== CONT  TestAccDataSourceApplicationAssociatedQuotas_basic
--- PASS: TestAccDataSourceApplicationAssociatedQuotas_basic (141.35s)
PASS
coverage: 6.2% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      141.465s        coverage: 6.2% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.