### PR TITLE
feat(sfsturbo): new datasource to query quotas

### DIFF
--- a/docs/data-sources/sfs_turbo_quotas.md
+++ b/docs/data-sources/sfs_turbo_quotas.md
@@ -1,0 +1,49 @@
+---
+subcategory: "SFS Turbo"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_sfs_turbo_quotas"
+description: |-
+  Use this data source to get the list of SFS Turbo quotas and their usage.
+---
+
+# huaweicloud_sfs_turbo_quotas
+
+Use this data source to get the list of SFS Turbo quotas and their usage.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_sfs_turbo_quotas" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `quotas` - The list of SFS Turbo quotas and their usage.
+  The [quotas](#quotas_struct) structure is documented below.
+
+<a name="quotas_struct"></a>
+The `quotas` block contains:
+
+* `resources` - The list of quota resources.
+  The [resources](#resources_struct) structure is documented below.
+
+<a name="resources_struct"></a>
+The `resources` block contains:
+
+* `type` - The type of the quota. The value can be **shares** or **capacity**.
+* `max` - The maximum value of the quota.
+* `min` - The minimum value of the quota.
+* `quota` - The total quota value.
+* `unit` - The unit of the quota.
+* `used` - The used quota value.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1698,6 +1698,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_sfs_turbo_perm_rules":  sfsturbo.DataSourceSfsTurboPermRules(),
 			"huaweicloud_sfs_turbo_tags":        sfsturbo.DataSourceSfsTurboTags(),
 			"huaweicloud_sfs_turbo_share_types": sfsturbo.DataSourceSfsTurboShareTypes(),
+			"huaweicloud_sfs_turbo_quotas":      sfsturbo.DataSourceSfsTurboQuotas(),
 			"huaweicloud_sfs_turbo_mounted_ips": sfsturbo.DataSourceSfsTurboMountedIps(),
 
 			"huaweicloud_swr_organizations":             swr.DataSourceOrganizations(),

--- a/huaweicloud/services/acceptance/sfsturbo/data_source_huaweicloud_sfs_turbo_quotas_test.go
+++ b/huaweicloud/services/acceptance/sfsturbo/data_source_huaweicloud_sfs_turbo_quotas_test.go
@@ -1,0 +1,35 @@
+package sfsturbo
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSfsTurboQuotas_basic(t *testing.T) {
+	resourceName := "data.huaweicloud_sfs_turbo_quotas.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSfsTurboQuotas_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "region"),
+					resource.TestCheckResourceAttrSet(resourceName, "quotas.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "quotas.0.resources.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "quotas.0.resources.0.type"),
+					resource.TestCheckResourceAttrSet(resourceName, "quotas.0.resources.0.max"),
+					resource.TestCheckResourceAttrSet(resourceName, "quotas.0.resources.0.min"),
+					resource.TestCheckResourceAttrSet(resourceName, "quotas.0.resources.0.quota"),
+					resource.TestCheckResourceAttrSet(resourceName, "quotas.0.resources.0.used"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceSfsTurboQuotas_basic = `data "huaweicloud_sfs_turbo_quotas" "test" {}`

--- a/huaweicloud/services/sfsturbo/data_source_huaweicloud_sfs_turbo_quotas.go
+++ b/huaweicloud/services/sfsturbo/data_source_huaweicloud_sfs_turbo_quotas.go
@@ -1,0 +1,153 @@
+package sfsturbo
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SFSTurbo GET /v1/{project_id}/sfs-turbo/quotas
+func DataSourceSfsTurboQuotas() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSfsTurboQuotasRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"quotas": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     buildQuotasSchema(),
+			},
+		},
+	}
+}
+
+func buildQuotasSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     buildQuotaResourceSchema(),
+			},
+		},
+	}
+}
+
+func buildQuotaResourceSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"max": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"min": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"quota": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"unit": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"used": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceSfsTurboQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/sfs-turbo/quotas"
+	)
+
+	client, err := cfg.NewServiceClient("sfs-turbo", region)
+	if err != nil {
+		return diag.Errorf("error creating SFS Turbo client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving SFS Turbo quotas: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("quotas", flattenQuotas(utils.PathSearch("quotas", respBody, nil))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenQuotas(respBody interface{}) []map[string]interface{} {
+	if respBody == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"resources": flattenQuotaResources(utils.PathSearch("resources", respBody, make([]interface{}, 0)).([]interface{})),
+		},
+	}
+}
+
+func flattenQuotaResources(respArray []interface{}) []map[string]interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(respArray))
+	for _, respBody := range respArray {
+		result = append(result, map[string]interface{}{
+			"max":   utils.PathSearch("max", respBody, nil),
+			"min":   utils.PathSearch("min", respBody, nil),
+			"quota": utils.PathSearch("quota", respBody, nil),
+			"type":  utils.PathSearch("type", respBody, nil),
+			"unit":  utils.PathSearch("unit", respBody, nil),
+			"used":  utils.PathSearch("used", respBody, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query quotas.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o sfsturbo -f TestAccDataSourceSfsTurboQuotas_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/sfsturbo" -v -coverprofile="./huaweicloud/services/acceptance/sfsturbo/sfsturbo_coverage.cov" -coverpkg="./huaweicloud/services/sfsturbo" -run TestAccDataSourceSfsTurboQuotas_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceSfsTurboQuotas_basic
=== PAUSE TestAccDataSourceSfsTurboQuotas_basic
=== CONT  TestAccDataSourceSfsTurboQuotas_basic
--- PASS: TestAccDataSourceSfsTurboQuotas_basic (11.67s)
PASS
coverage: 3.9% of statements in ./huaweicloud/services/sfsturbo
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sfsturbo  11.749s coverage: 3.9% of statements in ./huaweicloud/services/sfsturbo
```
<img width="1277" height="77" alt="image" src="https://github.com/user-attachments/assets/459f3d4d-4821-420d-ada1-996a34d137a2" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
