### PR TITLE
feat(aom): prometheus instance supports update function

### DIFF
--- a/docs/resources/aom_prom_instance.md
+++ b/docs/resources/aom_prom_instance.md
@@ -18,6 +18,11 @@ resource "huaweicloud_aom_prom_instance" "instance" {
   prom_name             = "test_demo"
   prom_type             = "ECS"
   enterprise_project_id = var.enterprise_project_id
+  prom_version          = "1.5"
+  
+  prom_limits {
+    compactor_blocks_retention_period = "360h"
+  }
 }
 ```
 
@@ -25,23 +30,39 @@ resource "huaweicloud_aom_prom_instance" "instance" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region in which to create the AOM prometheus instance.
+* `region` - (Optional, String, ForceNew) Specifies the region where the prometheus instance is located.
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `prom_name` - (Required, String, ForceNew) Specifies the name of the AOM prometheus instance.
+* `prom_name` - (Required, String) Specifies the name of the prometheus instance.  
   The value can contain `1` to `100` characters. Only Chinese and English letters, digits, underscores (_)
   and hyphens (-) are allowed, and it must start with letters, digits or Chinese characters.
-  Changing this parameter will create a new resource.
 
-* `prom_type` - (Required, String, ForceNew) Specifies the type of the AOM prometheus instance.
+* `prom_type` - (Required, String, ForceNew) Specifies the type of the prometheus instance.
   The value can be: **ECS**, **VPC**, **CCE**, **REMOTE_WRITE**, **KUBERNETES**,
   **CLOUD_SERVICE** or **ACROSS_ACCOUNT**.
   Changing this parameter will create a new resource.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of the
-  AOM prometheus instance. Defaults to **0**. Changing this parameter will create a new resource.
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the prometheus
+  instance belongs.  
+  This field is only valid for enterprise users, if omitted, default enterprise project will be used.  
+  Changing this parameter will create a new resource.
 
-* `prom_version` - (Optional, String, ForceNew) Specifies the version of AOM prometheus instance.
+* `prom_version` - (Optional, String, ForceNew) Specifies the version of the prometheus instance.
+
+* `prom_limits` - (Optional, List) Specifies the limit configurations of the prometheus instance.
+  The [prom_limits](#aom_prom_instance_prom_limits) structure is documented below.
+
+  -> The limits can only be updated once every `24` hours.
+
+<a name="aom_prom_instance_prom_limits"></a>
+The `prom_limits` block supports:
+
+* `compactor_blocks_retention_period` - (Required, String) Specifies the retention period for the compactor blocks.  
+  The valid values are as follows:
+  + **360h**
+  + **420h**
+  + **1440h**
+  + **2160h**
 
 ## Attribute Reference
 
@@ -49,17 +70,17 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
 
-* `created_at` - The creation time of AOM prometheus instance.
+* `prom_http_api_endpoint` - The HTTP URL for calling the prometheus instance.
 
-* `prom_http_api_endpoint` - The url for calling the AOM Prometheus instance.
+* `remote_read_url` - The remote read address of the prometheus instance.
 
-* `remote_read_url` - The remote read address of AOM Prometheus instance.
+* `remote_write_url` - The remote write address of the Prometheus instance.
 
-* `remote_write_url` - The remote write address of AOM Prometheus instance.
+* `created_at` - The creation time of the prometheus instance, in RFC3339 format.
 
 ## Import
 
-The AOM prometheus instance can be imported using `id`, e.g.
+The prometheus instance can be imported using `id`, e.g.
 
 ```bash
 $ terraform import huaweicloud_aom_prom_instance.test <id>

--- a/huaweicloud/services/acceptance/aom/data_source_huaweicloud_aom_prom_instances_test.go
+++ b/huaweicloud/services/acceptance/aom/data_source_huaweicloud_aom_prom_instances_test.go
@@ -47,9 +47,20 @@ func TestAccDataSourceAomPromInstances_basic(t *testing.T) {
 	})
 }
 
