### PR TITLE
feat(modelarts): add new resource to batch reboot nodes

### DIFF
--- a/docs/resources/modelartsv2_node_batch_reboot.md
+++ b/docs/resources/modelartsv2_node_batch_reboot.md
@@ -1,0 +1,52 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelartsv2_node_batch_reboot"
+description: |-
+  Use this resource to batch reboot the ModelArts nodes within HuaweiCloud.
+---
+
+# huaweicloud_modelartsv2_node_batch_reboot
+
+Use this resource to batch reboot the ModelArts nodes within HuaweiCloud.
+
+-> This resource is only a one-time action resource for batch reboot the ModelArts nodes. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "resource_pool_name" {}
+variable "node_names" {
+  type = list(string)
+}
+
+resource "huaweicloud_modelartsv2_node_batch_reboot" "test" {
+  resource_pool_name = var.resource_pool_name
+  node_names         = var.node_names
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the resource nodes are located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `resource_pool_name` - (Required, String, NonUpdatable) Specifies the resource pool name to which the resource nodes
+  belong.
+
+* `node_names` - (Required, List, NonUpdatable) Specifies the name list of resource nodes to be rebooted.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 45 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2900,6 +2900,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_resource_pool_node_batch_resize": modelarts.ResourceResourcePoolNodeBatchResize(),
 			// Resource management via V2 APIs.
 			"huaweicloud_modelartsv2_node_batch_delete":      modelarts.ResourceV2NodeBatchDelete(),
+			"huaweicloud_modelartsv2_node_batch_reboot":      modelarts.ResourceV2NodeBatchReboot(),
 			"huaweicloud_modelartsv2_node_batch_unsubscribe": modelarts.ResourceV2NodeBatchUnsubscribe(),
 			"huaweicloud_modelartsv2_service":                modelarts.ResourceV2Service(),
 			"huaweicloud_modelartsv2_service_action":         modelarts.ResourceV2ServiceAction(),

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelartsv2_node_batch_reboot_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelartsv2_node_batch_reboot_test.go
@@ -1,0 +1,69 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceV2NodeBatchReboot_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckModelArtsResourcePoolName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceV2NodeBatchReboot_invalidResourcePoolName,
+				ExpectError: regexp.MustCompile(`\\"invalid-resource-pool-name\\" not found`),
+			},
+			{
+				Config: testAccResourceV2NodeBatchReboot_basic_step1(),
+			},
+		},
+	})
+}
+
+const testAccResourceV2NodeBatchReboot_invalidResourcePoolName string = `
+resource "huaweicloud_modelartsv2_node_batch_reboot" "invalid" {
+  resource_pool_name = "invalid-resource-pool-name"
+  node_names         = ["invalid-node-name"]
+}
+`
+
+func testAccResourceV2NodeBatchReboot_basic_step1() string {
+	return fmt.Sprintf(`
+data "huaweicloud_modelartsv2_resource_pools" "test" {}
+
+locals {
+  resourcePool = [for pool in data.huaweicloud_modelartsv2_resource_pools.test.resource_pools : pool if pool.name == "%[1]s"][0]
+}
+
+data "huaweicloud_modelartsv2_resource_pool_nodes" "test" {
+  resource_pool_name = local.resourcePool.metadata[0].name
+}
+
+locals {
+  node_names = try(data.huaweicloud_modelartsv2_resource_pool_nodes.test.nodes[*].metadata[0].name, [])
+}
+
+resource "huaweicloud_modelartsv2_node_batch_reboot" "test" {
+  resource_pool_name = local.resourcePool.metadata[0].name
+  node_names         = local.node_names
+
+  lifecycle {
+    ignore_changes = [
+      node_names,
+    ]
+  }
+}
+`, acceptance.HW_MODELARTS_RESOURCE_POOL_NAME)
+}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_node_batch_reboot.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_node_batch_reboot.go
@@ -1,0 +1,205 @@
+package modelarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var v2NodeBatchRebootNonUpdatableParams = []string{
+	"resource_pool_name",
+	"node_names",
+}
+
+// @API ModelArts POST /v2/{project_id}/pools/{pool_name}/nodes/batch-reboot
+// @API ModelArts GET /v2/{project_id}/jobs/{job_id}
+func ResourceV2NodeBatchReboot() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceV2NodeBatchRebootCreate,
+		ReadContext:   resourceV2NodeBatchRebootRead,
+		UpdateContext: resourceV2NodeBatchRebootUpdate,
+		DeleteContext: resourceV2NodeBatchRebootDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(45 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(v2NodeBatchRebootNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the resource nodes are located.`,
+			},
+
+			// Required parameters.
+			"resource_pool_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The resource pool name to which the resource nodes belong.`,
+			},
+			"node_names": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The name list of resource nodes to be rebooted.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func getV2JobById(client *golangsdk.ServiceClient, jobId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/jobs/{job_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{job_id}", jobId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func refreshV2JobStatus(client *golangsdk.ServiceClient, jobId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		nodes, err := getV2JobById(client, jobId)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+		status := utils.PathSearch("phase", nodes, "").(string)
+		if utils.IsStrContainsSliceElement(status, []string{"Failed"}, false, true) {
+			return nodes, "ERROR", fmt.Errorf("unexpected status: %s", status)
+		}
+		if status == "Success" {
+			return nodes, "COMPLETED", nil
+		}
+		return nodes, "PENDING", nil
+	}
+}
+
+func waitForV2JobCompleted(ctx context.Context, client *golangsdk.ServiceClient, jobId string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshV2JobStatus(client, jobId),
+		Timeout:      timeout,
+		Delay:        30 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func rebootV2ResourcePoolNodes(ctx context.Context, client *golangsdk.ServiceClient, resourcePoolName string,
+	nodeNames []interface{}, timeout time.Duration) error {
+	httpUrl := "v2/{project_id}/pools/{pool_name}/nodes/batch-reboot"
+	actionPath := client.Endpoint + httpUrl
+	actionPath = strings.ReplaceAll(actionPath, "{project_id}", client.ProjectID)
+	actionPath = strings.ReplaceAll(actionPath, "{pool_name}", resourcePoolName)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"nodeNames": nodeNames,
+		},
+	}
+
+	requestResp, err := client.Request("POST", actionPath, &opt)
+	if err != nil {
+		return fmt.Errorf("error executing batch reboot operation for the specified nodes (%v): %s", nodeNames, err)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return err
+	}
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return fmt.Errorf("unable to find job ID under the resource pool (%s) in API response", resourcePoolName)
+	}
+	err = waitForV2JobCompleted(ctx, client, jobId, timeout)
+	if err != nil {
+		return fmt.Errorf("error waiting for the job status of resource pool (%s) creation to complete: %s", resourcePoolName, err)
+	}
+	return nil
+}
+
+func resourceV2NodeBatchRebootCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		resourcePoolName = d.Get("resource_pool_name").(string)
+		nodeNames        = d.Get("node_names").([]interface{})
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	err = rebootV2ResourcePoolNodes(ctx, client, resourcePoolName, nodeNames, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	return resourceV2NodeBatchRebootRead(ctx, d, meta)
+}
+
+func resourceV2NodeBatchRebootRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceV2NodeBatchRebootUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceV2NodeBatchRebootDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for batch reboot the ModelArts nodes. Deleting this
+resource will not clear the corresponding request record, but will only remove the resource information from the tfstate
+file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new one-time action resource to batch reboot the resource nodes.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1094" height="397" alt="image" src="https://github.com/user-attachments/assets/0322e6da-766b-4974-b242-a72266eb5cf1" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new resource to batch reboot nodes
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccResourceV2NodeBatchReboot_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccResourceV2NodeBatchReboot_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceV2NodeBatchReboot_basic
=== PAUSE TestAccResourceV2NodeBatchReboot_basic
=== CONT  TestAccResourceV2NodeBatchReboot_basic
--- PASS: TestAccResourceV2NodeBatchReboot_basic (111.25s)
PASS
coverage: 10.1% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 111.373s        coverage: 10.1% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
