### PR TITLE
feat(waf/domain): add new API to support update parameter `access_status`

### DIFF
--- a/docs/resources/waf_domain.md
+++ b/docs/resources/waf_domain.md
@@ -144,6 +144,9 @@ The following arguments are supported:
 
   Default value is `0`.
 
+* `access_status` - (Optional, Int) Specifies whether a domain name is connected to WAF.  
+  `0`: The domain name is not connected to WAF, `1`: The domain name is connected to WAF, `2`: Skip access.
+
 * `pci_3ds` - (Optional, Bool) Specifies the status of the PCI 3DS compliance certification check.
   This parameter must be used together with `tls` and `cipher`.
 
@@ -276,9 +279,6 @@ The `traffic_mark` block supports:
 The following attributes are exported:
 
 * `id` - ID of the domain.
-
-* `access_status` - Whether a domain name is connected to WAF. 0: The domain name is not connected to WAF, 1: The domain
-  name is connected to WAF.
 
 * `access_code` - The CNAME prefix. The CNAME suffix is `.vip1.huaweicloudwaf.com`.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add new API to support update parameter `access_status`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

add new API to support update parameter `access_status`

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```

Due to environmental and permission restrictions, the API test for the `access_status` parameter has not been effective, and there is currently no testing in the test cases.

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
