### PR TITLE
feat(kafka): add new data source to get maintain windows

### DIFF
--- a/docs/data-sources/dms_kafka_maintainwindows.md
+++ b/docs/data-sources/dms_kafka_maintainwindows.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_maintainwindows"
+description: |-
+  Use this data source to get the list of Kafka maintain windows within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_maintainwindows
+
+Use this data source to get the list of Kafka maintain windows within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_dms_kafka_maintainwindows" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the maintain windows are located.  
+  If omitted, the provider-level region will be used.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `maintain_windows` - The list of the maintain windows.  
+  The [maintain_windows](#kafka_maintain_windows_attribute) attribute is documented below.
+
+<a name="kafka_maintain_windows_attribute"></a>
+The `maintain_windows` block supports:
+
+* `default` - Whether this is the default time window.
+
+* `begin` - The start time of the maintain window.
+
+* `end` - The end time of the maintain window.
+
+* `seq` - The sequence number.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1042,6 +1042,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_extend_flavors":          kafka.DataSourceDmsKafkaExtendFlavors(),
 			"huaweicloud_dms_kafka_flavors":                 kafka.DataSourceKafkaFlavors(),
 			"huaweicloud_dms_kafka_instances":               kafka.DataSourceDmsKafkaInstances(),
+			"huaweicloud_dms_kafka_maintainwindows":         kafka.DataSourceMaintainWindows(),
 			"huaweicloud_dms_kafka_message_diagnosis_tasks": kafka.DataSourceDmsKafkaMessageDiagnosisTasks(),
 			"huaweicloud_dms_kafka_messages":                kafka.DataSourceDmsKafkaMessages(),
 			"huaweicloud_dms_kafka_smart_connect_tasks":     kafka.DataSourceDmsKafkaSmartConnectTasks(),

--- a/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_maintainwindows_test.go
+++ b/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_maintainwindows_test.go
@@ -1,0 +1,37 @@
+package kafka
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataMaintainWindows_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_dms_kafka_maintainwindows.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataMaintainWindows_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "maintain_windows.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "maintain_windows.0.default"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "maintain_windows.0.begin"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "maintain_windows.0.end"),
+					resource.TestMatchResourceAttr(dataSourceName, "maintain_windows.0.seq", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataMaintainWindows_basic = `
+data "huaweicloud_dms_kafka_maintainwindows" "test" {}
+`

--- a/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_maintainwindows.go
+++ b/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_maintainwindows.go
@@ -1,0 +1,118 @@
+package kafka
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Kafka GET /v2/instances/maintain-windows
+func DataSourceMaintainWindows() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceMaintainWindowsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the maintain windows are located.`,
+			},
+			"maintain_windows": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the maintain windows.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"default": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether this is the default time window.`,
+						},
+						"begin": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The start time of the maintain window.`,
+						},
+						"end": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The end time of the maintain window.`,
+						},
+						"seq": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The sequence number.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceMaintainWindowsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/instances/maintain-windows"
+	)
+
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=utf-8"},
+	}
+
+	resp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return diag.Errorf("error retrieving maintain windows: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(randomId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("maintain_windows", flattenMaintainWindows(utils.PathSearch("maintain_windows",
+			respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenMaintainWindows(maintainWindows []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(maintainWindows))
+	for _, window := range maintainWindows {
+		result = append(result, map[string]interface{}{
+			"default": utils.PathSearch("default", window, nil),
+			"begin":   utils.PathSearch("begin", window, nil),
+			"end":     utils.PathSearch("end", window, nil),
+			"seq":     utils.PathSearch("seq", window, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data source (`huaweicloud_dms_kafka_maintainwindowns`) to query Kafka maintain windows.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source and its corresponding to document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccDataMaintainWindows_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccDataMaintainWindows_basic -timeout 360m -parallel 10
=== RUN   TestAccDataMaintainWindows_basic
=== PAUSE TestAccDataMaintainWindows_basic
=== CONT  TestAccDataMaintainWindows_basic
--- PASS: TestAccDataMaintainWindows_basic (23.12s)
PASS
coverage: 2.0% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     23.414s coverage: 2.0% of statements in ./huaweicloud/services/kafka
```
<img width="1002" height="206" alt="image" src="https://github.com/user-attachments/assets/e444fcdd-61cc-438f-a53a-766e2fd37798" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
