### PR TITLE
feat(hss): add new data source to query the number of hosts

### DIFF
--- a/docs/data-sources/hss_asset_overview_status_host_protection.md
+++ b/docs/data-sources/hss_asset_overview_status_host_protection.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_asset_overview_status_host_protection"
+description: |-
+  Use this data source to query the number of hosts based on the host protection status.
+---
+
+# huaweicloud_hss_asset_overview_status_host_protection
+
+Use this data source to query the number of hosts based on the host protection status.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_asset_overview_status_host_protection" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `no_risk` - The number of risk free hosts.
+
+* `risk` - The number of risky hosts.
+
+* `no_protect` - The number of unprotected hosts.
+
+* `total_num` - The total number of hosts.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1262,6 +1262,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_app_statistics":                        hss.DataSourceAppStatistics(),
 			"huaweicloud_hss_asset_apps":                            hss.DataSourceAssetApps(),
 			"huaweicloud_hss_asset_manual_collect":                  hss.DataSourceAssetManualCollect(),
+			"huaweicloud_hss_asset_overview_status_host_protection": hss.DataSourceAssetOverviewStatusHostProtection(),
 			"huaweicloud_hss_asset_port_info":                       hss.DataSourceAssetPortInfo(),
 			"huaweicloud_hss_asset_port_statistics":                 hss.DataSourceAssetPortStatistics(),
 			"huaweicloud_hss_asset_ports":                           hss.DataSourceAssetPorts(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_asset_overview_status_host_protection_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_asset_overview_status_host_protection_test.go
@@ -1,0 +1,43 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAssetOverviewStatusHostProtection_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_asset_overview_status_host_protection.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting a host ID with host protection enabled.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAssetOverviewStatusHostProtection_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "no_risk"),
+					resource.TestCheckResourceAttrSet(dataSource, "risk"),
+					resource.TestCheckResourceAttrSet(dataSource, "no_protect"),
+					resource.TestCheckResourceAttrSet(dataSource, "total_num"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAssetOverviewStatusHostProtection_basic = `
+data "huaweicloud_hss_asset_overview_status_host_protection" "test" {
+  enterprise_project_id = "all_granted_eps"
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_asset_overview_status_host_protection.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_asset_overview_status_host_protection.go
@@ -1,0 +1,103 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/asset/overview/status/host/protection
+func DataSourceAssetOverviewStatusHostProtection() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAssetOverviewStatusHostProtectionRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"no_risk": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"risk": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"no_protect": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAssetOverviewStatusHostProtectionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v5/{project_id}/asset/overview/status/host/protection"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	if epsId != "" {
+		getPath = fmt.Sprintf("%s?enterprise_project_id=%s", getPath, epsId)
+	}
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the number of hosts: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("no_risk", utils.PathSearch("no_risk", respBody, nil)),
+		d.Set("risk", utils.PathSearch("risk", respBody, nil)),
+		d.Set("no_protect", utils.PathSearch("no_protect", respBody, nil)),
+		d.Set("total_num", utils.PathSearch("total_num", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to query the number of hosts based on the host protection status.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceAssetOverviewStatusHostProtection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceAssetOverviewStatusHostProtection_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAssetOverviewStatusHostProtection_basic
--- PASS: TestAccDataSourceAssetOverviewStatusHostProtection_basic (11.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       11.236s
```
<img width="1145" height="16" alt="image" src="https://github.com/user-attachments/assets/fac79727-a57a-4d70-96bf-17f8e369bf8c" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
