### PR TITLE
feat(hss): add new data source to get list of two-factor hosts

### DIFF
--- a/docs/data-sources/hss_setting_two_factor_login_hosts.md
+++ b/docs/data-sources/hss_setting_two_factor_login_hosts.md
@@ -1,0 +1,69 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_setting_two_factor_login_hosts"
+description: |-
+  Use this data source to get the list of two-factor hosts.
+---
+
+# huaweicloud_hss_setting_two_factor_login_hosts
+
+Use this data source to get the list of two-factor hosts.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_setting_two_factor_login_hosts" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `host_name` - (Optional, String) Specifies the host name.
+
+* `display_name` - (Optional, String) Specifies the SMN topic display name.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data_list` - The two-factor host list.
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `host_id` - The host ID.
+
+* `host_name` - The host name.
+
+* `os_type` - The operating system type.
+  The valid values are as follows:
+  + **linux**
+  + **windows**
+
+* `auth_switch` - Whether the two-factor authentication is enabled.
+
+* `auth_type` - The two-factor authentication type.
+  The valid values are as follows:
+  + **sms**: Indicates SMS and email verification.
+  + **code**: Indicates captcha code verification.
+
+* `topic_display_name` - The SMN topic display name.
+
+* `topic_urn` - The SMN topic urn.
+
+* `outside_host` - Whether the host is an external (non-HuaweiCloud) matchine.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1294,6 +1294,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_resource_quotas":                       hss.DataSourceResourceQuotas(),
 			"huaweicloud_hss_setting_login_common_ips":              hss.DataSourceSettingLoginCommonIps(),
 			"huaweicloud_hss_setting_login_common_locations":        hss.DataSourceSettingLoginCommonLocations(),
+			"huaweicloud_hss_setting_two_factor_login_hosts":        hss.DataSourceSettingTwoFactorLoginHosts(),
 			"huaweicloud_hss_tags":                                  hss.DataSourceHssTags(),
 			"huaweicloud_hss_vulnerabilities":                       hss.DataSourceVulnerabilities(),
 			"huaweicloud_hss_vulnerability_handle_history":          hss.DataSourceVulnerabilityHandleHistory(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_setting_two_factor_login_hosts_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_setting_two_factor_login_hosts_test.go
@@ -1,0 +1,88 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSettingTwoFactorLoginHosts_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_setting_two_factor_login_hosts.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Before running the test, you need to prepare a host with host protection enabled.
+			// And setting two-factor authentication on console for the host.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+
+			{
+				Config: testAccDataSourceSettingTwoFactorHosts_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.host_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.host_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.os_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.auth_switch"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.auth_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.topic_display_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.topic_urn"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.outside_host"),
+
+					resource.TestCheckOutput("is_host_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_display_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_eps_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceSettingTwoFactorHosts_basic = `
+data "huaweicloud_hss_setting_two_factor_login_hosts" "test" {}
+
+locals {
+  host_name = data.huaweicloud_hss_setting_two_factor_login_hosts.test.data_list[0].host_name
+}
+
+data "huaweicloud_hss_setting_two_factor_login_hosts" "host_name_filter" {
+  host_name = local.host_name
+}
+
+output "is_host_name_filter_useful" {
+  value = length(data.huaweicloud_hss_setting_two_factor_login_hosts.host_name_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_setting_two_factor_login_hosts.host_name_filter.data_list[*].host_name : v == local.host_name]
+  )
+}
+
+locals {
+  display_name = data.huaweicloud_hss_setting_two_factor_login_hosts.test.data_list[0].topic_display_name
+}
+
+data "huaweicloud_hss_setting_two_factor_login_hosts" "display_name_filter" {
+  display_name = local.display_name
+}
+
+output "is_display_name_filter_useful" {
+  value = length(data.huaweicloud_hss_setting_two_factor_login_hosts.display_name_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_setting_two_factor_login_hosts.display_name_filter.data_list[*].topic_display_name : v == local.display_name]
+  )
+}
+
+data "huaweicloud_hss_setting_two_factor_login_hosts" "eps_filter" {
+  enterprise_project_id = "all_granted_eps"
+}
+
+output "is_eps_filter_useful" {
+  value = length(data.huaweicloud_hss_setting_two_factor_login_hosts.eps_filter.data_list) > 0
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_setting_two_factor_login_hosts.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_setting_two_factor_login_hosts.go
@@ -1,0 +1,176 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/setting/two-factor-login/hosts
+func DataSourceSettingTwoFactorLoginHosts() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTwoFactorHostsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"host_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"host_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"os_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"auth_switch": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"auth_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"topic_display_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"topic_urn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"outside_host": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildTwoFactorHostsQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=200"
+
+	if v, ok := d.GetOk("host_name"); ok {
+		queryParams = fmt.Sprintf("%s&host_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("display_name"); ok {
+		queryParams = fmt.Sprintf("%s&display_name=%v", queryParams, v)
+	}
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+
+	return queryParams
+}
+
+func dataSourceTwoFactorHostsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v5/{project_id}/setting/two-factor-login/hosts"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildTwoFactorHostsQueryParams(d, epsId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", getPath, offset)
+		getResp, err := client.Request("GET", currentPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving two factor hosts: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataResp := utils.PathSearch("data_list", getRespBody, make([]interface{}, 0)).([]interface{})
+		if len(dataResp) == 0 {
+			break
+		}
+
+		result = append(result, dataResp...)
+		offset += len(dataResp)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data_list", flattenTwoFactorHostsDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenTwoFactorHostsDataList(dataResp []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(dataResp))
+	for _, v := range dataResp {
+		result = append(result, map[string]interface{}{
+			"host_id":            utils.PathSearch("host_id", v, nil),
+			"host_name":          utils.PathSearch("host_name", v, nil),
+			"os_type":            utils.PathSearch("os_type", v, nil),
+			"auth_switch":        utils.PathSearch("auth_switch", v, nil),
+			"auth_type":          utils.PathSearch("auth_type", v, nil),
+			"topic_display_name": utils.PathSearch("topic_display_name", v, nil),
+			"topic_urn":          utils.PathSearch("topic_urn", v, nil),
+			"outside_host":       utils.PathSearch("outside_host", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get list of two-factor hosts.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceSettingTwoFactorLoginHosts_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceSettingTwoFactorLoginHosts_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSettingTwoFactorLoginHosts_basic
=== PAUSE TestAccDataSourceSettingTwoFactorLoginHosts_basic
=== CONT  TestAccDataSourceSettingTwoFactorLoginHosts_basic
--- PASS: TestAccDataSourceSettingTwoFactorLoginHosts_basic (12.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       12.716s
```
<img width="1117" height="19" alt="image" src="https://github.com/user-attachments/assets/bb22f41f-100b-4ba7-9a2e-9f8328a8102b" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
