### PR TITLE
feat(SWR): support enterprise instance access control

### DIFF
--- a/docs/resources/swr_enterprise_instance.md
+++ b/docs/resources/swr_enterprise_instance.md
@@ -48,6 +48,14 @@ The following arguments are supported:
 
 * `anonymous_access` - (Optional, Bool) Specifies whether to enable anonymous access. Default to **false**.
 
+* `public_network_access_control_status` - (Optional, String) Specifies the public network access control status.
+  Options are **Disable** and **Enable**. Default to **Disable**.
+
+* `public_network_access_white_ip_list` - (Optional, List) Specifies the public network access white IP list.
+  The [public_network_access_white_ip_list](#block--public_network_access_white_ip_list) structure is documented below.
+
+  -> It can be updated only when `public_network_access_control_status` is **Enable**.
+
 * `delete_dns` - (Optional, Bool) Specifies whether to delete DNS resources when deleting instance. Default to **false**.
 
 * `delete_obs` - (Optional, Bool) Specifies whether to delete OBS bucket when deleting instance. Default to **false**.
@@ -61,6 +69,13 @@ The following arguments are supported:
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the instance.
 
 * `description` - (Optional, String, NonUpdatable) Specifies the description.
+
+<a name="block--public_network_access_white_ip_list"></a>
+The `public_network_access_white_ip_list` block supports:
+
+* `ip` - (Required, String) Specifies the IP address or CIDR block.
+
+* `description` - (Optional, String) Specifies the description.
 
 ## Attribute Reference
 
@@ -97,6 +112,7 @@ In addition to all arguments above, the following attributes are exported:
 This resource provides the following timeouts configuration options:
 
 * `create` - Default is 40 minutes.
+* `update` - Default is 20 minutes.
 
 ## Import
 

--- a/docs/resources/swr_enterprise_private_network_access_control.md
+++ b/docs/resources/swr_enterprise_private_network_access_control.md
@@ -1,0 +1,87 @@
+---
+subcategory: "Software Repository for Container (SWR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_swr_enterprise_private_network_access_control"
+description: |-
+  Manages a SWR enterprise instance private network access control resource within HuaweiCloud.
+---
+
+# huaweicloud_swr_enterprise_private_network_access_control
+
+Manages a SWR enterprise instance private network access control resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+variable "description" {}
+
+resource "huaweicloud_swr_enterprise_private_network_access_control" "test" {
+  instance_id = var.instance_id
+  vpc_id      = var.vpc_id
+  subnet_id   = var.subnet_id
+  description = var.description
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the enterprise instance ID.
+
+* `subnet_id` - (Required, String, NonUpdatable) Specifies the subnet ID.
+
+* `vpc_id` - (Required, String, NonUpdatable) Specifies the VPC ID.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the description.
+
+* `project_id` - (Optional, String, NonUpdatable) Specifies the project ID to which the VPC belongs.
+  Default to the project ID of the instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `vpcep_endpoint_id` - Indicates the VPCEP endpoint ID.
+
+* `endpoint_ip` - Indicates the endpoint IP.
+
+* `status` - Indicates the endpoint status.
+
+* `status_text` - Indicates the status text
+
+* `project_name` - Indicates the project name to which the VPC belongs.
+
+* `vpc_cidr` - Indicates the VPC cidr.
+
+* `vpc_name` - Indicates the VPC name.
+
+* `subnet_cidr` - Indicates the subnet cidr.
+
+* `subnet_name` - Indicates the subnet name.
+
+* `created_at` - Indicates the creation time of the private network access control.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The private network access control can be imported using `instance_id` and `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_swr_enterprise_private_network_access_control.test <instance_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3100,10 +3100,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_swr_image_auto_sync":          swr.ResourceSwrImageAutoSync(),
 			"huaweicloud_swr_temporary_login_command":  swr.ResourceSwrTemporaryLoginCommand(),
 
-			"huaweicloud_swr_enterprise_instance":             swrenterprise.ResourceSwrEnterpriseInstance(),
-			"huaweicloud_swr_enterprise_namespace":            swrenterprise.ResourceSwrEnterpriseNamespace(),
-			"huaweicloud_swr_enterprise_long_term_credential": swrenterprise.ResourceSwrEnterpriseLongTermCredential(),
-			"huaweicloud_swr_enterprise_temporary_credential": swrenterprise.ResourceSwrEnterpriseTemporaryCredential(),
+			"huaweicloud_swr_enterprise_instance":                       swrenterprise.ResourceSwrEnterpriseInstance(),
+			"huaweicloud_swr_enterprise_namespace":                      swrenterprise.ResourceSwrEnterpriseNamespace(),
+			"huaweicloud_swr_enterprise_long_term_credential":           swrenterprise.ResourceSwrEnterpriseLongTermCredential(),
+			"huaweicloud_swr_enterprise_temporary_credential":           swrenterprise.ResourceSwrEnterpriseTemporaryCredential(),
+			"huaweicloud_swr_enterprise_private_network_access_control": swrenterprise.ResourceSwrEnterprisePrivateNetworkAccessControl(),
 
 			"huaweicloud_tms_resource_tags": tms.ResourceResourceTags(),
 			"huaweicloud_tms_tags":          tms.ResourceTmsTag(),

--- a/huaweicloud/services/acceptance/swrenterprise/resource_huaweicloud_swr_enterprise_instance_test.go
+++ b/huaweicloud/services/acceptance/swrenterprise/resource_huaweicloud_swr_enterprise_instance_test.go
@@ -108,6 +108,18 @@ resource "huaweicloud_swr_enterprise_instance" "test" {
   enterprise_project_id = "0"
   anonymous_access      = true
 
+  public_network_access_control_status = "Enable"
+
+  public_network_access_white_ip_list {
+    ip          = "192.168.1.0/24"
+    description = "test-cidr"
+  }
+
+  public_network_access_white_ip_list {
+    ip          = "192.168.1.2/32"
+    description = "test-ip"
+  }
+
   tags = {
     key = "value"
     foo = "bar"
@@ -129,6 +141,8 @@ resource "huaweicloud_swr_enterprise_instance" "test" {
   anonymous_access      = false
   delete_obs            = true
   delete_dns            = true
+
+  public_network_access_control_status = "Disable"
 
   tags = {
     key = "value1"

--- a/huaweicloud/services/acceptance/swrenterprise/resource_huaweicloud_swr_enterprise_private_network_access_control_test.go
+++ b/huaweicloud/services/acceptance/swrenterprise/resource_huaweicloud_swr_enterprise_private_network_access_control_test.go
@@ -1,0 +1,118 @@
+package swrenterprise
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getResourceSwrEnterprisePrivateNetworkAccessControl(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("swr", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SWR client: %s", err)
+	}
+
+	getHttpUrl := "v2/{project_id}/instances/{instance_id}/internal-endpoints/{internal_endpoints_id}"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", state.Primary.Attributes["instance_id"])
+	getPath = strings.ReplaceAll(getPath, "{internal_endpoints_id}", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return getRespBody, nil
+}
+
+func TestAccSwrEnterprisePrivateNetworkAccessControl_basic(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceNameWithDash()
+	rName2 := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_swr_enterprise_private_network_access_control.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getResourceSwrEnterprisePrivateNetworkAccessControl,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSwrEnterprisePrivateNetworkAccessControl_basic(rName, rName2),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "huaweicloud_swr_enterprise_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "huaweicloud_vpc.test2", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "huaweicloud_vpc_subnet.test2", "id"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testSwrEnterprisePrivateNetworkAccessControlImportState(resourceName),
+			},
+		},
+	})
+}
+
+func testAccSwrEnterprisePrivateNetworkAccessControl_basic(rName, rName2 string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_vpc" "test2" {
+  name = "%[2]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test2" {
+  name       = "%[2]s"
+  vpc_id     = huaweicloud_vpc.test2.id
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+}
+
+resource "huaweicloud_swr_enterprise_private_network_access_control" "test" {
+  instance_id = huaweicloud_swr_enterprise_instance.test.id
+  vpc_id      = huaweicloud_vpc.test2.id
+  subnet_id   = huaweicloud_vpc_subnet.test2.id
+  description = "test"
+}
+`, testAccSwrEnterpriseInstance_update(rName), rName2)
+}
+
+func testSwrEnterprisePrivateNetworkAccessControlImportState(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+		if rs.Primary.ID == "" || rs.Primary.Attributes["instance_id"] == "" {
+			return "", fmt.Errorf("resource (%s) instance ID not found: %s", rName, rs)
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.ID), nil
+	}
+}

