### PR TITLE
feat(waf): new resource to manage alarm notification

### DIFF
--- a/docs/resources/waf_alarm_notification.md
+++ b/docs/resources/waf_alarm_notification.md
@@ -1,0 +1,88 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_alarm_notification"
+description: |-
+  Manages a WAF alarm notification resource within HuaweiCloud.
+---
+
+# huaweicloud_waf_alarm_notification
+
+Manages a WAF alarm notification resource within HuaweiCloud.
+
+-> All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be used.
+
+## Example Usage
+
+```hcl
+variable "name" {}
+variable "topic_urn" {}
+variable "notice_class" {}
+variable "enterprise_project_id" {}
+
+resource "huaweicloud_waf_alarm_notification" "test" {
+  name                  = var.name
+  topic_urn             = var.topic_urn
+  notice_class          = var.notice_class
+  enterprise_project_id = var.enterprise_project_id
+  enabled               = true
+  sendfreq              = 5
+  locale                = "zh-cn"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the alarm notification.
+
+* `topic_urn` - (Required, String) Specifies the topic URN of the SMN.
+
+* `notice_class` - (Required, String) Specifies the type of the alarm notification.
+
+* `enterprise_project_id` - (Required, String, NonUpdatable) Specifies the enterprise project ID.
+
+* `enabled` - (Optional, Bool) Specifies whether to enable the alarm notification. Defaults to **false**.
+
+* `sendfreq` - (Optional, Int) Specifies the time interval, in minutes.
+  If the notification type is protection event, an alarm notification is sent when the number of attacks is greater than
+  or equal to the threshold within the specified interval.
+  The value can be `5`, `15`, `30`, `60`, `120`, `360`, `720`, or `1440`.
+
+  When the notification type is certificate expiration, this parameter indicates the interval for sending an alarm
+  notification. The value can be `1` day or `1` week (converted into minutes).
+
+* `locale` - (Optional, String) Specifies the language. The value can be `zh-cn` or `en-us`.
+
+* `times` - (Optional, Int) Specifies the threshold of attack. This parameter is mandatory when notification type is set
+  to protection event. WAF will report a notification when the number of attacks reaches the configured threshold.
+
+* `threat` - (Optional, List, NonUpdatable) Specifies the event type.
+
+* `nearly_expired_time` - (Optional, String) Specifies number of days in advance for notification.
+  This parameter is mandatory when the notification type is certificate expiration notification.
+
+* `is_all_enterprise_project` - (Optional, Bool) Specifies whether all enterprise projects are involved.
+  Defaults to **false**.
+
+* `description` - (Optional, String) Specifies the description of the alarm notification.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (alarm notification ID).
+
+* `update_time` - The update time, in milliseconds.
+
+## Import
+
+The resource can be imported using the `id` and `enterprise_project_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_alarm_notification.test <id>/<enterprise_project_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3212,6 +3212,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_domain":                              waf.ResourceWafDomain(),
 			"huaweicloud_waf_ip_intelligence_rule":                waf.ResourceIpIntelligenceRule(),
 			"huaweicloud_waf_modify_alarm_notification":           waf.ResourceModifyAlarmNotification(),
