### PR TITLE
feat(cdn): add new resource for associate certificate with multi domains

### DIFF
--- a/docs/resources/cdn_certificate_associate_domains.md
+++ b/docs/resources/cdn_certificate_associate_domains.md
@@ -1,0 +1,115 @@
+---
+subcategory: "Content Delivery Network (CDN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cdn_certificate_associate_domains"
+description: |-
+  Use this resource to associate a certificate with multiple CDN domains within HuaweiCloud.
+---
+
+# huaweicloud_cdn_certificate_associate_domains
+
+Use this resource to associate a certificate with multiple CDN domains within HuaweiCloud.
+
+-> This resource is only a one-time action resource for bind certificate on the list of domains. Deleting this
+   resource will not clear the corresponding request record, but will only remove the resource information from
+   the tfstate file.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+variable target_domain_names {}
+variable certificate_name {}
+
+resource "huaweicloud_cdn_certificate_associate_domains" "test" {
+  domain_names = var.target_domain_names
+  https_switch = 1
+  cert_name    = var.certificate_name
+  certificate  = file("path/to/certificate.pem")
+  private_key  = file("path/to/private.key")
+}
+```
+
+### With Force Redirect Configuration
+
+```hcl
+variable target_domain_names {}
+variable certificate_name {}
+
+resource "huaweicloud_cdn_certificate_associate_domains" "test" {
+  domain_names = var.target_domain_names
+  https_switch = 1
+  cert_name    = var.certificate_name
+  certificate  = file("path/to/certificate.pem")
+  private_key  = file("path/to/private.key")
+  
+  force_redirect_config {
+    switch        = 1
+    redirect_type = "https"
+  }
+  
+  http2 = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_names` - (Required, String, NonUpdatable) The list of domain names to associate with the certificate.  
+  When there are multiple domains, separate them with comma (,).
+
+* `https_switch` - (Required, Int, NonUpdatable) The HTTPS certificate configuration switch.  
+  The valid values are as follows:
+  + **0**: Disable HTTPS
+  + **1**: Enable HTTPS
+
+* `access_origin_way` - (Optional, Int, NonUpdatable) The origin protocol configuration.  
+  The valid values are as follows:
+  + **1**: Protocol follow
+  + **2**: HTTP protocol (default)
+  + **3**: HTTPS protocol
+
+* `force_redirect_https` - (Optional, Int, NonUpdatable) Whether to enable HTTPS force redirect.  
+  The valid values are as follows:
+  + **0**: Disable (default)
+  + **1**: Enable
+
+* `force_redirect_config` - (Optional, List, NonUpdatable) The force redirect configuration.  
+  The [force_redirect_config](#cdn_force_redirect_config)structure is documented below.
+
+* `http2` - (Optional, Int, NonUpdatable) The HTTP/2 protocol switch.  
+  The valid values are as follows:
+  + **0**: Disable (default)
+  + **1**: Enable
+
+* `cert_name` - (Optional, String, NonUpdatable) The certificate name.
+
+* `certificate` - (Optional, String, NonUpdatable, Sensitive) The SSL certificate content in PEM format.
+
+* `private_key` - (Optional, String, NonUpdatable, Sensitive) The SSL certificate private key content in PEM format.
+
+* `certificate_type` - (Optional, Int, NonUpdatable) The certificate type.  
+  The valid values are as follows:
+  + **0**: Free certificate (default)
+  + **1**: Paid certificate
+
+<a name="cdn_force_redirect_config"></a>
+The `force_redirect_config` block supports:
+
+* `switch` - (Required, Int, NonUpdatable) The force redirect switch.  
+  The valid values are as follows:
+  + **0**: Disable
+  + **1**: Enable
+
+* `redirect_type` - (Optional, String, NonUpdatable) The redirect type.  
+  The valid values are as follows:
+  + **http**: Redirect to HTTP
+  + **https**: Redirect to HTTPS
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2301,11 +2301,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdm_job":            cdm.ResourceCdmJob(),
 			"huaweicloud_cdm_link":           cdm.ResourceCdmLink(),
 
-			"huaweicloud_cdn_domain":         cdn.ResourceCdnDomain(),
-			"huaweicloud_cdn_domain_rule":    cdn.ResourceCdnDomainRule(),
-			"huaweicloud_cdn_billing_option": cdn.ResourceBillingOption(),
-			"huaweicloud_cdn_cache_preheat":  cdn.ResourceCachePreheat(),
-			"huaweicloud_cdn_cache_refresh":  cdn.ResourceCacheRefresh(),
+			"huaweicloud_cdn_domain":                        cdn.ResourceCdnDomain(),
+			"huaweicloud_cdn_domain_rule":                   cdn.ResourceCdnDomainRule(),
+			"huaweicloud_cdn_billing_option":                cdn.ResourceBillingOption(),
+			"huaweicloud_cdn_cache_preheat":                 cdn.ResourceCachePreheat(),
+			"huaweicloud_cdn_cache_refresh":                 cdn.ResourceCacheRefresh(),
+			"huaweicloud_cdn_certificate_associate_domains": cdn.ResourceCertificateAssociateDomains(),
 
 			"huaweicloud_ces_alarmrule":                                     ces.ResourceAlarmRule(),
 			"huaweicloud_ces_alarm_template":                                ces.ResourceCesAlarmTemplate(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -173,16 +173,17 @@ var (
 
 	HW_CDN_DOMAIN_NAME = os.Getenv("HW_CDN_DOMAIN_NAME")
 	// `HW_CDN_CERT_DOMAIN_NAME` Configure the domain name environment variable of the certificate type.
-	HW_CDN_CERT_DOMAIN_NAME = os.Getenv("HW_CDN_CERT_DOMAIN_NAME")
-	HW_CDN_DOMAIN_URL       = os.Getenv("HW_CDN_DOMAIN_URL")
-	HW_CDN_CERT_PATH        = os.Getenv("HW_CDN_CERT_PATH")
-	HW_CDN_PRIVATE_KEY_PATH = os.Getenv("HW_CDN_PRIVATE_KEY_PATH")
-	HW_CDN_ENABLE_FLAG      = os.Getenv("HW_CDN_ENABLE_FLAG")
-	HW_CDN_TIMESTAMP        = os.Getenv("HW_CDN_TIMESTAMP")
-	HW_CDN_START_TIME       = os.Getenv("HW_CDN_START_TIME")
-	HW_CDN_END_TIME         = os.Getenv("HW_CDN_END_TIME")
-	HW_CDN_STAT_TYPE        = os.Getenv("HW_CDN_STAT_TYPE")
-	HW_CDN_IP_ADDRESSES     = os.Getenv("HW_CDN_IP_ADDRESSES")
+	HW_CDN_CERT_DOMAIN_NAME   = os.Getenv("HW_CDN_CERT_DOMAIN_NAME")
+	HW_CDN_DOMAIN_URL         = os.Getenv("HW_CDN_DOMAIN_URL")
+	HW_CDN_TARGET_DOMAIN_URLS = os.Getenv("HW_CDN_TARGET_DOMAIN_URLS")
+	HW_CDN_CERT_PATH          = os.Getenv("HW_CDN_CERT_PATH")
+	HW_CDN_PRIVATE_KEY_PATH   = os.Getenv("HW_CDN_PRIVATE_KEY_PATH")
+	HW_CDN_ENABLE_FLAG        = os.Getenv("HW_CDN_ENABLE_FLAG")
+	HW_CDN_TIMESTAMP          = os.Getenv("HW_CDN_TIMESTAMP")
+	HW_CDN_START_TIME         = os.Getenv("HW_CDN_START_TIME")
+	HW_CDN_END_TIME           = os.Getenv("HW_CDN_END_TIME")
+	HW_CDN_STAT_TYPE          = os.Getenv("HW_CDN_STAT_TYPE")
+	HW_CDN_IP_ADDRESSES       = os.Getenv("HW_CDN_IP_ADDRESSES")
 
 	// CCM environment
 	HW_CCM_CERTIFICATE_CONTENT_PATH    = os.Getenv("HW_CCM_CERTIFICATE_CONTENT_PATH")
@@ -3017,6 +3018,13 @@ func TestAccPreCheckCertCDN(t *testing.T) {
 func TestAccPreCheckCDNURL(t *testing.T) {
 	if HW_CDN_DOMAIN_URL == "" {
 		t.Skip("HW_CDN_DOMAIN_URL must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCDNTargetDomainUrls(t *testing.T, n int) {
+	if len(strings.Split(HW_CDN_TARGET_DOMAIN_URLS, ",")) < n {
+		t.Skipf("at lease %d domain URL(s) for HW_CDN_TARGET_DOMAIN_URLS must be set, separated by the comma (,) character", n)
 	}
 }
 

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_certificate_associate_domains_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_certificate_associate_domains_test.go
@@ -1,0 +1,64 @@
+package cdn
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccCdnCertificateAssociateDomains_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCDNTargetDomainUrls(t, 1)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCdnCertificateAssociateDomains_basic_step1(name),
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+			{
+				Config:      testAccCdnCertificateAssociateDomains_basic_step2(),
+				ExpectError: regexp.MustCompile("error associating certificate with domains"),
+			},
+		},
+	})
+}
+
+func testAccCdnCertificateAssociateDomains_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_certificate_associate_domains" "test" {
+  domain_names = "%[1]s"
+  https_switch = 1
+  cert_name    = "%[2]s"
+  certificate  = file("%[3]s")
+  private_key  = file("%[4]s")
+}
+`, acceptance.HW_CDN_TARGET_DOMAIN_URLS, name,
+		acceptance.HW_CCM_CERTIFICATE_CONTENT_PATH,
+		acceptance.HW_CCM_PRIVATE_KEY_PATH)
+}
+
+func testAccCdnCertificateAssociateDomains_basic_step2() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_certificate_associate_domains" "test_with_invalid_cert" {
+  domain_names = "%[1]s"
+  https_switch = 1
+  cert_name    = "invalid_cert"
+  certificate  = "----------------------invalid content----------------------"
+  private_key  = "----------------------invalid private key----------------------"
+}
+`, acceptance.HW_CDN_TARGET_DOMAIN_URLS)
+}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_certificate_associate_domains.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_certificate_associate_domains.go
@@ -1,0 +1,233 @@
+package cdn
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var cdnCertificateAssociateDomainsNonUpdatableParams = []string{"domain_names", "https_switch", "access_origin_way",
+	"force_redirect_https", "force_redirect_config", "http2", "cert_name", "certificate", "private_key", "certificate_type"}
+
+// @API CDN PUT /v1.0/cdn/domains/config-https-info
+func ResourceCertificateAssociateDomains() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCertificateAssociateDomainsCreate,
+		ReadContext:   resourceCertificateAssociateDomainsRead,
+		UpdateContext: resourceCertificateAssociateDomainsUpdate,
+		DeleteContext: resourceCertificateAssociateDomainsDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(cdnCertificateAssociateDomainsNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"domain_names": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The list of domain names to associate with the certificate.`,
+			},
+			"https_switch": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The HTTPS certificate configuration switch.`,
+			},
+
+			// Optional parameters.
+			"access_origin_way": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     2,
+				Description: `The origin protocol configuration.`,
+			},
+			"force_redirect_https": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     0,
+				Description: `Whether to enable HTTPS force redirect.`,
+			},
+			"force_redirect_config": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem:        forceRedirectConfigSchema(),
+				Description: `The force redirect configuration.`,
+			},
+			"http2": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     0,
+				Description: `The HTTP/2 protocol switch.`,
+			},
+			"cert_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The certificate name.`,
+			},
+			"certificate": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: `The SSL certificate content in PEM format.`,
+			},
+			"private_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: `The SSL certificate private key content in PEM format.`,
+			},
+			"certificate_type": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     0,
+				Description: `The certificate type.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func forceRedirectConfigSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"switch": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The force redirect switch.`,
+			},
+			"redirect_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The redirect type.`,
+			},
+		},
+	}
+}
+
+func buildForceRedirectConfig(redirectConfigs []interface{}) map[string]interface{} {
+	if len(redirectConfigs) < 1 {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"switch":        utils.PathSearch("switch", redirectConfigs[0], nil),
+		"redirect_type": utils.PathSearch("redirect_type", redirectConfigs[0], nil),
+	}
+}
+
+func buildCertificateAssociateDomainsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"domain_name":           d.Get("domain_names"),
+		"https_switch":          d.Get("https_switch"),
+		"access_origin_way":     utils.ValueIgnoreEmpty(d.Get("access_origin_way")),
+		"force_redirect_https":  utils.ValueIgnoreEmpty(d.Get("force_redirect_https")),
+		"force_redirect_config": buildForceRedirectConfig(d.Get("force_redirect_config").([]interface{})),
+		"http2":                 utils.ValueIgnoreEmpty(d.Get("http2")),
+		"cert_name":             utils.ValueIgnoreEmpty(d.Get("cert_name")),
+		"certificate":           utils.ValueIgnoreEmpty(d.Get("certificate")),
+		"private_key":           utils.ValueIgnoreEmpty(d.Get("private_key")),
+		"certificate_type":      utils.ValueIgnoreEmpty(d.Get("certificate_type")),
+	}
+
+	return map[string]interface{}{
+		"https": bodyParams,
+	}
+}
+
+func parseCertificateAssociateDomainsError(respBody interface{}) error {
+	status := utils.PathSearch("status", respBody, "").(string)
+	if status == "success" {
+		return nil
+	}
+
+	results := utils.PathSearch("result", respBody, make([]interface{}, 0)).([]interface{})
+	var errorDetails []string
+	for _, result := range results {
+		domain := utils.PathSearch("domain_name", result, "").(string)
+		reason := utils.PathSearch("reason", result, "").(string)
+		if reason != "" {
+			errorDetails = append(errorDetails, fmt.Sprintf("domain %s: %s", domain, reason))
+		}
+	}
+
+	if len(errorDetails) > 0 {
+		return fmt.Errorf("error associating certificate with domains: %s. Details: %s",
+			status, strings.Join(errorDetails, "; "))
+	}
+	return fmt.Errorf("error associating certificate with domains: %s", status)
+}
+
+func resourceCertificateAssociateDomainsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v1.0/cdn/domains/config-https-info"
+	)
+
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildCertificateAssociateDomainsBodyParams(d),
+	}
+
+	resp, err := client.Request("PUT", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error associating certificate with domains: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.Errorf("error parsing response: %s", err)
+	}
+
+	if err := parseCertificateAssociateDomainsError(respBody); err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceCertificateAssociateDomainsRead(ctx, d, meta)
+}
+
+func resourceCertificateAssociateDomainsRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceCertificateAssociateDomainsUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceCertificateAssociateDomainsDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for bind certificate on the list of domains. Deleting this 
+resource will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(cdn): add new resource for associate certificate with multi domains

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccCdnCertificateAssociateDomains_basic -timeout 360m -parallel 10
=== RUN   TestAccCdnCertificateAssociateDomains_basic
--- PASS: TestAccCdnCertificateAssociateDomains_basic (33.66s)
PASS
coverage: 4.4% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       33.771s coverage: 4.4% of statements in ./huaweicloud/services/cdn
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.