--- a/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_private_network_access_control.go
+++ b/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_private_network_access_control.go
@@ -1,0 +1,344 @@
+package swrenterprise
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var enterprisePrivateNetworkAccessControlNonUpdatableParams = []string{
+	"instance_id", "vpc_id", "subnet_id", "project_id", "description",
+}
+
+// @API SWR POST /v2/{project_id}/instances/{instance_id}/internal-endpoints
+// @API SWR GET /v2/{project_id}/instances/{instance_id}/internal-endpoints/{internal_endpoints_id}
+// @API SWR DELETE /v2/{project_id}/instances/{instance_id}/internal-endpoints/{internal_endpoints_id}
+func ResourceSwrEnterprisePrivateNetworkAccessControl() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSwrEnterprisePrivateNetworkAccessControlCreate,
+		UpdateContext: resourceSwrEnterprisePrivateNetworkAccessControlUpdate,
+		ReadContext:   resourceSwrEnterprisePrivateNetworkAccessControlRead,
+		DeleteContext: resourceSwrEnterprisePrivateNetworkAccessControlDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceSwrEnterprisePrivateNetworkAccessControlImportStateFunc,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(enterprisePrivateNetworkAccessControlNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the enterprise instance ID.`,
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the VPC ID.`,
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the subnet ID.`,
+			},
+			// VPC should be in same region with the enterprise instance, but can belong to different project with the instance,
+			// use same project_id of region in default
+			"project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the project ID to which the VPC belongs.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the description.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"vpcep_endpoint_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the VPCEP endpoint ID.`,
+			},
+			"project_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the project name to which the VPC belongs.`,
+			},
+			"vpc_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the VPC name.`,
+			},
+			"vpc_cidr": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the VPC cidr.`,
+			},
+			"subnet_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the subnet name.`,
+			},
+			"subnet_cidr": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the subnet cidr.`,
+			},
+			"endpoint_ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the endpoint IP.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the endpoint status.`,
+			},
+			"status_text": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the status text`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the creation time of the private network access control.`,
+			},
+		},
+	}
+}
+
+func resourceSwrEnterprisePrivateNetworkAccessControlCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("swr", region)
+	if err != nil {
+		return diag.Errorf("error creating SWR client: %s", err)
+	}
+
+	createHttpUrl := "v2/{project_id}/instances/{instance_id}/internal-endpoints"
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", d.Get("instance_id").(string))
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateSwrEnterprisePrivateNetworkAccessControlBodyParams(d, client.ProjectID)),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating SWR enterprise instance private network access control: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("id", createRespBody, "").(string)
+	if id == "" {
+		return diag.Errorf("unable to find ID from the API response")
+	}
+
+	d.SetId(id)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"SUCCESS"},
+		Refresh:      getPrivateNetworkAccessControlStatusRefreshFunc(client, d, false),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for private network access control (%s) status to be completed: %s", d.Id(), err)
+	}
+
+	return resourceSwrEnterprisePrivateNetworkAccessControlRead(ctx, d, meta)
+}
+
+func buildCreateSwrEnterprisePrivateNetworkAccessControlBodyParams(d *schema.ResourceData, projectId string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"vpc_id":      d.Get("vpc_id"),
+		"subnet_id":   d.Get("subnet_id"),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+		"project_id":  projectId,
+	}
+
+	if v, ok := d.GetOk("project_id"); ok {
+		bodyParams["project_id"] = v
+	}
+
+	return bodyParams
+}
+
+func getPrivateNetworkAccessControlStatusRefreshFunc(client *golangsdk.ServiceClient, d *schema.ResourceData,
+	isDelete bool) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		rst, err := getSwrEnterprisePrivateNetworkAccessControl(client, d)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok && isDelete {
+				return "Resource Not Found", "DELETED", nil
+			}
+			return nil, "ERROR", err
+		}
+
+		status := utils.PathSearch("status", rst, "").(string)
+		if status == "Running" {
+			return rst, "SUCCESS", nil
+		}
+		if status == "CreateError" || status == "DeleteError" {
+			return nil, "ERROR", errors.New("status unnormal")
+		}
+
+		return rst, "PENDING", nil
+	}
+}
+
+func resourceSwrEnterprisePrivateNetworkAccessControlRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("swr", region)
+	if err != nil {
+		return diag.Errorf("error creating SWR client: %s", err)
+	}
+
+	rst, err := getSwrEnterprisePrivateNetworkAccessControl(client, d)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving SWR enterprise instance private network access control")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("vpc_id", utils.PathSearch("vpc_id", rst, nil)),
+		d.Set("subnet_id", utils.PathSearch("subnet_id", rst, nil)),
+		d.Set("project_id", utils.PathSearch("project_id", rst, nil)),
+		d.Set("description", utils.PathSearch("description", rst, nil)),
+		d.Set("vpcep_endpoint_id", utils.PathSearch("vpcep_endpoint_id", rst, nil)),
+		d.Set("project_name", utils.PathSearch("project_name", rst, nil)),
+		d.Set("vpc_name", utils.PathSearch("vpc_name", rst, nil)),
+		d.Set("vpc_cidr", utils.PathSearch("vpc_cidr", rst, nil)),
+		d.Set("subnet_name", utils.PathSearch("subnet_name", rst, nil)),
+		d.Set("subnet_cidr", utils.PathSearch("subnet_cidr", rst, nil)),
+		d.Set("endpoint_ip", utils.PathSearch("endpoint_ip", rst, nil)),
+		d.Set("status", utils.PathSearch("status", rst, nil)),
+		d.Set("status_text", utils.PathSearch("status_text", rst, nil)),
+		d.Set("created_at", utils.PathSearch("created_at", rst, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func getSwrEnterprisePrivateNetworkAccessControl(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	getHttpUrl := "v2/{project_id}/instances/{instance_id}/internal-endpoints/{internal_endpoints_id}"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", d.Get("instance_id").(string))
+	getPath = strings.ReplaceAll(getPath, "{internal_endpoints_id}", d.Id())
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return getRespBody, nil
+}
+
+func resourceSwrEnterprisePrivateNetworkAccessControlUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceSwrEnterprisePrivateNetworkAccessControlDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("swr", region)
+	if err != nil {
+		return diag.Errorf("error creating SWR client: %s", err)
+	}
+
+	deleteHttpUrl := "v2/{project_id}/instances/{instance_id}/internal-endpoints/{internal_endpoints_id}"
+	deletePath := client.Endpoint + deleteHttpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", d.Get("instance_id").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{internal_endpoints_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting SWR enterprise instance private network access control")
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"DELETED"},
+		Refresh:      getPrivateNetworkAccessControlStatusRefreshFunc(client, d, true),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for private network access control (%s) status to be deleted: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceSwrEnterprisePrivateNetworkAccessControlImportStateFunc(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<id>', but got '%s'", d.Id())
+	}
+
+	d.SetId(parts[1])
+	if err := d.Set("instance_id", parts[0]); err != nil {
+		return nil, fmt.Errorf("error saving instance ID: %s", err)
+	}
+
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support enterprise instance access control
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support enterprise instance access control
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/swrenterprise' TESTARGS='-run TestAccSwrEnterprisePrivateNetworkAccessControl_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swrenterprise -v -run TestAccSwrEnterprisePrivateNetworkAccessControl_basic -timeout 360m -parallel 4
=== RUN   TestAccSwrEnterprisePrivateNetworkAccessControl_basic
=== PAUSE TestAccSwrEnterprisePrivateNetworkAccessControl_basic
=== CONT  TestAccSwrEnterprisePrivateNetworkAccessControl_basic
--- PASS: TestAccSwrEnterprisePrivateNetworkAccessControl_basic (454.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swrenterprise     454.766s

make testacc TEST='./huaweicloud/services/acceptance/swrenterprise' TESTARGS='-run TestAccSwrEnterpriseInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swrenterprise -v -run TestAccSwrEnterpriseInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccSwrEnterpriseInstance_basic
=== PAUSE TestAccSwrEnterpriseInstance_basic
=== CONT  TestAccSwrEnterpriseInstance_basic
--- PASS: TestAccSwrEnterpriseInstance_basic (438.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swrenterprise     438.833s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
    <img width="1215" height="218" alt="image" src="https://github.com/user-attachments/assets/1923db44-8c72-4b0a-b016-71e099ad4813" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
    <img width="1382" height="183" alt="image" src="https://github.com/user-attachments/assets/a752c8e3-777c-4be4-8ef9-514f14812c28" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
