### PR TITLE
feat(sfs): new resource to manage ldap configuration

### DIFF
--- a/docs/incubating/sfs_turbo_ldap_config.md
+++ b/docs/incubating/sfs_turbo_ldap_config.md
@@ -1,0 +1,101 @@
+---
+subcategory: "SFS Turbo"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_sfs_turbo_ldap_config"
+description: |-
+  Use this resource to manage the LDAP configuration of the SFS Turbo within HuaweiCloud.
+---
+
+# huaweicloud_sfs_turbo_ldap_config
+
+Use this resource to manage the LDAP configuration of the SFS Turbo within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "share_id" {}
+variable "url" {}
+variable "base_dn" {}
+variable "user_dn" {}
+variable "password" {}
+
+resource "huaweicloud_sfs_turbo_ldap_config" "test" {
+  share_id = var.share_id
+  url      = var.url
+  base_dn  = var.base_dn
+  user_dn  = var.user_dn
+  password = var.password
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `share_id` - (Required, String, NonUpdatable) Specifies the ID of the SFS Turbo file system.
+
+* `url` - (Required, String) Specifies the URL of the LDAP server.
+  The format is `ldap://{ip_address}:{port_number}` or `ldaps://{ip_address}:{port_number}`,
+  for example, **ldap://192.168.xx.xx:60000**.
+
+* `base_dn` - (Required, String) Specifies the base distinguished name (DN) for LDAP searches.
+
+* `user_dn` - (Optional, String) Specifies the bind DN used to authenticate to the LDAP server.
+
+* `password` - (Optional, String) Specifies the password for the bind DN. This field is sensitive and will not be
+  displayed in the state.
+
+* `vpc_id` - (Optional, String) Specifies the ID of the VPC that the specified LDAP server can connect to.
+  This parameter is only required when the SFS Turbo file system is used across VPCs.
+
+* `backup_url` - (Optional, String) Specifies the URL of the standby LDAP server.
+  The format is `ldap://{ip_address}:{port_number}` or `ldaps://{ip_address}:{port_number}`,
+  for example, **ldap://192.168.xx.xx:60000**.
+
+* `schema` - (Optional, String) Specifies the LDAP schema. If not specified, **RFC2307** will be used.
+
+* `search_timeout` - (Optional, Int) Specifies the LDAP search timeout interval, in seconds.
+  If not specified, `3` seconds will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, which is the same as the `share_id`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The SFS Turbo LDAP configuration can be imported using the `share_id`, e.g.
+
+```bash
+$ terraform import huaweicloud_sfs_turbo_ldap_config.test <share_id>
+```
+
+```
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `password`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the imported state. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_sfs_turbo_ldap_config" "test" {
+    ...
+  lifecycle {
+    ignore_changes = [
+      password,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3088,6 +3088,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_sfs_turbo_dir_quota":          sfsturbo.ResourceSfsTurboDirQuota(),
 			"huaweicloud_sfs_turbo_data_task":          sfsturbo.ResourceDataTask(),
 			"huaweicloud_sfs_turbo_du_task":            sfsturbo.ResourceDuTask(),
+			"huaweicloud_sfs_turbo_ldap_config":        sfsturbo.ResourceLdapConfig(),
 			"huaweicloud_sfs_turbo_obs_target":         sfsturbo.ResourceOBSTarget(),
 			"huaweicloud_sfs_turbo_perm_rule":          sfsturbo.ResourceSFSTurboPermRule(),
 			"huaweicloud_sfs_turbo_change_charge_mode": sfsturbo.ResourceSFSTurboChangeChargeMode(),

--- a/huaweicloud/services/acceptance/sfsturbo/resource_huaweicloud_sfs_turbo_ldap_config_test.go
+++ b/huaweicloud/services/acceptance/sfsturbo/resource_huaweicloud_sfs_turbo_ldap_config_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2023 Huawei Technologies Co.,Ltd.
+//
+// The provider is licensed under the Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan PSL v2.
+// You may obtain a copy of Mulan PSL v2 at:
+//
+//     http://license.coscl.org.cn/MulanPSL2
+//
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+// EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+// MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+// See the Mulan PSL v2 for more details.
+
+package sfsturbo_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/sfsturbo"
+)
+
+func getSFSTurboLdapConfigResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		product = "sfs-turbo"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SFS Turbo client: %s", err)
+	}
+
+	return sfsturbo.ReadLdapConfig(client, state.Primary.ID)
+}
+
+func TestAccSFSTurboLdapConfig_basic(t *testing.T) {
+	var obj interface{}
+	resourceName := "huaweicloud_sfs_turbo_ldap_config.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getSFSTurboLdapConfigResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckSFSTurboShareId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccSFSTurboLdapConfig_basic(),
+				ExpectError: regexp.MustCompile("error waiting for SFS Turbo LDAP configuration creation to complete"),
+			},
+		},
+	})
+}
+
+func testAccSFSTurboLdapConfig_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_sfs_turbo_ldap_config" "test" {
+  share_id       = "%[1]s"
+  url            = "ldap://192.168.0.1:60001"
+  base_dn        = "dc=example,dc=com"
+  user_dn        = "cn=admin,dc=example,dc=com"
+  password       = "password"
+  backup_url     = "ldap://192.168.0.2:60002"
+  search_timeout = 10
+}
+`, acceptance.HW_SFS_TURBO_SHARE_ID)
+}

