### PR TITLE
feat(ECS): fix ecs interface attach params

### DIFF
--- a/docs/resources/compute_interface_attach.md
+++ b/docs/resources/compute_interface_attach.md
@@ -84,14 +84,15 @@ The following arguments are supported:
 * `port_id` - (Optional, String, ForceNew) The ID of the Port to attach to an Instance.
   This option and `network_id` are mutually exclusive.
 
-* `network_id` - (Optional, String, ForceNew) The ID of the Network to attach to an Instance. A port will be created
-  automatically.
+* `network_id` - (Optional, String) The ID of the Network to attach to an Instance. A port will be created automatically.
   This option and `port_id` are mutually exclusive.
 
-* `fixed_ip` - (Optional, String, ForceNew) An IP address to associate with the port.
+* `fixed_ip` - (Optional, String) An IP address to associate with the port.
 
-  ->This option cannot be used with port_id. You must specify a network_id. The IP address must lie in a range on
+  ->This option cannot be used with `port_id`. You must specify a `network_id`. The IP address must lie in a range on
   the supplied network.
+
+* `fixed_ipv6` - (Optional, String) The IPv6 address.
 
 * `source_dest_check` - (Optional, Bool) Specifies whether the ECS processes only traffic that is destined specifically
   for it. This function is enabled by default but should be disabled if the ECS functions as a SNAT server or has a
@@ -99,6 +100,10 @@ The following arguments are supported:
 
 * `security_group_ids` - (Optional, List) Specifies the list of security group IDs bound to the specified port.  
   Defaults to the default security group.
+
+* `delete_on_termination` - (Optional, String) Whether to delete a NIC when detaching it. Value options:
+  + **true**: Delete the NIC.
+  + **false**: Do not delete the NIC.
 
 * `ipv6_enable` - (Optional, Bool, ForceNew) Specifies if the NIC supporting IPv6 or not.
 
@@ -111,8 +116,6 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The resource ID in format of ECS instance ID and port ID separated by a slash.
 
 * `mac` - The MAC address of the NIC.
-
-* `fixed_ipv6` - The IPv6 address.
 
 ## Timeouts
 

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_interface_attach_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_interface_attach_test.go
@@ -68,6 +68,7 @@ func TestAccComputeInterfaceAttach_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "source_dest_check", "false"),
+					resource.TestCheckResourceAttr(resourceName, "delete_on_termination", "false"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_ids.0",
 						"huaweicloud_networking_secgroup.test", "id"),
 				),
@@ -77,6 +78,7 @@ func TestAccComputeInterfaceAttach_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "source_dest_check", "true"),
+					resource.TestCheckResourceAttr(resourceName, "delete_on_termination", "true"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_ids.0",
 						"huaweicloud_networking_secgroup.test", "id"),
 				),
@@ -145,10 +147,11 @@ func testAccComputeInterfaceAttach_basic(rName string) string {
 %s
 
 resource "huaweicloud_compute_interface_attach" "test" {
-  instance_id        = huaweicloud_compute_instance.test.id
-  network_id         = huaweicloud_vpc_subnet.test.id
-  security_group_ids = [huaweicloud_networking_secgroup.test.id]
-  source_dest_check  = false
+  instance_id           = huaweicloud_compute_instance.test.id
+  network_id            = huaweicloud_vpc_subnet.test.id
+  security_group_ids    = [huaweicloud_networking_secgroup.test.id]
+  source_dest_check     = false
+  delete_on_termination = false
 }
 `, testAccComputeInterfaceAttachBase(rName))
 }
@@ -158,9 +161,10 @@ func testAccComputeInterfaceAttach_update(rName string) string {
 %s
 
 resource "huaweicloud_compute_interface_attach" "test" {
-  instance_id        = huaweicloud_compute_instance.test.id
-  network_id         = huaweicloud_vpc_subnet.test.id
-  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  instance_id           = huaweicloud_compute_instance.test.id
+  network_id            = huaweicloud_vpc_subnet.test.id
+  security_group_ids    = [huaweicloud_networking_secgroup.test.id]
+  delete_on_termination = true
 }
 `, testAccComputeInterfaceAttachBase(rName))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix ecs interface attach params
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix ecs interface attach params
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/ecs/ TESTARGS='-run TestAccComputeInterfaceAttach_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs/ -v -run TestAccComputeInterfaceAttach_Basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInterfaceAttach_Basic
=== PAUSE TestAccComputeInterfaceAttach_Basic
=== CONT  TestAccComputeInterfaceAttach_Basic
--- PASS: TestAccComputeInterfaceAttach_Basic (430.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       430.718s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