+func testDataSourceDataSourceAomPromInstances_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_aom_prom_instance" "test" {
+  prom_name             = "%[1]s"
+  prom_type             = "VPC"
+  enterprise_project_id = "%[2]s"
+  prom_version          = "1.5"
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
 func testDataSourceDataSourceAomPromInstances_basic(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 data "huaweicloud_aom_prom_instances" "test" {
   enterprise_project_id = "all_granted_eps"
@@ -74,6 +85,5 @@ output "prom_type_validation" {
 output "prom_id_validation" {
   value = alltrue([for v in local.test_id_filter_results.instances[*].id : v == huaweicloud_aom_prom_instance.test.id])
 }
-
-`, testAOMPromInstance_basic(name))
+`, testDataSourceDataSourceAomPromInstances_base(name))
 }

--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_prom_instance_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_prom_instance_test.go
@@ -2,17 +2,14 @@ package aom
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/aom"
 )
 
 func getPromInstanceResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -21,42 +18,20 @@ func getPromInstanceResourceFunc(conf *config.Config, state *terraform.ResourceS
 		return nil, fmt.Errorf("error creating AOM client: %s", err)
 	}
 
-	getPrometheusInstanceHttpUrl := "v1/{project_id}/aom/prometheus"
-	getPrometheusInstanceHttpUrl = strings.ReplaceAll(getPrometheusInstanceHttpUrl, "{project_id}", client.ProjectID)
-	getPrometheusInstanceHttpUrl += fmt.Sprintf("?prom_id=%s", state.Primary.ID)
-	getPrometheusInstancePath := client.Endpoint + getPrometheusInstanceHttpUrl
-
-	getPrometheusInstanceOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders:      buildHeaders(state),
-	}
-	getPrometheusInstanceResp, err := client.Request("GET", getPrometheusInstancePath, &getPrometheusInstanceOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving AOM prometheus instance: %s", err)
-	}
-
-	getPrometheusInstanceRespBody, err := utils.FlattenResponse(getPrometheusInstanceResp)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving AOM prometheus instance: %s", err)
-	}
-
-	curJson := utils.PathSearch("prometheus[0]", getPrometheusInstanceRespBody, nil)
-	if curJson == nil {
-		return nil, fmt.Errorf("unable to find the instance from the API response")
-	}
-
-	return curJson, nil
+	return aom.GetPrometheusInstanceById(client, state.Primary.ID)
 }
 
 func TestAccPromInstance_basic(t *testing.T) {
-	var obj interface{}
-	rName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_aom_prom_instance.test"
+	var (
+		obj interface{}
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&obj,
-		getPromInstanceResourceFunc,
+		updateAfterCreate  = "huaweicloud_aom_prom_instance.update_limits_after_create"
+		rcAfterCreate      = acceptance.InitResourceCheck(updateAfterCreate, &obj, getPromInstanceResourceFunc)
+		updateDuringUpdate = "huaweicloud_aom_prom_instance.update_limits_during_update"
+		rcDuringUpdate     = acceptance.InitResourceCheck(updateDuringUpdate, &obj, getPromInstanceResourceFunc)
+
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -65,24 +40,72 @@ func TestAccPromInstance_basic(t *testing.T) {
 			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcAfterCreate.CheckResourceDestroy(),
+			rcDuringUpdate.CheckResourceDestroy(),
+		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAOMPromInstance_basic(rName),
+				Config: testAOMPromInstance_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "prom_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "prom_type", "VPC"),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
-					resource.TestCheckResourceAttr(resourceName, "prom_version", "1.5"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "remote_write_url"),
-					resource.TestCheckResourceAttrSet(resourceName, "remote_read_url"),
-					resource.TestCheckResourceAttrSet(resourceName, "prom_http_api_endpoint"),
+					rcAfterCreate.CheckResourceExists(),
+					resource.TestCheckResourceAttr(updateAfterCreate, "prom_name", fmt.Sprintf("%s_after_create", name)),
+					resource.TestCheckResourceAttr(updateAfterCreate, "prom_type", "VPC"),
+					resource.TestCheckResourceAttr(updateAfterCreate, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(updateAfterCreate, "prom_version", "1.5"),
+					resource.TestCheckResourceAttr(updateAfterCreate, "prom_limits.#", "1"),
+					resource.TestCheckResourceAttr(updateAfterCreate, "prom_limits.0.compactor_blocks_retention_period", "360h"),
+					resource.TestCheckResourceAttrSet(updateAfterCreate, "created_at"),
+					resource.TestCheckResourceAttrSet(updateAfterCreate, "remote_write_url"),
+					resource.TestCheckResourceAttrSet(updateAfterCreate, "remote_read_url"),
+					resource.TestCheckResourceAttrSet(updateAfterCreate, "prom_http_api_endpoint"),
+					rcDuringUpdate.CheckResourceExists(),
+					resource.TestCheckResourceAttr(updateDuringUpdate, "prom_name", fmt.Sprintf("%s_during_update", name)),
+					resource.TestCheckResourceAttr(updateDuringUpdate, "prom_type", "VPC"),
+					resource.TestCheckResourceAttr(updateDuringUpdate, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(updateDuringUpdate, "prom_version", "1.5"),
+					resource.TestCheckResourceAttr(updateDuringUpdate, "prom_limits.#", "1"),
+					resource.TestCheckResourceAttrSet(updateDuringUpdate, "prom_limits.0.compactor_blocks_retention_period"),
+					resource.TestCheckResourceAttrSet(updateDuringUpdate, "created_at"),
+					resource.TestCheckResourceAttrSet(updateDuringUpdate, "remote_write_url"),
+					resource.TestCheckResourceAttrSet(updateDuringUpdate, "remote_read_url"),
+					resource.TestCheckResourceAttrSet(updateDuringUpdate, "prom_http_api_endpoint"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
+				Config: testAOMPromInstance_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rcAfterCreate.CheckResourceExists(),
+					resource.TestCheckResourceAttr(updateAfterCreate, "prom_name", fmt.Sprintf("%s_after_create", updateName)),
+					resource.TestCheckResourceAttr(updateAfterCreate, "prom_type", "VPC"),
+					resource.TestCheckResourceAttr(updateAfterCreate, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(updateAfterCreate, "prom_version", "1.5"),
+					resource.TestCheckResourceAttr(updateAfterCreate, "prom_limits.#", "1"),
+					resource.TestCheckResourceAttr(updateAfterCreate, "prom_limits.0.compactor_blocks_retention_period", "360h"),
+					resource.TestCheckResourceAttrSet(updateAfterCreate, "created_at"),
+					resource.TestCheckResourceAttrSet(updateAfterCreate, "remote_write_url"),
+					resource.TestCheckResourceAttrSet(updateAfterCreate, "remote_read_url"),
+					resource.TestCheckResourceAttrSet(updateAfterCreate, "prom_http_api_endpoint"),
+					rcDuringUpdate.CheckResourceExists(),
+					resource.TestCheckResourceAttr(updateDuringUpdate, "prom_name", fmt.Sprintf("%s_during_update", updateName)),
+					resource.TestCheckResourceAttr(updateDuringUpdate, "prom_type", "VPC"),
+					resource.TestCheckResourceAttr(updateDuringUpdate, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(updateDuringUpdate, "prom_version", "1.5"),
+					resource.TestCheckResourceAttr(updateDuringUpdate, "prom_limits.#", "1"),
+					resource.TestCheckResourceAttr(updateDuringUpdate, "prom_limits.0.compactor_blocks_retention_period", "1440h"),
+					resource.TestCheckResourceAttrSet(updateDuringUpdate, "created_at"),
+					resource.TestCheckResourceAttrSet(updateDuringUpdate, "remote_write_url"),
+					resource.TestCheckResourceAttrSet(updateDuringUpdate, "remote_read_url"),
+					resource.TestCheckResourceAttrSet(updateDuringUpdate, "prom_http_api_endpoint"),
+				),
+			},
+			{
+				ResourceName:      updateAfterCreate,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      updateDuringUpdate,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -90,13 +113,50 @@ func TestAccPromInstance_basic(t *testing.T) {
 	})
 }
 
-func testAOMPromInstance_basic(name string) string {
+func testAOMPromInstance_basic_step1(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_aom_prom_instance" "test" {
-  prom_name             = "%s"
+resource "huaweicloud_aom_prom_instance" "update_limits_after_create" {
+  prom_name             = "%[1]s_after_create"
   prom_type             = "VPC"
-  enterprise_project_id = "%s"
+  enterprise_project_id = "%[2]s"
   prom_version          = "1.5"
+
+  prom_limits {
+    compactor_blocks_retention_period = "360h"
+  }
+}
+
+resource "huaweicloud_aom_prom_instance" "update_limits_during_update" {
+  prom_name             = "%[1]s_during_update"
+  prom_type             = "VPC"
+  enterprise_project_id = "%[2]s"
+  prom_version          = "1.5"
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAOMPromInstance_basic_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_aom_prom_instance" "update_limits_after_create" {
+  prom_name             = "%[1]s_after_create"
+  prom_type             = "VPC"
+  enterprise_project_id = "%[2]s"
+  prom_version          = "1.5"
+
+  prom_limits {
+    compactor_blocks_retention_period = "360h"
+  }
+}
+
+resource "huaweicloud_aom_prom_instance" "update_limits_during_update" {
+  prom_name             = "%[1]s_during_update"
+  prom_type             = "VPC"
+  enterprise_project_id = "%[2]s"
+  prom_version          = "1.5"
+
+  prom_limits {
+    compactor_blocks_retention_period = "1440h"
+  }
 }
 `, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_cloud_service_access.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_cloud_service_access.go
@@ -120,7 +120,7 @@ func resourceCloudServiceAccessRead(_ context.Context, d *schema.ResourceData, m
 	// get eps_id for import
 	epsID := cfg.GetEnterpriseProjectID(d)
 	if epsID == "" {
-		instance, err := getPromInstance(client, d.Get("instance_id").(string))
+		instance, err := GetPrometheusInstanceById(client, d.Get("instance_id").(string))
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_prom_instance.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_prom_instance.go
@@ -21,124 +21,208 @@ const (
 )
 
 // @API AOM POST /v1/{project_id}/aom/prometheus
-// @API AOM DELETE /v1/{project_id}/aom/prometheus
 // @API AOM GET /v1/{project_id}/aom/prometheus
+// @API AOM PUT /v1/{project_id}/aom/prometheus
+// @API AOM DELETE /v1/{project_id}/aom/prometheus
 func ResourcePromInstance() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourcePromInstanceCreate,
 		ReadContext:   resourcePromInstanceRead,
+		UpdateContext: resourcePromInstanceUpdate,
 		DeleteContext: resourcePromInstanceDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the prometheus instance is located.`,
 			},
+
+			// Required Parameters
 			"prom_name": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the prometheus instance.`,
 			},
 			"prom_type": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The type of the prometheus instance.`,
 			},
+
+			// Optional Parameters
 			"enterprise_project_id": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The enterprise project ID to which the prometheus instance belongs.`,
 			},
 			"prom_version": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The version of the prometheus instance.`,
 			},
-			// attributes
-			"remote_write_url": {
-				Type:     schema.TypeString,
+			"prom_limits": {
+				Type:     schema.TypeList,
+				Optional: true,
 				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"compactor_blocks_retention_period": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The retention period for the compactor blocks.`,
+						},
+					},
+				},
+				MaxItems:    1,
+				Description: `The limit configurations of the prometheus instance.`,
+			},
+
+			// Attributes
+			"prom_http_api_endpoint": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The HTTP URL for calling the prometheus instance.`,
 			},
 			"remote_read_url": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The remote read address of the prometheus instance.`,
 			},
-			"prom_http_api_endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
+			"remote_write_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The remote write address of the prometheus instance.`,
 			},
 			"created_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the prometheus instance, in RFC3339 format.`,
 			},
 		},
 	}
 }
 
