### PR TITLE
feat(waf/dedicated_domain): add new API to support update parameter ` access_status`

### DIFF
--- a/docs/resources/waf_dedicated_domain.md
+++ b/docs/resources/waf_dedicated_domain.md
@@ -145,6 +145,11 @@ The following arguments are supported:
 * `protect_status` - (Optional, Int) Specifies the protection status of domain, `0`: suspended, `1`: enabled.
   Defaults to `0`.
 
+* `access_status` - (Optional, Int) Specifies whether a domain name is connected to WAF. Valid values are:
+  + `0` - The domain name is not connected to WAF.
+  + `1` - The domain name is connected to WAF.
+  + `2` - DNS resolution exception.
+
 * `tls` - (Optional, String) Specifies the minimum required TLS version. The valid values are: **TLS v1.0**,
   **TLS v1.1** and **TLS v1.2**.
 
@@ -333,10 +338,6 @@ The following attributes are exported:
 * `id` - ID of the domain.
 
 * `certificate_name` - The name of the certificate used by the domain name.
-
-* `access_status` - Whether a domain name is connected to WAF. Valid values are:
-  + `0` - The domain name is not connected to WAF,
-  + `1` - The domain name is connected to WAF.
 
 * `protocol` - The protocol type of the client. The options are `HTTP` and `HTTPS`.
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add new API to support update parameter ` access_status`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

add new API to support update parameter ` access_status`

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
Due to environmental and permission restrictions, the API test for the `access_status` parameter has not been effective, and there is currently no testing in the test cases.
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
