### PR TITLE
feat(kafka): add new data source to query topics under consumer group

### DIFF
--- a/docs/data-sources/dms_kafka_consumer_group_topics.md
+++ b/docs/data-sources/dms_kafka_consumer_group_topics.md
@@ -1,0 +1,82 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_consumer_group_topics"
+description: |-
+  Use this data source to get the list of topics consumed by a consumer group within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_consumer_group_topics
+
+Use this data source to get the list of topics consumed by a consumer group within HuaweiCloud.
+
+## Example Usage
+
+### Query topic list under the specified consumer group
+
+```hcl
+variable "instance_id" {}
+variable "consumer_group_id" {}
+
+data "huaweicloud_dms_kafka_consumer_group_topics" "test" {
+  instance_id = var.instance_id
+  group       = var.consumer_group_id
+}
+```
+
+### Query topic list by the specified topic name
+
+```hcl
+variable "instance_id" {}
+variable "consumer_group_id" {}
+variable "topic_name" {}
+
+data "huaweicloud_dms_kafka_consumer_group_topics" "test" {
+  instance_id = var.instance_id
+  group       = var.consumer_group_id
+  topic       = var.topic_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the Kafka instance and consumer group are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the Kafka instance.
+
+* `group` - (Required, String) Specifies the ID of the consumer group.
+
+* `topic` - (Optional, String) Specifies the name of the topic to be queried.  
+  Fuzzy search is supported.
+
+* `sort_key` - (Optional, String) Specifies the sorting field for the query result.  
+  The valid values are as follows:
+  + **topic**: Sort by topic name.
+  + **partition**: Sort by number of partitions.
+  + **messages**: Sort by number of messages (default).
+
+* `sort_dir` - (Optional, String) Specifies the sorting order for the query result.  
+  The valid values are as follows:
+  + **asc**: Ascending order.
+  + **desc**: Descending order (default).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `topics` - The list of topics that match the filter parameters.  
+  The [topics](#kafka_consumer_group_topics_topics_attr) structure is documented below.
+
+<a name="kafka_consumer_group_topics_topics_attr"></a>
+The `topics` block supports:
+
+* `topic` - The name of the topic.
+
+* `partitions` - The number of partitions.
+
+* `lag` - The number of message accumulations.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1040,6 +1040,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_maintainwindow": dms.DataSourceDmsMaintainWindow(),
 
 			"huaweicloud_dms_kafka_background_tasks":         kafka.DataSourceDmsKafkaBackgroundTasks(),
+			"huaweicloud_dms_kafka_consumer_group_topics":    kafka.DataSourceConsumerGroupTopics(),
 			"huaweicloud_dms_kafka_consumer_groups":          kafka.DataSourceDmsKafkaConsumerGroups(),
 			"huaweicloud_dms_kafka_extend_flavors":           kafka.DataSourceDmsKafkaExtendFlavors(),
 			"huaweicloud_dms_kafka_flavors":                  kafka.DataSourceKafkaFlavors(),

--- a/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_consumer_group_topics_test.go
+++ b/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_consumer_group_topics_test.go
@@ -1,0 +1,148 @@
+package kafka
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this test, make sure that the subscribed topic exists under the consumer group.
+func TestAccDataConsumerGroupTopics_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dms_kafka_consumer_group_topics.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byTopic   = "data.huaweicloud_dms_kafka_consumer_group_topics.filter_by_topic"
+		dcByTopic = acceptance.InitDataSourceCheck(byTopic)
+
+		bySortAsc   = "data.huaweicloud_dms_kafka_consumer_group_topics.filter_by_sort_asc"
+		dcBySortAsc = acceptance.InitDataSourceCheck(bySortAsc)
+
+		bySortDesc   = "data.huaweicloud_dms_kafka_consumer_group_topics.filter_by_sort_desc"
+		dcBySortDesc = acceptance.InitDataSourceCheck(bySortDesc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
+			acceptance.TestAccPreCheckDMSKafkaConsumerGroupName(t)
+			acceptance.TestAccPreCheckDMSKafkaTopicName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"null": {
+				Source:            "hashicorp/null",
+				VersionConstraint: "3.2.1",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataConsumerGroupTopics_instanceNotFound(),
+				ExpectError: regexp.MustCompile(`This DMS instance does not exist`),
+			},
+			{
+				Config: testAccDataConsumerGroupTopics_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "topics.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "topics.0.topic"),
+					resource.TestMatchResourceAttr(all, "topics.0.partitions", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByTopic.CheckResourceExists(),
+					resource.TestCheckOutput("is_topic_filter_useful", "true"),
+					dcBySortAsc.CheckResourceExists(),
+					dcBySortDesc.CheckResourceExists(),
+					resource.TestCheckOutput("is_sort_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataConsumerGroupTopics_instanceNotFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dms_kafka_consumer_group_topics" "test" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+}
+`, randomId, acceptance.HW_DMS_KAFKA_CONSUMER_GROUP_NAME)
+}
+
+func testAccDataConsumerGroupTopics_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_message_produce" "test" {
+  instance_id = "%[1]s"
+  topic       = "%[3]s"
+  body        = "terraform test"
+}
+
+# Wait for the message to be produced.
+resource "null_resource" "test" {
+  provisioner "local-exec" {
+    command = "sleep 20"
+  }
+
+  depends_on = [huaweicloud_dms_kafka_message_produce.test]
+}
+
+data "huaweicloud_dms_kafka_consumer_group_topics" "test" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+
+  depends_on = [null_resource.test]
+}
+
+# Fuzzy search.
+data "huaweicloud_dms_kafka_consumer_group_topics" "filter_by_topic" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+  topic       = "%[3]s"
+
+  depends_on = [null_resource.test]
+}
+
+locals {
+  filter_by_topic_result = [for v in data.huaweicloud_dms_kafka_consumer_group_topics.filter_by_topic.topics : strcontains(v.topic, "%[3]s")]
+}
+
+output "is_topic_filter_useful" {
+  value = length(local.filter_by_topic_result) > 0 && alltrue(local.filter_by_topic_result)
+}
+
+data "huaweicloud_dms_kafka_consumer_group_topics" "filter_by_sort_asc" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+  sort_key    = "topic"
+  sort_dir    = "asc"
+
+  depends_on = [null_resource.test]
+}
+
+data "huaweicloud_dms_kafka_consumer_group_topics" "filter_by_sort_desc" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+  sort_key    = "topic"
+
+  depends_on = [null_resource.test]
+}
+
+locals {
+  filter_by_sort_asc_result  = data.huaweicloud_dms_kafka_consumer_group_topics.filter_by_sort_asc.topics[*].topic
+  filter_by_sort_desc_result = data.huaweicloud_dms_kafka_consumer_group_topics.filter_by_sort_desc.topics[*].topic
+}
+
+output "is_sort_filter_useful" {
+  value = (
+    length(local.filter_by_sort_asc_result) > 0
+    && length(local.filter_by_sort_asc_result) == length(local.filter_by_sort_desc_result)
+    && local.filter_by_sort_asc_result[0] == local.filter_by_sort_desc_result[length(local.filter_by_sort_desc_result) - 1]
+  )
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, acceptance.HW_DMS_KAFKA_CONSUMER_GROUP_NAME, acceptance.HW_DMS_KAFKA_TOPIC_NAME)
+}

