### PR TITLE
feat(apig): add new data source to get domains associated with certificate

### DIFF
--- a/docs/data-sources/apig_certificate_associated_domains.md
+++ b/docs/data-sources/apig_certificate_associated_domains.md
@@ -1,0 +1,78 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_certificate_associated_domains"
+description: |-
+  Use this data source to get domain list associated with the specified SSL certificate within HuaweiCloud.
+---
+
+# huaweicloud_apig_certificate_associated_domains
+
+Use this data source to get domain list associated with the specified SSL certificate within HuaweiCloud.
+
+## Example Usage
+
+### Query all domains under the specified SSL certificate
+
+```hcl
+variable "certificate_id" {}
+
+data "huaweicloud_apig_certificate_associated_domains" "test" {
+  certificate_id = var.certificate_id
+}
+```
+
+### Query domains under the specified SSL certificate by domain name
+
+```hcl
+variable "certificate_id" {}
+variable "domain_name" {}
+
+data "huaweicloud_apig_certificate_associated_domains" "test" {
+  certificate_id = var.certificate_id
+  url_domain     = var.domain_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the domains are located.  
+  If omitted, the provider-level region will be used.
+
+* `certificate_id` - (Required, String) Specifies the ID of the certificate associated with the domains.
+
+* `url_domain` - (Optional, String) Specifies the associated domain name to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `domains` - All domains that match the filter parameters.  
+  The [domains](#apig_data_certificate_associated_domains) structure is documented below.
+
+<a name="apig_data_certificate_associated_domains"></a>
+The `domains` block supports:
+
+* `id` - The ID of the associated domain.
+
+* `url_domain` - The associated domain name.
+
+* `instance_id` - The ID of the dedicated instance to which the domain belongs.
+
+* `status` - The CNAME resolution status of the domain name.
+  + **1**: Not resolved.
+  + **2**: Resolving.
+  + **3**: Resolved.
+  + **4**: Resolution failed.
+
+* `min_ssl_version` - The minimum SSL protocol version of the domain.
+
+* `verified_client_certificate_enabled` - Whether client certificate verification is enabled.
+
+* `api_group_id` - The ID of the API group to which the domain belongs.
+
+* `api_group_name` - The name of the API group to which the domain belongs.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -571,6 +571,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_application_acl":                    apig.DataSourceApplicationAcl(),
 			"huaweicloud_apig_application_associated_quota":       apig.DataSourceApplicationAssociatedQuota(),
 			"huaweicloud_apig_application_quotas":                 apig.DataSourceApigApplicationQuotas(),
+			"huaweicloud_apig_certificate_associated_domains":     apig.DataSourceCertificateAssociatedDomains(),
 			"huaweicloud_apig_channels":                           apig.DataSourceChannels(),
 			"huaweicloud_apig_custom_authorizers":                 apig.DataSourceCustomAuthorizers(),
 			"huaweicloud_apig_endpoint_connections":               apig.DataSourceApigEndpointConnections(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_certificate_associated_domains_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_certificate_associated_domains_test.go
@@ -1,0 +1,145 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataCertificateAssociatedDomains_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_apig_certificate_associated_domains.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byUrlDomain   = "data.huaweicloud_apig_certificate_associated_domains.filter_by_url_domain"
+		dcByUrlDomain = acceptance.InitDataSourceCheck(byUrlDomain)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+			acceptance.TestAccPreCheckCertificateBase(t)
+			acceptance.TestAccPreCheckCertificateRootCA(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataCertificateAssociatedDomains_certificateNotFound(),
+				ExpectError: regexp.MustCompile(`ssl with certId [a-f0-9]+ not found`),
+			},
+			{
+				Config: testAccDataCertificateAssociatedDomains_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "domains.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByUrlDomain.CheckResourceExists(),
+					resource.TestCheckOutput("url_domain_filter_is_useful", "true"),
+					resource.TestCheckResourceAttrSet(dataSource, "domains.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "domains.0.url_domain"),
+					resource.TestCheckResourceAttrSet(dataSource, "domains.0.instance_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "domains.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "domains.0.min_ssl_version"),
+					resource.TestCheckResourceAttr(dataSource, "domains.0.verified_client_certificate_enabled", "true"),
+					resource.TestCheckResourceAttrSet(dataSource, "domains.0.api_group_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "domains.0.api_group_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataCertificateAssociatedDomains_base() string {
+	name := acceptance.RandomAccResourceName()
+	return fmt.Sprintf(`
+resource "huaweicloud_apig_certificate" "test" {
+  instance_id     = "%[1]s"
+  name            = "%[2]s"
+  type            = "instance"
+  content         = "%[3]s"
+  private_key     = "%[4]s"
+  trusted_root_ca = "%[5]s"
+}
+
+data "huaweicloud_apig_instance_ssl_certificates" "test" {
+  instance_id = "%[1]s"
+  name        = huaweicloud_apig_certificate.test.name
+
+  depends_on = [huaweicloud_apig_certificate.test]
+}
+
+locals {
+  domain_name = try([for v in data.huaweicloud_apig_instance_ssl_certificates.test.certificates : v.common_name
+  if v.id == huaweicloud_apig_certificate.test.id][0], null)
+}
+
+resource "huaweicloud_apig_group" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+}
+
+resource "huaweicloud_apig_group_domain_associate" "test" {
+  instance_id     = "%[1]s"
+  group_id        = huaweicloud_apig_group.test.id
+  url_domain      = local.domain_name
+  min_ssl_version = "TLSv1.1"
+}
+
+resource "huaweicloud_apig_certificate_batch_domains_associate" "test" {
+  instance_id    = "%[1]s"
+  certificate_id = huaweicloud_apig_certificate.test.id
+
+  verify_enabled_domain_names = [local.domain_name]
+
+  depends_on = [huaweicloud_apig_group_domain_associate.test]
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID,
+		name,
+		acceptance.HW_CERTIFICATE_CONTENT,
+		acceptance.HW_CERTIFICATE_PRIVATE_KEY,
+		acceptance.HW_CERTIFICATE_ROOT_CA,
+	)
+}
+
+func testAccDataCertificateAssociatedDomains_certificateNotFound() string {
+	randomUUID, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_apig_certificate_associated_domains" "test" {
+  certificate_id = replace("%[1]s", "-", "")
+}
+`, randomUUID)
+}
+
+func testAccDataCertificateAssociatedDomains_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_certificate_associated_domains" "test" {
+  certificate_id = huaweicloud_apig_certificate.test.id
+
+  depends_on = [huaweicloud_apig_certificate_batch_domains_associate.test]
+}
+
+data "huaweicloud_apig_certificate_associated_domains" "filter_by_url_domain" {
+  certificate_id = huaweicloud_apig_certificate.test.id
+  url_domain     = local.domain_name
+
+  depends_on = [huaweicloud_apig_certificate_batch_domains_associate.test]
+}
+
+locals {
+  url_domain_filter_result = [
+    for v in data.huaweicloud_apig_certificate_associated_domains.filter_by_url_domain.domains[*].url_domain : v == local.domain_name
+  ]
+}
+
+output "url_domain_filter_is_useful" {
+  value = length(local.url_domain_filter_result) > 0 && alltrue(local.url_domain_filter_result)
+}
+`, testAccDataCertificateAssociatedDomains_base())
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_certificate_associated_domains.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_certificate_associated_domains.go
@@ -1,0 +1,194 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/certificates/{certificate_id}/attached-domains
+func DataSourceCertificateAssociatedDomains() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCertificateAssociatedDomainsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the domains are located.`,
+			},
+			"certificate_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the certificate associated with the domains.`,
+			},
+			"url_domain": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The associated domain name to be queried.`,
+			},
+			"domains": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the associated domain.`,
+						},
+						"url_domain": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The associated domain name.`,
+						},
+						"instance_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the dedicated instance to which the domain belongs.`,
+						},
+						"status": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The CNAME resolution status of the domain name.`,
+						},
+						"min_ssl_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The minimum SSL protocol version of the domain.",
+						},
+						"verified_client_certificate_enabled": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether client certificate verification is enabled.`,
+						},
+						"api_group_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the API group to which the domain belongs.`,
+						},
+						"api_group_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the API group to which the domain belongs.`,
+						},
+					},
+				},
+				Description: `All domains that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildCertificateAssociatedDomainsBodyParams(d *schema.ResourceData) string {
+	res := ""
+	if domainName, ok := d.GetOk("url_domain"); ok {
+		res = fmt.Sprintf("%s&url_domain=%v", res, domainName)
+	}
+
+	return res
+}
+
+func queryCertificateAssociatedDomains(client *golangsdk.ServiceClient, d *schema.ResourceData, certificateId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/apigw/certificates/{certificate_id}/attached-domains"
+		// The default limit is 20.
+		limit  = 100
+		offset = 0
+		result = make([]interface{}, 0)
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{certificate_id}", certificateId)
+	listPath += fmt.Sprintf("?limit=%d", limit)
+	listPath += buildCertificateAssociatedDomainsBodyParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		attachedDomains := utils.PathSearch("bound_domains", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, attachedDomains...)
+		if len(attachedDomains) < limit {
+			break
+		}
+
+		offset += len(attachedDomains)
+	}
+	return result, nil
+}
+
+func dataSourceCertificateAssociatedDomainsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		certificateId = d.Get("certificate_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	domains, err := queryCertificateAssociatedDomains(client, d, certificateId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("domains", flattenCertificateAssociatedDomainInfos(domains)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCertificateAssociatedDomainInfos(domains []interface{}) []interface{} {
+	if len(domains) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(domains))
+	for _, domain := range domains {
+		result = append(result, map[string]interface{}{
+			"id":                                  utils.PathSearch("id", domain, nil),
+			"url_domain":                          utils.PathSearch("url_domain", domain, nil),
+			"instance_id":                         utils.PathSearch("instance_id", domain, nil),
+			"status":                              utils.PathSearch("status", domain, nil),
+			"min_ssl_version":                     utils.PathSearch("min_ssl_version", domain, nil),
+			"verified_client_certificate_enabled": utils.PathSearch("verified_client_certificate_enabled", domain, nil),
+			"api_group_id":                        utils.PathSearch("api_group_id", domain, nil),
+			"api_group_name":                      utils.PathSearch("api_group_name", domain, nil),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source (`huaweicloud_apig_certificate_associated_domains`) to query domains associated with the specified certificate.

Some attribute under **domains** return empty values, but they actually have values, so they are not provided for the time being.
+ is_http_redirect_to_https
+ ingress_http_port
+ ingress_https_port
+ ssl_id
+ ssl_name

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
2. add corresponding documation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccDataCertificateAssociatedDomains_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataCertificateAssociatedDomains_basic -timeout 360m -parallel 10
=== RUN   TestAccDataCertificateAssociatedDomains_basic
=== PAUSE TestAccDataCertificateAssociatedDomains_basic
=== CONT  TestAccDataCertificateAssociatedDomains_basic
--- PASS: TestAccDataCertificateAssociatedDomains_basic (41.95s)
PASS
coverage: 6.6% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      42.180s coverage: 6.6% of statements in ./huaweicloud/services/apig
```
<img width="999" height="503" alt="image" src="https://github.com/user-attachments/assets/95ea1e54-1794-4bed-82c4-58dce3a4529d" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
