### PR TITLE
feat(kafka): add new resource to manage topic quota

### DIFF
--- a/docs/resources/dms_kafka_topic_quota.md
+++ b/docs/resources/dms_kafka_topic_quota.md
@@ -1,0 +1,60 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_topic_quota"
+description: |-
+  Manages a Kafka topic quota resource within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_topic_quota
+
+Manages a Kafka topic quota resource within HuaweiCloud.
+
+-> This resource is unavailable for single-node instance Kafka.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "topic_name" {}
+
+resource "huaweicloud_dms_kafka_topic_quota" "test" {
+  instance_id        = var.instance_id
+  topic              = var.topic_name
+  producer_byte_rate = 2097152
+  consumer_byte_rate = 3145728
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the topic quota is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the Kafka instance to which the topic quota belongs.
+
+* `topic` - (Required, String, NonUpdatable) Specifies the name of the topic.
+
+* `producer_byte_rate` - (Optional, Int) Specifies the producer rate limit. The unit is byte/s.
+  The valid value range `2,097,152` to `1,073,741,824`. `0` means no limit.
+
+* `consumer_byte_rate` - (Optional, Int) Specifies the consumer rate limit. The unit is byte/s.
+  The valid value range `2,097,152` to `1,073,741,824`. `0` means no limit.
+
+-> At least one of `producer_byte_rate` and `consumer_byte_rate` must be specified.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in format `<instance_id>/<topic>`.
+
+## Import
+
+Topic quotas can be imported using its the `id` (consist of `instance_id` and `topic`, separated by a slash (/)), e.g.
+
+```bash
+$ terraform import huaweicloud_dms_kafka_topic_quota.test <instance_id>/<topic>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2517,6 +2517,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_smart_connect_task_action": kafka.ResourceDmsKafkaSmartConnectTaskAction(),
 			"huaweicloud_dms_kafka_smart_connector_validate":  kafka.ResourceSmartConnectorValidate(),
 			"huaweicloud_dms_kafka_topic":                     kafka.ResourceDmsKafkaTopic(),
+			"huaweicloud_dms_kafka_topic_quota":               kafka.ResourceTopicQuota(),
 			"huaweicloud_dms_kafka_user":                      kafka.ResourceDmsKafkaUser(),
 			"huaweicloud_dms_kafka_user_client_quota":         kafka.ResourceDmsKafkaUserClientQuota(),
 			"huaweicloud_dms_kafka_user_password_reset":       kafka.ResourceUserPasswordReset(),

--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_topic_quota_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_topic_quota_test.go
@@ -1,0 +1,104 @@
+package kafka
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/kafka"
+)
+
+func getTopicQuotaResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DMS client: %s", err)
+	}
+	return kafka.GetTopicQuotaByTopicName(client, state.Primary.Attributes["instance_id"], state.Primary.Attributes["topic"])
+}
+
+// Before running this test, ensure the instance is not a single-node instance.
+func TestAccTopicQuota_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		rName = "huaweicloud_dms_kafka_topic_quota.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getTopicQuotaResourceFunc)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTopicQuota_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "topic", name),
+					resource.TestCheckResourceAttr(rName, "producer_byte_rate", "2097152"),
+					resource.TestCheckResourceAttr(rName, "consumer_byte_rate", "3145728"),
+				),
+			},
+			{
+				Config: testAccTopicQuota_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "producer_byte_rate", "3145728"),
+					resource.TestCheckResourceAttr(rName, "consumer_byte_rate", "0"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccTopicQuota_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+  partitions  = 20
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, name)
+}
+
+func testAccTopicQuota_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dms_kafka_topic_quota" "test" {
+  instance_id = "%[2]s"
+  topic       = huaweicloud_dms_kafka_topic.test.name
+
+  # 2097152 B/s corresponds to 2 MB/s.
+  producer_byte_rate = 2097152
+  consumer_byte_rate = 3145728
+}
+`, testAccTopicQuota_base(name), acceptance.HW_DMS_KAFKA_INSTANCE_ID)
+}
+
+func testAccTopicQuota_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dms_kafka_topic_quota" "test" {
+  instance_id        = "%[2]s"
+  topic              = huaweicloud_dms_kafka_topic.test.name
+  producer_byte_rate = 3145728
+}
+`, testAccTopicQuota_base(name), acceptance.HW_DMS_KAFKA_INSTANCE_ID)
+}

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_topic_quota.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_topic_quota.go
@@ -1,0 +1,353 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var topicQuotaNonUpdatableParams = []string{"instance_id", "topic"}
+
+// @API Kafka POST /v2/kafka/{project_id}/instances/{instance_id}/kafka-topic-quota
+// @API Kafka GET /v2/kafka/{project_id}/instances/{instance_id}/kafka-topic-quota
+// @API Kafka DELETE /v2/kafka/{project_id}/instances/{instance_id}/kafka-topic-quota
+// @API Kafka GET /v2/{project_id}/instances/{instance_id}/tasks/{task_id}
+func ResourceTopicQuota() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTopicQuotaCreate,
+		ReadContext:   resourceTopicQuotaRead,
+		UpdateContext: resourceTopicQuotaUpdate,
+		DeleteContext: resourceTopicQuotaDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceTopicQuotaImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(topicQuotaNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The region where the topic quota is located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the Kafka instance to which the topic quota belongs.`,
+			},
+			"topic": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the topic.`,
+			},
+			"producer_byte_rate": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The producer rate limit. The unit is byte/s.`,
+			},
+			"consumer_byte_rate": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The consumer rate limit. The unit is byte/s.`,
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildTopicQuotaBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"topic":              d.Get("topic"),
+		"producer-byte-rate": utils.ValueIgnoreEmpty(d.Get("producer_byte_rate")),
+		"consumer-byte-rate": utils.ValueIgnoreEmpty(d.Get("consumer_byte_rate")),
+	}
+}
+
+func resourceTopicQuotaCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		instanceId = d.Get("instance_id").(string)
+		topic      = d.Get("topic").(string)
+		httpUrl    = "v2/kafka/{project_id}/instances/{instance_id}/kafka-topic-quota"
+	)
+	client, err := cfg.NewServiceClient("dmsv2", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	httpUrl = strings.ReplaceAll(httpUrl, "{project_id}", client.ProjectID)
+	httpUrl = strings.ReplaceAll(httpUrl, "{instance_id}", instanceId)
+	createPath := client.Endpoint + httpUrl
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+		JSONBody: utils.RemoveNil(buildTopicQuotaBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating topic quota of the instance (%s): %s", instanceId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find the job ID from the API response")
+	}
+
+	err = waitForInstanceTaskStatusComplete(ctx, client, instanceId, jobId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for the topic quota of the instance (%s) to be created: %s", instanceId, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", instanceId, topic))
+
+	return resourceTopicQuotaRead(ctx, d, meta)
+}
+
+func getTopicQuotas(client *golangsdk.ServiceClient, instanceId, topicName string) (interface{}, error) {
+	var (
+		httpUrl = "v2/kafka/{project_id}/instances/{instance_id}/kafka-topic-quota"
+		result  = make([]interface{}, 0)
+		offset  = 0
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	// The `limit` default is `10` and `keyword` is fuzzy match.
+	listPath = fmt.Sprintf("%s?type=topic&limit=100", listPath)
+	if topicName != "" {
+		listPath = fmt.Sprintf("%s&keyword=%s", listPath, topicName)
+	}
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		quotas := utils.PathSearch("quotas", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, quotas...)
+		offset += len(quotas)
+		// offset cannot be greater than or equal to the total number of quotas.
+		if offset >= int(utils.PathSearch("count", respBody, float64(0)).(float64)) {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func GetTopicQuotaByTopicName(client *golangsdk.ServiceClient, instanceId, topicName string) (interface{}, error) {
+	quotas, err := getTopicQuotas(client, instanceId, topicName)
+	if err != nil {
+		return nil, err
+	}
+
+	topicQuota := utils.PathSearch(fmt.Sprintf("[?topic=='%s']|[0]", topicName), quotas, nil)
+	if topicQuota == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v2/kafka/{project_id}/instances/{instance_id}/kafka-topic-quota",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("The topic (%s) quota of the instance (%s) was not found.", topicName, instanceId)),
+			},
+		}
+	}
+	return topicQuota, nil
+}
+
+func resourceTopicQuotaRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+		topicName  = d.Get("topic").(string)
+	)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	respBody, err := GetTopicQuotaByTopicName(client, instanceId, topicName)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error getting topic (%s) quota of the instance (%s)", topicName, instanceId))
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("topic", utils.PathSearch("topic", respBody, nil)),
+		d.Set("producer_byte_rate", utils.PathSearch(`"producer-byte-rate"`, respBody, nil)),
+		d.Set("consumer_byte_rate", utils.PathSearch(`"consumer-byte-rate"`, respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceTopicQuotaUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		instanceId = d.Get("instance_id").(string)
+		httpUrl    = "v2/kafka/{project_id}/instances/{instance_id}/kafka-topic-quota"
+		topic      = d.Get("topic").(string)
+	)
+	client, err := cfg.NewServiceClient("dmsv2", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	httpUrl = strings.ReplaceAll(httpUrl, "{project_id}", client.ProjectID)
+	httpUrl = strings.ReplaceAll(httpUrl, "{instance_id}", instanceId)
+	updatePath := client.Endpoint + httpUrl
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+		JSONBody: utils.RemoveNil(buildTopicQuotaBodyParams(d)),
+	}
+
+	resp, err := client.Request("PUT", updatePath, &opt)
+	if err != nil {
+		return diag.Errorf("error updating topic (%s) quota of the instance (%s): %s", topic, instanceId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find the job ID from the API response")
+	}
+
+	err = waitForInstanceTaskStatusComplete(ctx, client, instanceId, jobId, d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return diag.Errorf("error waiting for the topic (%s) quota of the instance (%s) to be updated: %s", topic, instanceId, err)
+	}
+
+	return resourceTopicQuotaRead(ctx, d, meta)
+}
+
+func resourceTopicQuotaDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		instanceId = d.Get("instance_id").(string)
+		httpUrl    = "v2/kafka/{project_id}/instances/{instance_id}/kafka-topic-quota"
+		topicName  = d.Get("topic").(string)
+	)
+	client, err := cfg.NewServiceClient("dmsv2", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	// When the topic quota does not exist, the delete API will return 200, but the status in the query task API response body is "FAILED".
+	// So we need to check if the topic quota exists before deleting it.
+	_, err = GetTopicQuotaByTopicName(client, instanceId, topicName)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("The topic (%s) quota of the instance (%s) was not found",
+			topicName, instanceId))
+	}
+
+	httpUrl = strings.ReplaceAll(httpUrl, "{project_id}", client.ProjectID)
+	httpUrl = strings.ReplaceAll(httpUrl, "{instance_id}", instanceId)
+	deletePath := client.Endpoint + httpUrl
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+		JSONBody: map[string]interface{}{
+			"topic": topicName,
+		},
+	}
+
+	resp, err := client.Request("DELETE", deletePath, &opt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting topic (%s) quota of the instance (%s)",
+			topicName, instanceId))
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find the job ID from the API response")
+	}
+
+	err = waitForInstanceTaskStatusComplete(ctx, client, instanceId, jobId, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return diag.Errorf("error waiting for the topic (%s) quota of the instance (%s) to be deleted: %s",
+			topicName, instanceId, err)
+	}
+
+	return nil
+}
+
+func resourceTopicQuotaImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<topic>', but got '%s'", d.Id())
+	}
+
+	mErr := multierror.Append(
+		d.Set("instance_id", parts[0]),
+		d.Set("topic", parts[1]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new resource (`huaweicloud_dms_kafka_topic_quota`) to manage Kafka topic quota.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new resource and its corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccTopicQuota_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccTopicQuota_basic -timeout 360m -parallel 10
=== RUN   TestAccTopicQuota_basic
=== PAUSE TestAccTopicQuota_basic
=== CONT  TestAccTopicQuota_basic
--- PASS: TestAccTopicQuota_basic (150.56s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     150.649s        coverage: 5.1% of statements in ./huaweicloud/services/kafka
```
<img width="973" height="507" alt="image" src="https://github.com/user-attachments/assets/8a8f3a18-6a3c-449e-a1b1-44ea23f31202" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1650" height="881" alt="image" src="https://github.com/user-attachments/assets/957572df-b8bb-4df4-ac0a-fe9cdc173565" />


    ab. Related resources (parent resources) not found
    <img width="1458" height="864" alt="image" src="https://github.com/user-attachments/assets/73a5acda-8669-4004-bb9b-772ea2672abf" />

 
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1185" height="818" alt="image" src="https://github.com/user-attachments/assets/ac1e58c2-c42b-473a-b174-b638c6a34776" />
  bb. Related resources (parent resources) not found
    <img width="1207" height="827" alt="image" src="https://github.com/user-attachments/assets/92f3d37c-0a26-43f5-a380-15d0af65cbb4" />

