### PR TITLE
feat(waf): add datasource to query threat intelligence control protection options

### DIFF
--- a/docs/data-sources/waf_tag_ip_reputation_map.md
+++ b/docs/data-sources/waf_tag_ip_reputation_map.md
@@ -1,0 +1,53 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_tag_ip_reputation_map"
+description: |-
+  Use this data source to query details about threat intelligence control protection options.
+---
+
+# huaweicloud_waf_tag_ip_reputation_map
+
+Use this data source to query details about threat intelligence control protection options.
+
+## Example Usage
+
+```hcl
+variable "lang" {}
+variable "type" {}
+
+data "huaweicloud_waf_tag_ip_reputation_map" "test" {
+  lang = var.lang
+  type = var.type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `lang` - (Required, String) Specifies the language.
+  The value can be **cn** or **en**.
+
+* `type` - (Required, String) Specifies the language.
+  The value only can be **idc**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `ip_reputation_map` - The content type of the threat intelligence control protection options.
+
+  The [ip_reputation_map](reputaion_struct) structure is documented below.
+
+* `locale` - The description of each option in the threat intelligence control protection options.
+
+<a name="reputaion_struct"></a>
+The `ip_reputation_map` block supports:
+
+* `idc` - The types of content controlled by threat intelligence.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1843,6 +1843,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_security_report_subscriptions":        waf.DataSourceSecurityReportSubscriptions(),
 			"huaweicloud_waf_source_ips":                           waf.DataSourceWafSourceIps(),
 			"huaweicloud_waf_tag_antileakage_map":                  waf.DataSourceTagAntileakageMap(),
+			"huaweicloud_waf_tag_ip_reputation_map":                waf.DataSourceTagIpReputationMap(),
 
 			"huaweicloud_dws_alarm_subscriptions":             dws.DataSourceAlarmSubscriptions(),
 			"huaweicloud_dws_availability_zones":              dws.DataSourceDwsAvailabilityZones(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_tag_ip_reputation_map_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_tag_ip_reputation_map_test.go
@@ -1,0 +1,40 @@
+package waf
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceTagIpReputationMap_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_waf_tag_ip_reputation_map.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceTagIpReputationMap_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "ip_reputation_map.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "ip_reputation_map.0.idc.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceTagIpReputationMap_basic = `
+data "huaweicloud_waf_tag_ip_reputation_map" "test" {
+  lang = "en"
+  type = "idc"
+}`

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_tag_ip_reputation_map.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_tag_ip_reputation_map.go
@@ -1,0 +1,118 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/waf/tag/ip-reputaion/map
+func DataSourceTagIpReputationMap() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTagIpReputationMapRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"lang": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ip_reputation_map": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"idc": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"locale": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceTagIpReputationMapRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/tag/ip-reputation/map"
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = fmt.Sprintf("%s?lang=%v&type=%v", listPath, d.Get("lang"), d.Get("type"))
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	listResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving threat intelligence control protection options: %s", err)
+	}
+
+	listRespBody, err := utils.FlattenResponse(listResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("ip_reputation_map", flattenTagIpReputationMap(utils.PathSearch("ip_reputation_map", listRespBody, nil))),
+		d.Set("locale", utils.PathSearch("locale", listRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenTagIpReputationMap(contentType interface{}) []interface{} {
+	if contentType == nil {
+		return nil
+	}
+
+	result := map[string]interface{}{
+		"idc": utils.PathSearch("idc", contentType, nil),
+	}
+
+	return []interface{}{result}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to query details about threat intelligence control protection options.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccDataSourceTagIpReputationMap_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceTagIpReputationMap_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceTagIpReputationMap_basic
--- PASS: TestAccDataSourceTagIpReputationMap_basic (12.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       12.528s
```
<img width="1117" height="19" alt="image" src="https://github.com/user-attachments/assets/b81a676e-9f80-4b4c-8964-d540118f3faa" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
