### PR TITLE
feat(waf/dedicated_instance_action): support `waf_dedicated_instance_action` resource

### DIFF
--- a/docs/resources/waf_dedicated_instance_action.md
+++ b/docs/resources/waf_dedicated_instance_action.md
@@ -1,0 +1,124 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_dedicated_instance_action"
+description: |-
+  Manages a WAF dedicated instance action resource within HuaweiCloud.
+---
+
+# huaweicloud_waf_dedicated_instance_action
+
+Manages a WAF dedicated instance action resource within HuaweiCloud.
+
+-> This resource is only a one-time action resource using to operate WAF dedicated instance. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+### Modify security group
+
+```hcl
+variable instance_id {}
+variable security_group_id {}
+
+resource "huaweicloud_waf_dedicated_instance_action" "test" {
+  instance_id = var.instance_id
+  action      = "security_groups"
+  params      = [var.security_group_id]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this setting will create a new instance.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of WAF dedicated instance.
+
+* `action` - (Required, String, NonUpdatable) Specifies the operation name.
+
+* `params` - (Optional, List, NonUpdatable) Specifies the specific request body, which is a list of strings.
+
+-> The valid values for parameters `action` and `params` can be found in the Example Usage section of the document.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - The resource ID (also the WAF dedicated instance ID).
+
+* `instancename` - The name of the WAF dedicated instance.
+
+* `server_id` - The ID of the ECS hosting the dedicated engine.
+
+* `zone` - The availability zone code.
+
+* `arch` - The CPU architecture code.
+
+* `cpu_flavor` - The ECS specification code.
+
+* `vpc_id` - The VPC ID where the dedicated engine is located.
+
+* `subnet_id` - The subnet ID of the VPC where the dedicated engine is located.
+
+* `service_ip` - The service plane IP address of the WAF dedicated instance.
+
+* `service_ipv6` - The service plane IPv6 address of the WAF dedicated instance.
+
+* `float_ip` - The management plane IP of the dedicated engine.
+
+* `security_group_ids` - The security groups bound to the dedicated engine ECS.
+
+* `status` - The billing status of the instance.  
+  The valid values are as follows:
+  + **0**: Normal billing.
+  + **1**: Frozen (resources and data will be retained, but tenants can no longer use cloud services normally).
+  + **2**: Terminated (resources and data will be cleared).
+
+* `run_status` - The running status of the instance.  
+  The valid values are as follows:
+  + **0**: Creating.
+  + **1**: Running.
+  + **2**: Deleting.
+  + **3**: Deleted.
+  + **4**: Creation failed.
+  + **5**: Frozen.
+  + **6**: Abnormal.
+  + **7**: Updating.
+  + **8**: Update failed.
+
+* `access_status` - The access status of the instance. `0`: inaccessible, `1`: accessible.
+
+* `upgradable` - Whether the dedicated engine can be upgraded. `0`: Cannot be upgraded, `1`: Can be upgraded.
+
+* `cloud_service_type` - The cloud service code.
+
+* `resource_type` - The cloud service resource type.
+
+* `resource_spec_code` - The cloud service resource code.
+
+* `specification` - The ECS specification of the dedicated engine, such as **8vCPUs | 16GB**.
+
+* `hosts` - The domains protected by the dedicated engine.
+
+  The [hosts](#dedicated_domain_instance_hosts) structure is documented below.
+
+* `volume_type` - The storage type.
+
+* `cluster_id` - The storage resource pool ID.
+
+* `pool_id` - The ID of the WAF group where the dedicated engine is located (only applicable to special dedicated mode).
+
+* `charge_mode` - The billing mode.  
+  The valid values are as follows:
+  + **0**: Package cycle.
+  + **1**: On-demand.
+
+<a name="dedicated_domain_instance_hosts"></a>
+The `hosts` block supports:
+
+* `id` - The ID of the protected domain.
+
+* `hostname` - The protected domain name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3191,6 +3191,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_cloud_instance":                      waf.ResourceCloudInstance(),
 			"huaweicloud_waf_dedicated_domain":                    waf.ResourceWafDedicatedDomain(),
 			"huaweicloud_waf_dedicated_instance":                  waf.ResourceWafDedicatedInstance(),
+			"huaweicloud_waf_dedicated_instance_action":           waf.ResourceDedicatedInstanceAction(),
 			"huaweicloud_waf_domain_associate_certificate":        waf.ResourceDomainAssociateCertificate(),
 			"huaweicloud_waf_domain":                              waf.ResourceWafDomain(),
 			"huaweicloud_waf_modify_alarm_notification":           waf.ResourceModifyAlarmNotification(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -113,16 +113,18 @@ var (
 	HW_DEPRECATED_ENVIRONMENT = os.Getenv("HW_DEPRECATED_ENVIRONMENT")
 	HW_INTERNAL_USED          = os.Getenv("HW_INTERNAL_USED")
 
-	HW_WAF_ENABLE_FLAG         = os.Getenv("HW_WAF_ENABLE_FLAG")
-	HW_WAF_CERTIFICATE_ID      = os.Getenv("HW_WAF_CERTIFICATE_ID")
-	HW_WAF_DOMAIN_ID           = os.Getenv("HW_WAF_DOMAIN_ID")
-	HW_WAF_TYPE                = os.Getenv("HW_WAF_TYPE")
-	HW_WAF_CLOUD_INSTANCE_FLAG = os.Getenv("HW_WAF_CLOUD_INSTANCE_FLAG")
-	HW_WAF_INTERNATIONAL_FLAG  = os.Getenv("HW_WAF_INTERNATIONAL_FLAG")
-	HW_WAF_GROUP_FLAG          = os.Getenv("HW_WAF_GROUP_FLAG")
-	HW_WAF_POLICY_ID           = os.Getenv("HW_WAF_POLICY_ID")
-	HW_WAF_WEB_TAMPER_RULE_ID  = os.Getenv("HW_WAF_WEB_TAMPER_RULE_ID")
-	HW_WAF_ALERT_ID            = os.Getenv("HW_WAF_ALERT_ID")
+	HW_WAF_ENABLE_FLAG                          = os.Getenv("HW_WAF_ENABLE_FLAG")
+	HW_WAF_CERTIFICATE_ID                       = os.Getenv("HW_WAF_CERTIFICATE_ID")
+	HW_WAF_DOMAIN_ID                            = os.Getenv("HW_WAF_DOMAIN_ID")
+	HW_WAF_TYPE                                 = os.Getenv("HW_WAF_TYPE")
+	HW_WAF_CLOUD_INSTANCE_FLAG                  = os.Getenv("HW_WAF_CLOUD_INSTANCE_FLAG")
+	HW_WAF_INTERNATIONAL_FLAG                   = os.Getenv("HW_WAF_INTERNATIONAL_FLAG")
+	HW_WAF_GROUP_FLAG                           = os.Getenv("HW_WAF_GROUP_FLAG")
+	HW_WAF_POLICY_ID                            = os.Getenv("HW_WAF_POLICY_ID")
+	HW_WAF_WEB_TAMPER_RULE_ID                   = os.Getenv("HW_WAF_WEB_TAMPER_RULE_ID")
+	HW_WAF_ALERT_ID                             = os.Getenv("HW_WAF_ALERT_ID")
+	HW_WAF_DEDICATED_INSTANCE_ID                = os.Getenv("HW_WAF_DEDICATED_INSTANCE_ID")
+	HW_WAF_DEDICATED_INSTANCE_SECURITY_GROUP_ID = os.Getenv("HW_WAF_DEDICATED_INSTANCE_SECURITY_GROUP_ID")
 
 	HW_ELB_CERT_ID         = os.Getenv("HW_ELB_CERT_ID")
 	HW_ELB_LOADBALANCER_ID = os.Getenv("HW_ELB_LOADBALANCER_ID")
@@ -1197,6 +1199,13 @@ func TestAccPreCheckWafWebTamperRuleId(t *testing.T) {
 func TestAccPreCheckWafAlertId(t *testing.T) {
 	if HW_WAF_ALERT_ID == "" {
 		t.Skip("HW_WAF_ALERT_ID must be set for this acceptance test.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckWafDedicatedInstanceAction(t *testing.T) {
+	if HW_WAF_DEDICATED_INSTANCE_ID == "" || HW_WAF_DEDICATED_INSTANCE_SECURITY_GROUP_ID == "" {
+		t.Skip("HW_WAF_DEDICATED_INSTANCE_ID and HW_WAF_DEDICATED_INSTANCE_SECURITY_GROUP_ID must be set for this acceptance test.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_instance_action_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_instance_action_test.go
@@ -1,0 +1,39 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// The operation tested in this test case is to modify the security group of the WAF dedicated instance.
+func TestAccDedicatedInstanceAction_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// WAF dedicated instance is only supported in some regions, `cn-east-5` is currently supported.
+			// Prepare a WAF dedicated instance and a security group before executing this test case.
+			acceptance.TestAccPreCheckWafDedicatedInstanceAction(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDedicatedInstanceAction_basic(),
+			},
+		},
+	})
+}
+
+func testAccDedicatedInstanceAction_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_dedicated_instance_action" "test" {
+  instance_id = "%[1]s"
+  action      = "security_groups"
+  params      = ["%[2]s"]
+}
+`, acceptance.HW_WAF_DEDICATED_INSTANCE_ID, acceptance.HW_WAF_DEDICATED_INSTANCE_SECURITY_GROUP_ID)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_instance_action.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_instance_action.go
@@ -1,0 +1,290 @@
+package waf
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableDedicatedInstanceActionParams = []string{
+	"instance_id",
+	"action",
+	"params",
+}
+
+// @API WAF POST /v1/{project_id}/premium-waf/instance/{instance_id}/action
+func ResourceDedicatedInstanceAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDedicatedInstanceActionCreate,
+		ReadContext:   resourceDedicatedInstanceActionRead,
+		UpdateContext: resourceDedicatedInstanceActionUpdate,
+		DeleteContext: resourceDedicatedInstanceActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableDedicatedInstanceActionParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"params": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"instancename": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"server_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"arch": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cpu_flavor": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_ipv6": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"float_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"security_group_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"run_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"access_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"upgradable": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"cloud_service_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_spec_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"specification": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"hosts": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"hostname": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"volume_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"pool_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"charge_mode": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCreateDedicatedInstanceActionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"action": d.Get("action"),
+		"params": utils.ValueIgnoreEmpty(utils.ExpandToStringList(d.Get("params").([]interface{}))),
+	}
+}
+
+func resourceDedicatedInstanceActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v1/{project_id}/premium-waf/instance/{instance_id}/action"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{instance_id}", d.Get("instance_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateDedicatedInstanceActionBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating WAF dedicated instance action: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("id", respBody, "").(string)
+	if id == "" {
+		return diag.Errorf("error creating WAF dedicated instance action: ID is not found in API response")
+	}
+
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("instance_id", id),
+		d.Set("instancename", utils.PathSearch("instancename", respBody, nil)),
+		d.Set("server_id", utils.PathSearch("serverId", respBody, nil)),
+		d.Set("zone", utils.PathSearch("zone", respBody, nil)),
+		d.Set("arch", utils.PathSearch("arch", respBody, nil)),
+		d.Set("cpu_flavor", utils.PathSearch("cpu_flavor", respBody, nil)),
+		d.Set("vpc_id", utils.PathSearch("vpc_id", respBody, nil)),
+		d.Set("subnet_id", utils.PathSearch("subnet_id", respBody, nil)),
+		d.Set("service_ip", utils.PathSearch("service_ip", respBody, nil)),
+		d.Set("service_ipv6", utils.PathSearch("service_ipv6", respBody, nil)),
+		d.Set("float_ip", utils.PathSearch("floatIp", respBody, nil)),
+		d.Set("security_group_ids", utils.ExpandToStringList(
+			utils.PathSearch("security_group_ids", respBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("run_status", utils.PathSearch("run_status", respBody, nil)),
+		d.Set("access_status", utils.PathSearch("access_status", respBody, nil)),
+		d.Set("upgradable", utils.PathSearch("upgradable", respBody, nil)),
+		d.Set("cloud_service_type", utils.PathSearch("cloudServiceType", respBody, nil)),
+		d.Set("resource_type", utils.PathSearch("resourceType", respBody, nil)),
+		d.Set("resource_spec_code", utils.PathSearch("resourceSpecCode", respBody, nil)),
+		d.Set("specification", utils.PathSearch("specification", respBody, nil)),
+		d.Set("hosts", flattenDedicatedInstanceActionHosts(
+			utils.PathSearch("hosts", respBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("volume_type", utils.PathSearch("volume_type", respBody, nil)),
+		d.Set("cluster_id", utils.PathSearch("cluster_id", respBody, nil)),
+		d.Set("pool_id", utils.PathSearch("pool_id", respBody, nil)),
+		d.Set("charge_mode", utils.PathSearch("charge_mode", respBody, nil)),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.FromErr(mErr)
+	}
+
+	return resourceDedicatedInstanceActionRead(ctx, d, meta)
+}
+
+func flattenDedicatedInstanceActionHosts(hostsResp []interface{}) []map[string]interface{} {
+	if len(hostsResp) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(hostsResp))
+	for _, v := range hostsResp {
+		result = append(result, map[string]interface{}{
+			"id":       utils.PathSearch("id", v, nil),
+			"hostname": utils.PathSearch("hostname", v, nil),
+		})
+	}
+
+	return result
+}
+
+func resourceDedicatedInstanceActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDedicatedInstanceActionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDedicatedInstanceActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to operate WAF dedicated instance. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information from the
+    tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `waf_dedicated_instance_action` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `waf_dedicated_instance_action` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccDedicatedInstanceAction_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDedicatedInstanceAction_basic -timeout 360m -parallel 4
=== RUN   TestAccDedicatedInstanceAction_basic
=== PAUSE TestAccDedicatedInstanceAction_basic
=== CONT  TestAccDedicatedInstanceAction_basic
--- PASS: TestAccDedicatedInstanceAction_basic (14.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       14.472s

```
<img width="921" height="47" alt="image" src="https://github.com/user-attachments/assets/402a6fab-7578-4b09-948c-5009f903da04" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