--- a/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_consumer_group_topics.go
+++ b/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_consumer_group_topics.go
@@ -1,0 +1,188 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Kafka GET /v2/{engine}/{project_id}/instances/{instance_id}/groups/{group}/topics
+func DataSourceConsumerGroupTopics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceConsumerGroupTopicsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the Kafka instance and consumer group are located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the Kafka instance.`,
+			},
+			"group": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the consumer group.`,
+			},
+			"topic": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the topic to be queried.`,
+			},
+			"sort_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The sorting field for the query result.`,
+			},
+			"sort_dir": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The sorting order for the query result.`,
+			},
+			"topics": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of topics that match the filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"topic": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the topic.`,
+						},
+						"partitions": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The number of partitions.`,
+						},
+						"lag": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The number of message accumulations.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildConsumerGroupTopicsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if topic, ok := d.GetOk("topic"); ok {
+		res += fmt.Sprintf("&topic=%s", topic)
+	}
+
+	if sortKey, ok := d.GetOk("sort_key"); ok {
+		res += fmt.Sprintf("&sort_key=%s", sortKey)
+	}
+	if sortDir, ok := d.GetOk("sort_dir"); ok {
+		res += fmt.Sprintf("&sort_dir=%s", sortDir)
+	}
+
+	return res
+}
+
+func listConsumerGroupTopics(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		// The limit maximum value is 50, default is 10.
+		httpUrl = "v2/kafka/{project_id}/instances/{instance_id}/groups/{group}/topics?limit=50"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", d.Get("instance_id").(string))
+	listPath = strings.ReplaceAll(listPath, "{group}", d.Get("group").(string))
+	listPath += buildConsumerGroupTopicsQueryParams(d)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &getOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		topics := utils.PathSearch("topics", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, topics...)
+		// The `offset` cannot be greater than or equal to the total number of topics. Otherwise, the response is as follows:
+		// {"error_code": "DMS.00400062","error_msg": "Invalid {0} parameter in the request."}
+		offset += len(topics)
+		if offset >= int(utils.PathSearch("total", respBody, float64(0)).(float64)) {
+			break
+		}
+	}
+	return result, nil
+}
+
+func dataSourceConsumerGroupTopicsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	topics, err := listConsumerGroupTopics(client, d)
+	if err != nil {
+		return diag.Errorf("error querying topic list under consumer group (%s): %s", d.Get("group").(string), err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("topics", flattenConsumerGroupTopics(topics)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenConsumerGroupTopics(topics []interface{}) []interface{} {
+	if len(topics) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(topics))
+	for _, v := range topics {
+		rst = append(rst, map[string]interface{}{
+			"topic":      utils.PathSearch("topic", v, nil),
+			"partitions": utils.PathSearch("partitions", v, nil),
+			"lag":        utils.PathSearch("lag", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source (`huaweicloud_dms_kafka_consumer_group_topics`) to query topics under consumer group.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source and its corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccDataConsumerGroupTopics_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccDataConsumerGroupTopics_basic -timeout 360m -parallel 10
=== RUN   TestAccDataConsumerGroupTopics_basic
=== PAUSE TestAccDataConsumerGroupTopics_basic
=== CONT  TestAccDataConsumerGroupTopics_basic
--- PASS: TestAccDataConsumerGroupTopics_basic (38.77s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     38.888s coverage: 3.7% of statements in ./huaweicloud/services/kafka
```
<img width="1012" height="101" alt="image" src="https://github.com/user-attachments/assets/cacf7ee3-e9e3-4b85-b5fa-848a360f0579" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
