### PR TITLE
feat(ECS): add params to ecs volume attach

### DIFF
--- a/docs/resources/compute_volume_attach.md
+++ b/docs/resources/compute_volume_attach.md
@@ -93,6 +93,11 @@ The following arguments are supported:
   update the device upon subsequent applying which will cause the volume to be detached and reattached indefinitely.
   Please use with caution.
 
+* `delete_on_termination` - (Optional, String) Specifies whether the disk attached to the ECS is deleted when the ECS is
+  deleted. Value options:
+  + **true**: The disk is deleted when the ECS is deleted.
+  + **false**: The disk is not deleted when the ECS is deleted.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_volume_attach_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_volume_attach_test.go
@@ -55,7 +55,15 @@ func TestAccComputeVolumeAttach_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "instance_id",
 						"huaweicloud_compute_instance.instance_1", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "volume_id", "huaweicloud_evs_volume.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "delete_on_termination", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "pci_address"),
+				),
+			},
+			{
+				Config: testAccComputeVolumeAttach_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "delete_on_termination", "false"),
 				),
 			},
 			{
@@ -129,7 +137,7 @@ func TestAccComputeVolumeAttach_multiple(t *testing.T) {
 	})
 }
 
-func testAccComputeVolumeAttach_basic(rName string) string {
+func testAccComputeVolumeAttach_base(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -150,12 +158,31 @@ resource "huaweicloud_compute_instance" "instance_1" {
     uuid = data.huaweicloud_vpc_subnet.test.id
   }
 }
+`, testAccCompute_data, rName, rName)
+}
+
+func testAccComputeVolumeAttach_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
 
 resource "huaweicloud_compute_volume_attach" "va_1" {
-  instance_id = huaweicloud_compute_instance.instance_1.id
-  volume_id   = huaweicloud_evs_volume.test.id
+  instance_id           = huaweicloud_compute_instance.instance_1.id
+  volume_id             = huaweicloud_evs_volume.test.id
+  delete_on_termination = "true"
 }
-`, testAccCompute_data, rName, rName)
+`, testAccComputeVolumeAttach_base(rName))
+}
+
+func testAccComputeVolumeAttach_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_compute_volume_attach" "va_1" {
+  instance_id           = huaweicloud_compute_instance.instance_1.id
+  volume_id             = huaweicloud_evs_volume.test.id
+  delete_on_termination = "false"
+}
+`, testAccComputeVolumeAttach_base(rName))
 }
 
 func testAccComputeVolumeAttach_device(rName string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add params to ecs volume attach
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add params to ecs volume attach
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/ecs/ TESTARGS='-run TestAccComputeVolumeAttach_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs/ -v -run TestAccComputeVolumeAttach_ -timeout 360m -parallel 4
=== RUN   TestAccComputeVolumeAttach_basic
=== PAUSE TestAccComputeVolumeAttach_basic
=== RUN   TestAccComputeVolumeAttach_device
=== PAUSE TestAccComputeVolumeAttach_device
=== RUN   TestAccComputeVolumeAttach_multiple
=== PAUSE TestAccComputeVolumeAttach_multiple
=== CONT  TestAccComputeVolumeAttach_basic
=== CONT  TestAccComputeVolumeAttach_multiple
=== CONT  TestAccComputeVolumeAttach_device
--- PASS: TestAccComputeVolumeAttach_device (271.92s)
--- PASS: TestAccComputeVolumeAttach_multiple (320.96s)
--- PASS: TestAccComputeVolumeAttach_basic (361.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       361.388s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
