### PR TITLE
chore(kafka/message_offset_reset): replace API and optimize code

### DIFF
--- a/docs/resources/dms_kafka_message_offset_reset.md
+++ b/docs/resources/dms_kafka_message_offset_reset.md
@@ -3,12 +3,17 @@ subcategory: "Distributed Message Service (DMS)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_dms_kafka_message_offset_reset"
 description: |-
-  Manage DMS kafka message offset reset resource within HuaweiCloud.
+  Use this resource to reset the message offset under the specified consumer group within HuaweiCloud.
 ---
 
 # huaweicloud_dms_kafka_message_offset_reset
 
-Manage DMS kafka message offset reset resource within HuaweiCloud.
+Use this resource to reset the message offset under the specified consumer group within HuaweiCloud.
+
+-> 1. Before using this resource to reset the consumption progress, you must stop the client of the reset consumer group.
+   <br>2. This resource is only a one-time action resource for resetting the consumption progress of the consumer group.
+   Deleting this resource will not clear the corresponding request record, but will only remove the resource information
+   from the tfstate file.
 
 ## Example Usage
 
@@ -16,14 +21,13 @@ Manage DMS kafka message offset reset resource within HuaweiCloud.
 
 ```hcl
 variable "instance_id" {}
-variable "group" {}
+variable "consumer_group_name" {}
 
 resource "huaweicloud_dms_kafka_message_offset_reset" "test" {
   instance_id = var.instance_id
-  group       = var.group
-  topic       = ""
+  group       = var.consumer_group_name
   partition   = -1
-  timestamp   = 0
+  timestamp   = "0"
 }
 ```
 
@@ -31,15 +35,15 @@ resource "huaweicloud_dms_kafka_message_offset_reset" "test" {
 
 ```hcl
 variable "instance_id" {}
-variable "group" {}
-variable "topic" {}
+variable "consumer_group_name" {}
+variable "topic_name" {}
 
 resource "huaweicloud_dms_kafka_message_offset_reset" "test" {
   instance_id = var.instance_id
-  group       = var.group
-  topic       = var.topic
+  group       = var.consumer_group_name
+  topic       = var.topic_name
   partition   = -1
-  timestamp   = 0
+  timestamp   = "0"
 }
 ```
 
@@ -47,15 +51,15 @@ resource "huaweicloud_dms_kafka_message_offset_reset" "test" {
 
 ```hcl
 variable "instance_id" {}
-variable "group" {}
-variable "topic" {}
+variable "consumer_group_name" {}
+variable "topic_name" {}
 
 resource "huaweicloud_dms_kafka_message_offset_reset" "test" {
   instance_id    = var.instance_id
-  group          = var.group
-  topic          = var.topic
-  partition      = -1
-  message_offset = 0
+  group          = var.consumer_group_name
+  topic          = var.topic_name
+  partition      = 0
+  message_offset = "0"
 }
 ```
 
@@ -63,30 +67,28 @@ resource "huaweicloud_dms_kafka_message_offset_reset" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+* `region` - (Optional, String, ForceNew) Specifies the region where the consumption progress is to be reset is located.
   If omitted, the provider-level region will be used.
   Changing this creates a new resource.
 
-* `instance_id` - (Required, String, ForceNew) Specifies the instance ID.
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the Kafka instance.  
   Changing this creates a new resource.
 
-* `group` - (Required, String, ForceNew) Specifies the group name.
+* `group` - (Required, String, ForceNew) Specifies the name of the consumer group.  
   Changing this creates a new resource.
 
 * `partition` - (Required, Int, ForceNew) Specifies the partiton number.
-  + If value is **-1**, reset all partitions. When `topic` is empty, only support reset all partitions.
-  + If value is specific number, reset that partiton only.
+  
+  -> If value is `-1`, it means to reset offset of all partitions.
 
+* `topic` - (Optional, String, ForceNew) Specifies name of the topic.  
   Changing this creates a new resource.
 
-* `topic` - (Optional, String, ForceNew) Specifies the topic name. If it is empty, reset all topic.
-  Changing this creates a new resource.
+  -> When `topic` is not specified, it means to reset offset of all topics.
 
-* `message_offset` - (Optional, String, ForceNew) Specifies the message offset.
+* `message_offset` - (Optional, String, ForceNew) Specifies the offset to reset the consumption progress.
   + If this offset is earlier than the current earliest offset, the offset will be reset to the earliest offset.
   + If this offset is later than the current largest offset, the offset will be reset to the latest offset.
-
-  Changing this creates a new resource.
 
 * `timestamp` - (Optional, String, ForceNew) Specifies the time that the offset is to be reset to.
   The value is a Unix timestamp, in millisecond.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2704,7 +2704,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_instance_rebalance_log":            kafka.ResourceInstanceRebalanceLog(),
 			"huaweicloud_dms_kafka_instance_restart":                  kafka.ResourceDmsKafkaInstanceRestart(),
 			"huaweicloud_dms_kafka_message_diagnosis_task":            kafka.ResourceDmsKafkaMessageDiagnosisTask(),
-			"huaweicloud_dms_kafka_message_offset_reset":              kafka.ResourceDmsKafkaMessageOffsetReset(),
+			"huaweicloud_dms_kafka_message_offset_reset":              kafka.ResourceMessageOffsetReset(),
 			"huaweicloud_dms_kafka_message_produce":                   kafka.ResourceDmsKafkaMessageProduce(),
 			"huaweicloud_dms_kafka_partition_reassign":                kafka.ResourceDmsKafkaPartitionReassign(),
 			"huaweicloud_dms_kafka_permissions":                       kafka.ResourceDmsKafkaPermissions(),

--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_message_offset_reset_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_message_offset_reset_test.go
@@ -2,37 +2,72 @@ package kafka
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccKafkaMessageOffsetReset_basic(t *testing.T) {
+// Before running this test, ensure the consumer group status is `EMPTY` and has consumed the topic.
+// The topic has produced messages.
+func TestAccMessageOffsetReset_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
 			acceptance.TestAccPreCheckDMSKafkaConsumerGroupName(t)
+			acceptance.TestAccPreCheckDMSKafkaTopicName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKafkaMessageOffsetReset_basic(),
+				Config:      testAccMessageOffsetReset_instanceNotFound(),
+				ExpectError: regexp.MustCompile(`This DMS instance does not exist`),
+			},
+			{
+				Config: testAccMessageOffsetReset_basic_step1(),
+			},
+			{
+				Config: testAccMessageOffsetReset_basic_step2(),
 			},
 		},
 	})
 }
 
