### PR TITLE
feat(waf): new datasource to query all ip reputation policy rules

### DIFF
--- a/docs/data-sources/waf_all_ip_reputation_policy_rules.md
+++ b/docs/data-sources/waf_all_ip_reputation_policy_rules.md
@@ -1,0 +1,73 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_all_ip_reputation_policy_rules"
+description: |-
+  Use this data source to get list of the WAF IP reputation policy rules under all policies.
+---
+
+# huaweicloud_waf_all_ip_reputation_policy_rules
+
+Use this data source to get list of the WAF IP reputation policy rules under all policies.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_waf_all_ip_reputation_policy_rules" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `policyids` - (Optional, String) Specifies the ID of the policy.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  If you want to query resources under all enterprise projects, set this parameter to **all_granted_eps**.
+  Defaults to **0**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `items` - The list of the WAF IP reputation policy rules.
+
+  The [items](#items_struct) structure is documented below.
+
+<a name="items_struct"></a>
+The `items` block supports:
+
+* `id` - The ID of the rule.
+
+* `policyid` - The ID of the policy.
+
+* `name` - The name of the rule.
+
+* `type` - The reputation type of the rule.
+
+* `description` - The description of the rule.
+
+* `tags` - The list of IDC data centers for the reputation type.
+
+* `status` - The status of the rule.
+  The valid values are as follows:
+  + `0`: Disabled
+  + `1`: Enabled
+
+* `action` - The protection action of the rule.
+
+  The [action](#action_struct) structure is documented below.
+
+<a name="action_struct"></a>
+The `action` block supports:
+
+* `category` - The action type of the rule.
+  The valid values are as follows:
+  + **pass**: Allow
+  + **block**: Block
+  + **log**: Log only

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1823,6 +1823,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_all_data_masking_rules":               waf.DataSourceAllDataMaskingRules(),
 			"huaweicloud_waf_all_geo_ip_policy_rules":              waf.DataSourceAllGeoIpPolicyRules(),
 			"huaweicloud_waf_all_policy_cc_rules":                  waf.DataSourceAllPolicyCcRules(),
+			"huaweicloud_waf_all_ip_reputation_policy_rules":       waf.DataSourceAllIpReputationPolicyRules(),
 			"huaweicloud_waf_all_domains":                          waf.DataSourceWafAllDomains(),
 			"huaweicloud_waf_all_precise_protection_rules":         waf.DataSourceAllPreciseProtectionRules(),
 			"huaweicloud_waf_all_whiteblackip_rules":               waf.DataSourceAllWhiteblackipRules(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -115,6 +115,7 @@ var (
 
 	HW_WAF_ENABLE_FLAG                          = os.Getenv("HW_WAF_ENABLE_FLAG")
 	HW_WAF_PRECHECK_GEO_IP_POLICY_RULES         = os.Getenv("HW_WAF_PRECHECK_GEO_IP_POLICY_RULES")
+	HW_WAF_PRECHECK_IP_REPUTATION_POLICY_RULES  = os.Getenv("HW_WAF_PRECHECK_IP_REPUTATION_POLICY_RULES")
 	HW_WAF_CERTIFICATE_ID                       = os.Getenv("HW_WAF_CERTIFICATE_ID")
 	HW_WAF_DOMAIN_ID                            = os.Getenv("HW_WAF_DOMAIN_ID")
 	HW_WAF_TYPE                                 = os.Getenv("HW_WAF_TYPE")
@@ -1146,6 +1147,13 @@ func TestAccPrecheckWafInstance(t *testing.T) {
 func TestAccPrecheckWafGeoIpPolicyRules(t *testing.T) {
 	if HW_WAF_PRECHECK_GEO_IP_POLICY_RULES == "" {
 		t.Skip("Skip the WAF geo IP policy rules acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPrecheckWafIpReputationPolicyRules(t *testing.T) {
+	if HW_WAF_PRECHECK_IP_REPUTATION_POLICY_RULES == "" {
+		t.Skip("Skip the WAF IP reputation policy rules acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_all_ip_reputation_policy_rules_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_all_ip_reputation_policy_rules_test.go
@@ -1,0 +1,71 @@
+package waf
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAllIpReputationPolicyRules_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_waf_all_ip_reputation_policy_rules.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			// Prepare a WAF IP reputation policy rule in default enterprise project before test
+			acceptance.TestAccPrecheckWafIpReputationPolicyRules(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAllIpReputationPolicyRules_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.policyid"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.tags.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.action.0.category"),
+
+					resource.TestCheckOutput("policyid_filter_is_useful", "true"),
+					resource.TestCheckOutput("eps_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAllIpReputationPolicyRules_basic = `
+data "huaweicloud_waf_all_ip_reputation_policy_rules" "test" {}
+
+locals {
+  policyid = data.huaweicloud_waf_all_ip_reputation_policy_rules.test.items[0].policyid
+}
+
+data "huaweicloud_waf_all_ip_reputation_policy_rules" "filter_by_policyid" {
+  policyids = local.policyid
+}
+
+output "policyid_filter_is_useful" {
+  value = length(data.huaweicloud_waf_all_ip_reputation_policy_rules.filter_by_policyid.items) > 0 && alltrue(
+    [for v in data.huaweicloud_waf_all_ip_reputation_policy_rules.filter_by_policyid.items[*].policyid : v == local.policyid]
+  )
+}
+
+data "huaweicloud_waf_all_ip_reputation_policy_rules" "filter_by_eps" {
+  enterprise_project_id = "0"
+}
+
+output "eps_filter_is_useful" {
+  value = length(data.huaweicloud_waf_all_ip_reputation_policy_rules.filter_by_eps.items) > 0
+}
+`

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_all_ip_reputation_policy_rules.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_all_ip_reputation_policy_rules.go
@@ -1,0 +1,194 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{projectid}/waf/rule/ip-reputation
+func DataSourceAllIpReputationPolicyRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAllIpReputationPolicyRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"policyids": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policyid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"status": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"action": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"category": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAllIpReputationPolicyRulesQueryParams(d *schema.ResourceData, epsId string) string {
+	res := "?pagesize=1000"
+	if v, ok := d.GetOk("policyids"); ok {
+		res = fmt.Sprintf("%s&policyids=%v", res, v)
+	}
+	if epsId != "" {
+		res = fmt.Sprintf("%s&enterprise_project_id=%v", res, epsId)
+	}
+
+	return res
+}
+
+func dataSourceAllIpReputationPolicyRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		mErr        *multierror.Error
+		httpUrl     = "v1/{projectid}/waf/rule/ip-reputation"
+		allRules    []interface{}
+		currentPage = 1
+		epsId       = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{projectid}", client.ProjectID)
+	requestPath += buildAllIpReputationPolicyRulesQueryParams(d, epsId)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithPage := fmt.Sprintf("%s&page=%d", requestPath, currentPage)
+		resp, err := client.Request("GET", requestPathWithPage, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving WAF all IP reputation policy rules: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		rulesResp := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		if len(rulesResp) == 0 {
+			break
+		}
+
+		allRules = append(allRules, rulesResp...)
+		currentPage++
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("items", flattenAllIpReputationPolicyRules(allRules)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAllIpReputationPolicyRules(rules []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(rules))
+	for _, v := range rules {
+		rst = append(rst, map[string]interface{}{
+			"id":          utils.PathSearch("id", v, nil),
+			"policyid":    utils.PathSearch("policyid", v, nil),
+			"name":        utils.PathSearch("name", v, nil),
+			"type":        utils.PathSearch("type", v, nil),
+			"description": utils.PathSearch("description", v, nil),
+			"tags":        utils.PathSearch("tags", v, nil),
+			"status":      utils.PathSearch("status", v, nil),
+			"action":      flattenIpReputationRuleAction(v),
+		})
+	}
+	return rst
+}
+
+func flattenIpReputationRuleAction(rule interface{}) []interface{} {
+	action := utils.PathSearch("action", rule, nil)
+	if action == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"category": utils.PathSearch("category", action, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query all ip reputation policy rules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccDataSourceAllIpReputationPolicyRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccDataSourceAllIpReputationPolicyRules_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAllIpReputationPolicyRules_basic
=== PAUSE TestAccDataSourceAllIpReputationPolicyRules_basic
=== CONT  TestAccDataSourceAllIpReputationPolicyRules_basic
--- PASS: TestAccDataSourceAllIpReputationPolicyRules_basic (12.60s)
PASS
coverage: 3.9% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       12.699s coverage: 3.9% of statements in ./huaweicloud/services/waf
```
<img width="1333" height="80" alt="image" src="https://github.com/user-attachments/assets/f85a4f10-33c0-49bd-b838-9c7ba8e10fb0" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
