### PR TITLE
fix(tags): using public method to avoid unknow value panic

### DIFF
--- a/huaweicloud/config/default_tags.go
+++ b/huaweicloud/config/default_tags.go
@@ -3,36 +3,19 @@ package config
 import (
 	"context"
 
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
-
-func GetRawConfigTags(rawConfig cty.Value) map[string]interface{} {
-	tagsRaw := rawConfig.GetAttr("tags")
-
-	if tagsRaw.IsNull() || !tagsRaw.IsKnown() || !tagsRaw.Type().IsMapType() {
-		return nil
-	}
-
-	result := make(map[string]interface{})
-	for k, v := range tagsRaw.AsValueMap() {
-		if !v.IsNull() {
-			result[k] = v.AsString()
-		}
-	}
-	return result
-}
 
 func MergeDefaultTags() schema.CustomizeDiffFunc {
 	return func(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
-		cfg := meta.(*Config)
-		defaultTags := cfg.DefaultTags
+		var (
+			cfg          = meta.(*Config)
+			resourceTags = utils.TryMapValueAnalysis(utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "tags"))
+			mergedTags   = make(map[string]interface{})
+		)
 
-		rawConfig := d.GetRawConfig()
-		resourceTags := GetRawConfigTags(rawConfig)
-
-		mergedTags := make(map[string]interface{})
-		for k, v := range defaultTags {
+		for k, v := range cfg.DefaultTags {
 			mergedTags[k] = v
 		}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The current method will trigger panic that it is using to get tags value from resource's raw configuration
Then we using `GetNestedObjectFromRawConfig()` method to replace it and fix this issue.

The panic will report after command `terraform plan` or `terraform apply` execution:
<img width="1203" height="846" alt="image" src="https://github.com/user-attachments/assets/0d0740ec-8d0c-4c6f-8503-320802474837" />

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. using public method to avoid unknow value panic
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

<img width="940" height="1101" alt="image" src="https://github.com/user-attachments/assets/69451e35-b316-4c39-993c-26d02379547e" />
<img width="973" height="1116" alt="image" src="https://github.com/user-attachments/assets/1303a993-a6c4-441f-9bc1-3abc5e0dd1d4" />

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