-func resourcePromInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	product := "aom"
-
-	client, err := cfg.NewServiceClient(product, cfg.GetRegion(d))
-	if err != nil {
-		return diag.Errorf("error creating AOM client: %s", err)
-	}
-
-	createPrometheusInstanceHttpUrl := "v1/{project_id}/aom/prometheus"
-	createPrometheusInstanceHttpUrl = strings.ReplaceAll(createPrometheusInstanceHttpUrl, "{project_id}", client.ProjectID)
-	createPrometheusInstancePath := client.Endpoint + createPrometheusInstanceHttpUrl
-
-	createPrometheusInstanceOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
-	}
-
-	createPrometheusInstanceOpt.JSONBody = utils.RemoveNil(buildCreatePrometheusInstanceBodyParams(d, cfg))
-	createPrometheusInstanceResp, err := client.Request("POST", createPrometheusInstancePath, &createPrometheusInstanceOpt)
-	if err != nil {
-		return diag.Errorf("error creating AOM prometheus instance: %s", err)
-	}
-	createPrometheusInstanceRespBody, err := utils.FlattenResponse(createPrometheusInstanceResp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	expression := fmt.Sprintf("prometheus[?prom_name== '%s'].prom_id | [0]", d.Get("prom_name"))
-	id := utils.PathSearch(expression, createPrometheusInstanceRespBody, "").(string)
-	if id == "" {
-		return diag.Errorf("unable to find prometheus instance ID from the API response")
-	}
-
-	d.SetId(id)
-
-	return resourcePromInstanceRead(ctx, d, meta)
-}
-
 func buildCreatePrometheusInstanceBodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
