### PR TITLE
feat(kafka): add a one-time resource to delete topic messages

### DIFF
--- a/docs/resources/dms_kafka_topic_message_batch_delete.md
+++ b/docs/resources/dms_kafka_topic_message_batch_delete.md
@@ -1,0 +1,85 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_topic_message_batch_delete"
+description: |-
+  Use this resource to delete messages under the specified topics within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_topic_message_batch_delete
+
+Use this resource to delete messages under the specified topics within HuaweiCloud.
+
+-> This resource is only a one-time action resource for deleting topic messages in batches. Deleting this
+   resource will not clear the corresponding request record, but will only remove the resource information from the
+   tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "topic_name" {}
+variable "partitions" {
+  type = list(object({
+    partition = number
+    offset    = number
+  }))
+}
+
+resource "huaweicloud_dms_kafka_topic_message_batch_delete" "test" {
+  instance_id = var.instance_id
+  topic       = var.topic_name
+
+  dynamic "partitions" {
+    for_each = var.partitions
+
+    content {
+      partition = partitions.value.partition
+      offset    = partitions.value.offset
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the topic messages to be deleted are located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the Kafka instance.
+
+* `topic` - (Required, String, NonUpdatable) Specifies the name of the topic.
+
+* `partitions` - (Required, List, NonUpdatable) Specifies the partition configuration list to which the messages
+  to be deleted belong.  
+  The [partitions](#kafka_topic_message_delete_partitions) structure is documented below.
+
+<a name="kafka_topic_message_delete_partitions"></a>
+The `partitions` block supports:
+
+* `partition` - (Required, Int, NonUpdatable) Specifies the number of the partition.
+
+* `offset` - (Required, Int, NonUpdatable) Specifies the offset of the message to be deleted.
+
+ -> The data after the earliest offset and before this offset will be deleted. For example, if the earliest offset
+   is `2` and the entered offset is `5`, the messages whose offset ranges from `2` to `4` will be deleted.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `result` - The result of the message delete operation.  
+ The [result](#kafka_topic_message_delete_result) structure is documented below.
+
+<a name="kafka_topic_message_delete_result"></a>
+The `result` block supports:
+
+* `partition` - The number of the partition.
+
+* `result` - The operation result.
+
+* `error_code` - The error code if the operation failed.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2615,6 +2615,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_smart_connect_task_action":         kafka.ResourceDmsKafkaSmartConnectTaskAction(),
 			"huaweicloud_dms_kafka_smart_connector_validate":          kafka.ResourceSmartConnectorValidate(),
 			"huaweicloud_dms_kafka_topic":                             kafka.ResourceDmsKafkaTopic(),
+			"huaweicloud_dms_kafka_topic_message_batch_delete":        kafka.ResourceTopicMessageBatchDelete(),
 			"huaweicloud_dms_kafka_topic_quota":                       kafka.ResourceTopicQuota(),
 			"huaweicloud_dms_kafka_user":                              kafka.ResourceDmsKafkaUser(),
 			"huaweicloud_dms_kafka_user_client_quota":                 kafka.ResourceDmsKafkaUserClientQuota(),

--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_topic_message_batch_delete_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_topic_message_batch_delete_test.go
@@ -1,0 +1,106 @@
+package kafka
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccTopicMessageBatchDelete_basic(t *testing.T) {
+	rName := "huaweicloud_dms_kafka_topic_message_batch_delete.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This is a one-time action resource not delete logic.
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTopicMessageBatchDelete_instanceNotFound(),
+				ExpectError: regexp.MustCompile(`This DMS instance does not exist`),
+			},
+			{
+				Config:      testAccTopicMessageBatchDelete_topicNotFound(),
+				ExpectError: regexp.MustCompile(`Invalid topic in the request`),
+			},
+			{
+				Config: testAccTopicMessageBatchDelete_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "result.#", "1"),
+					resource.TestCheckResourceAttr(rName, "result.0.partition", "0"),
+					resource.TestCheckResourceAttr(rName, "result.0.result", "success"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTopicMessageBatchDelete_instanceNotFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_topic_message_batch_delete" "test" {
+  instance_id = "%[1]s"
+  topic       = "instance_not_found"
+
+  partitions {
+    partition = 0
+    offset    = 1
+  }
+}
+`, randomId)
+}
+
+func testAccTopicMessageBatchDelete_topicNotFound() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_topic_message_batch_delete" "test" {
+  instance_id = "%[1]s"
+  topic       = "topic_not_found"
+
+  partitions {
+    partition = 0
+    offset    = 1
+  }
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID)
+}
+
+func testAccTopicMessageBatchDelete_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_topic" "test2" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+  partitions  = 2
+}
+
+resource "huaweicloud_dms_kafka_message_produce" "test" {
+  instance_id = "%[1]s"
+  topic       = huaweicloud_dms_kafka_topic.test2.name
+  body        = "tf test"
+
+  property_list {
+    name  = "PARTITION"
+    value = "0"
+  }
+}
+
+resource "huaweicloud_dms_kafka_topic_message_batch_delete" "test" {
+  instance_id = "%[1]s"
+  topic       = huaweicloud_dms_kafka_topic.test2.name
+
+  partitions {
+    partition = 0
+    offset    = 1
+  }
+
+  depends_on = [huaweicloud_dms_kafka_message_produce.test]
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, acceptance.RandomAccResourceName())
+}

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_topic_message_batch_delete.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_topic_message_batch_delete.go
@@ -1,0 +1,201 @@
+package kafka
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var topicMessageBatchDeleteNonUpdatableParams = []string{
+	"instance_id",
+	"topic",
+	"partitions",
+}
+
+// @API Kafka DELETE /v2/{project_id}/kafka/instances/{instance_id}/topics/{topic}/messages
+func ResourceTopicMessageBatchDelete() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTopicMessageBatchDeleteCreate,
+		ReadContext:   resourceTopicMessageBatchDeleteRead,
+		UpdateContext: resourceTopicMessageBatchDeleteUpdate,
+		DeleteContext: resourceTopicMessageBatchDeleteDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(topicMessageBatchDeleteNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the topic messages to be deleted are located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the Kafka instance.`,
+			},
+			"topic": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the topic.`,
+			},
+			"partitions": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"partition": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: `The number of the partition.`,
+						},
+						"offset": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: `The offset of the message to be deleted.`,
+						},
+					},
+				},
+				Description: `The partition configuration list to which the messages to be deleted belong.`,
+			},
+			// Attributes.
+			"result": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"partition": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The number of the partition.`,
+						},
+						"result": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The operation result.`,
+						},
+						"error_code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The error code if the operation failed.`,
+						},
+					},
+				},
+				Description: `The result of the message delete operation.`,
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildCreateTopicMessageBatchDeleteBodyParams(partitions []interface{}) map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(partitions))
+	for _, partition := range partitions {
+		result = append(result, map[string]interface{}{
+			"partition": utils.PathSearch("partition", partition, nil),
+			"offset":    utils.PathSearch("offset", partition, nil),
+		})
+	}
+
+	return map[string]interface{}{
+		"partitions": result,
+	}
+}
+
+func resourceTopicMessageBatchDeleteCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		httpUrl   = "v2/{project_id}/kafka/instances/{instance_id}/topics/{topic}/messages"
+		topicName = d.Get("topic").(string)
+	)
+	client, err := cfg.NewServiceClient("dmsv2", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", d.Get("instance_id").(string))
+	createPath = strings.ReplaceAll(createPath, "{topic}", topicName)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateTopicMessageBatchDeleteBodyParams(d.Get("partitions").([]interface{}))),
+	}
+
+	resp, err := client.Request("DELETE", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error deleting topic (%s) messages: %s", topicName, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("result", flattenTopicMessageBatchDeleteResult(utils.PathSearch("partitions",
+			respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenTopicMessageBatchDeleteResult(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rest := make([]interface{}, 0, len(resp))
+	for _, partition := range resp {
+		rest = append(rest, map[string]interface{}{
+			"partition":  utils.PathSearch("partition", partition, nil),
+			"result":     utils.PathSearch("result", partition, nil),
+			"error_code": utils.PathSearch("error_code", partition, nil),
+		})
+	}
+	return rest
+}
+
+func resourceTopicMessageBatchDeleteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceTopicMessageBatchDeleteUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceTopicMessageBatchDeleteDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for deleting topic messages in batches. Deleting
+this resource will not clear the corresponding request record, but will only remove the resource information from the
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new one-time resource (`huaweicloud_dms_kafka_topic_message_batch_delete`) to delete messages under the specified topics.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a one-time resource and its corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccTopicMessageBatchD
elete_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccTopicMessageBatchDelete_basic -timeout 360m -parallel 10
=== RUN   TestAccTopicMessageBatchDelete_basic
=== PAUSE TestAccTopicMessageBatchDelete_basic
=== CONT  TestAccTopicMessageBatchDelete_basic
--- PASS: TestAccTopicMessageBatchDelete_basic (29.53s)
PASS
coverage: 5.6% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     29.610s coverage: 5.6% of statements in ./huaweicloud/services/kafka
```
<img width="980" height="503" alt="image" src="https://github.com/user-attachments/assets/2125fc22-7339-4060-a3d6-a0edd9fac699" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
