### PR TITLE
chore(apig/instance_associated_certificates): rename name of the files

### DIFF
--- a/docs/data-sources/apig_instance_associated_certificates.md
+++ b/docs/data-sources/apig_instance_associated_certificates.md
@@ -1,12 +1,12 @@
 ---
 subcategory: "API Gateway (Dedicated APIG)"
 layout: "huaweicloud"
-page_title: "HuaweiCloud: huaweicloud_apig_instance_ssl_certificates"
+page_title: "HuaweiCloud: huaweicloud_apig_instance_associated_certificates"
 description: |-
   Use this data source to get SSL certificate list associated with the specified instance within HuaweiCloud.
 ---
 
-# huaweicloud_apig_instance_ssl_certificates
+# huaweicloud_apig_instance_associated_certificates
 
 Use this data source to get SSL certificate list associated with the specified instance within HuaweiCloud.
 
@@ -17,7 +17,7 @@ Use this data source to get SSL certificate list associated with the specified i
 ```hcl
 variable "instance_id" {}
 
-data "huaweicloud_apig_instance_ssl_certificates" "test" {
+data "huaweicloud_apig_instance_associated_certificates" "test" {
   instance_id = var.instance_id
 }
 ```
@@ -28,7 +28,7 @@ data "huaweicloud_apig_instance_ssl_certificates" "test" {
 variable "instance_id" {}
 variable "common_domain_name" {}
 
-data "huaweicloud_apig_instance_ssl_certificates" "test" {
+data "huaweicloud_apig_instance_associated_certificates" "test" {
   instance_id = var.instance_id
   common_name = var.common_domain_name
 }
@@ -66,6 +66,8 @@ In addition to all arguments above, the following attributes are exported:
 The `certificates` block supports:
 
 * `instance_id` - The ID of the dedicated instance to which the SSL certificates belong.
+
+* `project_id` - The ID of the tenant project.
 
 * `name` - The name of the SSL certificate.
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -582,7 +582,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_environments":                       apig.DataSourceEnvironments(),
 			"huaweicloud_apig_groups":                             apig.DataSourceGroups(),
 			"huaweicloud_apig_instance_api_tags":                  apig.DataSourceInstanceApiTags(),
-			"huaweicloud_apig_instance_ssl_certificates":          apig.DataSourceInstanceAssociatedSSLCertificates(),
+			"huaweicloud_apig_instance_associated_certificates":   apig.DataSourceInstanceAssociatedCertificates(),
 			"huaweicloud_apig_instance_features":                  apig.DataSourceInstanceFeatures(),
 			"huaweicloud_apig_instance_quotas":                    apig.DataSourceInstanceQuotas(),
 			"huaweicloud_apig_instance_supported_features":        apig.DataSourceInstanceSupportedFeatures(),
@@ -1943,7 +1943,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_cpts_projects": cpts.DataSourceCptsProjects(),
 
 			// Legacy
-			"huaweicloud_apig_apis_tags": apig.DataSourceInstanceApiTags(),
+			"huaweicloud_apig_apis_tags":                 apig.DataSourceInstanceApiTags(),
+			"huaweicloud_apig_instance_ssl_certificates": apig.DataSourceInstanceAssociatedCertificates(),
 
 			"huaweicloud_cdm_flavors_v1": cdm.DataSourceCdmFlavors(),
 

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_instance_associated_certificates_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_instance_associated_certificates_test.go
@@ -11,29 +11,29 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceInstanceAssociatedSSLCertificates_basic(t *testing.T) {
+func TestAccDataInstanceAssociatedCertificates_basic(t *testing.T) {
 	var (
 		name = acceptance.RandomAccResourceName()
 
-		dataSource = "data.huaweicloud_apig_instance_ssl_certificates.test"
+		dataSource = "data.huaweicloud_apig_instance_associated_certificates.test"
 		dc         = acceptance.InitDataSourceCheck(dataSource)
 
-		byInstanceId   = "data.huaweicloud_apig_instance_ssl_certificates.filter_by_instance_id"
+		byInstanceId   = "data.huaweicloud_apig_instance_associated_certificates.filter_by_instance_id"
 		dcByInstanceId = acceptance.InitDataSourceCheck(byInstanceId)
 
-		byName   = "data.huaweicloud_apig_instance_ssl_certificates.filter_by_name"
+		byName   = "data.huaweicloud_apig_instance_associated_certificates.filter_by_name"
 		dcByName = acceptance.InitDataSourceCheck(byName)
 
-		byCommonName   = "data.huaweicloud_apig_instance_ssl_certificates.filter_by_common_name"
+		byCommonName   = "data.huaweicloud_apig_instance_associated_certificates.filter_by_common_name"
 		dcByCommonName = acceptance.InitDataSourceCheck(byCommonName)
 
-		bySignatureAlgorithm   = "data.huaweicloud_apig_instance_ssl_certificates.filter_by_signature_algorithm"
+		bySignatureAlgorithm   = "data.huaweicloud_apig_instance_associated_certificates.filter_by_signature_algorithm"
 		dcBySignatureAlgorithm = acceptance.InitDataSourceCheck(bySignatureAlgorithm)
 
-		byType   = "data.huaweicloud_apig_instance_ssl_certificates.filter_by_type"
+		byType   = "data.huaweicloud_apig_instance_associated_certificates.filter_by_type"
 		dcByType = acceptance.InitDataSourceCheck(byType)
 
-		byAlgorithmType   = "data.huaweicloud_apig_instance_ssl_certificates.filter_by_algorithm_type"
+		byAlgorithmType   = "data.huaweicloud_apig_instance_associated_certificates.filter_by_algorithm_type"
 		dcByAlgorithmType = acceptance.InitDataSourceCheck(byAlgorithmType)
 	)
 
@@ -46,11 +46,11 @@ func TestAccDataSourceInstanceAssociatedSSLCertificates_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccDataSourceInstanceAssociatedSSLCertificates_instanceNotFound(),
+				Config:      testAccDataInstanceAssociatedSSLCertificates_instanceNotFound(),
 				ExpectError: regexp.MustCompile("The instance does not exist"),
 			},
 			{
-				Config: testAccDataSourceInstanceAssociatedSSLCertificates_basic(name),
+				Config: testAccDataInstanceAssociatedSSLCertificates_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestMatchResourceAttr(dataSource, "certificates.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
@@ -58,6 +58,9 @@ func TestAccDataSourceInstanceAssociatedSSLCertificates_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSource, "certificates.0.common_name"),
 					resource.TestCheckResourceAttrSet(dataSource, "certificates.0.signature_algorithm"),
 					resource.TestCheckResourceAttrSet(dataSource, "certificates.0.algorithm_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "certificates.0.update_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "certificates.0.update_time"),
+					resource.TestMatchResourceAttr(dataSource, "certificates.0.san.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
 					dcByInstanceId.CheckResourceExists(),
 					resource.TestCheckOutput("instance_id_filter_is_useful", "true"),
 					dcByName.CheckResourceExists(),
@@ -76,17 +79,17 @@ func TestAccDataSourceInstanceAssociatedSSLCertificates_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceInstanceAssociatedSSLCertificates_instanceNotFound() string {
+func testAccDataInstanceAssociatedSSLCertificates_instanceNotFound() string {
 	randomUUID, _ := uuid.GenerateUUID()
 	return fmt.Sprintf(`
 # Filter by Invalid Instance ID
-data "huaweicloud_apig_instance_ssl_certificates" "filter_by_invalid_instance_id" {
+data "huaweicloud_apig_instance_associated_certificates" "filter_by_invalid_instance_id" {
   instance_id = "%[1]s"
 }
 `, randomUUID)
 }
 
-func testAccDataSourceInstanceAssociatedSSLCertificates_basic(name string) string {
+func testAccDataInstanceAssociatedSSLCertificates_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -94,14 +97,14 @@ locals {
   instance_id = "%[2]s"
 }
 
-data "huaweicloud_apig_instance_ssl_certificates" "test" {
+data "huaweicloud_apig_instance_associated_certificates" "test" {
   depends_on = [huaweicloud_apig_certificate.test]
 
   instance_id = local.instance_id
 }
 
 # Filter by Instance ID
-data "huaweicloud_apig_instance_ssl_certificates" "filter_by_instance_id" {
+data "huaweicloud_apig_instance_associated_certificates" "filter_by_instance_id" {
   depends_on = [huaweicloud_apig_certificate.test]
 
   instance_id = local.instance_id
@@ -109,7 +112,8 @@ data "huaweicloud_apig_instance_ssl_certificates" "filter_by_instance_id" {
 
 locals {
   instance_id_filter_result = [
-    for v in data.huaweicloud_apig_instance_ssl_certificates.filter_by_instance_id.certificates[*].instance_id : v == local.instance_id || v == "common"
+    for v in data.huaweicloud_apig_instance_associated_certificates.filter_by_instance_id.certificates[*].instance_id :
+	v == local.instance_id || v == "common"
   ]
 }
 
@@ -122,7 +126,7 @@ locals {
   name = huaweicloud_apig_certificate.test.name
 }
 
-data "huaweicloud_apig_instance_ssl_certificates" "filter_by_name" {
+data "huaweicloud_apig_instance_associated_certificates" "filter_by_name" {
   depends_on = [huaweicloud_apig_certificate.test]
 
   instance_id = local.instance_id
@@ -131,7 +135,7 @@ data "huaweicloud_apig_instance_ssl_certificates" "filter_by_name" {
 
 locals {
   name_filter_result = [
-    for v in data.huaweicloud_apig_instance_ssl_certificates.filter_by_name.certificates[*].name : v == local.name
+    for v in data.huaweicloud_apig_instance_associated_certificates.filter_by_name.certificates[*].name : v == local.name
   ]
 }
 
@@ -141,10 +145,10 @@ output "certificate_name_filter_is_useful" {
 
 # Filter by Common Name
 locals {
-  common_name = data.huaweicloud_apig_instance_ssl_certificates.test.certificates[0].common_name
+  common_name = data.huaweicloud_apig_instance_associated_certificates.test.certificates[0].common_name
 }
 
-data "huaweicloud_apig_instance_ssl_certificates" "filter_by_common_name" {
+data "huaweicloud_apig_instance_associated_certificates" "filter_by_common_name" {
   depends_on = [huaweicloud_apig_certificate.test]
 
   instance_id = local.instance_id
@@ -153,7 +157,7 @@ data "huaweicloud_apig_instance_ssl_certificates" "filter_by_common_name" {
 
 locals {
   common_name_filter_result = [
-    for v in data.huaweicloud_apig_instance_ssl_certificates.filter_by_common_name.certificates[*].common_name : v == local.common_name
+    for v in data.huaweicloud_apig_instance_associated_certificates.filter_by_common_name.certificates[*].common_name : v == local.common_name
   ]
 }
 
@@ -163,10 +167,10 @@ output "certificate_common_name_filter_is_useful" {
 
 # Filter by Signature Algorithm
 locals {
-  signature_algorithm = data.huaweicloud_apig_instance_ssl_certificates.test.certificates[0].signature_algorithm
+  signature_algorithm = data.huaweicloud_apig_instance_associated_certificates.test.certificates[0].signature_algorithm
 }
 
-data "huaweicloud_apig_instance_ssl_certificates" "filter_by_signature_algorithm" {
+data "huaweicloud_apig_instance_associated_certificates" "filter_by_signature_algorithm" {
   depends_on = [huaweicloud_apig_certificate.test]
 
   instance_id         = local.instance_id
@@ -175,7 +179,8 @@ data "huaweicloud_apig_instance_ssl_certificates" "filter_by_signature_algorithm
 
 locals {
   signature_algorithm_filter_result = [
-    for v in data.huaweicloud_apig_instance_ssl_certificates.filter_by_signature_algorithm.certificates[*].signature_algorithm : v == local.signature_algorithm
+    for v in data.huaweicloud_apig_instance_associated_certificates.filter_by_signature_algorithm.certificates[*].signature_algorithm :
+	v == local.signature_algorithm
   ]
 }
 
@@ -188,7 +193,7 @@ locals {
   type = huaweicloud_apig_certificate.test.type
 }
 
-data "huaweicloud_apig_instance_ssl_certificates" "filter_by_type" {
+data "huaweicloud_apig_instance_associated_certificates" "filter_by_type" {
   depends_on = [huaweicloud_apig_certificate.test]
 
   instance_id = local.instance_id
@@ -197,7 +202,7 @@ data "huaweicloud_apig_instance_ssl_certificates" "filter_by_type" {
 
 locals {
   type_filter_result = [
-    for v in data.huaweicloud_apig_instance_ssl_certificates.filter_by_type.certificates[*].type : v == local.type
+    for v in data.huaweicloud_apig_instance_associated_certificates.filter_by_type.certificates[*].type : v == local.type
   ]
 }
 
@@ -207,10 +212,10 @@ output "certificate_type_filter_is_useful" {
 
 # Filter by Algorithm Type
 locals {
-  algorithm_type = data.huaweicloud_apig_instance_ssl_certificates.test.certificates[0].algorithm_type
+  algorithm_type = data.huaweicloud_apig_instance_associated_certificates.test.certificates[0].algorithm_type
 }
 
-data "huaweicloud_apig_instance_ssl_certificates" "filter_by_algorithm_type" {
+data "huaweicloud_apig_instance_associated_certificates" "filter_by_algorithm_type" {
   depends_on = [huaweicloud_apig_certificate.test]
 
   instance_id    = local.instance_id
@@ -219,7 +224,7 @@ data "huaweicloud_apig_instance_ssl_certificates" "filter_by_algorithm_type" {
 
 locals {
   algorithm_type_result = [
-    for v in data.huaweicloud_apig_instance_ssl_certificates.filter_by_algorithm_type[*].algorithm_type : v == local.algorithm_type
+    for v in data.huaweicloud_apig_instance_associated_certificates.filter_by_algorithm_type[*].algorithm_type : v == local.algorithm_type
   ]
 }
 

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_instance_associated_certificates.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_instance_associated_certificates.go
@@ -17,9 +17,9 @@ import (
 )
 
 // @API APIG GET /v2/{project_id}/apigw/certificates
-func DataSourceInstanceAssociatedSSLCertificates() *schema.Resource {
+func DataSourceInstanceAssociatedCertificates() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceInstanceAssociatedSSLCertificatesRead,
+		ReadContext: dataSourceInstanceAssociatedCertificatesRead,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -196,7 +196,7 @@ func listInstanceAssociatedSSLCertificates(client *golangsdk.ServiceClient, d *s
 	return result, nil
 }
 
-func dataSourceInstanceAssociatedSSLCertificatesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceInstanceAssociatedCertificatesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg    = meta.(*config.Config)
 		region = cfg.GetRegion(d)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Rename `huaweicloud_apig_instance_ssl_certificates` to `huaweicloud_apig_instance_associated_certificates`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccDataInstanceAssociatedCertificates_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataInstanceAssociatedCertificates_basic -timeout 360m -parallel 10
=== RUN   TestAccDataInstanceAssociatedCertificates_basic
=== PAUSE TestAccDataInstanceAssociatedCertificates_basic
=== CONT  TestAccDataInstanceAssociatedCertificates_basic
--- PASS: TestAccDataInstanceAssociatedCertificates_basic (23.37s)
PASS
coverage: 2.7% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      23.636s coverage: 2.7% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