+			"huaweicloud_waf_alarm_notification":                  waf.ResourceWafAlarmNotification(),
 			"huaweicloud_waf_migrate_domain":                      waf.ResourceMigrateDomain(),
 			"huaweicloud_waf_policy":                              waf.ResourceWafPolicy(),
 			"huaweicloud_waf_reference_table":                     waf.ResourceWafReferenceTable(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_alarm_notification_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_alarm_notification_test.go
@@ -1,0 +1,155 @@
+package waf
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/waf"
+)
+
+func getAlarmNotificationResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		product = "waf"
+		epsID   = state.Primary.Attributes["enterprise_project_id"]
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating WAF client: %s", err)
+	}
+
+	return waf.GetAlarmNotificationDetail(client, state.Primary.ID, epsID)
+}
+
+// Before running the test case, please ensure that there is at least one WAF instance in the current region.
+func TestAccAlarmNotification_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_waf_alarm_notification.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAlarmNotificationResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAlarmNotification_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "topic_urn", "huaweicloud_smn_topic.test", "topic_urn"),
+					resource.TestCheckResourceAttr(rName, "notice_class", "threat_alert_notice"),
+					resource.TestCheckResourceAttr(rName, "enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "sendfreq", "120"),
+					resource.TestCheckResourceAttr(rName, "locale", "en-us"),
+					resource.TestCheckResourceAttr(rName, "times", "5"),
+					resource.TestCheckResourceAttr(rName, "is_all_enterprise_project", "true"),
+					resource.TestCheckResourceAttr(rName, "description", "test-alarm-notification"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrSet(rName, "threat.#"),
+				),
+			},
+			{
+				Config: testAlarmNotification_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttrPair(rName, "topic_urn", "huaweicloud_smn_topic.test", "topic_urn"),
+					resource.TestCheckResourceAttr(rName, "notice_class", "threat_alert_notice"),
+					resource.TestCheckResourceAttr(rName, "enabled", "false"),
+					resource.TestCheckResourceAttr(rName, "sendfreq", "60"),
+					resource.TestCheckResourceAttr(rName, "locale", "en-us"),
+					resource.TestCheckResourceAttr(rName, "times", "6"),
+					resource.TestCheckResourceAttr(rName, "is_all_enterprise_project", "false"),
+					resource.TestCheckResourceAttr(rName, "description", "test-alarm-notification update"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrSet(rName, "threat.#"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAlarmNotificationImportState(rName),
+			},
+		},
+	})
+}
+
+func testAlarmNotification_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test" {
+  name                  = "%[1]s"
+  enterprise_project_id = "%[2]s"
+}
+
+resource "huaweicloud_waf_alarm_notification" "test" {
+  name                      = "%[1]s"
+  topic_urn                 = huaweicloud_smn_topic.test.topic_urn
+  notice_class              = "threat_alert_notice"
+  enterprise_project_id     = "%[2]s"
+  enabled                   = true
+  sendfreq                  = 120
+  locale                    = "en-us"
+  times                     = 5
+  threat                    = ["anticrawler", "cc"]
+  is_all_enterprise_project = true
+  description               = "test-alarm-notification"
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAlarmNotification_basic_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test" {
+  name                  = "%[1]s"
+  enterprise_project_id = "%[2]s"
+}
+
+resource "huaweicloud_waf_alarm_notification" "test" {
+  name                      = "%[1]s_update"
+  topic_urn                 = huaweicloud_smn_topic.test.topic_urn
+  notice_class              = "threat_alert_notice"
+  enterprise_project_id     = "%[2]s"
+  enabled                   = false
+  sendfreq                  = 60
+  locale                    = "en-us"
+  times                     = 6
+  threat                    = ["anticrawler", "cc"]
+  is_all_enterprise_project = false
+  description               = "test-alarm-notification update"
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAlarmNotificationImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+		epsID := rs.Primary.Attributes["enterprise_project_id"]
+		if epsID == "" {
+			return "", errors.New("enterprise_project_id is empty")
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.ID, epsID), nil
+	}
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_alarm_notification.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_alarm_notification.go
@@ -1,0 +1,352 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF POST /v2/{project_id}/waf/alert
+// @API WAF PUT /v2/{project_id}/waf/alert/{alert_id}
+// @API WAF GET /v2/{project_id}/waf/alerts
+func ResourceWafAlarmNotification() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafAlarmNotificationCreate,
+		ReadContext:   resourceWafAlarmNotificationRead,
+		UpdateContext: resourceWafAlarmNotificationUpdate,
+		DeleteContext: resourceWafAlarmNotificationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceWafAlarmNotificationImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"enterprise_project_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to create the resource.`,
+			},
+			// This field is Optional in API document, but it is required actually.
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`Specifies the name of the alarm notification.`,
+					utils.SchemaDescInput{
+						Required: true,
+					},
+				),
+			},
+			// This field is Optional in API document, but it is required actually.
+			"topic_urn": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`Specifies the topic URN of the SMN.`,
+					utils.SchemaDescInput{
+						Required: true,
+					},
+				),
+			},
+			// This field is Optional in API document, but it is required actually.
+			"notice_class": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`Specifies the type of the alarm notification.`,
+					utils.SchemaDescInput{
+						Required: true,
+					},
+				),
+			},
+			// This field `enterprise_project_id` only appears in the creation and reading API document,
+			// not in the update API document. So this field does not participate in the editing operation.
+			// The value of this field is always `0` in detail API response, so this field is not filled back when querying.
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			// For Optional fields, default values are not marked in the document, and the default value cannot be
+			// subjectively judged.
+			// Therefore, the default value of the Optional class field is not described in detail in the document.
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"sendfreq": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"locale": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"times": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			// This field `threat` only appears in the edit API document, not in the create API document.
+			// However, the actual test creation API also supports this field.
+			"threat": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"nearly_expired_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"is_all_enterprise_project": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			// This field `description` only appears in the creation API document, not in the edit API document.
+			// However, the actual test edit API also supports this field.
+			// This field supporting to be updated to empty, so it is not marked as Computed.
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"update_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildWafAlarmNotificationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":                      utils.ValueIgnoreEmpty(d.Get("name")),
+		"topic_urn":                 utils.ValueIgnoreEmpty(d.Get("topic_urn")),
+		"notice_class":              utils.ValueIgnoreEmpty(d.Get("notice_class")),
+		"enabled":                   d.Get("enabled"),
+		"sendfreq":                  utils.ValueIgnoreEmpty(d.Get("sendfreq")),
+		"locale":                    utils.ValueIgnoreEmpty(d.Get("locale")),
+		"times":                     utils.ValueIgnoreEmpty(d.Get("times")),
+		"threat":                    utils.ValueIgnoreEmpty(utils.ExpandToStringList(d.Get("threat").([]interface{}))),
+		"nearly_expired_time":       utils.ValueIgnoreEmpty(d.Get("nearly_expired_time")),
+		"is_all_enterprise_project": d.Get("is_all_enterprise_project"),
+		"description":               utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+
+	return bodyParams
+}
+
+func resourceWafAlarmNotificationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/waf/alert"
+		epsID   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	requestPath := client.Endpoint + fmt.Sprintf("%s?enterpriseProjectId=%s", httpUrl, epsID)
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+			"X-Language":   "en-us",
+		},
+		JSONBody: utils.RemoveNil(buildWafAlarmNotificationBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating WAF alert notice configuration: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("id", respBody, "").(string)
+	if id == "" {
+		return diag.Errorf("unable to find the alert notice ID from the API response")
+	}
+
+	d.SetId(id)
+
+	return resourceWafAlarmNotificationRead(ctx, d, meta)
+}
+
+func GetAlarmNotificationDetail(client *golangsdk.ServiceClient, alertID, epsID string) (interface{}, error) {
+	requestPath := client.Endpoint + "v2/{project_id}/waf/alerts"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	if epsID != "" {
+		requestPath = fmt.Sprintf("%s?enterprise_project_id=%s", requestPath, epsID)
+	}
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	expression := fmt.Sprintf("items[?id == '%s']|[0]", alertID)
+	alarmNotificationDetail := utils.PathSearch(expression, respBody, nil)
+	if alarmNotificationDetail == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return alarmNotificationDetail, nil
+}
+
+func resourceWafAlarmNotificationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		epsID  = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	respDetail, err := GetAlarmNotificationDetail(client, d.Id(), epsID)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving WAF alert notice configuration")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", respDetail, nil)),
+		d.Set("topic_urn", utils.PathSearch("topic_urn", respDetail, nil)),
+		d.Set("notice_class", utils.PathSearch("notice_class", respDetail, nil)),
+		d.Set("enabled", utils.PathSearch("enabled", respDetail, nil)),
+		d.Set("sendfreq", utils.PathSearch("sendfreq", respDetail, nil)),
+		d.Set("locale", utils.PathSearch("locale", respDetail, nil)),
+		d.Set("times", utils.PathSearch("times", respDetail, nil)),
+		d.Set("threat", utils.PathSearch("threat", respDetail, nil)),
+		d.Set("nearly_expired_time", utils.PathSearch("nearly_expired_time", respDetail, nil)),
+		d.Set("is_all_enterprise_project", utils.PathSearch("is_all_enterprise_project", respDetail, nil)),
+		d.Set("update_time", utils.PathSearch("update_time", respDetail, nil)),
+		d.Set("description", utils.PathSearch("description", respDetail, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdateAlarmNotificationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":                      utils.ValueIgnoreEmpty(d.Get("name")),
+		"topic_urn":                 utils.ValueIgnoreEmpty(d.Get("topic_urn")),
+		"notice_class":              utils.ValueIgnoreEmpty(d.Get("notice_class")),
+		"enabled":                   d.Get("enabled"),
+		"sendfreq":                  utils.ValueIgnoreEmpty(d.Get("sendfreq")),
+		"locale":                    utils.ValueIgnoreEmpty(d.Get("locale")),
+		"times":                     utils.ValueIgnoreEmpty(d.Get("times")),
+		"threat":                    utils.ValueIgnoreEmpty(utils.ExpandToStringList(d.Get("threat").([]interface{}))),
+		"nearly_expired_time":       utils.ValueIgnoreEmpty(d.Get("nearly_expired_time")),
+		"is_all_enterprise_project": d.Get("is_all_enterprise_project"),
+		// Field `description` supports to be updated to empty.
+		"description": d.Get("description"),
+	}
+
+	return bodyParams
+}
+
+func resourceWafAlarmNotificationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/waf/alert/{alert_id}"
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{alert_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+			"X-Language":   "en-us",
+		},
+		JSONBody: utils.RemoveNil(buildUpdateAlarmNotificationBodyParams(d)),
+	}
+
+	_, err = client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error updating WAF alert notice configuration: %s", err)
+	}
+
+	return resourceWafAlarmNotificationRead(ctx, d, meta)
+}
+
+func resourceWafAlarmNotificationDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `Deleting this resource will not destroy the WAF alert notice configuration,
+	but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}
+
+func resourceWafAlarmNotificationImportState(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf(`invalid format specified for import ID, must be <id>/<enterprise_project_id>,
+		but got %s`, d.Id())
+	}
+	d.SetId(parts[0])
+	return []*schema.ResourceData{d}, d.Set("enterprise_project_id", parts[1])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to manage alarm notification.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccAlarmNotification_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccAlarmNotification_basic -timeout 360m -parallel 10
=== RUN   TestAccAlarmNotification_basic
=== PAUSE TestAccAlarmNotification_basic
=== CONT  TestAccAlarmNotification_basic
--- PASS: TestAccAlarmNotification_basic (26.98s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       27.090s coverage: 4.5% of statements in ./huaweicloud/services/waf
```
<img width="1351" height="90" alt="image" src="https://github.com/user-attachments/assets/1566c584-66aa-4796-b194-40098b324bf7" />


* [X] Documentation updated.
* [X] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="904" height="170" alt="image" src="https://github.com/user-attachments/assets/f4212dea-9dea-47c8-a0a5-5ae9688874e2" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
