### PR TITLE
feat(kafka): add data source to query message offset under consumer group

### DIFF
--- a/docs/data-sources/dms_kafka_consumer_group_message_offsets.md
+++ b/docs/data-sources/dms_kafka_consumer_group_message_offsets.md
@@ -1,0 +1,64 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_consumer_group_message_offsets"
+description: |-
+  Use this data source to get the message offset list under the specified consumer group within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_consumer_group_message_offsets
+
+Use this data source to get the message offset list under the specified consumer group within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "consumer_group_name" {}
+variable "topic_name" {}
+
+data "huaweicloud_dms_kafka_consumer_group_message_offsets" "test" {
+  instance_id = var.instance_id
+  group       = var.consumer_group_name
+  topic       = var.topic_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the consumer group message offsets are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the Kafka instance.
+
+* `group` - (Required, String) Specifies the name of the consumer group.
+
+* `topic` - (Required, String) Specifies the name of the topic.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `message_offsets` - The list of consumer group message offsets.  
+  The [message_offsets](#kafka_consumer_group_message_offsets_struct) structure is documented below.
+
+<a name="kafka_consumer_group_message_offsets_struct"></a>
+The `message_offsets` block supports:
+
+* `partition` - The name of the partition.
+
+* `message_current_offset` - The current offset of the message.
+
+* `message_log_start_offset` - The start offset of the message.
+
+* `message_log_end_offset` - The end offset of the message.
+
+* `consumer_id` - The consumer ID of the consumed message.
+
+* `host` - The consumer address of the consumed message.
+
+* `client_id` - The ID of the client.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1079,6 +1079,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_dms_kafka_background_tasks":                 kafka.DataSourceDmsKafkaBackgroundTasks(),
 			"huaweicloud_dms_kafka_consumer_group_members":           kafka.DataSourceConsumerGroupMembers(),
+			"huaweicloud_dms_kafka_consumer_group_message_offsets":   kafka.DataSourceConsumerGroupMessageOffsets(),
 			"huaweicloud_dms_kafka_consumer_group_topics":            kafka.DataSourceConsumerGroupTopics(),
 			"huaweicloud_dms_kafka_consumer_groups":                  kafka.DataSourceDmsKafkaConsumerGroups(),
 			"huaweicloud_dms_kafka_extend_flavors":                   kafka.DataSourceDmsKafkaExtendFlavors(),

--- a/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_consumer_group_message_offsets_test.go
+++ b/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_consumer_group_message_offsets_test.go
@@ -1,0 +1,92 @@
+package kafka
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this test, make sure that the consumer group is online (status is STABLE).
+func TestAccDataConsumerGroupMessageOffsets_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dms_kafka_consumer_group_message_offsets.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
+			acceptance.TestAccPreCheckDMSKafkaConsumerGroupName(t)
+			acceptance.TestAccPreCheckDMSKafkaTopicName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataConsumerGroupMessageOffsets_instanceNotFound(),
+				ExpectError: regexp.MustCompile(`This DMS instance does not exist`),
+			},
+			{
+				Config: testAccDataConsumerGroupMessageOffsets_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "message_offsets.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "message_offsets.0.consumer_id"),
+					resource.TestCheckResourceAttrSet(all, "message_offsets.0.host"),
+					resource.TestCheckResourceAttrSet(all, "message_offsets.0.client_id"),
+					resource.TestCheckOutput("message_offset_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataConsumerGroupMessageOffsets_instanceNotFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dms_kafka_consumer_group_message_offsets" "test" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+  topic       = "%[3]s"
+}
+`, randomId, acceptance.HW_DMS_KAFKA_CONSUMER_GROUP_NAME, acceptance.HW_DMS_KAFKA_TOPIC_NAME)
+}
+
+func testAccDataConsumerGroupMessageOffsets_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_message_produce" "test" {
+  instance_id = "%[1]s"
+  topic       = "%[3]s"
+  body        = "terraform test"
+
+  property_list {
+    name  = "PARTITION"
+    value = "0"
+  }
+}
+
+data "huaweicloud_dms_kafka_consumer_group_message_offsets" "test" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+  topic       = "%[3]s"
+}
+
+locals {
+  message_offset = try([for v in data.huaweicloud_dms_kafka_consumer_group_message_offsets.test.message_offsets : v
+  if v.partition == 0][0], {})
+}
+
+output "message_offset_validation_pass" {
+  value = (
+    lookup(local.message_offset, "partition", null) == 0 &&
+    lookup(local.message_offset, "message_current_offset", null) > 0 &&
+    lookup(local.message_offset, "message_log_end_offset", null) > 0
+  )
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, acceptance.HW_DMS_KAFKA_CONSUMER_GROUP_NAME, acceptance.HW_DMS_KAFKA_TOPIC_NAME)
+}

--- a/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_consumer_group_message_offsets.go
+++ b/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_consumer_group_message_offsets.go
@@ -1,0 +1,185 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Kafka GET /v2/{engine}/{project_id}/instances/{instance_id}/groups/{group}/message-offset
+func DataSourceConsumerGroupMessageOffsets() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceConsumerGroupMessageOffsetsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the consumer group message offsets are located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the Kafka instance.`,
+			},
+			"group": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the consumer group.`,
+			},
+			"topic": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the topic.`,
+			},
+			"message_offsets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"partition": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The name of the partition.`,
+						},
+						"message_current_offset": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The current offset of the message.`,
+						},
+						"message_log_start_offset": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The start offset of the message.`,
+						},
+						"message_log_end_offset": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The end offset of the message.`,
+						},
+						"consumer_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The consumer ID of the consumed message.`,
+						},
+						"host": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The consumer address of the consumed message.`,
+						},
+						"client_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the client.`,
+						},
+					},
+				},
+				Description: `The list of consumer group message offsets.`,
+			},
+		},
+	}
+}
+
+func listConsumerGroupMessageOffsets(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/kafka/{project_id}/instances/{instance_id}/groups/{group}/message-offset"
+		result  = make([]interface{}, 0)
+		offset  = 0
+		// The limit maximum value is 50, default is 10.
+		limit   = 50
+		listOpt = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json;charset=utf-8",
+			},
+		}
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", d.Get("instance_id").(string))
+	listPath = strings.ReplaceAll(listPath, "{group}", d.Get("group").(string))
+	listPath = fmt.Sprintf("%s?topic=%s&limit=%d", listPath, d.Get("topic").(string), limit)
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		resp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		messageOffsets := utils.PathSearch("group_message_offsets", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, messageOffsets...)
+		if len(messageOffsets) < limit {
+			break
+		}
+
+		offset += len(messageOffsets)
+	}
+
+	return result, nil
+}
+
+func dataSourceConsumerGroupMessageOffsetsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	groupMessageOffsets, err := listConsumerGroupMessageOffsets(client, d)
+	if err != nil {
+		return diag.Errorf("error querying message offset list under consumer group (%s): %s", d.Get("group").(string), err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("message_offsets", flattenConsumerGroupMessageOffsets(groupMessageOffsets)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenConsumerGroupMessageOffsets(groupMessageOffsets []interface{}) []interface{} {
+	if len(groupMessageOffsets) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(groupMessageOffsets))
+	for _, v := range groupMessageOffsets {
+		rst = append(rst, map[string]interface{}{
+			"partition":                utils.PathSearch("partition", v, nil),
+			"message_current_offset":   utils.PathSearch("message_current_offset", v, nil),
+			"message_log_start_offset": utils.PathSearch("message_log_start_offset", v, nil),
+			"message_log_end_offset":   utils.PathSearch("message_log_end_offset", v, nil),
+			"consumer_id":              utils.PathSearch("consumer_id", v, nil),
+			"host":                     utils.PathSearch("host", v, nil),
+			"client_id":                utils.PathSearch("client_id", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data source (`huaweicloud_dms_kafka_consumer_group_message_offsets`) to query message offset under the specified consumer group.

**The `partition `filter condition is invalid, so this parameter is not provided for the time being.**

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source and its corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccDataConsumerGroupMessageOffsets_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccDataConsumerGroupMessageOffsets_basic -timeout 360m -parallel 10
=== RUN   TestAccDataConsumerGroupMessageOffsets_basic
=== PAUSE TestAccDataConsumerGroupMessageOffsets_basic
=== CONT  TestAccDataConsumerGroupMessageOffsets_basic
--- PASS: TestAccDataConsumerGroupMessageOffsets_basic (15.60s)
PASS
coverage: 3.5% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     15.779s coverage: 3.5% of statements in ./huaweicloud/services/kafka
```
<img width="1043" height="100" alt="image" src="https://github.com/user-attachments/assets/84158b55-c65f-48e4-8deb-215693d9acb9" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
