### PR TITLE
feat(waf/domain_route_update): support `waf_domain_route_update` resource

### DIFF
--- a/docs/resources/waf_domain_route_update.md
+++ b/docs/resources/waf_domain_route_update.md
@@ -1,0 +1,76 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_domain_route_update"
+description: |-
+  Manages a WAF domain route update resource within HuaweiCloud.
+---
+
+# huaweicloud_waf_domain_route_update
+
+Manages a WAF domain route update resource within HuaweiCloud.
+
+-> This resource is only a one-time action resource using to update WAF domain route. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "domain_id" {}
+
+resource "huaweicloud_waf_domain_route_update" "test" {
+  instance_id = var.domain_id
+
+  routes {
+    name  = "example_route"
+    cname = "example_cname"
+
+    servers {
+      back_protocol = "HTTP"
+      address       = "192.168.1.1"
+      port          = 80
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this setting will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of WAF domain.
+
+* `routes` - (Required, List, NonUpdatable) Specifies the list of route configurations.
+
+  The [routes](#domain_route_update_routes) structure is documented below.
+
+<a name="domain_route_update_routes"></a>
+The `routes` block supports:
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the WAF cluster.
+
+* `servers` - (Required, List, NonUpdatable) Specifies the list of protected domain source site server information.
+
+  The [servers](#domain_route_update_servers) structure is documented below.
+
+* `cname` - (Optional, String, NonUpdatable) Specifies the cname suffix of the WAF cluster.
+
+<a name="domain_route_update_servers"></a>
+The `servers` block supports:
+
+* `back_protocol` - (Optional, String, NonUpdatable) Specifies the protocol for WAF to forward client requests to the
+  protected domain origin server. The valid values are **HTTP** and **HTTPS**.
+
+* `address` - (Optional, String, NonUpdatable) Specifies the IP address of the source server for client access.
+
+* `port` - (Optional, Int, NonUpdatable) Specifies the business port for WAF to forward client requests to the source
+  service.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - The resource ID, which is the same as the `instance_id`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3210,6 +3210,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_dedicated_instance_action":           waf.ResourceDedicatedInstanceAction(),
 			"huaweicloud_waf_domain_associate_certificate":        waf.ResourceDomainAssociateCertificate(),
 			"huaweicloud_waf_domain":                              waf.ResourceWafDomain(),
+			"huaweicloud_waf_domain_route_update":                 waf.ResourceDomainRouteUpdate(),
 			"huaweicloud_waf_ip_intelligence_rule":                waf.ResourceIpIntelligenceRule(),
 			"huaweicloud_waf_modify_alarm_notification":           waf.ResourceModifyAlarmNotification(),
 			"huaweicloud_waf_migrate_domain":                      waf.ResourceMigrateDomain(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_route_update_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_route_update_test.go
@@ -1,0 +1,70 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDomainRouteUpdate_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// The value of the `routes` parameter is obtained through API queries, if this value is not used, the
+			// resource execution will report an error.
+			// So when the value of `instance_id` changes, the execution of this test case may result in an error.
+			acceptance.TestAccPreCheckWafDomainId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainRouteUpdate_basic(),
+			},
+		},
+	})
+}
+
+func testAccDomainRouteUpdate_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_domain_route_update" "test" {
+  instance_id = "%[1]s"
+
+  routes {
+    name  = "Beijing"
+    cname = "a59802a4b1c041328e1301a6c46eae7d"
+
+    servers {
+      back_protocol = "HTTP"
+      address       = "167.168.0.16"
+      port          = 80
+    }
+  }
+
+  routes {
+    name  = "Langfang"
+    cname = "62371ea53d584cfea6239a4594c9c529"
+
+    servers {
+      back_protocol = "HTTP"
+      address       = "167.168.0.16"
+      port          = 80
+    }
+  }
+
+  routes {
+    name  = "Internal"
+    cname = "3c360f2a90d243bb84edca4aec080722"
+
+    servers {
+      back_protocol = "HTTP"
+      address       = "167.168.0.16"
+      port          = 80
+    }
+  }
+}
+`, acceptance.HW_WAF_DOMAIN_ID)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_domain_route_update.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_domain_route_update.go
@@ -1,0 +1,180 @@
+package waf
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableDomainRouteUpdateParams = []string{
+	"instance_id",
+	"routes",
+	"routes.*.name",
+	"routes.*.servers",
+	"routes.*.servers.*.back_protocol",
+	"routes.*.servers.*.address",
+	"routes.*.servers.*.port",
+	"routes.*.cname",
+}
+
+// @API WAF PUT /v1/{project_id}/waf/instance/{instance_id}/route
+func ResourceDomainRouteUpdate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDomainRouteUpdateCreate,
+		ReadContext:   resourceDomainRouteUpdateRead,
+		UpdateContext: resourceDomainRouteUpdateUpdate,
+		DeleteContext: resourceDomainRouteUpdateDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableDomainRouteUpdateParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"routes": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"servers": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"back_protocol": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"address": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"port": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"cname": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildDomainRouteUpdateBodyParams(d *schema.ResourceData) []map[string]interface{} {
+	rawRoutes := d.Get("routes").([]interface{})
+	routeParams := make([]map[string]interface{}, 0, len(rawRoutes))
+
+	for _, r := range rawRoutes {
+		routeMap := r.(map[string]interface{})
+		rawServers := routeMap["servers"].([]interface{})
+
+		servers := make([]map[string]interface{}, 0, len(rawServers))
+		for _, s := range rawServers {
+			serverMap := s.(map[string]interface{})
+			server := map[string]interface{}{
+				"back_protocol": utils.ValueIgnoreEmpty(serverMap["back_protocol"]),
+				"address":       utils.ValueIgnoreEmpty(serverMap["address"]),
+				"port":          utils.ValueIgnoreEmpty(serverMap["port"]),
+			}
+			servers = append(servers, utils.RemoveNil(server))
+		}
+
+		route := map[string]interface{}{
+			"name":    routeMap["name"],
+			"servers": servers,
+			"cname":   utils.ValueIgnoreEmpty(routeMap["cname"]),
+		}
+		routeParams = append(routeParams, utils.RemoveNil(route))
+	}
+
+	return routeParams
+}
+
+func resourceDomainRouteUpdateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		product    = "waf"
+		httpUrl    = "v1/{project_id}/waf/instance/{instance_id}/route"
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{instance_id}", instanceId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: buildDomainRouteUpdateBodyParams(d),
+	}
+
+	_, err = client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error updating WAF domain route: %s", err)
+	}
+
+	d.SetId(instanceId)
+
+	return resourceDomainRouteUpdateRead(ctx, d, meta)
+}
+
+func resourceDomainRouteUpdateRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDomainRouteUpdateUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDomainRouteUpdateDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to update WAF domain route. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information from the
+    tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `waf_domain_route_update` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `waf_domain_route_update` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccDomainRouteUpdate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDomainRouteUpdate_basic -timeout 360m -parallel 4
=== RUN   TestAccDomainRouteUpdate_basic
=== PAUSE TestAccDomainRouteUpdate_basic
=== CONT  TestAccDomainRouteUpdate_basic
--- PASS: TestAccDomainRouteUpdate_basic (22.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       22.339s

```
<img width="872" height="38" alt="image" src="https://github.com/user-attachments/assets/f9ea0c87-7269-4741-a21e-6df51595bc29" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
