### PR TITLE
feat(waf): add new data source to query the attacked URLs

### DIFF
--- a/docs/data-sources/waf_overviews_attack_url.md
+++ b/docs/data-sources/waf_overviews_attack_url.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_overviews_attack_url"
+description: |-
+  Use this data source to query attacked URLs.
+---
+
+# huaweicloud_waf_overviews_attack_url
+
+Use this data source to query attacked URLs.
+
+## Example Usage
+
+```hcl
+variable "start_time" {}
+variable "end_time" {}
+
+data "huaweicloud_waf_overviews_attack_url" "test" {
+  from = var.start_time
+  to   = var.end_time
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `from` - (Required, Int) Specifies the query start time.
+  The format is 13-digit timestamp in millisecond.
+
+* `to` - (Required, Int) Specifies the query end time.
+  The format is 13-digit timestamp in millisecond.
+
+* `top` - (Optional, Int) Specifies the first several results to query.
+  The valid value ranges from `1` to `10`.
+
+* `hosts` - (Optional, String) Specifies the ID of the domain.
+
+* `instances` - (Optional, String) Specifies the ID of the instance.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `items` - The detail information.
+  The [items](#items_struct) structure is documented below.
+
+<a name="items_struct"></a>
+The `items` block supports:
+
+* `key` - The attack type.
+
+* `num` - The quantity.
+
+* `host` - The protected domain name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1812,6 +1812,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_overviews_abnormal":                   waf.DataSourceWafOverviewsAbnormal(),
 			"huaweicloud_waf_overviews_attack_action_types":        waf.DataSourceOverviewsAttackActionTypes(),
 			"huaweicloud_waf_overviews_attack_top_domains":         waf.DataSourceOverviewsAttackTopDomains(),
+			"huaweicloud_waf_overviews_attack_url":                 waf.DataSourceOverviewsAttackUrl(),
 			"huaweicloud_waf_overviews_bandwidth_timeline":         waf.DataSourceWafOverviewsBandwidthTimeline(),
 			"huaweicloud_waf_overviews_classification":             waf.DataSourceWafOverviewsClassification(),
 			"huaweicloud_waf_overviews_qps_timeline":               waf.DataSourceWafOverviewsQPSTimeline(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_overviews_attack_url_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_overviews_attack_url_test.go
@@ -1,0 +1,56 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceOverviewsAttacUrl_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_waf_overviews_attack_url.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		startTime      = time.Now().Add(-24*time.Hour).UnixNano() / int64(time.Millisecond)
+		endTime        = time.Now().UnixNano() / int64(time.Millisecond)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			// Because there is no available data for testing, the test case is only
+			// used to verify that the API can be invoked.
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceOverviewsAttackUrl_basic(startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.#"),
+
+					resource.TestCheckOutput("test_verify", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceOverviewsAttackUrl_basic(startTime, endTime int64) string {
+	return fmt.Sprintf(`
+data "huaweicloud_waf_overviews_attack_url" "test" {
+  from                  = %[1]d
+  to                    = %[2]d
+  top                   = 5
+  enterprise_project_id = "0"
+}
+
+output "test_verify" {
+  value = length(data.huaweicloud_waf_overviews_attack_url.test.items) == 0
+}
+`, startTime, endTime)
+}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_overviews_attack_url.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_overviews_attack_url.go
@@ -1,0 +1,161 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/waf/overviews/attack/url
+func DataSourceOverviewsAttackUrl() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceOverviewsAttackUrlRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"from": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"to": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"top": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"hosts": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instances": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"host": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildOverviewsAttackUrlQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := fmt.Sprintf("?from=%v&to=%v", d.Get("from"), d.Get("to"))
+
+	if v, ok := d.GetOk("top"); ok {
+		queryParams = fmt.Sprintf("%s&top=%v", queryParams, v)
+	}
+
+	if v, ok := d.GetOk("hosts"); ok {
+		queryParams = fmt.Sprintf("%s&hosts=%v", queryParams, v)
+	}
+
+	if v, ok := d.GetOk("instances"); ok {
+		queryParams = fmt.Sprintf("%s&instances=%v", queryParams, v)
+	}
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+
+	return queryParams
+}
+
+func dataSourceOverviewsAttackUrlRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/overviews/attack/url"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildOverviewsAttackUrlQueryParams(d, epsId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving attacked URLs: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	items := utils.PathSearch("items", getRespBody, make([]interface{}, 0)).([]interface{})
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("items", flattenOverviewsAttackUrl(items)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenOverviewsAttackUrl(subscriptions []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(subscriptions))
+	for _, v := range subscriptions {
+		result = append(result, map[string]interface{}{
+			"key":  utils.PathSearch("key", v, nil),
+			"num":  utils.PathSearch("num", v, nil),
+			"host": utils.PathSearch("host", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to query the attacked URLs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccDataSourceOverviewsAttacUrl_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceOverviewsAttacUrl_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceOverviewsAttacUrl_basic
=== PAUSE TestAccDataSourceOverviewsAttacUrl_basic
=== CONT  TestAccDataSourceOverviewsAttacUrl_basic
--- PASS: TestAccDataSourceOverviewsAttacUrl_basic (12.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       12.338s
```
<img width="1117" height="19" alt="image" src="https://github.com/user-attachments/assets/12b44c25-358e-4e9d-b449-ab41e3c56811" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
