### PR TITLE
fix(RDS): fix rds mysql database character_set

### DIFF
--- a/huaweicloud/services/rds/resource_huaweicloud_rds_mysql_database.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_mysql_database.go
@@ -203,12 +203,14 @@ func resourceMysqlDatabaseRead(_ context.Context, d *schema.ResourceData, meta i
 		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
 	}
 
+	characterSet := utils.PathSearch("character_set", database, "").(string)
+	characterSet = strings.TrimSuffix(characterSet, "mb3")
 	mErr = multierror.Append(
 		mErr,
 		d.Set("region", region),
 		d.Set("instance_id", instanceId),
 		d.Set("name", utils.PathSearch("name", database, nil)),
-		d.Set("character_set", utils.PathSearch("character_set", database, nil)),
+		d.Set("character_set", characterSet),
 		d.Set("description", utils.PathSearch("comment", database, nil)),
 	)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix rds mysql database character_set
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix rds mysql database character_set
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
