### PR TITLE
fix(apig): fix channel member resource bug

### DIFF
--- a/docs/resources/apig_channel_member.md
+++ b/docs/resources/apig_channel_member.md
@@ -17,15 +17,16 @@ Use this resource to manage a channel member within HuaweiCloud.
 ```hcl
 variable "instance_id" {}
 variable "vpc_channel_id" {}
+variable "member_group_name" {}
 variable "member_ip_address" {}
 variable "port" {}
 
 resource "huaweicloud_apig_channel_member" "test" {
   instance_id       = var.instance_id
   vpc_channel_id    = var.vpc_channel_id
+  member_group_name = var.member_group_name
   member_ip_address = var.member_ip_address
   port              = var.port
-  weight            = 10
 }
 ```
 
@@ -34,19 +35,20 @@ resource "huaweicloud_apig_channel_member" "test" {
 ```hcl
 variable "instance_id" {}
 variable "vpc_channel_id" {}
+variable "member_group_name" {}
 variable "ecs_id" {}
 variable "ecs_name" {}
 variable "port" {}
 
 resource "huaweicloud_apig_channel_member" "test" {
-  instance_id    = var.instance_id
-  vpc_channel_id = var.vpc_channel_id
-  ecs_id         = var.ecs_id
-  ecs_name       = var.ecs_name
-  port           = var.port
-  weight         = 10
-  is_backup      = false
-  status         = 1
+  instance_id       = var.instance_id
+  vpc_channel_id    = var.vpc_channel_id
+  member_group_name = var.member_group_name
+  ecs_id            = var.ecs_id
+  ecs_name          = var.ecs_name
+  port              = var.port
+  is_backup         = false
+  status            = 1
 }
 ```
 
@@ -63,25 +65,12 @@ The following arguments are supported:
 
 * `vpc_channel_id` - (Required, String, NonUpdatable) Specifies the ID of the VPC channel.
 
-* `weight` - (Optional, Int) Specifies the weight value of the channel member.  
-  This weight value is automatically used for weight allocation, and the valid value is range from `0` to `10,000`.
-  The greater the weight of a channel member, the more requests will be dispatched to it.
-
-* `port` - (Optional, Int) Specifies the port number of the channel member.  
-  The valid value is range from `0` to `65,535`.
-
-* `is_backup` - (Optional, Bool) Specifies whether this member is the backup member.  
-  When enabled, the corresponding backend service is a backup node and only works when all non-backup nodes fail.  
-  The default value is `false`.
-
-* `member_group_name` - (Optional, String) Specifies the name of the channel member group.  
+* `member_group_name` - (Required, String, NonUpdatable) Specifies the name of the channel member group.  
   This is used to select a channel member group for easy unified modification of the corresponding server group backend
   attributes.
 
-* `status` - (Optional, Int) Specifies the status of the channel member.  
-  The valid values are as follow:
-  + **1**: Available
-  + **2**: Unavailable
+* `port` - (Required, Int, NonUpdatable) Specifies the port number of the channel member.  
+  The valid value is range from `0` to `65,535`.
 
 * `member_ip_address` - (Optional, String) Specifies the IP address of the channel member.  
   The member_ip_address contain a maximum of `255` characters.
@@ -98,11 +87,22 @@ The following arguments are supported:
 
 -> Parameter `ecs_id` and `ecs_name` are required if the type of vpc channel is **ecs**.
 
+* `status` - (Optional, Int) Specifies the status of the channel member.  
+  The valid values are as follow:
+  + **1**: Available
+  + **2**: Unavailable
+
+* `is_backup` - (Optional, Bool) Specifies whether this member is the backup member.  
+  When enabled, the corresponding backend service is a backup node and only works when all non-backup nodes fail.  
+  The default value is `false`.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
+
+* `weight` - The weight value of the channel member.
 
 * `create_time` - The creation time of the channel member, in RFC3339 format.
 
@@ -112,9 +112,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Channel members can be imported using their `id`, the ID of the related dedicated instance and the ID of the related VPC
-channel, separated by slashes, e.g.
+Channel members can be imported using their `id`, the ID of the related dedicated instance, the ID of the related VPC
+channel and the name of the related member group, separated by slashes, e.g.
 
 ```bash
-$ terraform import huaweicloud_apig_channel_member.test <instance_id>/<vpc_channel_id>/<id>
+$ terraform import huaweicloud_apig_channel_member.test <instance_id>/<vpc_channel_id>/<member_group_name>/<id>
 ```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix(apig): fix channel member resource bug

**Which issue this PR fixes**:
1. Since the APIG service manages backends through a single VPC channel, it cannot modify more than one backend instance at
the same time; therefore, we serialize all update operations on the instances to avoid race conditions. 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. serialize all update operations on the instances to avoid race conditions
2. `weight` attribute can not modify.
3. `member_group_name`, `member_ip_address`, `port`, `ecs_id`, `ecs_name` cannot be updated.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccChannelMember_basic -timeout 360m -parallel 10
=== RUN   TestAccChannelMember_basic
=== PAUSE TestAccChannelMember_basic
=== CONT  TestAccChannelMember_basic
--- PASS: TestAccChannelMember_basic (560.57s)
PASS
coverage: 6.0% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      560.690s        coverage: 6.0% of statements in ./huaweicloud/services/apig
```

<img width="1662" height="167" alt="image" src="https://github.com/user-attachments/assets/aa7d13e1-135e-4a26-8cea-d14421fb44b3" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.