### PR TITLE
feat(hss): new resource to record vulnerability task user trace

### DIFF
--- a/docs/resources/hss_vulnerability_task_user_trace.md
+++ b/docs/resources/hss_vulnerability_task_user_trace.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_vulnerability_task_user_trace"
+description: |-
+  Manages an HSS vulnerability task user trace recording resource within HuaweiCloud.
+---
+
+# huaweicloud_hss_vulnerability_task_user_trace
+
+Manages an HSS vulnerability task user trace recording resource within HuaweiCloud.
+
+-> This resource is a one-time action resource used to record the last time a user viewed vulnerability tasks.
+   Deleting this resource will not clear the corresponding request record, but will only remove the resource
+   information from the Terraform state file.
+
+## Example Usage
+
+```hcl
+variable "task_type" {}
+
+resource "huaweicloud_hss_vulnerability_task_user_trace" "example" {
+  task_type = var.task_type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource. If omitted, the
+  provider-level region will be used. Changing this parameter will create a new resource.
+
+* `task_type` - (Required, String, NonUpdatable) Specifies the type of the vulnerability task. The value can be:
+  + **vul_scan**: Indicates a vulnerability scan task.
+  + **vul_repair**: Indicates a vulnerability repair task.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the hosts under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2747,6 +2747,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_image_batch_scan":                               hss.ResourceImageBatchScan(),
 			"huaweicloud_hss_switch_honeypot_port_policy":                    hss.ResourceSwitchHoneypotPortPolicy(),
 			"huaweicloud_hss_vulnerability_information_export":               hss.ResourceVulnerabilityInformationExport(),
+			"huaweicloud_hss_vulnerability_task_user_trace":                  hss.ResourceVulnerabilityTaskUserTrace(),
 			"huaweicloud_hss_file_download":                                  hss.ResourceFileDownload(),
 			"huaweicloud_hss_ignore_failed_pcc":                              hss.ResourceIgnoreFailedPCC(),
 			"huaweicloud_hss_antivirus_create_virus_scan_task":               hss.ResourceCreateVirusScanTask(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_vulnerability_task_user_trace_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_vulnerability_task_user_trace_test.go
@@ -1,0 +1,29 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccVulnerabilityTaskUserTrace_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testVulnerabilityTaskUserTrace_basic,
+			},
+		},
+	})
+}
+
+const testVulnerabilityTaskUserTrace_basic = `
+resource "huaweicloud_hss_vulnerability_task_user_trace" "test" {
+  task_type = "vul_scan"
+}`

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_vulnerability_task_user_trace.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_vulnerability_task_user_trace.go
@@ -1,0 +1,131 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var vulnerabilityTaskUserTraceNonUpdatableParams = []string{
+	"task_type",
+	"enterprise_project_id",
+}
+
+// @API HSS POST /v5/{project_id}/vulnerability/task/user/trace
+func ResourceVulnerabilityTaskUserTrace() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVulnerabilityTaskUserTraceCreate,
+		ReadContext:   resourceVulnerabilityTaskUserTraceRead,
+		UpdateContext: resourceVulnerabilityTaskUserTraceUpdate,
+		DeleteContext: resourceVulnerabilityTaskUserTraceDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(vulnerabilityTaskUserTraceNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"task_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildVulnerabilityTaskUserTraceQueryParams(epsID string) string {
+	if epsID != "" {
+		return fmt.Sprintf("?enterprise_project_id=%s", epsID)
+	}
+	return ""
+}
+
+func buildVulnerabilityTaskUserTraceBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"task_type": d.Get("task_type").(string),
+	}
+	return bodyParams
+}
+
+func resourceVulnerabilityTaskUserTraceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v5/{project_id}/vulnerability/task/user/trace"
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	epsID := cfg.GetEnterpriseProjectID(d)
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildVulnerabilityTaskUserTraceQueryParams(epsID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildVulnerabilityTaskUserTraceBodyParams(d),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error recording vulnerability task user trace: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID)
+
+	return resourceVulnerabilityTaskUserTraceRead(ctx, d, meta)
+}
+
+func resourceVulnerabilityTaskUserTraceRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// This is a one-time action resource, no need to implement read
+	return nil
+}
+
+func resourceVulnerabilityTaskUserTraceUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// This is a one-time action resource, no updates are allowed
+	return nil
+}
+
+func resourceVulnerabilityTaskUserTraceDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to record the last time a user viewed vulnerability tasks.
+	Deleting this resource will not clear the corresponding request record, but will only remove the resource
+	information from the Terraform state file.`
+
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to record vulnerability task user trace.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccVulnerabilityTaskUserTrace_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccVulnerabilityTaskUserTrace_basic -timeout 360m -parallel 10
=== RUN   TestAccVulnerabilityTaskUserTrace_basic
=== PAUSE TestAccVulnerabilityTaskUserTrace_basic
=== CONT  TestAccVulnerabilityTaskUserTrace_basic
--- PASS: TestAccVulnerabilityTaskUserTrace_basic (11.11s)
PASS
coverage: 3.0% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       11.218s coverage: 3.0% of statements in ./huaweicloud/services/hss
```
<img width="1475" height="85" alt="image" src="https://github.com/user-attachments/assets/23de83bd-5286-4497-a7d5-61db9c06b69c" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
