### PR TITLE
feat(aom): cloud service authorizations supports need_optimized

### DIFF
--- a/docs/data-sources/aom_cloud_service_authorizations.md
+++ b/docs/data-sources/aom_cloud_service_authorizations.md
@@ -20,7 +20,7 @@ data "huaweicloud_aom_cloud_service_authorizations" "test" {}
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to query the data source.
+* `region` - (Optional, String)  Specifies the region where the cloud service authorizations are located.  
   If omitted, the provider-level region will be used.
 
 ## Attribute Reference
@@ -29,14 +29,16 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID.
 
-* `authorizations` - Indicates the authorizations list.
-  The [authorizations](#attrblock--authorizations) structure is documented below.
+* `authorizations` - The list of cloud service authorizations.
+  The [authorizations](#aom_cloud_service_authorizations) structure is documented below.
 
-<a name="attrblock--authorizations"></a>
+<a name="aom_cloud_service_authorizations"></a>
 The `authorizations` block supports:
 
-* `service` - Indicates the authorization service.
+* `service` - The authorization service name.
 
-* `role_name` - Indicates the role names list.
+* `role_name` - The role names list.
 
-* `status` - Indicates the authorization status.
+* `status` - Whether the authorization is enabled.
+
+* `need_optimized` - Whether the authorization needs optimization.

--- a/huaweicloud/services/acceptance/aom/data_source_huaweicloud_aom_cloud_service_authorizations_test.go
+++ b/huaweicloud/services/acceptance/aom/data_source_huaweicloud_aom_cloud_service_authorizations_test.go
@@ -26,6 +26,7 @@ func TestAccDataSourceCloudServiceAuthorizations_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSource, "authorizations.0.service"),
 					resource.TestCheckResourceAttrSet(dataSource, "authorizations.0.role_name.#"),
 					resource.TestCheckResourceAttrSet(dataSource, "authorizations.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "authorizations.0.need_optimized"),
 				),
 			},
 		},

--- a/huaweicloud/services/aom/data_source_huaweicloud_aom_cloud_service_authorizations.go
+++ b/huaweicloud/services/aom/data_source_huaweicloud_aom_cloud_service_authorizations.go
@@ -25,29 +25,34 @@ func DataSourceCloudServiceAuthorizations() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+				Description: `The region where the cloud service authorizations are located.`,
 			},
 			"authorizations": {
 				Type:        schema.TypeList,
 				Computed:    true,
-				Description: `Indicates the authorizations list.`,
+				Description: `The list of cloud service authorizations.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"service": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the authorization service.`,
+							Description: `The authorization service name.`,
 						},
 						"role_name": {
 							Type:        schema.TypeList,
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Computed:    true,
-							Description: `Indicates the role names list.`,
+							Description: `The role names list.`,
 						},
 						"status": {
 							Type:        schema.TypeBool,
 							Computed:    true,
-							Description: `Indicates the authorization status.`,
+							Description: `Whether the authorization is enabled.`,
+						},
+						"need_optimized": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the authorization needs optimization.`,
 						},
 					},
 				},
@@ -102,9 +107,10 @@ func flattenCloudServiceAuthorizations(resp interface{}) interface{} {
 		rst := make([]map[string]interface{}, 0, len(m))
 		for k, v := range m {
 			rst = append(rst, map[string]interface{}{
-				"service":   k,
-				"role_name": utils.PathSearch("role_name", v, nil),
-				"status":    utils.PathSearch("status", v, nil),
+				"service":        k,
+				"role_name":      utils.PathSearch("role_name", v, nil),
+				"status":         utils.PathSearch("status", v, nil),
+				"need_optimized": utils.PathSearch("needOptimized", v, nil),
 			})
 		}
 		return rst


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Data source 'huaweicloud_aom_cloud_service_authorizations' supports new parameter 'need_optimized'.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1051" height="598" alt="image" src="https://github.com/user-attachments/assets/2a824b24-c63b-443e-8886-88cedb7ec20b" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. cloud service authorizations supports need_optimized
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o aom -f TestAccDataSourceCloudServiceAuthorizations_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/aom" -v -coverprofile="./huaweicloud/services/acceptance/aom/aom_coverage.cov" -coverpkg="./huaweicloud/services/aom" -run TestAccDataSourceCloudServiceAuthorizations_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCloudServiceAuthorizations_basic
=== PAUSE TestAccDataSourceCloudServiceAuthorizations_basic
=== CONT  TestAccDataSourceCloudServiceAuthorizations_basic
--- PASS: TestAccDataSourceCloudServiceAuthorizations_basic (11.26s)
PASS
coverage: 3.6% of statements in ./huaweicloud/services/aom
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       11.333s coverage: 3.6% of statements in ./huaweicloud/services/aom
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
