### PR TITLE
feat(apig): add new data source for query instance restriction

### DIFF
--- a/docs/data-sources/apig_instance_restriction.md
+++ b/docs/data-sources/apig_instance_restriction.md
@@ -1,0 +1,40 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_instance_restriction"
+description: |-
+  Use this data source to query the restricted information of the dedicated instance within HuaweiCloud.
+---
+
+# huaweicloud_apig_instance_restriction
+
+Use this data source to query the restricted information of the dedicated instance within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_apig_instance_restriction" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the dedicated instance is located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `restrict_cidrs` - The list of restricted IP CIDR blocks.
+
+* `resource_subnet_cidr` - The CIDR block of the resource subnet.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -589,6 +589,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_instance_tags":                      apig.DataSourceInstanceTags(),
 			"huaweicloud_apig_instances_filter":                   apig.DataSourceInstancesFilter(),
 			"huaweicloud_apig_instances":                          apig.DataSourceInstances(),
+			"huaweicloud_apig_instance_restriction":               apig.DataSourceInstanceRestriction(),
 			"huaweicloud_apig_orchestration_rules":                apig.DataSourceOrchestrationRules(),
 			"huaweicloud_apig_orchestration_rule_associated_apis": apig.DataSourceOrchestrationRuleAssociatedApis(),
 			"huaweicloud_apig_plugins":                            apig.DataSourcePlugins(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_instance_restriction_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_instance_restriction_test.go
@@ -1,0 +1,52 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceInstanceRestriction_basic(t *testing.T) {
+	var (
+		dcName = "data.huaweicloud_apig_instance_restriction.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceInstanceRestriction_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dcName, "restrict_cidrs.#", regexp.MustCompile(`^[1-9]([0-9]+)?$`)),
+					resource.TestCheckResourceAttrSet(dcName, "resource_subnet_cidr"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceInstanceRestriction_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[1]s"
+}
+
+locals {
+  instance_id = data.huaweicloud_apig_instances.test.instances[0].id
+}
+
+data "huaweicloud_apig_instance_restriction" "test" {
+  instance_id = local.instance_id
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_instance_restriction.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_instance_restriction.go
@@ -1,0 +1,102 @@
+package apig
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/restriction
+func DataSourceInstanceRestriction() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstanceRestrictionRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the dedicated instance is located.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to be queried.`,
+			},
+
+			// Attributes.
+			"restrict_cidrs": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of restricted IP CIDR blocks.`,
+			},
+			"resource_subnet_cidr": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The CIDR block of the resource subnet.`,
+			},
+		},
+	}
+}
+
+func getInstanceRestriction(client *golangsdk.ServiceClient, instanceId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/restriction"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func dataSourceInstanceRestrictionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+	)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	resp, err := getInstanceRestriction(client, instanceId)
+	if err != nil {
+		return diag.Errorf("error querying the restricted information of the dedicated instance (%s): %s", instanceId, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("restrict_cidrs", utils.PathSearch("restrict_cidrs", resp, make([]interface{}, 0))),
+		d.Set("resource_subnet_cidr", utils.PathSearch("resource_subnet_cidr", resp, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(apig): add new data source for query instance restriction

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataSourceInstanceRestriction_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceInstanceRestriction_basic
=== PAUSE TestAccDataSourceInstanceRestriction_basic
=== CONT  TestAccDataSourceInstanceRestriction_basic
--- PASS: TestAccDataSourceInstanceRestriction_basic (36.13s)
PASS
coverage: 2.5% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      36.274s coverage: 2.5% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.