--- a/huaweicloud/services/sfsturbo/resource_huaweicloud_sfs_turbo_ldap_config.go
+++ b/huaweicloud/services/sfsturbo/resource_huaweicloud_sfs_turbo_ldap_config.go
@@ -1,0 +1,361 @@
+package sfsturbo
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// Due to the lack of a test LDAP test environment, this resource has not been fully tested and the code coverage is
+// only 35%, so the document is temporarily placed in the incubating directory.
+
+// @API SFSTurbo POST /v1/{project_id}/sfs-turbo/shares/{share_id}/fs/ldap
+// @API SFSTurbo GET /v1/{project_id}/sfs-turbo/shares/{share_id}/fs/ldap
+// @API SFSTurbo DELETE /v1/{project_id}/sfs-turbo/shares/{share_id}/fs/ldap
+// @API SFSTurbo PUT /v1/{project_id}/sfs-turbo/shares/{share_id}/fs/ldap
+// @API SFSTurbo GET /v1/{project_id}/sfs-turbo/jobs/{job_id}
+func ResourceLdapConfig() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceLdapConfigCreate,
+		ReadContext:   resourceLdapConfigRead,
+		UpdateContext: resourceLdapConfigUpdate,
+		DeleteContext: resourceLdapConfigDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{"share_id"}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level
+				region will be used.`,
+			},
+			"share_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the file system ID.`,
+			},
+			"url": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the URL of the LDAP server.`,
+			},
+			"base_dn": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the base DN.`,
+			},
+			"user_dn": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the bind DN.`,
+			},
+			// This field is not returned by the API
+			"password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: `Specifies the LDAP authentication password.`,
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the ID of the VPC that the specified LDAP server can connect to.`,
+			},
+			"backup_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the URL of the standby LDAP server.`,
+			},
+			"schema": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the LDAP schema.`,
+			},
+			"search_timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the LDAP search timeout interval, in seconds. `,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildLdapConfigBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"url":            d.Get("url"),
+		"base_dn":        d.Get("base_dn"),
+		"user_dn":        utils.ValueIgnoreEmpty(d.Get("user_dn")),
+		"password":       utils.ValueIgnoreEmpty(d.Get("password")),
+		"vpc_id":         utils.ValueIgnoreEmpty(d.Get("vpc_id")),
+		"backup_url":     utils.ValueIgnoreEmpty(d.Get("backup_url")),
+		"schema":         utils.ValueIgnoreEmpty(d.Get("schema")),
+		"search_timeout": utils.ValueIgnoreEmpty(d.Get("search_timeout")),
+	}
+
+	return bodyParams
+}
+
+func getTurboJobDetail(client *golangsdk.ServiceClient, jobID string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/sfs-turbo/jobs/{job_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", jobID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func waitingForTurboJobSuccess(ctx context.Context, client *golangsdk.ServiceClient, jobID string,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			jobDetail, err := getTurboJobDetail(client, jobID)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			status := utils.PathSearch("status", jobDetail, "").(string)
+			if status == "" {
+				return nil, "ERROR", errors.New("status is not found in job API response")
+			}
+
+			if status == "failed" {
+				return jobDetail, status, nil
+			}
+
+			if status == "success" {
+				return jobDetail, "COMPLETED", nil
+			}
+
+			return jobDetail, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceLdapConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		shareID = d.Get("share_id").(string)
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/ldap"
+	)
+
+	client, err := cfg.NewServiceClient("sfs-turbo", region)
+	if err != nil {
+		return diag.Errorf("error creating SFS Turbo client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{share_id}", shareID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildLdapConfigBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating SFS Turbo LDAP configuration: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobID := utils.PathSearch("jobId", respBody, "").(string)
+	if jobID == "" {
+		return diag.Errorf("error creating SFS Turbo LDAP configuration: job ID is empty")
+	}
+
+	if err := waitingForTurboJobSuccess(ctx, client, jobID, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("error waiting for SFS Turbo LDAP configuration creation to complete: %s", err)
+	}
+
+	d.SetId(shareID)
+
+	return resourceLdapConfigRead(ctx, d, meta)
+}
+
+func ReadLdapConfig(client *golangsdk.ServiceClient, shareID string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/ldap"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{share_id}", shareID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceLdapConfigRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		shareID = d.Get("share_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("sfs-turbo", region)
+	if err != nil {
+		return diag.Errorf("error creating SFS Turbo client: %s", err)
+	}
+
+	respBody, err := ReadLdapConfig(client, shareID)
+	if err != nil {
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected403ErrInto404Err(err, "errCode", "SFS.TURBO.9000"),
+			"error retrieving SFS Turbo LDAP configuration")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("url", utils.PathSearch("url", respBody, nil)),
+		d.Set("base_dn", utils.PathSearch("base_dn", respBody, nil)),
+		d.Set("user_dn", utils.PathSearch("user_dn", respBody, nil)),
+		d.Set("vpc_id", utils.PathSearch("vpc_id", respBody, nil)),
+		d.Set("backup_url", utils.PathSearch("backup_url", respBody, nil)),
+		d.Set("schema", utils.PathSearch("schema", respBody, nil)),
+		d.Set("search_timeout", utils.PathSearch("search_timeout", respBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceLdapConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		shareID = d.Get("share_id").(string)
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/ldap"
+	)
+
+	client, err := cfg.NewServiceClient("sfs-turbo", region)
+	if err != nil {
+		return diag.Errorf("error creating SFS Turbo client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{share_id}", shareID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildLdapConfigBodyParams(d)),
+	}
+
+	resp, err := client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error updating SFS Turbo LDAP configuration: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobID := utils.PathSearch("jobId", respBody, "").(string)
+	if jobID == "" {
+		return diag.Errorf("error updating SFS Turbo LDAP configuration: job ID is empty")
+	}
+
+	if err := waitingForTurboJobSuccess(ctx, client, jobID, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return diag.Errorf("error waiting for SFS Turbo LDAP configuration update to complete: %s", err)
+	}
+
+	return resourceLdapConfigRead(ctx, d, meta)
+}
+
+func resourceLdapConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		shareID = d.Get("share_id").(string)
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/ldap"
+	)
+
+	client, err := cfg.NewServiceClient("sfs-turbo", region)
+	if err != nil {
+		return diag.Errorf("error creating SFS Turbo client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{share_id}", shareID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting SFS Turbo LDAP configuration: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobID := utils.PathSearch("jobId", respBody, "").(string)
+	if jobID == "" {
+		return diag.Errorf("error deleting SFS Turbo LDAP configuration: job ID is empty")
+	}
+
+	if err := waitingForTurboJobSuccess(ctx, client, jobID, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.Errorf("error waiting for SFS Turbo LDAP configuration deletion to complete: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to manage ldap configuration.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o sfsturbo -f TestAccSFSTurboLdapConfig_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/sfsturbo" -v -coverprofile="./huaweicloud/services/acceptance/sfsturbo/sfsturbo_coverage.cov" -coverpkg="./huaweicloud/services/sfsturbo" -run TestAccSFSTurboLdapConfig_basic -timeout 360m -parallel 10                                                                               loud/services/sfsturbo" -r
=== RUN   TestAccSFSTurboLdapConfig_basic
=== PAUSE TestAccSFSTurboLdapConfig_basic
=== CONT  TestAccSFSTurboLdapConfig_basic
--- PASS: TestAccSFSTurboLdapConfig_basic (24.20s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/sfsturbo
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sfsturbo  24.307s coverage: 4.5% of statements in ./huaweicloud/services/sfsturbo
```
<img width="1289" height="82" alt="image" src="https://github.com/user-attachments/assets/e8feea6f-15b6-4e5e-b308-779012dfc996" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
