### PR TITLE
feat(kafka): add new data source to query members under consumer group

### DIFF
--- a/docs/data-sources/dms_kafka_consumer_group_members.md
+++ b/docs/data-sources/dms_kafka_consumer_group_members.md
@@ -1,0 +1,74 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_consumer_group_members"
+description: |-
+  Use this data source to get the member list under the specified consumer group within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_consumer_group_members
+
+Use this data source to get the member list under the specified consumer group within HuaweiCloud.
+
+## Example Usage
+
+### Query all member list under the specified consumer group
+
+```hcl
+variable "instance_id" {}
+variable "consumer_group_id" {}
+
+data "huaweicloud_dms_kafka_consumer_group_members" "test" {
+  instance_id = var.instance_id
+  group       = var.consumer_group_id
+}
+```
+
+### Query member list by the specified consumer address
+
+```hcl
+variable "instance_id" {}
+variable "consumer_group_id" {}
+variable "consumer_address" {}
+
+data "huaweicloud_dms_kafka_consumer_group_members" "test" {
+  instance_id = var.instance_id
+  group       = var.consumer_group_id
+  host        = var.consumer_address
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the consumer group members are located.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the Kafka instance.
+
+* `group` - (Required, String) Specifies the ID of the consumer group.
+
+* `host` - (Optional, String) Specifies the address of the consumer.  
+  Fuzzy search is supported.
+
+* `member_id` - (Optional, String) Specifies the ID of the consumer.  
+  Fuzzy search is supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `members` - The list of consumer group members that match the filter parameters.  
+  The [members](#kafka_consumer_group_members_struct) structure is documented below.
+
+<a name="kafka_consumer_group_members_struct"></a>
+The `members` block supports:
+
+* `id` - The ID of the consumer.
+
+* `host` - The address of the consumer.
+
+* `client_id` - The ID of the client.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1042,6 +1042,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_maintainwindow": dms.DataSourceDmsMaintainWindow(),
 
 			"huaweicloud_dms_kafka_background_tasks":         kafka.DataSourceDmsKafkaBackgroundTasks(),
+			"huaweicloud_dms_kafka_consumer_group_members":   kafka.DataSourceConsumerGroupMembers(),
 			"huaweicloud_dms_kafka_consumer_group_topics":    kafka.DataSourceConsumerGroupTopics(),
 			"huaweicloud_dms_kafka_consumer_groups":          kafka.DataSourceDmsKafkaConsumerGroups(),
 			"huaweicloud_dms_kafka_extend_flavors":           kafka.DataSourceDmsKafkaExtendFlavors(),

--- a/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_consumer_group_members_test.go
+++ b/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_consumer_group_members_test.go
@@ -1,0 +1,108 @@
+package kafka
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this test, make sure that the consumer group status is `STABLE`.
+func TestAccDataConsumerGroupMembers_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dms_kafka_consumer_group_members.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byHost   = "data.huaweicloud_dms_kafka_consumer_group_members.filter_by_host"
+		dcByHost = acceptance.InitDataSourceCheck(byHost)
+
+		byMemberId   = "data.huaweicloud_dms_kafka_consumer_group_members.filter_by_member_id"
+		dcByMemberId = acceptance.InitDataSourceCheck(byMemberId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
+			acceptance.TestAccPreCheckDMSKafkaConsumerGroupName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataConsumerGroupMembers_instanceNotFound(),
+				ExpectError: regexp.MustCompile(`This DMS instance does not exist`),
+			},
+			{
+				Config: testAccDataConsumerGroupMembers_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "members.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "members.0.id"),
+					resource.TestCheckResourceAttrSet(all, "members.0.host"),
+					resource.TestCheckResourceAttrSet(all, "members.0.client_id"),
+					dcByHost.CheckResourceExists(),
+					resource.TestCheckOutput("is_host_filter_useful", "true"),
+					dcByMemberId.CheckResourceExists(),
+					resource.TestCheckOutput("is_member_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataConsumerGroupMembers_instanceNotFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dms_kafka_consumer_group_members" "test" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+}
+`, randomId, acceptance.HW_DMS_KAFKA_CONSUMER_GROUP_NAME)
+}
+
+func testAccDataConsumerGroupMembers_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dms_kafka_consumer_group_members" "test" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+}
+
+locals {
+  host      = try(data.huaweicloud_dms_kafka_consumer_group_members.test.members[0].host, null)
+  member_id = try(data.huaweicloud_dms_kafka_consumer_group_members.test.members[0].id, null)
+}
+
+data "huaweicloud_dms_kafka_consumer_group_members" "filter_by_host" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+  host        = local.host
+}
+
+locals {
+  filter_by_host_result = [for v in data.huaweicloud_dms_kafka_consumer_group_members.filter_by_host.members : strcontains(v.host, local.host)]
+}
+
+output "is_host_filter_useful" {
+  value = length(local.filter_by_host_result) >= 0 && alltrue(local.filter_by_host_result)
+}
+
+data "huaweicloud_dms_kafka_consumer_group_members" "filter_by_member_id" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+  member_id   = local.member_id
+}
+
+locals {
+  filter_by_member_id_result = [for v in data.huaweicloud_dms_kafka_consumer_group_members.filter_by_member_id.members :
+  strcontains(v.id, local.member_id)]
+}
+
+output "is_member_id_filter_useful" {
+  value = length(local.filter_by_member_id_result) >= 0 && alltrue(local.filter_by_member_id_result)
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, acceptance.HW_DMS_KAFKA_CONSUMER_GROUP_NAME)
+}

