### PR TITLE
feat(kafka): add new resource to batch operate instances

### DIFF
--- a/docs/resources/dms_kafka_instance_batch_action.md
+++ b/docs/resources/dms_kafka_instance_batch_action.md
@@ -1,0 +1,71 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_instance_batch_action"
+description: |-
+  Use this resource to batch operate Kafka instances within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_instance_batch_action
+
+Use this resource to batch operate Kafka instances within HuaweiCloud.
+
+-> This resource is only a one-time action resource for restarting or deleting Kafka instances. Deleting this
+   resource will not clear the corresponding request record, but will only remove the resource information from the
+   tfstate file.
+
+## Example Usage
+
+### Restart Kafka instances
+
+```hcl
+variable "instance_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_dms_kafka_instance_batch_action" "test" {
+  instance_ids = var.instance_ids
+  action       = "restart"
+}
+```
+
+### Delete Kafka instances
+
+```hcl
+variable "instance_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_dms_kafka_instance_batch_action" "test" {
+  instance_ids = var.instance_ids
+  action       = "delete"
+}
+```
+
+### Delete all failed Kafka instances
+
+```hcl
+resource "huaweicloud_dms_kafka_instance_batch_action" "test" {
+  action      = "delete"
+  all_failure = "kafka"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the instances to be operated are located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `action` - (Required, String, NonUpdatable) Specifies the type of the action.
+
+* `instances` - (Optional, List, NonUpdatable) Specifies the list of instance IDs to be operated.
+
+* `all_failure` - (Optional, String, NonUpdatable) Specifies whether to delete all instances that failed
+  to be created.  
+  The valid values are as follows:
+  + **kafka**: Delete all failed Kafka instances.
+
+* `force_delete` - (Optional, Bool, NonUpdatable) Specifies whether to force delete instances.  
+  Defaults to **false**. Force delete instances do not enter the recycle bin.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2473,6 +2473,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_message_produce":           kafka.ResourceDmsKafkaMessageProduce(),
 			"huaweicloud_dms_kafka_partition_reassign":        kafka.ResourceDmsKafkaPartitionReassign(),
 			"huaweicloud_dms_kafka_consumer_group":            kafka.ResourceDmsKafkaConsumerGroup(),
+			"huaweicloud_dms_kafka_instance_batch_action":     kafka.ResourceInstanceBatchAction(),
 			"huaweicloud_dms_kafka_message_offset_reset":      kafka.ResourceDmsKafkaMessageOffsetReset(),
 			"huaweicloud_dms_kafka_smart_connect":             kafka.ResourceDmsKafkaSmartConnect(),
 			"huaweicloud_dms_kafka_smart_connect_task":        kafka.ResourceDmsKafkaSmartConnectTask(),

--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_instance_batch_action_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_instance_batch_action_test.go
@@ -1,0 +1,107 @@
+package kafka
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccInstanceBatchAction_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testInstanceBatchAction_basic_step1(name),
+			},
+			{
+				Config: testInstanceBatchAction_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckOutput("is_delete_success", "true"),
+				),
+				// After deleting an instance using huaweicloud_dms_kafka_instance_batch_action, terraform will detect
+				// the change in the next plan because the instance status is modified. Set ExpectNonEmptyPlan to true to expect
+				// this non-empty plan as the normal behavior.
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testInstanceBatchAction_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_dms_kafka_flavors" "test" {
+  type = "single"
+}
+
+locals {
+  flavor = data.huaweicloud_dms_kafka_flavors.test.flavors[0]
+}
+
+resource "huaweicloud_dms_kafka_instance" "test" {
+  count = 2
+
+  name               = "%[2]s${count.index}"
+  vpc_id             = huaweicloud_vpc.test.id
+  network_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id  = huaweicloud_networking_secgroup.test.id
+  flavor_id          = local.flavor.id
+  storage_spec_code  = "dms.physical.storage.extreme"
+  engine_version     = "3.x"
+  broker_num         = 1
+  storage_space      = try(local.flavor.properties[0].min_broker * local.flavor.properties[0].min_storage_per_node, null)
+  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testInstanceBatchAction_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dms_kafka_instance_batch_action" "test" {
+  instances = huaweicloud_dms_kafka_instance.test[*].id
+  action    = "restart"
+}
+`, testInstanceBatchAction_base(name))
+}
+
+func testInstanceBatchAction_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dms_kafka_instance_batch_action" "delete" {
+  instances    = huaweicloud_dms_kafka_instance.test[*].id
+  action       = "delete"
+  force_delete = true
+
+  lifecycle {
+    ignore_changes = [instances]
+  }
+}
+
+data "huaweicloud_dms_kafka_instances" "test" {
+  count = 2
+
+  instance_id = huaweicloud_dms_kafka_instance.test[count.index].id
+
+  depends_on = [huaweicloud_dms_kafka_instance_batch_action.delete]
+}
+
+output "is_delete_success" {
+  value = length(flatten(data.huaweicloud_dms_kafka_instances.test[*].instances)) == 0
+}
+`, testInstanceBatchAction_base(name))
+}

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance_batch_action.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance_batch_action.go
@@ -1,0 +1,189 @@
+package kafka
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var instanceBatchActionNonUpdatableParams = []string{"action", "instances", "all_failure", "force_delete"}
+
+// @API Kafka POST /v2/{project_id}/instances/action
+// @API Kafka GET /v2/{project_id}/instances/{instance_id}
+func ResourceInstanceBatchAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInstanceBatchActionCreate,
+		ReadContext:   resourceInstanceBatchActionRead,
+		UpdateContext: resourceInstanceBatchActionUpdate,
+		DeleteContext: resourceInstanceBatchActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(instanceBatchActionNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the instances to be operated are located.`,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the operation.`,
+			},
+			"instances": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of instance IDs to be operated.`,
+			},
+			"all_failure": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Whether to delete all instances that failed to be created.`,
+			},
+			"force_delete": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to force delete instances.`,
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildCreateInstanceBatchActionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"action":       d.Get("action"),
+		"instances":    utils.ValueIgnoreEmpty(d.Get("instances")),
+		"all_failure":  utils.ValueIgnoreEmpty(d.Get("all_failure")),
+		"force_delete": d.Get("force_delete"),
+	}
+}
+
+func resourceInstanceBatchActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		action = d.Get("action").(string)
+	)
+	client, err := cfg.NewServiceClient("dmsv2", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	createHttpUrl := "v2/{project_id}/instances/action"
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateInstanceBatchActionBodyParams(d)),
+		// `204`: Delete all created failed Kafka instances successfully.
+		OkCodes: []int{
+			200, 204,
+		},
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("unable to batch %s instances: %s", action, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	operatedSuccessedInstanceIds := utils.PathSearch("results[?result=='success'].instance", respBody, make([]interface{}, 0)).([]interface{})
+	if len(operatedSuccessedInstanceIds) == 0 {
+		return diag.Errorf("unable to batch %s instances: no successed instances", action)
+	}
+
+	for _, instanceId := range operatedSuccessedInstanceIds {
+		stateConf := &resource.StateChangeConf{
+			Pending:      []string{"PENDING"},
+			Target:       []string{"COMPLETED"},
+			Refresh:      refreshBatchActionInstancesState(client, instanceId.(string)),
+			Timeout:      d.Timeout(schema.TimeoutCreate),
+			Delay:        20 * time.Second,
+			PollInterval: 20 * time.Second,
+		}
+		_, err = stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			// Some instances may be operation failed, so use log to record the error.
+			log.Printf("[ERROR] error waiting for the instance (%v) to be %s completed: %s", instanceId, action, err)
+		}
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+	return nil
+}
+
+func refreshBatchActionInstancesState(client *golangsdk.ServiceClient, instanceId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		// When an instance is deleted, the query instance list API returns data that no longer contains the instance,
+		// but the instance is actually in the deletion state. Therefore, use the query instance details API
+		respBody, err := instances.Get(client, instanceId).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return respBody, "COMPLETED", nil
+			}
+			return nil, "QUERY ERROR", err
+		}
+
+		// If the recycle bin function is enabled, the status of non-forced deletion instances is `RECYCLE`.
+		if respBody.Status == "RUNNING" || respBody.Status == "RECYCLE" {
+			return respBody, "COMPLETED", nil
+		}
+
+		return respBody, "PENDING", nil
+	}
+}
+
+func resourceInstanceBatchActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceInstanceBatchActionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceInstanceBatchActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for restarting or deleting Kafka instances. Deleting
+this resource will not clear the corresponding request record, but will only remove the resource information from the
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new one-time action resource(`huaweicloud_dms_kafka_instance_batch_action`) to batch operate Kafka instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new resource and corresponding documation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccInstanceBatchAction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccInstanceBatchAction_basic -timeout 360m -parallel 10
=== RUN   TestAccInstanceBatchAction_basic
=== PAUSE TestAccInstanceBatchAction_basic
=== CONT  TestAccInstanceBatchAction_basic
--- PASS: TestAccInstanceBatchAction_basic (678.14s)
PASS
coverage: 11.4% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     678.269s        coverage: 11.4% of statements in ./huaweicloud/services/kafka
```
<img width="1092" height="455" alt="image" src="https://github.com/user-attachments/assets/1ed6248d-86d7-4131-a170-aa94b0368d1d" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
