### PR TITLE
feat(hss): add new resource to set two-factor login configuration

### DIFF
--- a/docs/resources/hss_setting_two_factor_login_config.md
+++ b/docs/resources/hss_setting_two_factor_login_config.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_setting_two_factor_login_config"
+description: |-
+  Manages a resource to set two-factor login configuration within HuaweiCloud.
+---
+
+# huaweicloud_hss_setting_two_factor_login_config
+
+Manages a resource to set two-factor login configuration within HuaweiCloud.
+
+-> This resource is a one-time action resource. Deleting this resource will not clear the corresponding request record,
+  but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "host_id_list" {
+  type = list(string)
+}
+
+resource "huaweicloud_smn_topic" "test" {
+  ...
+}
+
+resource "huaweicloud_hss_setting_two_factor_login_config" "test" {
+  enabled            = true
+  auth_type          = "sms"
+  host_id_list       = var.host_id_list
+  topic_display_name = huaweicloud_smn_topic.test.display_name
+  topic_urn          = huaweicloud_smn_topic.test.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `enabled` - (Required, Bool, NonUpdatable) Specifies whether the two-factor authentication enabled.
+
+* `auth_type` - (Required, String, NonUpdatable) Specifies the authentication type.
+  The valid values are as follows:
+  + **sms**: Indicates SMS and email verification.
+  + **code**: Indicates captcha code verification.
+
+* `host_id_list` - (Required, List, NonUpdatable) Specifies the host IDs.
+
+* `topic_display_name` - (Optional, String, NonUpdatable) Specifies the SMN topic display name.
+
+* `topic_urn` - (Optional, String, NonUpdatable) Specifies the SMN topic urn.
+
+-> The field `topic_display_name` and `topic_urn` are valid only when `auth_type` is set to **sms**.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the hosts under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2744,6 +2744,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_event_alarm_white_list_delete":                  hss.ResourceEventAlarmWhiteListDelete(),
 			"huaweicloud_hss_event_login_white_list":                         hss.ResourceEventLoginWhiteList(),
 			"huaweicloud_hss_image_batch_scan":                               hss.ResourceImageBatchScan(),
+			"huaweicloud_hss_setting_two_factor_login_config":                hss.ResourceSettingTwoFactorLoginConfig(),
 			"huaweicloud_hss_switch_honeypot_port_policy":                    hss.ResourceSwitchHoneypotPortPolicy(),
 			"huaweicloud_hss_vulnerability_information_export":               hss.ResourceVulnerabilityInformationExport(),
 			"huaweicloud_hss_file_download":                                  hss.ResourceFileDownload(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_setting_two_factor_login_config_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_setting_two_factor_login_config_test.go
@@ -1,0 +1,46 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccSettingTwoFactorLoginConfig_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting a host ID that has enabled host protection.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testSettingTwoFactorLoginConfig_basic(name),
+			},
+		},
+	})
+}
+
+func testSettingTwoFactorLoginConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test" {
+  name         = "%[1]s"
+  display_name = "display_%[1]s"
+}
+
+resource "huaweicloud_hss_setting_two_factor_login_config" "test" {
+  enabled               = true
+  auth_type             = "sms"
+  host_id_list          = ["%[2]s"]
+  topic_display_name    = huaweicloud_smn_topic.test.display_name
+  topic_urn             = huaweicloud_smn_topic.test.id
+  enterprise_project_id = "0"
+}
+`, name, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
+}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_setting_two_factor_login_config.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_setting_two_factor_login_config.go
@@ -1,0 +1,156 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var twoFactorLoginConfigNonUpdatableParams = []string{
+	"enabled",
+	"auth_type",
+	"host_id_list",
+	"topic_display_name",
+	"topic_urn",
+	"enterprise_project_id"}
+
+// @API HSS POST /v5/{project_id}/setting/two-factor-login/config
+func ResourceSettingTwoFactorLoginConfig() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSettingTwoFactorLoginConfigCreate,
+		ReadContext:   resourceSettingTwoFactorLoginConfigRead,
+		UpdateContext: resourceSettingTwoFactorLoginConfigUpdate,
+		DeleteContext: resourceSettingTwoFactorLoginConfigDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(twoFactorLoginConfigNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"auth_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"host_id_list": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"topic_display_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"topic_urn": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildTwoFactorLoginConfigQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+	}
+
+	return ""
+}
+
+func buildTwoFactorLoginConfigBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"enabled":            d.Get("enabled"),
+		"auth_type":          d.Get("auth_type"),
+		"host_id_list":       utils.ExpandToStringList(d.Get("host_id_list").([]interface{})),
+		"topic_display_name": utils.ValueIgnoreEmpty(d.Get("topic_display_name")),
+		"topic_urn":          utils.ValueIgnoreEmpty(d.Get("topic_urn")),
+	}
+
+	return bodyParams
+}
+
+func resourceSettingTwoFactorLoginConfigCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/setting/two-factor-login/config"
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildTwoFactorLoginConfigQueryParams(epsId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildTwoFactorLoginConfigBodyParams(d)),
+	}
+
+	_, err = client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error setting the two-factor login configuration: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return nil
+}
+
+func resourceSettingTwoFactorLoginConfigRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceSettingTwoFactorLoginConfigUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceSettingTwoFactorLoginConfigDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to set two-factor login configuration. Deleting this resource
+    will not clear the corresponding request record, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to set two-factor login configuration.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccSettingTwoFactorLoginConfig_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccSettingTwoFactorLoginConfig_basic -timeout 360m -parallel 4
=== RUN   TestAccSettingTwoFactorLoginConfig_basic
=== PAUSE TestAccSettingTwoFactorLoginConfig_basic
=== CONT  TestAccSettingTwoFactorLoginConfig_basic
--- PASS: TestAccSettingTwoFactorLoginConfig_basic (18.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       18.613s
```
<img width="1147" height="19" alt="image" src="https://github.com/user-attachments/assets/44a189dd-c2e4-4de1-a770-6ab07763ad64" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