--- a/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_consumer_group_members.go
+++ b/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_consumer_group_members.go
@@ -1,0 +1,179 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Kafka GET /v2/{engine}/{project_id}/instances/{instance_id}/groups/{group}/members
+func DataSourceConsumerGroupMembers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceConsumerGroupMembersRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the consumer group members are located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the Kafka instance.`,
+			},
+			"group": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the consumer group.`,
+			},
+			"host": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The address of the consumer.`,
+			},
+			"member_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the consumer.`,
+			},
+			"members": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of consumer group members that match the filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the consumer.`,
+						},
+						"host": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The address of the consumer.`,
+						},
+						"client_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the client.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildConsumerGroupMembersQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if host, ok := d.GetOk("host"); ok {
+		res += fmt.Sprintf("&host=%s", host)
+	}
+	if memberId, ok := d.GetOk("member_id"); ok {
+		res += fmt.Sprintf("&member_id=%s", memberId)
+	}
+
+	return res
+}
+
+func listConsumerGroupMembers(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		// The limit maximum value is 50, default is 10.
+		httpUrl = "v2/kafka/{project_id}/instances/{instance_id}/groups/{group}/members?limit=50"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", d.Get("instance_id").(string))
+	listPath = strings.ReplaceAll(listPath, "{group}", d.Get("group").(string))
+	listPath += buildConsumerGroupMembersQueryParams(d)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &getOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		members := utils.PathSearch("members", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, members...)
+		// The `offset` cannot be greater than or equal to the total number of members. Otherwise, the response is as follows:
+		// {"error_code": "DMS.00400062","error_msg": "Invalid {0} parameter in the request."}
+		offset += len(members)
+		if offset >= int(utils.PathSearch("total", respBody, float64(0)).(float64)) {
+			break
+		}
+	}
+	return result, nil
+}
+
+func dataSourceConsumerGroupMembersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	members, err := listConsumerGroupMembers(client, d)
+	if err != nil {
+		return diag.Errorf("error querying member list under consumer group (%s): %s", d.Get("group").(string), err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("members", flattenConsumerGroupMembers(members)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenConsumerGroupMembers(members []interface{}) []interface{} {
+	if len(members) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(members))
+	for _, v := range members {
+		rst = append(rst, map[string]interface{}{
+			"id":        utils.PathSearch("member_id", v, nil),
+			"host":      utils.PathSearch("host", v, nil),
+			"client_id": utils.PathSearch("client_id", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

 Add new data source (`huaweicloud_dms_kafka_consumer_group_members`) to query members under consumer group.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source and its corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccDataConsumerGroupMembers_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccDataConsumerGroupMembers_basic -timeout 360m -parallel 10
=== RUN   TestAccDataConsumerGroupMembers_basic
=== PAUSE TestAccDataConsumerGroupMembers_basic
=== CONT  TestAccDataConsumerGroupMembers_basic
--- PASS: TestAccDataConsumerGroupMembers_basic (16.12s)
PASS
coverage: 2.8% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     16.213s coverage: 2.8% of statements in ./huaweicloud/services/kafka
```
<img width="1008" height="100" alt="image" src="https://github.com/user-attachments/assets/897089b6-89ac-43b8-83dd-3e0e74caa9de" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