-	bodyParams := map[string]interface{}{
+	return map[string]interface{}{
 		"prom_name":             d.Get("prom_name"),
 		"prom_type":             d.Get("prom_type"),
 		"prom_version":          utils.ValueIgnoreEmpty(d.Get("prom_version")),
 		"enterprise_project_id": utils.ValueIgnoreEmpty(cfg.GetEnterpriseProjectID(d)),
 	}
-	return bodyParams
 }
 
-func resourcePromInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePromInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	product := "aom"
-	region := cfg.GetRegion(d)
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("aom", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating AOM client: %s", err)
 	}
 
-	instance, err := getPromInstance(client, d.Id())
+	httpUrl := "v1/{project_id}/aom/prometheus"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildCreatePrometheusInstanceBodyParams(d, cfg)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating AOM prometheus instance: %s", err)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resourceId := utils.PathSearch(fmt.Sprintf("prometheus[?prom_name=='%s']|[0].prom_id", d.Get("prom_name")), respBody, "").(string)
+	if resourceId == "" {
+		return diag.Errorf("unable to find prometheus instance ID from the API response")
+	}
+
+	d.SetId(resourceId)
+
+	if _, ok := d.GetOk("prom_limits"); ok {
+		err = updatePrometheusInstance(cfg, client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourcePromInstanceRead(ctx, d, meta)
+}
+
+func GetPrometheusInstanceById(client *golangsdk.ServiceClient, isntanceId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/aom/prometheus?prom_id={instance_id}"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", isntanceId)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type":          "application/json",
+			"Enterprise-Project-Id": "all_granted_eps",
+		},
+	}
+	requestResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving AOM prometheus instance: %s", err)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, fmt.Errorf("error flattening AOM prometheus instance: %s", err)
+	}
+
+	instance := utils.PathSearch("prometheus[0]", respBody, nil)
+	if instance == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/{project_id}/aom/prometheus",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("prometheus instance (%s) not found", isntanceId)),
+			},
+		}
+	}
+
+	return instance, nil
+}
+
+func flattenPrometheusInstancePromLimits(promLimits interface{}) interface{} {
+	if promLimits == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"compactor_blocks_retention_period": utils.PathSearch("compactor_blocks_retention_period", promLimits, nil),
+		},
+	}
+}
+
+func resourcePromInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("aom", region)
+	if err != nil {
+		return diag.Errorf("error creating AOM client: %s", err)
+	}
+
+	instance, err := GetPrometheusInstanceById(client, d.Id())
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "error retrieving AOM prometheus instance")
 	}
