### PR TITLE
feat(waf): new resource batch update geo ip rule

### DIFF
--- a/docs/resources/waf_geo_ip_rule_batch_update.md
+++ b/docs/resources/waf_geo_ip_rule_batch_update.md
@@ -1,0 +1,75 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_geo_ip_rule_batch_update"
+description: |-
+  Manages a resource to batch update the geo IP rules within HuaweiCloud.
+---
+
+# huaweicloud_waf_geo_ip_rule_batch_update
+
+Manages a resource to batch update the geo IP rules within HuaweiCloud.
+
+-> All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be used.
+
+-> This resource is only a one-time action resource using to batch update geo IP rules. Deleting this resource will
+not change the current geo IP rule configurations, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "policy_id" {}
+variable "rule_ids"  {
+  type = list(string)
+}
+
+resource "huaweicloud_waf_geo_ip_rule_batch_update" "test" {
+  geoip = "US|CA|JP"
+
+  policy_rule_ids {
+    policy_id = var.policy_id
+    rule_ids  = var.rule_ids
+  }
+
+  status = 1
+  name   = "updated_geo_rule"
+  white  = 2
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `geoip` - (Required, String, NonUpdatable) Specifies the geo location codes blocked by the rule, separated by '|'.
+
+* `policy_rule_ids` - (Optional, List, NonUpdatable) Specifies the policy and rule details.
+  The [policy_rule_ids](#geo_ip_policy_rules) structure is documented below.
+
+* `status` - (Optional, Int, NonUpdatable) Specifies the status of the geo IP rule.
+  The valid values are as follows:
+  + `0`: Disabled
+  + `1`: Enabled
+
+* `name` - (Optional, String, NonUpdatable) Specifies the name of the geo IP rule.
+
+* `white` - (Optional, Int, NonUpdatable) Specifies the protection action.
+  The valid values are as follows:
+  + `1`: Allow
+  + `2`: Block
+
+<a name="geo_ip_policy_rules"></a>
+The `policy_rule_ids` block supports:
+
+* `policy_id` - (Optional, String, NonUpdatable) Specifies the policy ID to which the geo IP rule belongs.
+
+* `rule_ids` - (Optional, List, NonUpdatable) Specifies the ID list of the geo IP rule.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3229,6 +3229,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_domain_associate_certificate":        waf.ResourceDomainAssociateCertificate(),
 			"huaweicloud_waf_domain":                              waf.ResourceWafDomain(),
 			"huaweicloud_waf_domain_route_update":                 waf.ResourceDomainRouteUpdate(),
+			"huaweicloud_waf_geo_ip_rule_batch_update":            waf.ResourceGeoIpRuleBatchUpdate(),
 			"huaweicloud_waf_ip_intelligence_rule":                waf.ResourceIpIntelligenceRule(),
 			"huaweicloud_waf_modify_alarm_notification":           waf.ResourceModifyAlarmNotification(),
 			"huaweicloud_waf_alarm_notification":                  waf.ResourceWafAlarmNotification(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -127,6 +127,7 @@ var (
 	HW_WAF_DEDICATED_INSTANCE_ID                = os.Getenv("HW_WAF_DEDICATED_INSTANCE_ID")
 	HW_WAF_DEDICATED_INSTANCE_SECURITY_GROUP_ID = os.Getenv("HW_WAF_DEDICATED_INSTANCE_SECURITY_GROUP_ID")
 	HW_WAF_RULE_ID                              = os.Getenv("HW_WAF_RULE_ID")
+	HW_WAF_GEO_RULE_ID                          = os.Getenv("HW_WAF_GEO_RULE_ID")
 
 	HW_ELB_CERT_ID         = os.Getenv("HW_ELB_CERT_ID")
 	HW_ELB_LOADBALANCER_ID = os.Getenv("HW_ELB_LOADBALANCER_ID")
@@ -1226,6 +1227,13 @@ func TestAccPreCheckWafDedicatedInstanceAction(t *testing.T) {
 func TestAccPreCheckWafRuleId(t *testing.T) {
 	if HW_WAF_RULE_ID == "" {
 		t.Skip("HW_WAF_RULE_ID must be set for this acceptance test.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckWafGeoRuleId(t *testing.T) {
+	if HW_WAF_GEO_RULE_ID == "" {
+		t.Skip("HW_WAF_GEO_RULE_ID must be set for this acceptance test.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_geo_ip_rule_batch_update_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_geo_ip_rule_batch_update_test.go
@@ -1,0 +1,46 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGeoIpRuleBatchUpdate_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Before running the test case, please ensure that there is at least one WAF instance in the current region.
+			// Prepare a WAF policy with a WAF geo IP rule.
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckWafPolicyId(t)
+			acceptance.TestAccPreCheckWafGeoRuleId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeoIpRuleBatchUpdate_basic(),
+			},
+		},
+	})
+}
+
+func testAccGeoIpRuleBatchUpdate_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_geo_ip_rule_batch_update" "test" {
+  geoip  = "US|CA|JP"
+  status = 1
+  name   = "updated_geo_rule"
+  white  = 2
+
+  policy_rule_ids {
+    policy_id = "%[1]s"
+    rule_ids  = ["%[2]s"]
+  }
+}
+`, acceptance.HW_WAF_POLICY_ID, acceptance.HW_WAF_GEO_RULE_ID)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_geo_ip_rule_batch_update.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_geo_ip_rule_batch_update.go
@@ -1,0 +1,186 @@
+package waf
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var geoIpRuleBatchUpdateNonUpdatableParams = []string{
+	"policy_rule_ids",
+	"policy_rule_ids.*.policy_id",
+	"policy_rule_ids.*.rule_ids",
+	"status",
+	"name",
+	"geoip",
+	"white",
+}
+
+// @API WAF POST /v1/{project_id}/waf/rule/geoip/batch-update
+func ResourceGeoIpRuleBatchUpdate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGeoIpRuleBatchUpdateCreate,
+		ReadContext:   resourceGeoIpRuleBatchUpdateRead,
+		UpdateContext: resourceGeoIpRuleBatchUpdateUpdate,
+		DeleteContext: resourceGeoIpRuleBatchUpdateDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(geoIpRuleBatchUpdateNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level
+				region will be used.`,
+			},
+			"geoip": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the geo location codes blocked by the rule, separated by '|'.`,
+			},
+			"policy_rule_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Description: `Specifies an array of policy and rule IDs, using to associate protection policies with
+				corresponding rule sets`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"policy_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the ID of the protection policy.`,
+						},
+						"rule_ids": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: `Specifies an array of rule IDs associated with the protection policy.`,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"status": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies the status of the geo IP rule (0: disabled, 1: enabled).`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the name of the geo IP rule.`,
+			},
+			"white": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies the protection action (1: allow, 2: block).`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildGeoIpPolicyRuleIdsBodyParams(rawParams []interface{}) []map[string]interface{} {
+	if len(rawParams) == 0 {
+		return nil
+	}
+
+	ruleParams := make([]map[string]interface{}, 0, len(rawParams))
+	for _, v := range rawParams {
+		raw, ok := v.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+
+		params := map[string]interface{}{
+			"policy_id": raw["policy_id"],
+			"rule_ids":  utils.ExpandToStringList(raw["rule_ids"].([]interface{})),
+		}
+		ruleParams = append(ruleParams, params)
+	}
+
+	return ruleParams
+}
+
+func buildGeoIpRuleBatchUpdateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"geoip":           d.Get("geoip"),
+		"policy_rule_ids": buildGeoIpPolicyRuleIdsBodyParams(d.Get("policy_rule_ids").([]interface{})),
+		"status":          d.Get("status"),
+		"name":            utils.ValueIgnoreEmpty(d.Get("name")),
+		"white":           utils.ValueIgnoreEmpty(d.Get("white")),
+	}
+}
+
+func resourceGeoIpRuleBatchUpdateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/rule/geoip/batch-update"
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: utils.RemoveNil(buildGeoIpRuleBatchUpdateBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error batch updating WAF GEO IP rules: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return resourceGeoIpRuleBatchUpdateRead(ctx, d, meta)
+}
+
+func resourceGeoIpRuleBatchUpdateRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a action resource.
+	return nil
+}
+
+func resourceGeoIpRuleBatchUpdateUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a action resource.
+	return nil
+}
+
+func resourceGeoIpRuleBatchUpdateDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to batch update WAF geo IP rules. 
+Deleting this resource will not change the current geo IP rule configurations, but will only remove the resource 
+information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource batch update geo ip rule.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccGeoIpRuleBatchUpdate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccGeoIpRuleBatchUpdate_basic -timeout 360m -parallel 10
=== RUN   TestAccGeoIpRuleBatchUpdate_basic
=== PAUSE TestAccGeoIpRuleBatchUpdate_basic
=== CONT  TestAccGeoIpRuleBatchUpdate_basic
--- PASS: TestAccGeoIpRuleBatchUpdate_basic (11.81s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       11.904s coverage: 3.7% of statements in ./huaweicloud/services/waf
```
<img width="1364" height="88" alt="image" src="https://github.com/user-attachments/assets/f00f7e1a-b3d6-49d4-ad1c-109b6b4eff5a" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
