### PR TITLE
feat(hss): new datasource to query container network policies

### DIFF
--- a/docs/data-sources/hss_container_network_policies.md
+++ b/docs/data-sources/hss_container_network_policies.md
@@ -1,0 +1,68 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_container_network_policies"
+description: |-
+  Use this data source to get the list of container network policies within HuaweiCloud.
+---
+# huaweicloud_hss_container_network_policies
+
+Use this data source to get the list of container network policies within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_hss_container_network_policies" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the cluster ID.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need to set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `namespace` - (Optional, String) Specifies the namespace to filter the network policies.
+
+* `keyword` - (Optional, String) Specifies the keyword to filter the network policies by name.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `total_num` - The total number of network policies.
+
+* `last_update_time` - The last update time of the network policies in milliseconds.
+
+* `data_list` - The list of network policies.
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `policy_id` - The ID of the network policy.
+
+* `name` - The name of the network policy.
+
+* `namespace` - The namespace to which the network policy belongs.
+
+* `policy_content` - The content of the network policy in JSON format.
+
+* `create_time` - The creation time of the network policy.
+
+* `deploy_status` - The deployment status of the network policy.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1283,6 +1283,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_container_node_statistics":                 hss.DataSourceContainerNodeStatistics(),
 			"huaweicloud_hss_container_cluster_risks":                   hss.DataSourceContainerClusterRisks(),
 			"huaweicloud_hss_container_cluster_risk_affected_resources": hss.DataSourceContainerClusterRiskAffectedResources(),
+			"huaweicloud_hss_container_network_policies":                hss.DataSourceContainerNetworkPolicies(),
 			"huaweicloud_hss_event_handle_history":                      hss.DataSourceEventHandleHistory(),
 			"huaweicloud_hss_event_system_user_white_lists":             hss.DataSourceEventSystemUserWhiteLists(),
 			"huaweicloud_hss_event_login_white_lists":                   hss.DataSourceEventLoginWhiteLists(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_network_policies_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_network_policies_test.go
@@ -1,0 +1,40 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceContainerNetworkPolicies_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_container_network_policies.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceContainerNetworkPolicies_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "total_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "last_update_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceContainerNetworkPolicies_basic string = `
+data "huaweicloud_hss_container_network_policies" "test" {
+  cluster_id = "non-exist-id"
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_container_network_policies.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_container_network_policies.go
@@ -1,0 +1,191 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/container-network/{cluster_id}/policy
+func DataSourceContainerNetworkPolicies() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceContainerNetworkPoliciesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"namespace": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"keyword": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"last_update_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"policy_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"namespace": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_content": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"deploy_status": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildContainerNetworkPoliciesQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=200"
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("namespace"); ok {
+		queryParams = fmt.Sprintf("%s&namespace=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("keyword"); ok {
+		queryParams = fmt.Sprintf("%s&keyword=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceContainerNetworkPoliciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		product        = "hss"
+		epsId          = cfg.GetEnterpriseProjectID(d)
+		result         = make([]interface{}, 0)
+		offset         = 0
+		totalNum       = 0
+		lastUpdateTime = 0
+		clusterID      = d.Get("cluster_id").(string)
+		httpUrl        = "v5/{project_id}/container-network/{cluster_id}/policy"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{cluster_id}", clusterID)
+	requestPath += buildContainerNetworkPoliciesQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving container network policies: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalNum = int(utils.PathSearch("total_num", respBody, float64(0)).(float64))
+		lastUpdateTime = int(utils.PathSearch("last_update_time", respBody, float64(0)).(float64))
+		dataList := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataList) == 0 {
+			break
+		}
+
+		result = append(result, dataList...)
+		offset += len(dataList)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_num", totalNum),
+		d.Set("last_update_time", lastUpdateTime),
+		d.Set("data_list", flattenContainerNetworkPoliciesDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenContainerNetworkPoliciesDataList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"policy_id":      utils.PathSearch("policy_id", v, nil),
+			"name":           utils.PathSearch("name", v, nil),
+			"namespace":      utils.PathSearch("namespace", v, nil),
+			"policy_content": utils.PathSearch("policy_content", v, nil),
+			"create_time":    utils.PathSearch("create_time", v, nil),
+			"deploy_status":  utils.PathSearch("deploy_status", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query container nerwork policies.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccDataSourceContainerNetworkPolicies_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccDataSourceContainerNetworkPolicies_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceContainerNetworkPolicies_basic
=== PAUSE TestAccDataSourceContainerNetworkPolicies_basic
=== CONT  TestAccDataSourceContainerNetworkPolicies_basic
--- PASS: TestAccDataSourceContainerNetworkPolicies_basic (10.32s)
PASS
coverage: 3.2% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       10.406s coverage: 3.2% of statements in ./huaweicloud/services/hss
```
<img width="1417" height="82" alt="image" src="https://github.com/user-attachments/assets/b51c310e-9d07-4d66-a546-7626223a0e7f" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
