### PR TITLE
feat(waf/policies_batch_delete): support `waf_policies_batch_delete` resource

### DIFF
--- a/docs/resources/waf_policies_batch_delete.md
+++ b/docs/resources/waf_policies_batch_delete.md
@@ -1,0 +1,44 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_policies_batch_delete"
+description: |-
+  Manages a WAF policies batch delete resource within HuaweiCloud.
+---
+
+# huaweicloud_waf_policies_batch_delete
+
+Manages a WAF policies batch delete resource within HuaweiCloud.
+
+-> This resource is only a one-time action resource using to batch delete WAF policies. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "policy_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_waf_policies_batch_delete" "test" {
+  policy_ids = var.policy_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this setting will create a new resource.
+
+* `policy_ids` - (Optional, List, NonUpdatable) Specifies the list of policy IDs to be deleted.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  For enterprise users, if omitted, default enterprise project will be used.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3210,6 +3210,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_modify_alarm_notification":           waf.ResourceModifyAlarmNotification(),
 			"huaweicloud_waf_migrate_domain":                      waf.ResourceMigrateDomain(),
 			"huaweicloud_waf_policy":                              waf.ResourceWafPolicy(),
+			"huaweicloud_waf_policies_batch_delete":               waf.ResourcePoliciesBatchDelete(),
 			"huaweicloud_waf_reference_table":                     waf.ResourceWafReferenceTable(),
 			"huaweicloud_waf_rule_anti_crawler":                   waf.ResourceRuleAntiCrawler(),
 			"huaweicloud_waf_rule_blacklist":                      waf.ResourceWafRuleBlackList(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_policies_batch_delete_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_policies_batch_delete_test.go
@@ -1,0 +1,36 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccPoliciesBatchDelete_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires the preparation of a policy ID under the default enterprise project.
+			acceptance.TestAccPreCheckWafPolicyId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPoliciesBatchDelete_basic(),
+			},
+		},
+	})
+}
+
+func testAccPoliciesBatchDelete_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_policies_batch_delete" "test" {
+  policy_ids            = ["%[1]s"]
+  enterprise_project_id = "0"
+}
+`, acceptance.HW_WAF_POLICY_ID)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_policies_batch_delete.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_policies_batch_delete.go
@@ -1,0 +1,128 @@
+package waf
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatablePoliciesBatchDeleteParams = []string{
+	"policy_ids",
+	"enterprise_project_id",
+}
+
+// @API WAF POST /v1/{project_id}/waf/policies/batch-delete
+func ResourcePoliciesBatchDelete() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePoliciesBatchDeleteCreate,
+		ReadContext:   resourcePoliciesBatchDeleteRead,
+		UpdateContext: resourcePoliciesBatchDeleteUpdate,
+		DeleteContext: resourcePoliciesBatchDeleteDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatablePoliciesBatchDeleteParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"policy_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildPoliciesBatchDeleteBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"policy_ids": utils.ValueIgnoreEmpty(utils.ExpandToStringList(d.Get("policy_ids").([]interface{}))),
+	}
+}
+
+func resourcePoliciesBatchDeleteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "waf"
+		httpUrl = "v1/{project_id}/waf/policies/batch-delete"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	epsId := cfg.GetEnterpriseProjectID(d)
+	if epsId != "" {
+		requestPath += "?enterprise_project_id=" + epsId
+	}
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: utils.RemoveNil(buildPoliciesBatchDeleteBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error batch deleting WAF policies: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return resourcePoliciesBatchDeleteRead(ctx, d, meta)
+}
+
+func resourcePoliciesBatchDeleteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourcePoliciesBatchDeleteUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourcePoliciesBatchDeleteDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to batch delete WAF policies. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information from the
+    tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `waf_policies_batch_delete` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `waf_policies_batch_delete` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccPoliciesBatchDelete_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccPoliciesBatchDelete_basic -timeout 360m -parallel 4
=== RUN   TestAccPoliciesBatchDelete_basic
=== PAUSE TestAccPoliciesBatchDelete_basic
=== CONT  TestAccPoliciesBatchDelete_basic
--- PASS: TestAccPoliciesBatchDelete_basic (11.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       11.182s

```
<img width="879" height="37" alt="image" src="https://github.com/user-attachments/assets/7ae54a3a-b8fe-45b9-8e80-9e4b1bde8344" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
