### PR TITLE
feat(kafka): add new resource support rebalance log

### DIFF
--- a/docs/resources/dms_kafka_instance_rebalance_log.md
+++ b/docs/resources/dms_kafka_instance_rebalance_log.md
@@ -1,0 +1,73 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_instance_rebalance_log"
+description: |-
+  Manages a Kafka rebalance log resource within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_instance_rebalance_log
+
+Manages a Kafka rebalance log resource within HuaweiCloud.
+
+-> 1. Only one `huaweicloud_dms_kafka_instance_rebalance_log` resource can be created under a Kafka instance.
+   <br>2. Single-node instance do not support rebalance log.
+   <br>3. Deleting the resource only disables rebalance logging. The existing LTS log groups and log streams will
+   remain and will still incur charges.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_dms_kafka_instance_rebalance_log" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the Kafka instance rebalance log is located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the Kafka instance to which the
+  rebalance log belongs.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, which is the same as the `instance_id`.
+
+* `log_group_id` - The ID of the log group.
+
+* `log_stream_id` - The ID of the log stream.
+
+* `dashboard_id` - The ID of the dashboard.
+
+* `log_type` - The type of the log.
+
+* `log_file_name` - The name of the log file.
+
+* `status` - The status of the rebalance log.
+
+* `created_at` - The creation time of the rebalance log, in RFC3339 format.
+
+* `updated_at` - The latest update time of the rebalance log, in RFC3339 format.
+
+## Timeouts
+
+This resource provides the following timeout configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+This resource can be imported using its `id`, e.g.
+
+```bash
+terraform import huaweicloud_dms_kafka_instance_rebalance_log.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2494,6 +2494,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_consumer_group":            kafka.ResourceDmsKafkaConsumerGroup(),
 			"huaweicloud_dms_kafka_instance_batch_action":     kafka.ResourceInstanceBatchAction(),
 			"huaweicloud_dms_kafka_instance":                  kafka.ResourceDmsKafkaInstance(),
+			"huaweicloud_dms_kafka_instance_rebalance_log":    kafka.ResourceInstanceRebalanceLog(),
 			"huaweicloud_dms_kafka_instance_restart":          kafka.ResourceDmsKafkaInstanceRestart(),
 			"huaweicloud_dms_kafka_message_diagnosis_task":    kafka.ResourceDmsKafkaMessageDiagnosisTask(),
 			"huaweicloud_dms_kafka_message_offset_reset":      kafka.ResourceDmsKafkaMessageOffsetReset(),

--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_instance_rebalance_log_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_instance_rebalance_log_test.go
@@ -1,0 +1,118 @@
+package kafka
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/kafka"
+)
+
+func getInstanceRebalanceLogResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dmsv2", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DMS client: %s", err)
+	}
+
+	return kafka.GetInstanceRebalanceLog(client, state.Primary.ID)
+}
+
+func TestAccInstanceRebalanceLog_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		rName = "huaweicloud_dms_kafka_instance_rebalance_log.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getInstanceRebalanceLogResourceFunc)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceRebalanceLog_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id", "huaweicloud_dms_kafka_instance.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "log_group_id"),
+					resource.TestCheckResourceAttrSet(rName, "log_stream_id"),
+					resource.TestCheckResourceAttrSet(rName, "dashboard_id"),
+					resource.TestCheckResourceAttrSet(rName, "log_type"),
+					resource.TestCheckResourceAttrSet(rName, "log_file_name"),
+					resource.TestCheckResourceAttr(rName, "status", "OPEN"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(rName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      testAccInstanceRebalanceLog_logExists(name),
+				ExpectError: regexp.MustCompile(`log already exists`),
+			},
+		},
+	})
+}
+
+func testAccInstanceRebalanceLog_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_dms_kafka_flavors" "test" {
+  type = "cluster.small"
+}
+
+locals {
+  flavor = try(data.huaweicloud_dms_kafka_flavors.test.flavors[0], {})
+}
+
+resource "huaweicloud_dms_kafka_instance" "test" {
+  name              = "%[2]s"
+  vpc_id            = huaweicloud_vpc.test.id
+  network_id        = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  flavor_id          = try(local.flavor.id, null)
+  storage_spec_code  = try(local.flavor.ios[0].storage_spec_code, null)
+  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  engine_version     = "3.x"
+  storage_space      = try(local.flavor.properties[0].min_broker * local.flavor.properties[0].min_storage_per_node, null)
+  broker_num         = 3
+}`, common.TestBaseNetwork(name), name)
+}
+
+func testAccInstanceRebalanceLog_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dms_kafka_instance_rebalance_log" "test" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+}
+`, testAccInstanceRebalanceLog_base(name))
+}
+
+func testAccInstanceRebalanceLog_logExists(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dms_kafka_instance_rebalance_log" "expect_error" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+}
+`, testAccInstanceRebalanceLog_basic(name))
+}

