### PR TITLE
feat(apig): add new data source for query channel members

### DIFF
--- a/docs/data-sources/apig_channel_members.md
+++ b/docs/data-sources/apig_channel_members.md
@@ -1,0 +1,87 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_channel_members"
+description: |-
+  Use this data source to query the list of channel members within HuaweiCloud.
+---
+
+# huaweicloud_apig_channel_members
+
+Use this data source to query the list of channel members within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "vpc_channel_id" {}
+variable "member_name" {}
+
+data "huaweicloud_apig_channel_members" "test" {
+  instance_id    = var.instance_id
+  vpc_channel_id = var.vpc_channel_id
+  name           = var.member_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the channel members are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the channel members belong.
+
+* `vpc_channel_id` - (Required, String) Specifies the ID of the VPC channel to which the members belong.
+
+* `name` - (Optional, String) Specifies the name of the channel member to be queried for fuzzy matching.
+
+* `member_group_name` - (Optional, String) Specifies the name of the channel member group to be queried for fuzzy
+  matching.
+
+* `member_group_id` - (Optional, String) Specifies the ID of the channel member group to be queried.
+
+* `precise_search` - (Optional, String) Specifies the parameter name for exact matching to be queried.  
+  When this parameter contains the field(s) to be queried, the corresponding field query will become an exact-match
+  query.  
+  The valid values are as follows:
+  + **name**
+  + **member_group_name**
+  When performing an exact query with multiple fields, separate the fields with commas(,).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `members` - The list of the channel members that matched filter parameters.  
+  The [members](#apig_channel_members) structure is documented below.
+
+<a name="apig_channel_members"></a>
+The `members` block supports:
+
+* `id` - The ID of the channel member.
+
+* `vpc_channel_id` - The ID of the VPC channel.
+
+* `member_group_name` - The name of the channel member group.
+
+* `member_group_id` - The ID of the channel member group.
+
+* `member_ip_address` - The IP address of the channel member.
+
+* `ecs_id` - The ID of the ECS instance.
+
+* `ecs_name` - The name of the ECS instance.
+
+* `port` - The port of the channel member.
+
+* `is_backup` - Whether the channel member is a backup node.
+
+* `status` - The status of the channel member.
+
+* `weight` - The weight value of the channel member.
+
+* `health_status` - The health status of the channel member.
+
+* `create_time` - The time when the channel member was added to the VPC channel, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -573,6 +573,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_application_quotas":                 apig.DataSourceApigApplicationQuotas(),
 			"huaweicloud_apig_certificate_associated_domains":     apig.DataSourceCertificateAssociatedDomains(),
 			"huaweicloud_apig_channels":                           apig.DataSourceChannels(),
+			"huaweicloud_apig_channel_members":                    apig.DataSourceChannelMembers(),
 			"huaweicloud_apig_channel_member_groups":              apig.DataSourceChannelMemberGroups(),
 			"huaweicloud_apig_custom_authorizers":                 apig.DataSourceCustomAuthorizers(),
 			"huaweicloud_apig_endpoint_connections":               apig.DataSourceApigEndpointConnections(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_channel_members_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_channel_members_test.go
@@ -1,0 +1,394 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceChannelMembers_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		ipAllName   = "data.huaweicloud_apig_channel_members.ip_all"
+		dcIpAllName = acceptance.InitDataSourceCheck(ipAllName)
+
+		ecsAllName   = "data.huaweicloud_apig_channel_members.ecs_all"
+		dcEcsAllName = acceptance.InitDataSourceCheck(ecsAllName)
+
+		ecsFilterByName   = "data.huaweicloud_apig_channel_members.ecs_filter_by_name"
+		dcEcsFilterByName = acceptance.InitDataSourceCheck(ecsFilterByName)
+
+		ecsFilterByGroupName   = "data.huaweicloud_apig_channel_members.ecs_filter_by_group_name"
+		dcEcsFilterByGroupName = acceptance.InitDataSourceCheck(ecsFilterByGroupName)
+
+		ipFilterByGroupName   = "data.huaweicloud_apig_channel_members.ip_filter_by_group_name"
+		dcIpFilterByGroupName = acceptance.InitDataSourceCheck(ipFilterByGroupName)
+
+		ecsFilterByGroupId   = "data.huaweicloud_apig_channel_members.ecs_filter_by_group_id"
+		dcEcsFilterByGroupId = acceptance.InitDataSourceCheck(ecsFilterByGroupId)
+
+		ipFilterByGroupId   = "data.huaweicloud_apig_channel_members.ip_filter_by_group_id"
+		dcIpFilterByGroupId = acceptance.InitDataSourceCheck(ipFilterByGroupId)
+
+		filterByPreciseSearch   = "data.huaweicloud_apig_channel_members.filter_by_precise_search"
+		dcFilterByPreciseSearch = acceptance.InitDataSourceCheck(filterByPreciseSearch)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+			acceptance.TestAccPreCheckApigChannelRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceChannelMembers_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dcIpAllName.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(ipAllName, "members.0.id"),
+					resource.TestCheckResourceAttrSet(ipAllName, "members.0.vpc_channel_id"),
+					resource.TestCheckResourceAttrSet(ipAllName, "members.0.member_group_name"),
+					resource.TestCheckResourceAttrSet(ipAllName, "members.0.member_group_id"),
+					resource.TestCheckResourceAttrSet(ipAllName, "members.0.member_ip_address"),
+					resource.TestCheckResourceAttrSet(ipAllName, "members.0.ecs_id"),
+					resource.TestCheckResourceAttrSet(ipAllName, "members.0.ecs_name"),
+					resource.TestCheckResourceAttrSet(ipAllName, "members.0.port"),
+					resource.TestCheckResourceAttrSet(ipAllName, "members.0.is_backup"),
+					resource.TestCheckResourceAttrSet(ipAllName, "members.0.status"),
+					resource.TestCheckResourceAttrSet(ipAllName, "members.0.weight"),
+					resource.TestMatchResourceAttr(ipAllName, "members.0.create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					dcEcsAllName.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(ecsAllName, "members.0.id"),
+					resource.TestCheckResourceAttrSet(ecsAllName, "members.0.vpc_channel_id"),
+					resource.TestCheckResourceAttrSet(ecsAllName, "members.0.member_group_name"),
+					resource.TestCheckResourceAttrSet(ecsAllName, "members.0.member_group_id"),
+					resource.TestCheckResourceAttrSet(ecsAllName, "members.0.member_ip_address"),
+					resource.TestCheckResourceAttrSet(ecsAllName, "members.0.ecs_id"),
+					resource.TestCheckResourceAttrSet(ecsAllName, "members.0.ecs_name"),
+					resource.TestCheckResourceAttrSet(ecsAllName, "members.0.port"),
+					resource.TestCheckResourceAttrSet(ecsAllName, "members.0.is_backup"),
+					resource.TestCheckResourceAttrSet(ecsAllName, "members.0.status"),
+					resource.TestCheckResourceAttrSet(ecsAllName, "members.0.weight"),
+					resource.TestMatchResourceAttr(ecsAllName, "members.0.create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					dcEcsAllName.CheckResourceExists(),
+					dcEcsFilterByName.CheckResourceExists(),
+					resource.TestCheckOutput("ecs_name_filter_is_useful", "true"),
+					dcEcsFilterByGroupName.CheckResourceExists(),
+					resource.TestCheckOutput("ecs_group_name_filter_is_useful", "true"),
+					dcIpFilterByGroupName.CheckResourceExists(),
+					resource.TestCheckOutput("ip_group_name_filter_is_useful", "true"),
+					dcEcsFilterByGroupId.CheckResourceExists(),
+					resource.TestCheckOutput("ecs_group_id_filter_is_useful", "true"),
+					dcIpFilterByGroupId.CheckResourceExists(),
+					resource.TestCheckOutput("ip_group_id_filter_is_useful", "true"),
+					dcFilterByPreciseSearch.CheckResourceExists(),
+					resource.TestCheckOutput("precise_search_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceChannelMembers_Compute_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  id = "%[2]s"
+}
+
+data "huaweicloud_images_image" "test" {
+  name        = "Ubuntu 18.04 server 64bit"
+  most_recent = true
+}
+
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  count = 2
+
+  name                = format("%[1]s_%%s", count.index)
+  description         = "terraform test"
+  image_id            = data.huaweicloud_images_image.test.id
+  flavor_id           = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids  = [data.huaweicloud_networking_secgroup.test.id]
+  stop_before_destroy = true
+  agency_name         = "test111"
+  agent_list          = "hss"
+
+  user_data = <<EOF
+#! /bin/bash
+echo user_test > /home/user.txt
+EOF
+
+  network {
+    uuid              = data.huaweicloud_vpc_subnet.test.id
+    source_dest_check = false
+  }
+
+  system_disk_type = "SAS"
+  system_disk_size = 50
+
+  data_disks {
+    type = "SAS"
+    size = "10"
+  }
+}`, name, acceptance.HW_APIG_DEDICATED_INSTANCE_USED_SUBNET_ID)
+}
+
+func testAccDataSourceChannelMembers_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[2]s"
+}
+
+resource "huaweicloud_apig_channel" "ip_channel" {
+  instance_id      = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  name             = format("%[3]s_%%s", "ip")
+  port             = 80
+  balance_strategy = 1
+  member_type      = "ip"
+  type             = "builtin"
+}
+
+resource "huaweicloud_apig_channel" "ecs_channel" {
+  instance_id      = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  name             = format("%[3]s_%%s", "ecs")
+  port             = 80
+  balance_strategy = 1
+  member_type      = "ecs"
+  type             = "builtin"
+}
+
+resource "huaweicloud_apig_channel_member_group" "ip_channel_member_group" {
+  instance_id    = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id = huaweicloud_apig_channel.ip_channel.id
+  name           = format("%[3]s_%%s", "ip")
+  weight         = 20
+  description    = "ip channel member group."
+}
+
+resource "huaweicloud_apig_channel_member_group" "ecs_channel_member_group" {
+  instance_id    = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id = huaweicloud_apig_channel.ecs_channel.id
+  name           = format("%[3]s_%%s", "ecs")
+  weight         = 20
+  description    = "ecs channel member group."
+}
+
+resource "huaweicloud_apig_channel_member" "ip_member" {
+  count = 2
+
+  instance_id       = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id    = huaweicloud_apig_channel.ip_channel.id
+  member_group_name = huaweicloud_apig_channel_member_group.ip_channel_member_group.name
+  member_ip_address = huaweicloud_compute_instance.test[count.index].access_ip_v4
+  port              = 80
+  status            = 2
+  is_backup         = true
+}
+
+resource "huaweicloud_apig_channel_member" "ecs_member" {
+  count = 2
+
+  instance_id       = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id    = huaweicloud_apig_channel.ecs_channel.id
+  member_group_name = huaweicloud_apig_channel_member_group.ecs_channel_member_group.name
+  ecs_id            = huaweicloud_compute_instance.test[count.index].id
+  ecs_name          = huaweicloud_compute_instance.test[count.index].name
+  port              = 80
+}
+`, testAccDataSourceChannelMembers_Compute_base(name), acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+}
+
+func testAccDataSourceChannelMembers_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Query all
+data "huaweicloud_apig_channel_members" "ip_all" {
+  instance_id    = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id = huaweicloud_apig_channel.ip_channel.id
+
+  depends_on = [
+    huaweicloud_apig_channel_member.ip_member,
+  ]
+}
+
+data "huaweicloud_apig_channel_members" "ecs_all" {
+  instance_id    = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id = huaweicloud_apig_channel.ecs_channel.id
+
+  depends_on = [
+	  huaweicloud_apig_channel_member.ecs_member,
+  ]
+}
+
+# Filter by name (fuzzy search)
+locals {
+  member_name_prefix = "%[2]s"
+}
+
+data "huaweicloud_apig_channel_members" "ecs_filter_by_name" {
+  instance_id    = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id = huaweicloud_apig_channel.ecs_channel.id
+  name           = local.member_name_prefix
+
+  depends_on = [
+    huaweicloud_apig_channel_member.ecs_member,
+  ]
+}
+
+locals {
+  ecs_name_filter_result = [
+    for v in data.huaweicloud_apig_channel_members.ecs_filter_by_name.members[*].ecs_name
+    : strcontains(v, local.member_name_prefix)
+  ]
+}
+
+output "ecs_name_filter_is_useful" {
+  value = length(local.ecs_name_filter_result) >= 2 && alltrue(local.ecs_name_filter_result)
+}
+
+# Filter by group name (fuzzy search)
+locals {
+  group_name_prefix = "%[2]s"
+}
+
+data "huaweicloud_apig_channel_members" "ecs_filter_by_group_name" {
+  instance_id       = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id    = huaweicloud_apig_channel.ecs_channel.id
+  member_group_name = local.group_name_prefix
+
+  depends_on = [
+    huaweicloud_apig_channel_member.ecs_member,
+  ]
+}
+
+locals {
+  ecs_group_name_filter_result = [
+    for v in data.huaweicloud_apig_channel_members.ecs_filter_by_group_name.members[*].member_group_name 
+    : strcontains(v, local.group_name_prefix)
+  ]
+}
+
+output "ecs_group_name_filter_is_useful" {
+  value = length(local.ecs_group_name_filter_result) >= 2 && alltrue(local.ecs_group_name_filter_result)
+}
+
+data "huaweicloud_apig_channel_members" "ip_filter_by_group_name" {
+  instance_id       = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id    = huaweicloud_apig_channel.ip_channel.id
+  member_group_name = local.group_name_prefix
+
+  depends_on = [
+    huaweicloud_apig_channel_member.ip_member,
+  ]
+}
+
+locals {
+  ip_group_name_filter_result = [
+    for v in data.huaweicloud_apig_channel_members.ip_filter_by_group_name.members[*].member_group_name 
+    : strcontains(v, local.group_name_prefix)
+  ]
+}
+
+output "ip_group_name_filter_is_useful" {
+  value = length(local.ip_group_name_filter_result) >= 2 && alltrue(local.ip_group_name_filter_result)
+}
+
+# Filter by group ID
+locals {
+  ip_group_id  = huaweicloud_apig_channel_member_group.ip_channel_member_group.id
+  ecs_group_id = huaweicloud_apig_channel_member_group.ecs_channel_member_group.id
+}
+
+data "huaweicloud_apig_channel_members" "ecs_filter_by_group_id" {
+  instance_id     = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id  = huaweicloud_apig_channel.ecs_channel.id
+  member_group_id = local.ecs_group_id
+
+  depends_on = [
+    huaweicloud_apig_channel_member.ecs_member,
+  ]
+}
+
+locals {
+  ecs_group_id_filter_result = [
+    for v in data.huaweicloud_apig_channel_members.ecs_filter_by_group_id.members[*].member_group_id
+    : v == local.ecs_group_id
+  ]
+}
+
+output "ecs_group_id_filter_is_useful" {
+  value = length(local.ecs_group_id_filter_result) >= 2 && alltrue(local.ecs_group_id_filter_result)
+}
+
+data "huaweicloud_apig_channel_members" "ip_filter_by_group_id" {
+  instance_id     = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id  = huaweicloud_apig_channel.ip_channel.id
+  member_group_id = local.ip_group_id
+
+  depends_on = [
+    huaweicloud_apig_channel_member.ip_member,
+  ]
+}
+
+locals {
+  ip_group_id_filter_result = [
+    for v in data.huaweicloud_apig_channel_members.ip_filter_by_group_id.members[*].member_group_id
+    : v == local.ip_group_id
+  ]
+}
+
+output "ip_group_id_filter_is_useful" {
+  value = length(local.ip_group_id_filter_result) >= 2 && alltrue(local.ip_group_id_filter_result)
+}
+
+# Filter by group name (exact search)
+locals {
+  exact_group_name = huaweicloud_apig_channel_member_group.ip_channel_member_group.name
+}
+
+data "huaweicloud_apig_channel_members" "filter_by_precise_search" {
+  instance_id       = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  vpc_channel_id    = huaweicloud_apig_channel.ip_channel.id
+  member_group_name = local.exact_group_name
+  precise_search    = "member_group_name"
+
+  depends_on = [
+    huaweicloud_apig_channel_member.ip_member,
+  ]
+}
+
+locals {
+  precise_search_filter_result = [
+    for v in data.huaweicloud_apig_channel_members.filter_by_precise_search.members[*].member_group_name
+    : v == local.exact_group_name
+  ]
+}
+
+output "precise_search_filter_is_useful" {
+  value = length(local.precise_search_filter_result) > 1 && alltrue(local.precise_search_filter_result)
+}
+`, testAccDataSourceChannelMembers_base(name), name)
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_channel_members.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_channel_members.go
@@ -1,0 +1,276 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/members
+func DataSourceChannelMembers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceChannelMembersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the channel members are located.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the channel members belong.`,
+			},
+			"vpc_channel_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the VPC channel to which the members belong.`,
+			},
+
+			// Optional parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the channel member to be queried for fuzzy matching.`,
+			},
+			"member_group_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the channel member group to be queried for fuzzy matching.`,
+			},
+			"member_group_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the channel member group to be queried.`,
+			},
+			"precise_search": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The parameter name for exact matching to be queried.`,
+			},
+
+			// Attributes.
+			"members": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        channelMemberSchema(),
+				Description: `The list of the channel members that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func channelMemberSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the channel member.`,
+			},
+			"vpc_channel_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the VPC channel.`,
+			},
+			"member_group_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the channel member group.`,
+			},
+			"member_group_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the channel member group.`,
+			},
+			"member_ip_address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The IP address of the channel member.`,
+			},
+			"ecs_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the ECS instance.`,
+			},
+			"ecs_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the ECS instance.`,
+			},
+			"port": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The port of the channel member.`,
+			},
+			"is_backup": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the channel member is a backup node.`,
+			},
+			"status": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The status of the channel member.`,
+			},
+			"weight": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The weight value of the channel member.`,
+			},
+			"health_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The health status of the channel member.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the channel member was added to the VPC channel, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func buildChannelMembersQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("member_group_name"); ok {
+		res = fmt.Sprintf("%s&member_group_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("member_group_id"); ok {
+		res = fmt.Sprintf("%s&member_group_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("precise_search"); ok {
+		res = fmt.Sprintf("%s&precise_search=%v", res, v)
+	}
+
+	return res
+}
+
+func listChannelMembers(client *golangsdk.ServiceClient, instanceId, vpcChannelId, memberGroupName string,
+	d ...*schema.ResourceData) ([]interface{}, error) {
+	var (
+		result  = make([]interface{}, 0)
+		httpUrl = "v2/{project_id}/apigw/instances/{instance_id}/vpc-channels/{vpc_channel_id}/members?limit={limit}"
+		limit   = 100
+		offset  = 0
+	)
+
+	listPathWithLimit := client.Endpoint + httpUrl
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{project_id}", client.ProjectID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{instance_id}", instanceId)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{vpc_channel_id}", vpcChannelId)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{limit}", strconv.Itoa(limit))
+	if len(d) > 0 {
+		listPathWithLimit += buildChannelMembersQueryParams(d[0])
+	} else {
+		listPathWithLimit = fmt.Sprintf(`%s&member_group_name=%s&precise_search=member_group_name`, listPathWithLimit, memberGroupName)
+	}
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPathWithLimit + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		members := utils.PathSearch("members", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, members...)
+		if len(members) < limit {
+			break
+		}
+		offset += len(members)
+	}
+
+	return result, nil
+}
+
+func flattenMembers(members []interface{}) []interface{} {
+	if len(members) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(members))
+	for _, item := range members {
+		result = append(result, map[string]interface{}{
+			"id":                utils.PathSearch("id", item, nil),
+			"vpc_channel_id":    utils.PathSearch("vpc_channel_id", item, nil),
+			"member_group_name": utils.PathSearch("member_group_name", item, nil),
+			"member_group_id":   utils.PathSearch("member_group_id", item, nil),
+			"member_ip_address": utils.PathSearch("host", item, nil),
+			"ecs_id":            utils.PathSearch("ecs_id", item, nil),
+			"ecs_name":          utils.PathSearch("ecs_name", item, nil),
+			"port":              utils.PathSearch("port", item, nil),
+			"is_backup":         utils.PathSearch("is_backup", item, nil),
+			"status":            utils.PathSearch("status", item, nil),
+			"weight":            utils.PathSearch("weight", item, nil),
+			"health_status":     utils.PathSearch("health_status", item, nil),
+			"create_time":       utils.PathSearch("create_time", item, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceChannelMembersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg             = meta.(*config.Config)
+		region          = cfg.GetRegion(d)
+		instanceId      = d.Get("instance_id").(string)
+		vpcChannelId    = d.Get("vpc_channel_id").(string)
+		memberGroupName = d.Get("member_group_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	members, err := listChannelMembers(client, instanceId, vpcChannelId, memberGroupName, d)
+	if err != nil {
+		return diag.Errorf("error querying channel members: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("members", flattenMembers(members)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(apig): add new data source for query channel members

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
`health_status` is nul

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataSourceChannelMembers_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceChannelMembers_basic
=== PAUSE TestAccDataSourceChannelMembers_basic
=== CONT  TestAccDataSourceChannelMembers_basic
--- PASS: TestAccDataSourceChannelMembers_basic (425.92s)
PASS
coverage: 5.8% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      426.048s        coverage: 5.8% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.