### PR TITLE
feat(cbr): add two new datasources to query features and single feature

### DIFF
--- a/docs/data-sources/cbr_feature.md
+++ b/docs/data-sources/cbr_feature.md
@@ -1,0 +1,44 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbr_feature"
+description: |-
+  Use this data source to query a specific feature of CBR within HuaweiCloud.
+---
+
+# huaweicloud_cbr_feature
+
+Use this data source to query a specific feature of CBR within HuaweiCloud.
+
+-> The API used by this datasource is currently in public beta and is temporarily unavailable in some regions.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cbr_feature" "test" {
+  feature_key = "replication.enable"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `feature_key` - (Required, String) Specifies the key of the feature to query.
+  Valid values are:
+  + **replication.enable**
+  + **replication.source_region**
+  + **replication.destination_regions**
+  + **replication.destination_dgw_regions**
+  + **features.backup_double_az**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `feature_value` - The value of the specified feature in JSON format.

--- a/docs/data-sources/cbr_features.md
+++ b/docs/data-sources/cbr_features.md
@@ -1,0 +1,34 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbr_features"
+description: |-
+  Use this data source to query the features of CBR within HuaweiCloud.
+---
+
+# huaweicloud_cbr_features
+
+Use this data source to query the features of CBR within HuaweiCloud.
+
+-> The API used by this datasource is currently in public beta and is temporarily unavailable in some regions.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cbr_features" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `feature_value` - The feature values in JSON format. This contains all the feature information provided by the CBR service.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -629,6 +629,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbr_policies":                 cbr.DataSourcePolicies(),
 			"huaweicloud_cbr_region_projects":          cbr.DataSourceCbrRegionProjects(),
 			"huaweicloud_cbr_storage_usages":           cbr.DataSourceStorageUsages(),
+			"huaweicloud_cbr_feature":                  cbr.DataSourceCbrFeature(),
 			"huaweicloud_cbr_features":                 cbr.DataSourceCbrFeatures(),
 			"huaweicloud_cbr_tags":                     cbr.DataSourceTags(),
 			"huaweicloud_cbr_vaults_by_tags":           cbr.DataSourceVaultsByTags(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -629,6 +629,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbr_policies":                 cbr.DataSourcePolicies(),
 			"huaweicloud_cbr_region_projects":          cbr.DataSourceCbrRegionProjects(),
 			"huaweicloud_cbr_storage_usages":           cbr.DataSourceStorageUsages(),
+			"huaweicloud_cbr_features":                 cbr.DataSourceCbrFeatures(),
 			"huaweicloud_cbr_tags":                     cbr.DataSourceTags(),
 			"huaweicloud_cbr_vaults_by_tags":           cbr.DataSourceVaultsByTags(),
 			"huaweicloud_cbr_vaults_summary":           cbr.DataSourceVolumeSummary(),

--- a/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_feature_test.go
+++ b/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_feature_test.go
@@ -1,0 +1,39 @@
+package cbr
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// The API used by this datasource is currently in public beta and is temporarily unavailable in some regions.
+func TestAccDataCbrFeature_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_cbr_feature.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCbrFeature_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "feature_value"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataCbrFeature_basic = `
+data "huaweicloud_cbr_feature" "test" {
+  feature_key = "replication.enable"
+}
+`

--- a/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_features_test.go
+++ b/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_features_test.go
@@ -1,0 +1,37 @@
+package cbr
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// The API used by this datasource is currently in public beta and is temporarily unavailable in some regions.
+func TestAccDataCbrFeatures_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_cbr_features.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCbrFeatures_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "feature_value"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataCbrFeatures_basic = `
+data "huaweicloud_cbr_features" "test" {}
+`

--- a/huaweicloud/services/cbr/data_source_huaweicloud_cbr_feature.go
+++ b/huaweicloud/services/cbr/data_source_huaweicloud_cbr_feature.go
@@ -1,0 +1,92 @@
+package cbr
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CBR GET /v3/{project_id}/cbr-features/{feature_key}
+func DataSourceCbrFeature() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCbrFeatureRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the region where the CBR feature is located.`,
+			},
+			"feature_key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the key of the feature to query.`,
+			},
+			"feature_value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The value of the specified feature in JSON format.`,
+			},
+		},
+	}
+}
+
+func dataSourceCbrFeatureRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/cbr-features/{feature_key}"
+		product = "cbr"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBR client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{feature_key}", d.Get("feature_key").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CBR feature: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	jsonString, err := json.Marshal(respBody)
+	if err != nil {
+		return diag.Errorf("error marshaling CBR feature: %s", err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("feature_value", string(jsonString)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/cbr/data_source_huaweicloud_cbr_features.go
+++ b/huaweicloud/services/cbr/data_source_huaweicloud_cbr_features.go
@@ -1,0 +1,89 @@
+package cbr
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// The paging parameters mentioned in the API documentation are meaningless here, and the paging function is ignored.
+
+// @API CBR GET /v3/{project_id}/cbr-features
+func DataSourceCbrFeatures() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCbrFeaturesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the region where the CBR features are located.`,
+			},
+			"feature_value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The feature values in JSON format.`,
+			},
+		},
+	}
+}
+
+func dataSourceCbrFeaturesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/cbr-features"
+		product = "cbr"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBR client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CBR features: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	// The response data is a Map structure, so it needs to be converted to a JSON string.
+	jsonString, err := json.Marshal(respBody)
+	if err != nil {
+		return diag.Errorf("error marshaling CBR features: %s", err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("feature_value", string(jsonString)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add two new datasources to query features and single feature.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cbr -f TestAccDataCbrFeatures_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccDataCbrFeatures_basic -timeout 360m -parallel 10
=== RUN   TestAccDataCbrFeatures_basic
=== PAUSE TestAccDataCbrFeatures_basic
=== CONT  TestAccDataCbrFeatures_basic
--- PASS: TestAccDataCbrFeatures_basic (14.26s)
PASS
coverage: 5.2% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       14.343s coverage: 5.2% of statements in ./huaweicloud/services/cbr
```
<img width="1285" height="88" alt="image" src="https://github.com/user-attachments/assets/4c3da133-2da8-4f2e-be15-e0d4b6d0239a" />


```
./scripts/coverage.sh -o cbr -f TestAccDataCbrFeature_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccDataCbrFeature_basic -timeout 360m -parallel 10
=== RUN   TestAccDataCbrFeature_basic
=== PAUSE TestAccDataCbrFeature_basic
=== CONT  TestAccDataCbrFeature_basic
--- PASS: TestAccDataCbrFeature_basic (12.00s)
PASS
coverage: 5.3% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       12.074s coverage: 5.3% of statements in ./huaweicloud/services/cbr
```
<img width="1288" height="82" alt="image" src="https://github.com/user-attachments/assets/b48d4fb2-9c39-4dc5-8ef7-2e8f779fe095" />



* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
