### PR TITLE
feat(kafka): add new data source to get topic quotas

### DIFF
--- a/docs/data-sources/dms_kafka_topic_quotas.md
+++ b/docs/data-sources/dms_kafka_topic_quotas.md
@@ -1,0 +1,66 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_topic_quotas"
+description: |-
+  Use this data source to get the list of Kafka topic quotas within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_topic_quotas
+
+Use this data source to get the list of Kafka topic quotas within HuaweiCloud.
+
+## Example Usage
+
+### Query all topic quotas under the specified instance
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_dms_kafka_topic_quotas" "test" {
+  instance_id = var.instance_id
+}
+```
+
+### Query topic quotas by keyword
+
+```hcl
+variable "instance_id" {}
+variable "topic_name" {}
+
+data "huaweicloud_dms_kafka_topic_quotas" "test" {
+  instance_id = var.instance_id
+  keyword     = var.topic_name
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the topic quotas are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the Kafka instance to which the topic quotas belong.
+
+* `keyword` - (Optional, String) Specifies the keyword of the topic quota to be queried.  
+  Fuzzy matching is supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `quotas` - All topic quotas that match the filter parameters.  
+  The [quotas](#kafka_topic_quotas_attr) structure is documented below.
+
+<a name="kafka_topic_quotas_attr"></a>
+The `quotas` block supports:
+
+* `topic` - The name of the topic.
+
+* `producer_byte_rate` - The producer byte rate limit. The unit is B/s.
+
+* `consumer_byte_rate` - The consumer byte rate limit. The unit is B/s.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1051,6 +1051,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_topic_partitions":        kafka.DataSourceDmsKafkaTopicPartitions(),
 			"huaweicloud_dms_kafka_topic_producers":         kafka.DataSourceDmsKafkaTopicProducers(),
 			"huaweicloud_dms_kafka_topics":                  kafka.DataSourceDmsKafkaTopics(),
+			"huaweicloud_dms_kafka_topic_quotas":            kafka.DataSourceTopicQuotas(),
 			"huaweicloud_dms_kafka_tags":                    kafka.DataSourceTags(),
 			"huaweicloud_dms_kafka_user_client_quotas":      kafka.DataSourceDmsKafkaUserClientQuotas(),
 			"huaweicloud_dms_kafka_users":                   kafka.DataSourceDmsKafkaUsers(),

--- a/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_topic_quotas_test.go
+++ b/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_topic_quotas_test.go
@@ -1,0 +1,108 @@
+package kafka
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataTopicQuotas_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_dms_kafka_topic_quotas.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byKeyword   = "data.huaweicloud_dms_kafka_topic_quotas.filter_by_keyword"
+		dcByKeyword = acceptance.InitDataSourceCheck(byKeyword)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataTopicQuotas_instanceNotFound(),
+				ExpectError: regexp.MustCompile("This DMS instance does not exist"),
+			},
+			{
+				Config: testAccDataTopicQuotas_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "quotas.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByKeyword.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.topic"),
+					resource.TestMatchResourceAttr(dataSource, "quotas.0.consumer_byte_rate", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestMatchResourceAttr(dataSource, "quotas.0.producer_byte_rate", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckOutput("is_keyword_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataTopicQuotas_instanceNotFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dms_kafka_topic_quotas" "test" {
+  instance_id = "%[1]s"
+}
+`, randomId)
+}
+
+func testAccDataTopicQuotas_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_topic" "test" {
+  count = 2
+
+  instance_id = "%[1]s"
+  name        = "%[2]s_${count.index}"
+  partitions  = 10
+}
+
+resource "huaweicloud_dms_kafka_topic_quota" "test" {
+  count = 2
+
+  instance_id        = "%[1]s"
+  topic              = huaweicloud_dms_kafka_topic.test[count.index].name
+  consumer_byte_rate = 2097152
+  producer_byte_rate = 2097152
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, name)
+}
+
+func testAccDataTopicQuotas_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_dms_kafka_topic_quotas" "test" {
+  instance_id = "%[2]s"
+
+  depends_on = [huaweicloud_dms_kafka_topic_quota.test]
+}
+
+data "huaweicloud_dms_kafka_topic_quotas" "filter_by_keyword" {
+  instance_id = "%[2]s"
+  keyword     = "%[3]s"
+
+  depends_on = [huaweicloud_dms_kafka_topic_quota.test]
+}
+
+locals {
+  keyword_filter_result = [for v in data.huaweicloud_dms_kafka_topic_quotas.filter_by_keyword.quotas :
+  strcontains(v.topic, "%[3]s")]
+}
+
+output "is_keyword_filter_useful" {
+  value = length(local.keyword_filter_result) >= 2 && alltrue(local.keyword_filter_result)
+}
+`, testAccDataTopicQuotas_base(name), acceptance.HW_DMS_KAFKA_INSTANCE_ID, name)
+}

--- a/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_topic_quotas.go
+++ b/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_topic_quotas.go
@@ -1,0 +1,109 @@
+package kafka
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Kafka GET /v2/kafka/{project_id}/instances/{instance_id}/kafka-topic-quota
+func DataSourceTopicQuotas() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTopicQuotasRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the topic quotas are located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the Kafka instance to which the topic quotas belong.`,
+			},
+			"keyword": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The keyword of the topic quota to be queried.`,
+			},
+			"quotas": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `All topic quotas that match the filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"topic": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the topic.`,
+						},
+						"producer_byte_rate": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The producer byte rate limit. The unit is B/s.`,
+						},
+						"consumer_byte_rate": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The consumer byte rate limit. The unit is B/s.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceTopicQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+	)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	quotas, err := getTopicQuotas(client, instanceId, d.Get("keyword").(string))
+	if err != nil {
+		return diag.Errorf("error getting topic quotas of the instance (%s): %s", instanceId, err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(randomId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("quotas", flattenTopicQuotas(quotas.([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenTopicQuotas(quotas []interface{}) []interface{} {
+	if len(quotas) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(quotas))
+	for _, quota := range quotas {
+		result = append(result, map[string]interface{}{
+			"topic":              utils.PathSearch("topic", quota, nil),
+			"producer_byte_rate": utils.PathSearch(`"producer-byte-rate"`, quota, nil),
+			"consumer_byte_rate": utils.PathSearch(`"consumer-byte-rate"`, quota, nil),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source (`huaweicloud_dms_kafka_topic_quotas`) to query topic quota list under the specified Kafka instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source and its corresponding to document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccDataTopicQuotas_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccDataTopicQuotas_basic -timeout 360m -parallel 10
=== RUN   TestAccDataTopicQuotas_basic
=== PAUSE TestAccDataTopicQuotas_basic
=== CONT  TestAccDataTopicQuotas_basic
--- PASS: TestAccDataTopicQuotas_basic (72.93s)
PASS
coverage: 7.4% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     73.009s coverage: 7.4% of statements in ./huaweicloud/services/kafka
```

<img width="987" height="349" alt="image" src="https://github.com/user-attachments/assets/4635af7b-30d0-460d-8868-b1dfe59458fc" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