@@ -148,9 +232,10 @@ func resourcePromInstanceRead(_ context.Context, d *schema.ResourceData, meta in
 		d.Set("prom_name", utils.PathSearch("prom_name", instance, nil)),
 		d.Set("prom_type", utils.PathSearch("prom_type", instance, nil)),
 		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", instance, nil)),
+		d.Set("prom_version", utils.PathSearch("prom_version", instance, nil)),
+		d.Set("prom_limits", flattenPrometheusInstancePromLimits(utils.PathSearch("prom_limits", instance, nil))),
 		d.Set("created_at", utils.FormatTimeStampRFC3339(
 			int64(utils.PathSearch("prom_create_timestamp", instance, float64(0)).(float64))/1000, false)),
-		d.Set("prom_version", utils.PathSearch("prom_version", instance, nil)),
 		d.Set("remote_write_url", utils.PathSearch("prom_spec_config.remote_write_url", instance, nil)),
 		d.Set("remote_read_url", utils.PathSearch("prom_spec_config.remote_read_url", instance, nil)),
 		d.Set("prom_http_api_endpoint", utils.PathSearch("prom_spec_config.prom_http_api_endpoint", instance, nil)),
@@ -163,60 +248,79 @@ func resourcePromInstanceRead(_ context.Context, d *schema.ResourceData, meta in
 	return nil
 }
 
-func getPromInstance(client *golangsdk.ServiceClient, id string) (interface{}, error) {
-	getPrometheusInstanceHttpUrl := "v1/{project_id}/aom/prometheus"
-	getPrometheusInstanceHttpUrl = strings.ReplaceAll(getPrometheusInstanceHttpUrl, "{project_id}", client.ProjectID)
-	getPrometheusInstanceHttpUrl += fmt.Sprintf("?prom_id=%s", id)
-	getPrometheusInstancePath := client.Endpoint + getPrometheusInstanceHttpUrl
-
-	getPrometheusInstanceOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type":          "application/json",
-			"Enterprise-Project-Id": "all_granted_eps",
-		},
-	}
-	getPrometheusInstanceResp, err := client.Request("GET", getPrometheusInstancePath, &getPrometheusInstanceOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving AOM prometheus instance: %s", err)
-	}
-	getPrometheusInstanceRespBody, err := utils.FlattenResponse(getPrometheusInstanceResp)
-	if err != nil {
-		return nil, fmt.Errorf("error flattening AOM prometheus instance: %s", err)
+func buildPrometheusInstancePromLimits(promLimits []interface{}) interface{} {
+	if len(promLimits) < 1 {
+		return nil
 	}
 
-	instance := utils.PathSearch("prometheus[0]", getPrometheusInstanceRespBody, nil)
-	if instance == nil {
-		return nil, golangsdk.ErrDefault404{}
+	promLimit := promLimits[0]
+	return map[string]interface{}{
+		"compactor_blocks_retention_period": utils.PathSearch("compactor_blocks_retention_period", promLimit, nil),
 	}
-
-	return instance, nil
 }
 
-func resourcePromInstanceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	product := "aom"
+func buildUpdatePrometheusInstanceBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"prom_id":     d.Id(),
+		"prom_name":   d.Get("prom_name"),
+		"prom_limits": buildPrometheusInstancePromLimits(d.Get("prom_limits").([]interface{})),
+	}
+}
 