-func testAccKafkaMessageOffsetReset_basic() string {
+func testAccMessageOffsetReset_instanceNotFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_message_offset_reset" "not_found" {
+  instance_id = "%[1]s"
+  group       = "%[2]s"
+  partition   = -1
+  timestamp   = "0"
+}`, randomId, acceptance.HW_DMS_KAFKA_CONSUMER_GROUP_NAME)
+}
+
+// Reset message offset for all topic with timestamp.
+func testAccMessageOffsetReset_basic_step1() string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dms_kafka_message_offset_reset" "test" {
   instance_id = "%[1]s"
   group       = "%[2]s"
-  topic       = ""
   partition   = -1
-  timestamp   = 0
+  timestamp   = "0"
 }`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, acceptance.HW_DMS_KAFKA_CONSUMER_GROUP_NAME)
+}
+
+// Reset message offset for all partition under specific topic with message offset.
+func testAccMessageOffsetReset_basic_step2() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_message_offset_reset" "test2" {
+  instance_id    = "%[1]s"
+  group          = "%[2]s"
+  topic          = "%[3]s"
+  partition      = 0
+  message_offset = "1"
+}`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, acceptance.HW_DMS_KAFKA_CONSUMER_GROUP_NAME, acceptance.HW_DMS_KAFKA_TOPIC_NAME)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Use new [API](https://support.huaweicloud.com/api-kafka/ResetMessageOffsetWithEngine.html) to replace old API and optimize code.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
use new API to replace old API and optimize code.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o kafka -f TestAccMessageOffsetReset_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccMessageOffsetReset_basic -timeout 360m -parallel 10
=== RUN   TestAccMessageOffsetReset_basic
=== PAUSE TestAccMessageOffsetReset_basic
=== CONT  TestAccMessageOffsetReset_basic
--- PASS: TestAccMessageOffsetReset_basic (43.10s)
PASS
coverage: 3.1% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     43.254s coverage: 3.1% of statements in ./huaweicloud/services/kafka
```
<img width="974" height="508" alt="image" src="https://github.com/user-attachments/assets/26841e1d-58de-41ff-9c6c-64164fccc0e0" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
