### PR TITLE
feat(waf): support `waf_alarm_optional_event_types` data source

### DIFF
--- a/docs/data-sources/waf_alarm_optional_event_types.md
+++ b/docs/data-sources/waf_alarm_optional_event_types.md
@@ -1,0 +1,95 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_alarm_optional_event_types"
+description: |-
+  Use this data source to query the alarm optional event types.
+---
+
+# huaweicloud_waf_alarm_optional_event_types
+
+Use this data source to query the alarm optional event types.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_waf_alarm_optional_event_types" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `threats` - The list of optional event types in alarm notifications.
+
+* `locale` - The description of each event type in alarm notifications.
+
+  The [locale](#locale_struct) structure is documented below.
+
+<a name="locale_struct"></a>
+The `locale` block supports:
+
+* `cmdi` - The command injection attack, in which an attacker injects malicious commands to perform unauthorized
+  operations.
+
+* `llm_prompt_injection` - The LLM prompt injection attack, in which an attacker constructs special inputs to tamper
+  with the prompts of an AI model.
+
+* `anticrawler` - The website anti-crawler policy, which is used to prevent automated programs from illegally obtaining
+  website content.
+
+* `custom_custom` - The precise protection, which is a custom security protection policy based on specific rules.
+
+* `third_bot_river` - The third-party bot, which is an automated interaction program from a third-party service.
+
+* `robot` - The malicious crawler, which is an automated program used to illegally obtain data or launch attacks.
+
+* `custom_idc_ip` - The IDC intelligence, which is threat intelligence based on data center IP addresses.
+
+* `antiscan_dir_traversal` - The directory traversal protection, which prevents attackers from accessing system files
+  through directory traversal.
+
+* `advanced_bot` - The advanced bot, which is an automated program with complex behavior patterns.
+
+* `xss` - The XSS attack, in which an attacker obtains user information by injecting malicious scripts.
+
+* `antiscan_high_freq_scan` - The scanning blocking, which identifies and blocks abnormal high-frequency requests.
+
+* `webshell` - The web shells, which are malicious programs uploaded by attackers to remotely control websites.
+
+* `cc` - The CC attack, a challenge attack, exhausting server resources by sending a large number of requests.
+
+* `botm` - The BOT attacks, malicious attacks using automated programs.
+
+* `illegal` - The invalid request, which violates security policies or service rules.
+
+* `llm_prompt_sensitive` - The large model prompt word compliance detection, identifying sensitive information in
+  prompts.
+
+* `sqli` - The SQL injection: Attackers inject malicious SQL statements to obtain or tamper with data.
+
+* `lfi` - The local file inclusion: Attackers exploit this vulnerability to include local files to obtain information.
+
+* `antitamper` - The web Tamper Protection, Protecting Website Content from Unauthorized Modification.
+
+* `custom_geoip` - The geolocation access control: geographical location-based access control policy.
+
+* `rfi` - The remote file inclusion: Attackers exploit this vulnerability to execute malicious code using remote files.
+
+* `vuln` - The other types of attacks, unclassified security vulnerabilities or attacks.
+
+* `llm_response_sensitive` - The foundation model responds to compliance detection and identifies sensitive information
+  in the AI model output.
+
+* `custom_whiteblackip` - The IP address blacklist and whitelist, IP address-based access control policy.
+
+* `leakage` - The website information leakage and accidental exposure of sensitive information.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1800,6 +1800,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_waf_address_groups":                       waf.DataSourceWafAddressGroups(),
 			"huaweicloud_waf_alarm_notifications":                  waf.DataSourceWafAlarmNotifications(),
+			"huaweicloud_waf_alarm_optional_event_types":           waf.DataSourceAlarmOptionalEventTypes(),
 			"huaweicloud_waf_all_domains":                          waf.DataSourceWafAllDomains(),
 			"huaweicloud_waf_bundle":                               waf.DataSourceUserBundle(),
 			"huaweicloud_waf_certificate":                          waf.DataSourceWafCertificate(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_alarm_optional_event_types_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_alarm_optional_event_types_test.go
@@ -1,0 +1,62 @@
+package waf
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAlarmOptionalEventTypes_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_waf_alarm_optional_event_types.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAlarmOptionalEventTypes_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "threats.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.cmdi"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.llm_prompt_injection"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.anticrawler"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.custom_custom"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.third_bot_river"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.robot"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.custom_idc_ip"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.antiscan_dir_traversal"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.advanced_bot"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.xss"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.antiscan_high_freq_scan"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.webshell"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.cc"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.botm"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.illegal"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.llm_prompt_sensitive"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.sqli"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.lfi"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.antitamper"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.custom_geoip"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.rfi"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.vuln"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.llm_response_sensitive"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.custom_whiteblackip"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "locale.0.leakage"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceAlarmOptionalEventTypes_basic = `
+data "huaweicloud_waf_alarm_optional_event_types" "test" {}
+`

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_alarm_optional_event_types.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_alarm_optional_event_types.go
@@ -1,0 +1,228 @@
+package waf
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/waf/tag/threat/map
+func DataSourceAlarmOptionalEventTypes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAlarmOptionalEventTypesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"threats": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"locale": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cmdi": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"llm_prompt_injection": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"anticrawler": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"custom_custom": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"third_bot_river": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"robot": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"custom_idc_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"antiscan_dir_traversal": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"advanced_bot": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"xss": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"antiscan_high_freq_scan": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"webshell": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cc": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"botm": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"illegal": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"llm_prompt_sensitive": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sqli": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"lfi": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"antitamper": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"custom_geoip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"rfi": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vuln": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"llm_response_sensitive": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"custom_whiteblackip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"leakage": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlarmOptionalEventTypesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/tag/threat/map"
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	requestResp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving WAF alarm optional event types: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("threats", utils.ExpandToStringList(utils.PathSearch("threats", respBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("locale", flattenAlarmOptionalEventTypesLocale(utils.PathSearch("locale", respBody, nil))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAlarmOptionalEventTypesLocale(rawLocale interface{}) []interface{} {
+	if rawLocale == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"cmdi":                    utils.PathSearch("cmdi", rawLocale, nil),
+			"llm_prompt_injection":    utils.PathSearch("llm_prompt_injection", rawLocale, nil),
+			"anticrawler":             utils.PathSearch("anticrawler", rawLocale, nil),
+			"custom_custom":           utils.PathSearch("custom_custom", rawLocale, nil),
+			"third_bot_river":         utils.PathSearch("third_bot_river", rawLocale, nil),
+			"robot":                   utils.PathSearch("robot", rawLocale, nil),
+			"custom_idc_ip":           utils.PathSearch("custom_idc_ip", rawLocale, nil),
+			"antiscan_dir_traversal":  utils.PathSearch("antiscan_dir_traversal", rawLocale, nil),
+			"advanced_bot":            utils.PathSearch("advanced_bot", rawLocale, nil),
+			"xss":                     utils.PathSearch("xss", rawLocale, nil),
+			"antiscan_high_freq_scan": utils.PathSearch("antiscan_high_freq_scan", rawLocale, nil),
+			"webshell":                utils.PathSearch("webshell", rawLocale, nil),
+			"cc":                      utils.PathSearch("cc", rawLocale, nil),
+			"botm":                    utils.PathSearch("botm", rawLocale, nil),
+			"illegal":                 utils.PathSearch("illegal", rawLocale, nil),
+			"llm_prompt_sensitive":    utils.PathSearch("llm_prompt_sensitive", rawLocale, nil),
+			"sqli":                    utils.PathSearch("sqli", rawLocale, nil),
+			"lfi":                     utils.PathSearch("lfi", rawLocale, nil),
+			"antitamper":              utils.PathSearch("antitamper", rawLocale, nil),
+			"custom_geoip":            utils.PathSearch("custom_geoip", rawLocale, nil),
+			"rfi":                     utils.PathSearch("rfi", rawLocale, nil),
+			"vuln":                    utils.PathSearch("vuln", rawLocale, nil),
+			"llm_response_sensitive":  utils.PathSearch("llm_response_sensitive", rawLocale, nil),
+			"custom_whiteblackip":     utils.PathSearch("custom_whiteblackip", rawLocale, nil),
+			"leakage":                 utils.PathSearch("leakage", rawLocale, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `waf_alarm_optional_event_types` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `waf_alarm_optional_event_types` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccDataSourceAlarmOptionalEventTypes_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceAlarmOptionalEventTypes_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAlarmOptionalEventTypes_basic
=== PAUSE TestAccDataSourceAlarmOptionalEventTypes_basic
=== CONT  TestAccDataSourceAlarmOptionalEventTypes_basic
--- PASS: TestAccDataSourceAlarmOptionalEventTypes_basic (9.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       9.994s

```
<img width="942" height="40" alt="image" src="https://github.com/user-attachments/assets/c9a72614-522a-4bae-8bae-3f2d33fdf663" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
