### PR TITLE
feat(hss): new datasource to query baseline check rule hab

### DIFF
--- a/docs/data-sources/hss_baseline_check_rule_hab.md
+++ b/docs/data-sources/hss_baseline_check_rule_hab.md
@@ -1,0 +1,114 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_baseline_check_rule_hab"
+description: |-
+  Use this data source to query the scope of operations for HSS baseline check rules.
+---
+
+# huaweicloud_hss_baseline_check_rule_hab
+
+Use this data source to query the scope of operations for HSS baseline check rules.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_baseline_check_rule_hab" "test" {
+  action        = "ignore"
+  handle_status = "unhandled"
+
+  check_rule_list {
+    check_name = "example_check"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource. If omitted, the provider-level
+  region will be used.
+
+* `action` - (Required, String) Specifies the operation to be performed on the baseline check rule.
+  Valid values are:
+  + **add_to_whitelist**: Add to whitelist.
+  + **ignore**: Ignore the check item.
+  + **unignore**: Cancel ignoring the check item.
+  + **fix**: Fix the check item.
+  + **verify**: Verify the check item.
+
+* `handle_status` - (Required, String) Specifies the current status of the baseline check rule.
+  Valid values are:
+  + **unhandled**: The check item is not processed.
+  + **fix-failed**: The check item fails to be fixed.
+  + **fixing**: The check item is being fixed.
+  + **verifying**: The check item is being verified.
+  + **ignored**: The check item is ignored.
+  + **safe**: The check item is secure.
+
+* `check_rule_list` - (Required, List) Specifies the list of baseline check rules to be handled.
+  The [check_rule_list](#check_rule_list_Struct) structure is documented below.
+
+* `host_id` - (Optional, String) Specifies the ID of the host to be queried.
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project. The value **0** indicates
+  the default enterprise project. To query all enterprise projects, set this parameter to **all_granted_eps**.
+  This field is valid only for enterprise project users.
+
+<a name="check_rule_list_Struct"></a>
+The `check_rule_list` block supports:
+
+* `check_name` - (Optional, String) Specifies the name of the baseline check.
+  The value can contain up to `256` characters.
+
+* `check_rule_id` - (Optional, String) Specifies the ID of the baseline check rule.
+  The value can contain up to `256` characters.
+
+* `standard` - (Optional, String) Specifies the standard type of the baseline check.
+  Valid values are:
+  + **cn_standard**: Compliance standard.
+  + **hw_standard**: Cloud security practice standard.
+  + **cis_standard**: General security standard.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `total_rule_num` - The total number of affected items.
+
+* `rule_num` - The number of check items affected by the operation.
+
+* `host_num` - The number of hosts affected by the operation.
+
+* `data_list` - The detailed information about the operation impact scope.
+  The [data_list](#data_list_Struct) structure is documented below.
+
+<a name="data_list_Struct"></a>
+The `data_list` block supports:
+
+* `host_id` - The ID of the affected host.
+
+* `host_name` - The name of the affected host.
+
+* `public_ip` - The public IP address of the host.
+
+* `private_ip` - The private IP address of the host.
+
+* `asset_value` - The asset value of the host. Valid values are:
+  + **important**: Important asset.
+  + **common**: Common asset.
+  + **test**: Test asset.
+
+* `check_type` - The name of the baseline check.
+
+* `standard` - The standard type of the host. Valid values are:
+  + **cn_standard**: Compliance standard.
+  + **hw_standard**: Cloud security practice standard.
+  + **cis_standard**: General security standard.
+
+* `tag` - The check type of check items in the baseline check.
+
+* `check_rule_name` - The name of check items in the baseline check.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1272,6 +1272,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_asset_users":                               hss.DataSourceAssetUsers(),
 			"huaweicloud_hss_auto_launch_statistics":                    hss.DataSourceAutoLaunchStatistics(),
 			"huaweicloud_hss_auto_launchs":                              hss.DataSourceAutoLaunchs(),
+			"huaweicloud_hss_baseline_check_rule_hab":                   hss.DataSourceBaselineCheckRuleHAB(),
 			"huaweicloud_hss_cluster_asset_statistics":                  hss.DataSourceClusterAssetStatistics(),
 			"huaweicloud_hss_common_tasks":                              hss.DataSourceCommonTasks(),
 			"huaweicloud_hss_container_kubernetes":                      hss.DataSourceContainerKubernetes(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_baseline_check_rule_hab_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_baseline_check_rule_hab_test.go
@@ -1,0 +1,46 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceBaselineCheckRuleHAB_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_baseline_check_rule_hab.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceBaselineCheckRuleHAB_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "total_rule_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "rule_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "host_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceBaselineCheckRuleHAB_basic = `
+data "huaweicloud_hss_baseline_check_rule_hab" "test" {
+  action        = "ignore"
+  handle_status = "unhandled"
+
+  check_rule_list {
+    check_name = "example_check"
+  }
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_baseline_check_rule_hab.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_baseline_check_rule_hab.go
@@ -1,0 +1,290 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS POST /v5/{project_id}/baseline/check-rule/handle-affect-baseline
+func DataSourceBaselineCheckRuleHAB() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBaselineCheckRuleHABRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			// Request Body Parameters.
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the operation performed during the baseline check.`,
+			},
+			"handle_status": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the handle status of the baseline check rule.`,
+			},
+			"check_rule_list": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        checkRuleListSchema(),
+				Description: `Specifies the list of baseline check rules to be handled.`,
+			},
+			"host_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the host ID.`,
+			},
+			// Request Query Parameters.
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the enterprise project ID.`,
+			},
+			// Attribute Parameters.
+			"total_rule_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The total number of affected items.`,
+			},
+			"rule_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of check items affected by the operation.`,
+			},
+			"host_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of hosts affected by the operation.`,
+			},
+			"data_list": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataListAttributeSchema(),
+				Description: `The detailed information about the operation impact scope.`,
+			},
+		},
+	}
+}
+
+func dataListAttributeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"host_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The host ID.`,
+			},
+			"host_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The host name.`,
+			},
+			"public_ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The public IP address of the host.`,
+			},
+			"private_ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The private IP address of the host.`,
+			},
+			"asset_value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The asset value of the host.`,
+			},
+			"check_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the baseline check.`,
+			},
+			"standard": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The standard type of the host.`,
+			},
+			"tag": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The check type of check items in the baseline check.`,
+			},
+			"check_rule_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of check items in the baseline check.`,
+			},
+		},
+	}
+}
+
+func checkRuleListSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"check_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the baseline check.`,
+			},
+			"check_rule_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the baseline check rule.`,
+			},
+			"standard": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The standard type of the host.`,
+			},
+		},
+	}
+}
+
+func buildBaselineCheckRuleHABQueryParams(epsId string) string {
+	rst := "?limit=200"
+	if epsId != "" {
+		rst = fmt.Sprintf("%s&enterprise_project_id=%s", rst, epsId)
+	}
+
+	return rst
+}
+
+func buildCheckRuleHABCheckRuleListRequestBody(rawArray []interface{}) []map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"check_name":    utils.ValueIgnoreEmpty(rawMap["check_name"]),
+			"check_rule_id": utils.ValueIgnoreEmpty(rawMap["check_rule_id"]),
+			"standard":      utils.ValueIgnoreEmpty(rawMap["standard"]),
+		})
+	}
+
+	return rst
+}
+
+func buildBaselineCheckRuleHABRequestBody(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"action":          d.Get("action"),
+		"handle_status":   d.Get("handle_status"),
+		"check_rule_list": buildCheckRuleHABCheckRuleListRequestBody(d.Get("check_rule_list").([]interface{})),
+		"host_id":         utils.ValueIgnoreEmpty(d.Get("host_id")),
+	}
+}
+
+func dataSourceBaselineCheckRuleHABRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		epsId        = cfg.GetEnterpriseProjectID(d)
+		product      = "hss"
+		httpUrl      = "v5/{project_id}/baseline/check-rule/handle-affect-baseline"
+		offset       = 0
+		allData      = make([]interface{}, 0)
+		totalRuleNum = 0
+		ruleNum      = 0
+		hostNum      = 0
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildBaselineCheckRuleHABQueryParams(epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildBaselineCheckRuleHABRequestBody(d)),
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%d", requestPath, offset)
+		resp, err := client.Request("POST", requestPathWithOffset, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS baseline check rule HAB: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalRuleNum = int(utils.PathSearch("total_rule_num", respBody, float64(0)).(float64))
+		ruleNum = int(utils.PathSearch("rule_num", respBody, float64(0)).(float64))
+		hostNum = int(utils.PathSearch("host_num", respBody, float64(0)).(float64))
+
+		dataList := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataList) == 0 {
+			break
+		}
+
+		offset += len(dataList)
+		allData = append(allData, dataList...)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_rule_num", totalRuleNum),
+		d.Set("rule_num", ruleNum),
+		d.Set("host_num", hostNum),
+		d.Set("data_list", flattenBaselineCheckRuleHABDataList(allData)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenBaselineCheckRuleHABDataList(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		result = append(result, map[string]interface{}{
+			"host_id":         utils.PathSearch("host_id", v, nil),
+			"host_name":       utils.PathSearch("host_name", v, nil),
+			"public_ip":       utils.PathSearch("public_ip", v, nil),
+			"private_ip":      utils.PathSearch("private_ip", v, nil),
+			"asset_value":     utils.PathSearch("asset_value", v, nil),
+			"check_type":      utils.PathSearch("check_type", v, nil),
+			"standard":        utils.PathSearch("standard", v, nil),
+			"tag":             utils.PathSearch("tag", v, nil),
+			"check_rule_name": utils.PathSearch("check_rule_name", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query baseline check rule hab.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccDataSourceBaselineCheckRuleHAB_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccDataSourceBaselineCheckRuleHAB_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceBaselineCheckRuleHAB_basic
--- PASS: TestAccDataSourceBaselineCheckRuleHAB_basic (11.34s)
PASS
coverage: 3.4% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       11.431s coverage: 3.4% of statements in ./huaweicloud/services/hss
```
<img width="1355" height="131" alt="image" src="https://github.com/user-attachments/assets/0ae787cc-7025-4845-ac94-884edb966d74" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
