### PR TITLE
feat(kafka): add new data source to query coordinator list

### DIFF
--- a/docs/data-sources/dms_kafka_instance_coordinators.md
+++ b/docs/data-sources/dms_kafka_instance_coordinators.md
@@ -1,0 +1,50 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_instance_coordinators"
+description: |-
+  Use this data source to get the coordinator list of the Kafka instance within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_instance_coordinators
+
+Use this data source to get the coordinator list of the Kafka instance within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_dms_kafka_instance_coordinators" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the coordinators are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the Kafka instance to which the coordinators belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `coordinators` - The list of coordinators corresponding to all consumer groups.  
+  The [coordinators](#kafka_instance_coordinators_attr) structure is documented below.
+
+<a name="kafka_instance_coordinators_attr"></a>
+The `coordinators` block supports:
+
+* `id` - The ID of the broker of the corresponding to the coordinator.
+
+* `group_id` - The ID of the consumer group.
+
+* `host` - The address of the broker of the corresponding to the coordinator.
+
+* `port` - The port number of the corresponding to the coordinator.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1043,6 +1043,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_consumer_groups":          kafka.DataSourceDmsKafkaConsumerGroups(),
 			"huaweicloud_dms_kafka_extend_flavors":           kafka.DataSourceDmsKafkaExtendFlavors(),
 			"huaweicloud_dms_kafka_flavors":                  kafka.DataSourceKafkaFlavors(),
+			"huaweicloud_dms_kafka_instance_coordinators":    kafka.DataSourceInstanceCoordinators(),
 			"huaweicloud_dms_kafka_instances":                kafka.DataSourceDmsKafkaInstances(),
 			"huaweicloud_dms_kafka_maintainwindows":          kafka.DataSourceMaintainWindows(),
 			"huaweicloud_dms_kafka_message_diagnosis_tasks":  kafka.DataSourceDmsKafkaMessageDiagnosisTasks(),

--- a/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_instance_coordinators_test.go
+++ b/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_instance_coordinators_test.go
@@ -1,0 +1,66 @@
+package kafka
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataInstanceCoordinators_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_dms_kafka_instance_coordinators.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataInstanceCoordinators_instanceNotFound(),
+				ExpectError: regexp.MustCompile(`This DMS instance does not exist`),
+			},
+			{
+				Config: testAccDataInstanceCoordinators_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "coordinators.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "coordinators.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "coordinators.0.host"),
+					resource.TestCheckResourceAttrSet(dataSource, "coordinators.0.port"),
+					resource.TestCheckResourceAttrSet(dataSource, "coordinators.0.group_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataInstanceCoordinators_instanceNotFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dms_kafka_instance_coordinators" "test" {
+  instance_id = "%[1]s"
+}
+`, randomId)
+}
+
+func testAccDataInstanceCoordinators_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_consumer_group" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+}
+
+data "huaweicloud_dms_kafka_instance_coordinators" "test" {
+  instance_id = "%[1]s"
+
+  depends_on = [huaweicloud_dms_kafka_consumer_group.test]
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, acceptance.RandomAccResourceName())
+}

--- a/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_instance_coordinators.go
+++ b/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_instance_coordinators.go
@@ -1,0 +1,132 @@
+package kafka
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Kafka GET /v2/{project_id}/instances/{instance_id}/management/coordinators
+func DataSourceInstanceCoordinators() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstanceCoordinatorsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the coordinators are located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the Kafka instance to which the coordinators belong.`,
+			},
+			"coordinators": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The ID of the broker of the corresponding to the coordinator.`,
+						},
+						"group_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the consumer group.`,
+						},
+						"host": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The address of the broker of the corresponding to the coordinator.`,
+						},
+						"port": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The port number of the corresponding to the coordinator.`,
+						},
+					},
+				},
+				Description: `The list of coordinators corresponding to all consumer groups.`,
+			},
+		},
+	}
+}
+
+func dataSourceInstanceCoordinatorsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+	)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	httpUrl := "v2/{project_id}/instances/{instance_id}/management/coordinators"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+	}
+
+	listResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving coordinator list of Kafka instance (%s): %s", instanceId, err)
+	}
+
+	listRespBody, err := utils.FlattenResponse(listResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(randomId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("coordinators", flattenCoordinators(utils.PathSearch("coordinators",
+			listRespBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCoordinators(coordinators []interface{}) []interface{} {
+	if len(coordinators) == 0 {
+		return nil
+	}
+
+	results := make([]interface{}, 0, len(coordinators))
+	for _, coordinator := range coordinators {
+		results = append(results, map[string]interface{}{
+			"group_id": utils.PathSearch("group_id", coordinator, nil),
+			"id":       utils.PathSearch("id", coordinator, nil),
+			"host":     utils.PathSearch("host", coordinator, nil),
+			"port":     utils.PathSearch("port", coordinator, nil),
+		})
+	}
+	return results
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data source (`huaweicloud_dms_kafka_instance_coordinators`) to query coordinator list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source and its corresponding to document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccDataInstanceCoordinators_
basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccDataInstanceCoordinators_basic -timeout 360m -parallel 10
=== RUN   TestAccDataInstanceCoordinators_basic
=== PAUSE TestAccDataInstanceCoordinators_basic
=== CONT  TestAccDataInstanceCoordinators_basic
--- PASS: TestAccDataInstanceCoordinators_basic (14.59s)
PASS
coverage: 4.0% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     14.709s coverage: 4.0% of statements in ./huaweicloud/services/kafka
```

<img width="1009" height="177" alt="image" src="https://github.com/user-attachments/assets/3fefa96b-4d73-4bd3-8dad-2b0bd85f228c" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