--- a/huaweicloud/services/kafka/common.go
+++ b/huaweicloud/services/kafka/common.go
@@ -1,0 +1,72 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getInstanceTask(client *golangsdk.ServiceClient, instanceId, taskId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/instances/{instance_id}/tasks/{task_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getPath = strings.ReplaceAll(getPath, "{task_id}", taskId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func instanceTaskStatusRefreshFunc(client *golangsdk.ServiceClient, instanceID, taskId string, targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := getInstanceTask(client, instanceID, taskId)
+		if err != nil {
+			return nil, "QUERY ERROR", err
+		}
+
+		// DELETED, SUCCESS, EXECUTING, FAILED
+		status := utils.PathSearch("tasks[0].status", resp, "").(string)
+		if status == "FAILED" || status == "DELETED" {
+			return resp, "FAILED", fmt.Errorf("unexpect status (%s)", status)
+		}
+
+		if utils.StrSliceContains(targets, status) {
+			return resp, "COMPLETED", nil
+		}
+
+		return resp, "PENDING", nil
+	}
+}
+
+func waitForInstanceTaskStatusComplete(ctx context.Context, client *golangsdk.ServiceClient, instanceId, taskId string,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      instanceTaskStatusRefreshFunc(client, instanceId, taskId, []string{"SUCCESS"}),
+		Timeout:      timeout,
+		Delay:        20 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance_rebalance_log.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance_rebalance_log.go
@@ -1,0 +1,270 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var instanceRebalanceLogNonUpdatableParams = []string{"instance_id"}
+
+// @API Kafka POST /v2/kafka/{project_id}/instances/{instance_id}/log/rebalance-log
+// @API Kafka GET /v2/kafka/{project_id}/instances/{instance_id}/log/rebalance-log
+// @API Kafka DELETE /v2/kafka/{project_id}/instances/{instance_id}/log/rebalance-log
+// @API Kafka GET /v2/{project_id}/instances/{instance_id}/tasks/{task_id}
+func ResourceInstanceRebalanceLog() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInstanceRebalanceLogCreate,
+		ReadContext:   resourceInstanceRebalanceLogRead,
+		UpdateContext: resourceInstanceRebalanceLogUpdate,
+		DeleteContext: resourceInstanceRebalanceLogDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(instanceRebalanceLogNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The region where the Kafka instance rebalance log is located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the Kafka instance to which the rebalance log belongs.`,
+			},
+			"log_group_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the log group.`,
+			},
+			"log_stream_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the log stream.`,
+			},
+			"dashboard_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the dashboard.`,
+			},
+			"log_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the log.`,
+			},
+			"log_file_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the log file.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the rebalance log.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the rebalance log, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the rebalance log, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func resourceInstanceRebalanceLogCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		instanceId = d.Get("instance_id").(string)
+		httpUrl    = "v2/kafka/{project_id}/instances/{instance_id}/log/rebalance-log"
+	)
+	client, err := cfg.NewServiceClient("dmsv2", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	httpUrl = strings.ReplaceAll(httpUrl, "{project_id}", client.ProjectID)
+	httpUrl = strings.ReplaceAll(httpUrl, "{instance_id}", instanceId)
+	createPath := client.Endpoint + httpUrl
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+	}
+
+	resp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error enabling rebalance log of the instance (%s): %s", instanceId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.Errorf("error parsing response: %s", err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find the job ID from the API response")
+	}
+
+	err = waitForInstanceTaskStatusComplete(ctx, client, instanceId, jobId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for the rebalance log of the instance (%s) to be enabled: %s", instanceId, err)
+	}
+
+	d.SetId(instanceId)
+
+	return resourceInstanceRebalanceLogRead(ctx, d, meta)
+}
+
+func GetInstanceRebalanceLog(client *golangsdk.ServiceClient, instanceId string) (interface{}, error) {
+	httpUrl := "v2/kafka/{project_id}/instances/{instance_id}/log/rebalance-log"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if utils.PathSearch("status", respBody, "") == "CLOSE" {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v2/kafka/{project_id}/instances/{instance_id}/log/rebalance-log",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("The rebalance log of the instance (%s) has been closed.", instanceId)),
+			},
+		}
+	}
+
+	return respBody, nil
+}
+
+func resourceInstanceRebalanceLogRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	respBody, err := GetInstanceRebalanceLog(client, instanceId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error getting rebalance log of the instance (%s)", instanceId))
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("instance_id", utils.PathSearch("instance_id", respBody, nil)),
+		d.Set("log_group_id", utils.PathSearch("log_group_id", respBody, nil)),
+		d.Set("log_stream_id", utils.PathSearch("log_stream_id", respBody, nil)),
+		d.Set("dashboard_id", utils.PathSearch("dashboard_id", respBody, nil)),
+		d.Set("log_type", utils.PathSearch("log_type", respBody, nil)),
+		d.Set("log_file_name", utils.PathSearch("log_file_name", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("created_at",
+			respBody, float64(0)).(float64))/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("updated_at",
+			respBody, float64(0)).(float64))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceInstanceRebalanceLogUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceInstanceRebalanceLogDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		instanceId = d.Get("instance_id").(string)
+		httpUrl    = "v2/kafka/{project_id}/instances/{instance_id}/log/rebalance-log"
+	)
+	client, err := cfg.NewServiceClient("dmsv2", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	httpUrl = strings.ReplaceAll(httpUrl, "{project_id}", client.ProjectID)
+	httpUrl = strings.ReplaceAll(httpUrl, "{instance_id}", instanceId)
+	deletePath := client.Endpoint + httpUrl
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+	}
+
+	resp, err := client.Request("DELETE", deletePath, &opt)
+	// DMS.00501007: The log has been closed.
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "DMS.00501007"),
+			fmt.Sprintf("error disabling rebalance log of the instance (%s)", instanceId),
+		)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find the job ID from the API response")
+	}
+
+	err = waitForInstanceTaskStatusComplete(ctx, client, instanceId, jobId, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return diag.Errorf("error waiting for the rebalance log of the instance (%s) to be disabled: %s", instanceId, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource （`huaweicloud_dms_kafka_instance_rebalance_log`） to manage rebalance log.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new resource and corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccInstanceRebalanceLog_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccInstanceRebalanceLog_basic -timeout 360m -parallel 10
=== RUN   TestAccInstanceRebalanceLog_basic
=== PAUSE TestAccInstanceRebalanceLog_basic
=== CONT  TestAccInstanceRebalanceLog_basic
--- PASS: TestAccInstanceRebalanceLog_basic (702.46s)
PASS
coverage: 12.6% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     702.621s        coverage: 12.6% of statements in ./huaweicloud/services/kafka
```
<img width="979" height="485" alt="image" src="https://github.com/user-attachments/assets/40486733-75de-45d0-a93c-80de676025ac" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
     <img width="1335" height="961" alt="image" src="https://github.com/user-attachments/assets/6176c61d-4e05-4ad1-b4ed-a3f8ce495427" />

    ab. Related resources (parent resources) not found
     <img width="1512" height="977" alt="image" src="https://github.com/user-attachments/assets/64921469-a304-47a8-9856-40c2a59b1286" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1348" height="938" alt="image" src="https://github.com/user-attachments/assets/c59db867-eae6-42f6-ae5e-06877dd1b3e6" />
    
    bb. Related resources (parent resources) not found
     <img width="1444" height="892" alt="image" src="https://github.com/user-attachments/assets/006a7a36-4c89-49c3-b6e2-10fff7f1f8a0" />


  