### PR TITLE
feat(SWR): support enterprise image signature policy execute

### DIFF
--- a/docs/resources/swr_enterprise_image_signature_policy_execute.md
+++ b/docs/resources/swr_enterprise_image_signature_policy_execute.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Software Repository for Container (SWR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_swr_enterprise_image_signature_policy_execute"
+description: |-
+  Manages a SWR enterprise image signature policy execute resource within HuaweiCloud.
+---
+
+# huaweicloud_swr_enterprise_image_signature_policy_execute
+
+Manages a SWR enterprise image signature policy execute resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "namespace_name" {}
+variable "policy_id" {}
+
+resource "huaweicloud_swr_enterprise_image_signature_policy_execute" "test" {
+  instance_id    = var.instance_id
+  namespace_name = var.namespace_name
+  policy_id      = var.policy_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the enterprise instance ID.
+
+* `namespace_name` - (Required, String, NonUpdatable) Specifies the namespace name.
+
+* `policy_id` - (Required, String, NonUpdatable) Specifies the policy ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `execution_id` - Specifies the execution ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3154,6 +3154,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_swr_enterprise_namespace":                      swrenterprise.ResourceSwrEnterpriseNamespace(),
 			"huaweicloud_swr_enterprise_trigger":                        swrenterprise.ResourceSwrEnterpriseTrigger(),
 			"huaweicloud_swr_enterprise_image_signature_policy":         swrenterprise.ResourceSwrEnterpriseImageSignaturePolicy(),
+			"huaweicloud_swr_enterprise_image_signature_policy_execute": swrenterprise.ResourceSwrEnterpriseImageSignaturePolicyExecute(),
 			"huaweicloud_swr_enterprise_job_delete":                     swrenterprise.ResourceSwrEnterpriseJobDelete(),
 			"huaweicloud_swr_enterprise_long_term_credential":           swrenterprise.ResourceSwrEnterpriseLongTermCredential(),
 			"huaweicloud_swr_enterprise_temporary_credential":           swrenterprise.ResourceSwrEnterpriseTemporaryCredential(),

--- a/huaweicloud/services/acceptance/swrenterprise/resource_huaweicloud_swr_enterprise_image_signature_policy_execute_test.go
+++ b/huaweicloud/services/acceptance/swrenterprise/resource_huaweicloud_swr_enterprise_image_signature_policy_execute_test.go
@@ -1,0 +1,38 @@
+package swrenterprise
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccSwrEnterpriseImageSignaturePolicyExecute_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSwrEnterpriseImageSignaturePolicyExecute_basic(rName),
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
+func testAccSwrEnterpriseImageSignaturePolicyExecute_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_swr_enterprise_image_signature_policy_execute" "test" {
+  instance_id    = huaweicloud_swr_enterprise_instance.test.id
+  namespace_name = "library"
+  policy_id      = huaweicloud_swr_enterprise_image_signature_policy.test.id
+}
+`, testAccSwrEnterpriseImageSignaturePolicy_basic(rName))
+}

--- a/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_image_signature_policy_execute.go
+++ b/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_image_signature_policy_execute.go
@@ -1,0 +1,137 @@
+package swrenterprise
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var enterpriseImageSignaturePolicyExecuteNonUpdatableParams = []string{
+	"instance_id", "namespace_name", "policy_id",
+}
+
+// @API SWR POST /v2/{project_id}/instances/{instance_id}/namespaces/{namespace_name}/signature/policies/{policy_id}/executions
+func ResourceSwrEnterpriseImageSignaturePolicyExecute() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSwrEnterpriseImageSignaturePolicyExecuteCreate,
+		UpdateContext: resourceSwrEnterpriseImageSignaturePolicyExecuteUpdate,
+		ReadContext:   resourceSwrEnterpriseImageSignaturePolicyExecuteRead,
+		DeleteContext: resourceSwrEnterpriseImageSignaturePolicyExecuteDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(enterpriseImageSignaturePolicyExecuteNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the enterprise instance ID.`,
+			},
+			"namespace_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the namespace name.`,
+			},
+			"policy_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the policy ID.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"execution_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Specifies the execution ID.`,
+			},
+		},
+	}
+}
+
+func resourceSwrEnterpriseImageSignaturePolicyExecuteCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("swr", region)
+	if err != nil {
+		return diag.Errorf("error creating SWR client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	namespaceName := d.Get("namespace_name").(string)
+	policyId := d.Get("policy_id").(string)
+
+	createHttpUrl := "v2/{project_id}/instances/{instance_id}/namespaces/{namespace_name}/signature/policies/{policy_id}/executions"
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createPath = strings.ReplaceAll(createPath, "{namespace_name}", namespaceName)
+	createPath = strings.ReplaceAll(createPath, "{policy_id}", policyId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error executing SWR iamge signature policy: %s", err)
+	}
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := int(utils.PathSearch("id", createRespBody, float64(-1)).(float64))
+	if id == -1 {
+		return diag.Errorf("unable to find SWR instance policy ID from the API response")
+	}
+
+	d.SetId(instanceId + "/" + namespaceName + "/" + strconv.Itoa(id))
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("execution_id", id),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceSwrEnterpriseImageSignaturePolicyExecuteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceSwrEnterpriseImageSignaturePolicyExecuteUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceSwrEnterpriseImageSignaturePolicyExecuteDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting SWR enterprise image signature policy resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support enterprise image signature policy execute
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support enterprise image signature policy execute
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/swrenterprise' TESTARGS='-run TestAccSwrEnterpriseImageSignaturePolicyExecute_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swrenterprise -v -run TestAccSwrEnterpriseImageSignaturePolicyExecute_basic -timeout 360m -parallel 4
=== RUN   TestAccSwrEnterpriseImageSignaturePolicyExecute_basic
=== PAUSE TestAccSwrEnterpriseImageSignaturePolicyExecute_basic
=== CONT  TestAccSwrEnterpriseImageSignaturePolicyExecute_basic
--- PASS: TestAccSwrEnterpriseImageSignaturePolicyExecute_basic (14.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swrenterprise     14.394s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
