### PR TITLE
feat(waf): add new resource to batch delete CC protection rules

### DIFF
--- a/docs/resources/waf_cc_protection_rule_batch_delete.md
+++ b/docs/resources/waf_cc_protection_rule_batch_delete.md
@@ -1,0 +1,57 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_cc_protection_rule_batch_delete"
+description: |-
+  Manages a resource to batch delete the CC protection rules within HuaweiCloud.
+---
+
+# huaweicloud_waf_cc_protection_rule_batch_delete
+
+Manages a resource to batch delete the CC protection rules within HuaweiCloud.
+
+-> All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be used.
+
+-> This resource is only a one-time action resource using to batch delete CC protection rules. Deleting this resource
+  will not clear the corresponding request record, but will only remove the resource information from the tf state
+  file.
+
+## Example Usage
+
+```hcl
+variable "policy_id" {}
+variable "rule_ids"  {
+  type = list(string)
+}
+
+resource "huaweicloud_waf_cc_protection_rule_batch_delete" "test" {
+  policy_rule_ids {
+    policy_id = var.policy_id
+    rule_ids  = var.rule_ids
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `policy_rule_ids` - (Required, List, NonUpdatable) Specifies the policy and rule details.
+  The [policy_rule_ids](#cc_protection_policy_rules) structure is documented below.
+
+<a name="cc_protection_policy_rules"></a>
+The `policy_rule_ids` block supports:
+
+* `policy_id` - (Required, String, NonUpdatable) Specifies the policy ID to which the CC protection rule belongs.
+
+* `rule_ids` - (Required, List, NonUpdatable) Specifies the ID list of the CC protection rule.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3203,6 +3203,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpn_p2c_gateway_job_delete":            vpn.ResourceP2CGatewayJobDelete(),
 
 			"huaweicloud_waf_address_group":                       waf.ResourceWafAddressGroup(),
+			"huaweicloud_waf_cc_protection_rule_batch_delete":     waf.ResourceCcRuleBatchDelete(),
 			"huaweicloud_waf_certificate":                         waf.ResourceWafCertificate(),
 			"huaweicloud_waf_cloud_instance":                      waf.ResourceCloudInstance(),
 			"huaweicloud_waf_dedicated_domain":                    waf.ResourceWafDedicatedDomain(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -125,6 +125,7 @@ var (
 	HW_WAF_ALERT_ID                             = os.Getenv("HW_WAF_ALERT_ID")
 	HW_WAF_DEDICATED_INSTANCE_ID                = os.Getenv("HW_WAF_DEDICATED_INSTANCE_ID")
 	HW_WAF_DEDICATED_INSTANCE_SECURITY_GROUP_ID = os.Getenv("HW_WAF_DEDICATED_INSTANCE_SECURITY_GROUP_ID")
+	HW_WAF_RULE_ID                              = os.Getenv("HW_WAF_RULE_ID")
 
 	HW_ELB_CERT_ID         = os.Getenv("HW_ELB_CERT_ID")
 	HW_ELB_LOADBALANCER_ID = os.Getenv("HW_ELB_LOADBALANCER_ID")
@@ -1210,6 +1211,13 @@ func TestAccPreCheckWafAlertId(t *testing.T) {
 func TestAccPreCheckWafDedicatedInstanceAction(t *testing.T) {
 	if HW_WAF_DEDICATED_INSTANCE_ID == "" || HW_WAF_DEDICATED_INSTANCE_SECURITY_GROUP_ID == "" {
 		t.Skip("HW_WAF_DEDICATED_INSTANCE_ID and HW_WAF_DEDICATED_INSTANCE_SECURITY_GROUP_ID must be set for this acceptance test.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckWafRuleId(t *testing.T) {
+	if HW_WAF_RULE_ID == "" {
+		t.Skip("HW_WAF_RULE_ID must be set for this acceptance test.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_cc_protection_rule_batch_delete_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_cc_protection_rule_batch_delete_test.go
@@ -1,0 +1,41 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccCcProtectionRuleBatchDelete_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Before running the test case, please ensure that there is at least one WAF instance in the current region.
+			// Prepare a WAF policy with a WAF CC protection rule.
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckWafPolicyId(t)
+			acceptance.TestAccPreCheckWafRuleId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCcProtectionRuleBatchDelete_basic(),
+			},
+		},
+	})
+}
+
+func testAccCcProtectionRuleBatchDelete_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_cc_protection_rule_batch_delete" "test" {
+  policy_rule_ids {
+    policy_id = "%[1]s"
+    rule_ids  = ["%[2]s"]
+  }
+}
+`, acceptance.HW_WAF_POLICY_ID, acceptance.HW_WAF_RULE_ID)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_cc_protection_rule_batch_delete.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_cc_protection_rule_batch_delete.go
@@ -1,0 +1,149 @@
+package waf
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var ccRuleBatchDeleteNonUpdatableParams = []string{
+	"policy_rule_ids",
+	"policy_rule_ids.*.policy_id",
+	"policy_rule_ids.*.rule_ids",
+}
+
+// @API WAF POST /v1/{project_id}/waf/rule/cc/batch-delete
+func ResourceCcRuleBatchDelete() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCcRuleBatchDeleteCreate,
+		ReadContext:   resourceCcRuleBatchDeleteRead,
+		UpdateContext: resourceCcRuleBatchDeleteUpdate,
+		DeleteContext: resourceCcRuleBatchDeleteDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(ccRuleBatchDeleteNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"policy_rule_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"policy_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"rule_ids": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildCcRuleBatchDeleteBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"policy_rule_ids": buildCcRuleBodyParams(d),
+	}
+
+	return bodyParams
+}
+
+func buildCcRuleBodyParams(d *schema.ResourceData) []map[string]interface{} {
+	rawParams := d.Get("policy_rule_ids").([]interface{})
+	if len(rawParams) == 0 {
+		return nil
+	}
+
+	ruleParams := make([]map[string]interface{}, 0, len(rawParams))
+	for _, v := range rawParams {
+		raw, ok := v.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+
+		params := map[string]interface{}{
+			"policy_id": raw["policy_id"],
+			"rule_ids":  utils.ExpandToStringList(raw["rule_ids"].([]interface{})),
+		}
+		ruleParams = append(ruleParams, params)
+	}
+
+	return ruleParams
+}
+
+func resourceCcRuleBatchDeleteCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/rule/cc/batch-delete"
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: buildCcRuleBatchDeleteBodyParams(d),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error deleting CC attack protection rules: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return nil
+}
+
+func resourceCcRuleBatchDeleteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a action resource.
+	return nil
+}
+
+func resourceCcRuleBatchDeleteUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a action resource.
+	return nil
+}
+
+func resourceCcRuleBatchDeleteDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Delete()' method because the resource is a action resource.
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to batch delete CC protection rules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccCcProtectionRuleBatchDelete_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccCcProtectionRuleBatchDelete_basic -timeout 360m -parallel 4
=== RUN   TestAccCcProtectionRuleBatchDelete_basic
=== PAUSE TestAccCcProtectionRuleBatchDelete_basic
=== CONT  TestAccCcProtectionRuleBatchDelete_basic
--- PASS: TestAccCcProtectionRuleBatchDelete_basic (13.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       13.618s
```
<img width="1117" height="19" alt="image" src="https://github.com/user-attachments/assets/3b38822a-346a-4e8f-9162-adea7512796b" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
