### PR TITLE
feat(waf): add new data source to get all information antileakage rules

### DIFF
--- a/docs/data-sources/waf_all_antileakage_rules.md
+++ b/docs/data-sources/waf_all_antileakage_rules.md
@@ -1,0 +1,62 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_all_antileakage_rules"
+description: |-
+  Use this data source to get list of the WAF information leakage prevention rules under all policies.
+---
+
+# huaweicloud_waf_all_antileakage_rules
+
+Use this data source to get list of the WAF information leakage prevention rules under all policies.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_waf_all_antileakage_rules" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `policyids` - (Optional, String) Specifies the ID of the policy.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  If you want to query resources under all enterprise projects, set this parameter to **all_granted_eps**.
+  Defaults to **0**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `items` - The list of the WAF data masking rules.
+
+  The [items](#items_struct) structure is documented below.
+
+<a name="items_struct"></a>
+The `items` block supports:
+
+* `id` - The ID of the rule.
+
+* `policyid` - The ID of the policy.
+
+* `url` - The URL for the rule application.
+
+* `category` - The rule category.
+
+* `contents` - The rule contents.
+
+* `timestamp` - The creation time of the rule, in milliseconds.
+
+* `status` - The status of the rule.
+  The valid values are as follows:
+  + `0`: Disabled.
+  + `1`: Enabled.
+
+* `description` - The description of the rule.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1818,6 +1818,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_address_groups":                       waf.DataSourceWafAddressGroups(),
 			"huaweicloud_waf_alarm_notifications":                  waf.DataSourceWafAlarmNotifications(),
 			"huaweicloud_waf_alarm_optional_event_types":           waf.DataSourceAlarmOptionalEventTypes(),
+			"huaweicloud_waf_all_antileakage_rules":                waf.DataSourceAllAntileakageRules(),
 			"huaweicloud_waf_all_data_masking_rules":               waf.DataSourceAllDataMaskingRules(),
 			"huaweicloud_waf_all_geo_ip_policy_rules":              waf.DataSourceAllGeoIpPolicyRules(),
 			"huaweicloud_waf_all_domains":                          waf.DataSourceWafAllDomains(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_all_antileakage_rules_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_all_antileakage_rules_test.go
@@ -1,0 +1,71 @@
+package waf
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAllAntileakageRules_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_waf_all_antileakage_rules.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Prepare a WAF information leakage prevention rule before test
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAllAntileakageRules_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.policyid"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.url"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.category"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.contents.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.timestamp"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.description"),
+
+					resource.TestCheckOutput("policyid_filter_is_useful", "true"),
+					resource.TestCheckOutput("eps_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAllAntileakageRules_basic = `
+data "huaweicloud_waf_all_antileakage_rules" "test" {}
+
+locals {
+  policyid = data.huaweicloud_waf_all_antileakage_rules.test.items[0].policyid
+}
+
+data "huaweicloud_waf_all_antileakage_rules" "filter_by_policyid" {
+  policyids = local.policyid
+}
+
+output "policyid_filter_is_useful" {
+  value = length(data.huaweicloud_waf_all_antileakage_rules.filter_by_policyid.items) > 0 && alltrue(
+    [for v in data.huaweicloud_waf_all_antileakage_rules.filter_by_policyid.items[*].policyid : v == local.policyid]
+  )
+}
+
+data "huaweicloud_waf_all_antileakage_rules" "filter_by_eps" {
+  enterprise_project_id = "0"
+}
+
+output "eps_filter_is_useful" {
+  value = length(data.huaweicloud_waf_all_antileakage_rules.filter_by_eps.items) > 0
+}
+`

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_all_antileakage_rules.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_all_antileakage_rules.go
@@ -1,0 +1,173 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{projectid}/waf/rule/antileakage
+func DataSourceAllAntileakageRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAllAntileakageRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"policyids": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policyid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"category": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"contents": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"timestamp": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAllAntileakageRulesQueryParams(d *schema.ResourceData, epsId string) string {
+	res := "?pagesize=1000"
+	if v, ok := d.GetOk("policyids"); ok {
+		res = fmt.Sprintf("%s&policyids=%v", res, v)
+	}
+	if epsId != "" {
+		res = fmt.Sprintf("%s&enterprise_project_id=%v", res, epsId)
+	}
+
+	return res
+}
+
+func dataSourceAllAntileakageRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		mErr        *multierror.Error
+		httpUrl     = "v1/{projectid}/waf/rule/antileakage"
+		allRules    []interface{}
+		currentPage = 1
+		epsId       = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{projectid}", client.ProjectID)
+	requestPath += buildAllAntileakageRulesQueryParams(d, epsId)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithPage := fmt.Sprintf("%s&page=%d", requestPath, currentPage)
+		resp, err := client.Request("GET", requestPathWithPage, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving WAF all information leakage prevention rules: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		rulesResp := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		if len(rulesResp) == 0 {
+			break
+		}
+
+		allRules = append(allRules, rulesResp...)
+		currentPage++
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("items", flattenAllAntileakageRules(allRules)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAllAntileakageRules(rules []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(rules))
+	for _, v := range rules {
+		rst = append(rst, map[string]interface{}{
+			"id":          utils.PathSearch("id", v, nil),
+			"policyid":    utils.PathSearch("policyid", v, nil),
+			"url":         utils.PathSearch("url", v, nil),
+			"category":    utils.PathSearch("category", v, nil),
+			"contents":    utils.PathSearch("contents", v, nil),
+			"timestamp":   utils.PathSearch("timestamp", v, nil),
+			"status":      utils.PathSearch("status", v, nil),
+			"description": utils.PathSearch("description", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get all information antileakage rules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccDataSourceAllAntileakageRules_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceAllAntileakageRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAllAntileakageRules_basic
=== PAUSE TestAccDataSourceAllAntileakageRules_basic
=== CONT  TestAccDataSourceAllAntileakageRules_basic
--- PASS: TestAccDataSourceAllAntileakageRules_basic (13.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       13.857s
```
<img width="1117" height="19" alt="image" src="https://github.com/user-attachments/assets/3213ca55-bdfa-4f10-a8f1-53f3a2975388" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
