### PR TITLE
feat(cdn): add new data source for query quotas

### DIFF
--- a/docs/data-sources/cdn_quotas.md
+++ b/docs/data-sources/cdn_quotas.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Content Delivery Network (CDN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cdn_quotas"
+description: |-
+  Use this data source to get the CDN resource quotas within HuaweiCloud.
+---
+
+# huaweicloud_cdn_quotas
+
+Use this data source to get the CDN resource quotas within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cdn_quotas" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the resource quotas are located.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `quotas` - The list of the resource quotas that matched filter parameters.  
+  The [quotas](#cdn_quotas) structure is documented below.
+
+<a name="cdn_quotas"></a>
+The `quotas` block supports:
+
+* `limit` - The limit of the resource quota.
+
+* `type` - The type of the resource quota.
+
+* `used` - The used capacity of the resource quota.
+
+* `user_domain_id` - The domain ID of the user to which the resource quota belong.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -740,6 +740,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdn_analytics":           cdn.DataSourceCdnAnalytics(),
 			"huaweicloud_cdn_domain_tags":         cdn.DataSourceDomainTags(),
 			"huaweicloud_cdn_ip_information":      cdn.DataSourceIpInformation(),
+			"huaweicloud_cdn_quotas":              cdn.DataSourceQuotas(),
 
 			"huaweicloud_ces_agent_dimensions":                  ces.DataSourceCesAgentDimensions(),
 			"huaweicloud_ces_agent_maintenance_tasks":           ces.DataSourceCesAgentMaintenanceTasks(),

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_quotas_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_quotas_test.go
@@ -1,0 +1,39 @@
+package cdn
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCdnQuotas_basic(t *testing.T) {
+	var (
+		dcName = "data.huaweicloud_cdn_quotas.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCdnQuotas_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dcName, "quotas.#", regexp.MustCompile("^[1-9]([0-9]*)?$")),
+					resource.TestCheckResourceAttrSet(dcName, "quotas.0.limit"),
+					resource.TestCheckResourceAttrSet(dcName, "quotas.0.type"),
+					resource.TestCheckResourceAttrSet(dcName, "quotas.0.used"),
+					resource.TestCheckResourceAttrSet(dcName, "quotas.0.user_domain_id"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceCdnQuotas_basic = `data "huaweicloud_cdn_quotas" "test" {}`

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_quotas.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_quotas.go
@@ -1,0 +1,133 @@
+package cdn
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CDN GET /v1.0/cdn/quota
+func DataSourceQuotas() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceQuotasRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the resource quotas are located.`,
+			},
+
+			// Attributes.
+			"quotas": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"limit": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The limit of the resource quota.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the resource quota.`,
+						},
+						"used": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The used capacity of the resource quota.`,
+						},
+						"user_domain_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The domain ID of the user to which the resource quota belong.`,
+						},
+					},
+				},
+				Description: `The list of the resource quotas that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func getQuotas(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	httpUrl := "v1.0/cdn/quota"
+	getPath := client.Endpoint + httpUrl
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("quotas", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenQuotas(quotas []interface{}) []map[string]interface{} {
+	if len(quotas) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(quotas))
+	for _, quota := range quotas {
+		result = append(result, map[string]interface{}{
+			"limit":          utils.PathSearch("quota_limit", quota, nil),
+			"type":           utils.PathSearch("type", quota, nil),
+			"used":           utils.PathSearch("used", quota, nil),
+			"user_domain_id": utils.PathSearch("user_domain_id", quota, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("cdn", region)
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	resp, err := getQuotas(client)
+	if err != nil {
+		return diag.Errorf("error querying resource quotas: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("quotas", flattenQuotas(resp)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(cdn): add new data source for query quotas

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccDataSourceCdnQuotas_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCdnQuotas_basic
=== PAUSE TestAccDataSourceCdnQuotas_basic
=== CONT  TestAccDataSourceCdnQuotas_basic
--- PASS: TestAccDataSourceCdnQuotas_basic (23.39s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       23.489s coverage: 3.7% of statements in ./huaweicloud/services/cdn
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.