-	client, err := cfg.NewServiceClient(product, cfg.GetRegion(d))
+func updatePrometheusInstance(cfg *config.Config, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/aom/prometheus"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildHeaders(cfg, d),
+		JSONBody:         utils.RemoveNil(buildUpdatePrometheusInstanceBodyParams(d)),
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func resourcePromInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("aom", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating AOM client: %s", err)
 	}
 
-	deletePrometheusInstanceHttpUrl := "v1/{project_id}/aom/prometheus"
-	deletePrometheusInstanceHttpUrl += fmt.Sprintf("?prom_id=%s", d.Id())
-	deletePrometheusInstancePath := client.Endpoint + deletePrometheusInstanceHttpUrl
-	deletePrometheusInstancePath = strings.ReplaceAll(deletePrometheusInstancePath, "{project_id}", client.ProjectID)
+	err = updatePrometheusInstance(cfg, client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	deletePrometheusInstanceOpt := golangsdk.RequestOpts{
+	return resourcePromInstanceRead(ctx, d, meta)
+}
+
+func resourcePromInstanceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("aom", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating AOM client: %s", err)
+	}
+
+	httpUrl := "v1/{project_id}/aom/prometheus?prom_id={instance_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", d.Id())
+
+	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      buildHeaders(cfg, d),
 	}
 
-	_, err = client.Request("DELETE", deletePrometheusInstancePath, &deletePrometheusInstanceOpt)
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
 		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", prometheusInstanceNotExistsCode),
 			"error deleting AOM prometheus instance")
 	}
-
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Prometheus instance supports update function and supports update the name and limits.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1017" height="360" alt="image" src="https://github.com/user-attachments/assets/74916802-a0b7-49a8-92ac-5594e2b9029a" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. prometheus instance supports update function
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o aom -f TestAccPromInstance_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/aom" -v -coverprofile="./huaweicloud/services/acceptance/aom/aom_coverage.cov" -coverpkg="./huaweicloud/services/aom" -run TestAccPromInstance_basic -timeout 360m -parallel 10
=== RUN   TestAccPromInstance_basic
=== PAUSE TestAccPromInstance_basic
=== CONT  TestAccPromInstance_basic
--- PASS: TestAccPromInstance_basic (25.74s)
PASS
coverage: 5.6% of statements in ./huaweicloud/services/aom
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       25.815s coverage: 5.6% of statements in ./huaweicloud/services/aom
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
