### PR TITLE
feat(hss/hss_webtamper_policy): support `hss_webtamper_policy` data source

### DIFF
--- a/docs/data-sources/hss_webtamper_policy.md
+++ b/docs/data-sources/hss_webtamper_policy.md
@@ -1,0 +1,131 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_webtamper_policy"
+description: |-
+  Use this data source to get the web tamper policy of HSS within HuaweiCloud.
+---
+
+# huaweicloud_hss_webtamper_policy
+
+Use this data source to get the web tamper policy of HSS within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "host_id" {}
+
+data "huaweicloud_hss_webtamper_policy" "test" {
+  host_id = var.host_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `host_id` - (Required, String) Specifies the host ID.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `protect_dir_num` - The number of protected directories.
+
+* `protect_dir_info` - The protected directory information.
+
+  The [protect_dir_info](#protect_dir_info_struct) structure is documented below.
+
+* `enable_timing_off` - Whether the scheduled shutdown function is enabled.  
+  The valid values are as follows:
+  + **true**: Activate the timed shutdown protection function.
+  + **false**: The timed shutdown protection function is not enabled.
+
+* `timing_off_config_info` - The scheduled shutdown configuration details.
+
+  The [timing_off_config_info](#timing_off_config_info_struct) structure is documented below.
+
+* `enable_rasp_protect` - Whether dynamic web page tamper protection is enabled. Only Linux servers support
+  dynamic web tamper protection.  
+  The valid values are as follows:
+  + **true**: Enable dynamic web tamper protection.
+  + **false**: Dynamic web tamper protection is not enabled.
+
+* `rasp_path` - The Tomcat bin directory for dynamic web page tamper protection.
+
+* `enable_privileged_process` - Whether the privileged process is enabled.  
+  The valid values are as follows:
+  + **true**: Activate the privileged process.
+  + **false**: The privileged process has not been enabled.
+
+* `privileged_child_status` - Whether the privileged process child process is trusted. This requires enabling the
+  privileged process first.  
+  The valid values are as follows:
+  + **true**: Enable the trusted sub process of the privileged process.
+  + **false**: The privileged process sub process is not enabled and trusted.
+
+* `privileged_process_path_list` - The list of privileged process file paths.
+
+<a name="protect_dir_info_struct"></a>
+The `protect_dir_info` block supports:
+
+* `protect_dir_list` - The list of protected directories.
+
+  The [protect_dir_list](#protect_dir_list_struct) structure is documented below.
+
+* `exclude_file_type` - The excluded file types.
+
+* `protect_mode` - The protection mode.  
+  + **recovery**: Intercept mode.
+  + **alarm**: Alarm mode, only Linux servers support alarm mode.
+
+<a name="protect_dir_list_struct"></a>
+The `protect_dir_list` block supports:
+
+* `protect_dir` - The protected directory.
+
+* `exclude_child_dir` - The excluded subdirectories.
+
+* `exclue_file_path` - The excluded file path.
+
+* `local_backup_dir` - The local backup path. Only Linux servers support setting a local backup path.
+
+* `protect_status` - The protection status.  
+  The valid values are as follows:
+  + **closed**: Not enabled.
+  + **opened**: Protection in progress.
+  + **opening**: Enabling protection.
+  + **closing**: Disabling protection.
+  + **open_failed**: Protection failed.
+
+* `error` - The failure reason. This exists when the protection status is **open_failed**.
+
+<a name="timing_off_config_info_struct"></a>
+The `timing_off_config_info` block supports:
+
+* `week_off_list` - The automatic shutdown protection cycle list. `1` represents Monday, `2` represents Tuesday,
+  `3` represents Wednesday, `4` represents Thursday, `5` represents Friday, `6` represents Saturday,
+  `7` represents Sunday.
+
+* `timing_range_list` - The automatic shutdown protection time periods.
+
+  The [timing_range_list](#timing_range_list_struct) structure is documented below.
+
+<a name="timing_range_list_struct"></a>
+The `timing_range_list` block supports:
+
+* `time_range` - The automatic shutdown protection time range.
+
+* `description` - The description of the automatic shutdown protection time period.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1327,6 +1327,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_vulnerability_statistics":                  hss.DataSourceVulnerabilityStatistics(),
 			"huaweicloud_hss_webtamper_hosts":                           hss.DataSourceWebTamperHosts(),
 			"huaweicloud_hss_webtamper_rasp_path":                       hss.DataSourceWebtamperRaspPath(),
+			"huaweicloud_hss_webtamper_policy":                          hss.DataSourceWebTamperPolicy(),
 			"huaweicloud_hss_antivirus_custom_scan_policies":            hss.DataSourceAntivirusCustomScanPolicies(),
 			"huaweicloud_hss_antivirus_available_hosts":                 hss.DataSourceAntivirusAvailableHosts(),
 			"huaweicloud_hss_antivirus_statistic":                       hss.DataSourceAntivirusStatistic(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_webtamper_policy_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_webtamper_policy_test.go
@@ -1,0 +1,56 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceWebTamperPolicy_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_webtamper_policy.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting a host ID with web tamper protection enabled under the
+			// default enterprise project.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceWebTamperPolicy_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "protect_dir_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "protect_dir_info.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "protect_dir_info.0.protect_dir_list.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "protect_dir_info.0.protect_dir_list.0.protect_dir"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "protect_dir_info.0.protect_dir_list.0.local_backup_dir"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "protect_dir_info.0.protect_dir_list.0.protect_status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "protect_dir_info.0.exclude_file_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "protect_dir_info.0.protect_mode"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "enable_timing_off"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "enable_rasp_protect"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "enable_privileged_process"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "privileged_child_status"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceWebTamperPolicy_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_hss_webtamper_policy" "test" {
+  host_id               = "%s"
+  enterprise_project_id = "0"
+}
+`, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_webtamper_policy.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_webtamper_policy.go
@@ -1,0 +1,278 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/webtamper/{host_id}/policy
+func DataSourceWebTamperPolicy() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceWebTamperPolicyRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"protect_dir_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"protect_dir_info": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protect_dir_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"protect_dir": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"exclude_child_dir": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"exclue_file_path": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"local_backup_dir": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"protect_status": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"error": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"exclude_file_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protect_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"enable_timing_off": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"timing_off_config_info": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"week_off_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeInt},
+						},
+						"timing_range_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"time_range": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"description": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"enable_rasp_protect": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"rasp_path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enable_privileged_process": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"privileged_child_status": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"privileged_process_path_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func buildWebTamperPolicyQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%v", epsId)
+	}
+
+	return ""
+}
+
+func dataSourceWebTamperPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		product = "hss"
+		hostId  = d.Get("host_id").(string)
+		httpUrl = "v5/{project_id}/webtamper/{host_id}/policy"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{host_id}", hostId)
+	requestPath += buildWebTamperPolicyQueryParams(epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS web tamper policy: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("protect_dir_num", utils.PathSearch("protect_dir_num", respBody, nil)),
+		d.Set("protect_dir_info", flattenProtectDirInfo(respBody)),
+		d.Set("enable_timing_off", utils.PathSearch("enable_timing_off", respBody, nil)),
+		d.Set("timing_off_config_info", flattenTimingOffConfigInfo(respBody)),
+		d.Set("enable_rasp_protect", utils.PathSearch("enable_rasp_protect", respBody, nil)),
+		d.Set("rasp_path", utils.PathSearch("rasp_path", respBody, nil)),
+		d.Set("enable_privileged_process", utils.PathSearch("enable_privileged_process", respBody, nil)),
+		d.Set("privileged_child_status", utils.PathSearch("privileged_child_status", respBody, nil)),
+		d.Set("privileged_process_path_list", utils.PathSearch("privileged_process_path_list", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenProtectDirInfo(resp interface{}) []interface{} {
+	dirInfoResp := utils.PathSearch("protect_dir_info", resp, nil)
+	if dirInfoResp == nil {
+		return nil
+	}
+
+	dirListResp := utils.PathSearch("protect_dir_list", dirInfoResp, make([]interface{}, 0)).([]interface{})
+	dirListResult := make([]map[string]interface{}, 0, len(dirListResp))
+	for _, v := range dirListResp {
+		dirListResult = append(dirListResult, map[string]interface{}{
+			"protect_dir":       utils.PathSearch("protect_dir", v, nil),
+			"exclude_child_dir": utils.PathSearch("exclude_child_dir", v, nil),
+			"exclue_file_path":  utils.PathSearch("exclue_file_path", v, nil),
+			"local_backup_dir":  utils.PathSearch("local_backup_dir", v, nil),
+			"protect_status":    utils.PathSearch("protect_status", v, nil),
+			"error":             utils.PathSearch("error", v, nil),
+		})
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"protect_dir_list":  dirListResult,
+			"exclude_file_type": utils.PathSearch("exclude_file_type", dirInfoResp, nil),
+			"protect_mode":      utils.PathSearch("protect_mode", dirInfoResp, nil),
+		},
+	}
+}
+
+func flattenTimingOffConfigInfo(resp interface{}) []interface{} {
+	infoResp := utils.PathSearch("timing_off_config_info", resp, nil)
+	if infoResp == nil {
+		return nil
+	}
+
+	rangeListResp := utils.PathSearch("timing_range_list", infoResp, make([]interface{}, 0)).([]interface{})
+	rangeListResult := make([]map[string]interface{}, 0, len(rangeListResp))
+	for _, v := range rangeListResp {
+		rangeListResult = append(rangeListResult, map[string]interface{}{
+			"time_range":  utils.PathSearch("time_range", v, nil),
+			"description": utils.PathSearch("description", v, nil),
+		})
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"week_off_list":     flattenWeekOffList(utils.PathSearch("week_off_list", infoResp, make([]interface{}, 0)).([]interface{})),
+			"timing_range_list": rangeListResult,
+		},
+	}
+}
+
+func flattenWeekOffList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		if num, ok := v.(float64); ok {
+			result = append(result, int(num))
+		} else if num, ok := v.(int); ok {
+			result = append(result, num)
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_webtamper_policy` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_webtamper_policy` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceWebTamperPolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceWebTamperPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWebTamperPolicy_basic
=== PAUSE TestAccDataSourceWebTamperPolicy_basic
=== CONT  TestAccDataSourceWebTamperPolicy_basic
--- PASS: TestAccDataSourceWebTamperPolicy_basic (11.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       11.209s
```
<img width="876" height="41" alt="image" src="https://github.com/user-attachments/assets/b0551c2e-0d0d-4ace-80eb-6f1efb0ecad9" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
