### PR TITLE
feat(cdn): add new data source for query domain tags

### DIFF
--- a/docs/data-sources/cdn_tags.md
+++ b/docs/data-sources/cdn_tags.md
@@ -1,0 +1,45 @@
+---
+subcategory: Content Delivery Network (CDN)
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cdn_domain_tags"
+description: |-
+  Use this data source to get a list of CDN domain tags within HuaweiCloud.
+---
+
+# huaweicloud_cdn_domain_tags
+
+Use this data source to get a list of CDN domain tags within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cdn_domain_id" {}
+
+data "huaweicloud_cdn_domain_tags" "test" {
+  resource_id = var.cdn_domain_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the domain tags are located.
+
+* `resource_id` - (Required, String) Specifies the ID of the domain to query tags.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tags` - The list of domain tags that matched filter parameters.  
+  The [tags](#cdn_domain_tags) structure is documented below.
+
+<a name="cdn_domain_tags"></a>
+The `tags` block supports:
+
+* `key` - The key of the tag.
+
+* `value` - The value of the tag.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -738,6 +738,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdn_billing_option":      cdn.DataSourceBillingOption(),
 			"huaweicloud_cdn_logs":                cdn.DataSourceCdnLogs(),
 			"huaweicloud_cdn_analytics":           cdn.DataSourceCdnAnalytics(),
+			"huaweicloud_cdn_domain_tags":         cdn.DataSourceDomainTags(),
 
 			"huaweicloud_ces_agent_dimensions":                  ces.DataSourceCesAgentDimensions(),
 			"huaweicloud_ces_agent_maintenance_tasks":           ces.DataSourceCesAgentMaintenanceTasks(),

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_tags_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_tags_test.go
@@ -1,0 +1,87 @@
+package cdn
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceDomainTags_basic(t *testing.T) {
+	var (
+		domainName = generateDomainName()
+
+		dcName = "data.huaweicloud_cdn_domain_tags.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceDomainTags_basic(domainName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dcName, "tags.#", regexp.MustCompile("^[1-9]([0-9]+)?$")),
+					resource.TestCheckResourceAttrSet(dcName, "tags.0.key"),
+					resource.TestCheckResourceAttrSet(dcName, "tags.0.value"),
+					resource.TestCheckResourceAttrSet(dcName, "tags.1.key"),
+					resource.TestCheckResourceAttrSet(dcName, "tags.1.value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceDomainTags_base(domainName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_domain" "test" {
+  name         = "%[1]s"
+  type         = "web"
+  service_area = "outside_mainland_china"
+
+  configs {
+    origin_protocol = "http"
+  }
+
+  sources {
+    active      = 1
+    origin      = "100.254.53.75"
+    origin_type = "ipaddr"
+    http_port   = 80
+    https_port  = 443
+  }
+
+  cache_settings {
+    rules {
+      rule_type           = "all"
+      ttl                 = 365
+      ttl_type            = "d"
+      priority            = 2
+      url_parameter_type  = "del_params"
+      url_parameter_value = "test_value"
+    }
+  }
+
+  tags = {
+    key = "val"
+    foo = "bar"
+  }
+}
+`, domainName)
+}
+
+func testAccDatasourceDomainTags_basic(domainName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_cdn_domain_tags" "test" {
+  resource_id = huaweicloud_cdn_domain.test.id
+}`, testAccDatasourceDomainTags_base(domainName))
+}

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_tags.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_tags.go
@@ -1,0 +1,131 @@
+package cdn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CDN GET /v1.0/cdn/configuration/tags
+func DataSourceDomainTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDomainTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the domain tags are located.`,
+			},
+
+			// Required parameters.
+			"resource_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the domain to query tags.`,
+			},
+
+			// Attributes.
+			"tags": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The key of the tag.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The value of the tag.`,
+						},
+					},
+				},
+				Description: `The list of domain tags that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func listTags(client *golangsdk.ServiceClient, resourceId string) ([]interface{}, error) {
+	httpUrl := "v1.0/cdn/configuration/tags"
+	listPath := client.Endpoint + httpUrl
+	listPath += fmt.Sprintf("?resource_id=%s", resourceId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("tags", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenTags(tags []interface{}) []map[string]interface{} {
+	if len(tags) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(tags))
+	for _, tag := range tags {
+		result = append(result, map[string]interface{}{
+			"key":   utils.PathSearch("key", tag, nil),
+			"value": utils.PathSearch("value", tag, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceDomainTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		resourceId = d.Get("resource_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("cdn", region)
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	tags, err := listTags(client, resourceId)
+	if err != nil {
+		return diag.Errorf("error querying domain tags: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("tags", flattenTags(tags)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(cdn): add new data source for query domain tags

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccDatasourceDomainTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourceDomainTags_basic
=== PAUSE TestAccDatasourceDomainTags_basic
=== CONT  TestAccDatasourceDomainTags_basic
--- PASS: TestAccDatasourceDomainTags_basic (363.73s)
PASS
coverage: 28.3% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       363.842s        coverage: 28.3% of statements in ./huaweicloud/services/cdn
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.