### PR TITLE
feat(hss): add new resource to update dynamic WTP Tomcat bin directory

### DIFF
--- a/docs/resources/hss_modify_webtamper_rasp_path.md
+++ b/docs/resources/hss_modify_webtamper_rasp_path.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_modify_webtamper_rasp_path"
+description: |-
+  Manages a resource to update the dynamic web tamper protection Tomcat bin directory within HuaweiCloud.
+---
+
+# huaweicloud_hss_modify_webtamper_rasp_path
+
+Manages a resource to update the dynamic web tamper protection Tomcat bin directory within HuaweiCloud.
+
+-> This resource is a one-time action resource. Deleting this resource will not clear the corresponding request record,
+  but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "host_id" {}
+variable "rasp_path" {}
+
+resource "huaweicloud_hss_modify_webtamper_rasp_path" "test" {
+  host_id   = var.host_id
+  rasp_path = var.rasp_path
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `host_id` - (Required, String, NonUpdatable) Specifies the server ID.
+  
+  -> Only Linux servers are supported. For this parameter to be valid, the server must have WTP enabled, or the WTP
+    policy is not deleted after WTP is disabled.
+
+* `rasp_path` - (Required, String, NonUpdatable) Specifies the Tomcat bin directory for dynamic WTP.
+  The value length is `1` to `256` characters. The value must start with a slash (/) and cannot end with a slash (/).
+  Only letters, numbers, underscores (_), hyphens (-), and periods (.) are allowed.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the hosts under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `host_name` - (Optional, String, NonUpdatable) Specifies the server name.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2769,6 +2769,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_event_alarm_white_list_delete":                  hss.ResourceEventAlarmWhiteListDelete(),
 			"huaweicloud_hss_event_login_white_list":                         hss.ResourceEventLoginWhiteList(),
 			"huaweicloud_hss_image_batch_scan":                               hss.ResourceImageBatchScan(),
+			"huaweicloud_hss_modify_webtamper_rasp_path":                     hss.ResourceModifyWebtamperRaspPath(),
 			"huaweicloud_hss_setting_two_factor_login_config":                hss.ResourceSettingTwoFactorLoginConfig(),
 			"huaweicloud_hss_switch_honeypot_port_policy":                    hss.ResourceSwitchHoneypotPortPolicy(),
 			"huaweicloud_hss_vulnerability_information_export":               hss.ResourceVulnerabilityInformationExport(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_modify_webtamper_rasp_path_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_modify_webtamper_rasp_path_test.go
@@ -1,0 +1,37 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccModifyWebtamperRaspPath_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting a host ID that has enabled web tamper protection.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testModifyWebtamperRaspPath_basic(),
+			},
+		},
+	})
+}
+
+func testModifyWebtamperRaspPath_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_hss_modify_webtamper_rasp_path" "test" {
+  host_id               = "%s"
+  rasp_path             = "/usr/workspace/apache-tomcat-8.5.15/bin"
+  enterprise_project_id = "0"
+}
+`, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
+}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_modify_webtamper_rasp_path.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_modify_webtamper_rasp_path.go
@@ -1,0 +1,137 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var modifyWebtamperRaspPathNonUpdatableParams = []string{"host_id", "rasp_path", "enterprise_project_id", "host_name"}
+
+// @API HSS PUT /v5/{project_id}/wtp/{host_id}/rasp-path
+func ResourceModifyWebtamperRaspPath() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceModifyWebtamperRaspPathCreate,
+		ReadContext:   resourceModifyWebtamperRaspPathRead,
+		UpdateContext: resourceModifyWebtamperRaspPathUpdate,
+		DeleteContext: resourceModifyWebtamperRaspPathDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(modifyWebtamperRaspPathNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"rasp_path": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// This parameter does not tack effect
+			"host_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildModifyWebtamperRaspPathBodyParams(d *schema.ResourceData, epsId string) string {
+	queryParams := ""
+
+	if v, ok := d.GetOk("host_name"); ok {
+		queryParams = fmt.Sprintf("%s&host_name=%v", queryParams, v)
+	}
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+
+	if queryParams != "" {
+		queryParams = "?" + queryParams[1:]
+	}
+
+	return queryParams
+}
+
+func resourceModifyWebtamperRaspPathCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v5/{project_id}/wtp/{host_id}/rasp-path"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		hostId  = d.Get("host_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{host_id}", hostId)
+	requestPath += buildModifyWebtamperRaspPathBodyParams(d, epsId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"rasp_path": d.Get("rasp_path"),
+		},
+	}
+
+	_, err = client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error updating the dynamic web tamper protection Tomcat bin directory: %s", err)
+	}
+
+	d.SetId(hostId)
+
+	return resourceModifyWebtamperRaspPathRead(ctx, d, meta)
+}
+
+func resourceModifyWebtamperRaspPathRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceModifyWebtamperRaspPathUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceModifyWebtamperRaspPathDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to updating the dynamic web tamper protection Tomcat bin directory.
+	  Deleting this resource will not clear the corresponding close records, but will only remove the resource information from
+	  the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to update dynamic WTP Tomcat bin directory.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccModifyWebtamperRaspPath_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccModifyWebtamperRaspPath_basic -timeout 360m -parallel 4
=== RUN   TestAccModifyWebtamperRaspPath_basic
=== PAUSE TestAccModifyWebtamperRaspPath_basic
=== CONT  TestAccModifyWebtamperRaspPath_basic
--- PASS: TestAccModifyWebtamperRaspPath_basic (12.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       12.727s
```
<img width="1144" height="21" alt="image" src="https://github.com/user-attachments/assets/27b1e656-e466-4670-bb47-60b76a9708b6" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
