### PR TITLE
feat(hss): new resource to export vulnerability history task

### DIFF
--- a/docs/resources/hss_vulnerability_history_export_task.md
+++ b/docs/resources/hss_vulnerability_history_export_task.md
@@ -1,0 +1,126 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_vulnerability_history_export_task"
+description: |-
+  Manages an HSS vulnerability history export task creation resource within HuaweiCloud.
+---
+
+# huaweicloud_hss_vulnerability_history_export_task
+
+Manages an HSS vulnerability history export task creation resource within HuaweiCloud.
+
+-> This resource is a one-time action resource using to create HSS vulnerability history export task. Deleting this
+ resource will not clear the corresponding request record, but will only remove the resource information from the tf
+ state file.
+
+## Example Usage
+
+```hcl
+variable "type" {}
+variable "handle_cycle" {}
+variable "export_headers" {
+  type = list(list(string))
+}
+
+resource "huaweicloud_hss_vulnerability_history_export_task" "test" {
+  type           = var.type
+  handle_cycle   = var.handle_cycle
+  export_headers = var.export_headers
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `export_headers` - (Required, List, NonUpdatable) Specifies the header information list for exported vulnerability data.
+  Each header item is a list containing two strings: [field_name, display_name].
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the hosts under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `vul_name` - (Optional, String, NonUpdatable) Specifies the vulnerability name.
+
+* `repair_priority` - (Optional, String, NonUpdatable) Specifies the vulnerability repair priority.
+  The valid values are as follows:
+  + **Critical**: Critical priority.
+  + **High**: High priority.
+  + **Medium**: Medium priority.
+  + **Low**: Low priority.
+
+* `host_name` - (Optional, String, NonUpdatable) Specifies the host name.
+
+* `host_ip` - (Optional, String, NonUpdatable) Specifies the host IP address.
+
+* `is_affect_business` - (Optional, Bool, NonUpdatable) Specifies whether the vulnerability affects business.
+  Defaults to **false**.
+
+* `status` - (Optional, String, NonUpdatable) Specifies the vulnerability status.
+  The valid values are as follows:
+  + **vul_status_unfix**: Unfixed.
+  + **vul_status_ignored**: Ignored.
+  + **vul_status_verified**: Under verification.
+  + **vul_status_fixing**: Fixing.
+  + **vul_status_fixed**: Fixed successfully.
+  + **vul_status_reboot**: Fixed successfully, restart required.
+  + **vul_status_failed**: Fix failed.
+  + **vul_status_fix_after_reboot**: Please restart the host to fix again.
+
+* `asset_value` - (Optional, String, NonUpdatable) Specifies the asset importance.
+  The valid values are as follows:
+  + **important**: Important.
+  + **common**: Common.
+  + **test**: Test.
+
+* `label` - (Optional, String, NonUpdatable) Specifies the vulnerability label.
+
+* `type` - (Optional, String, NonUpdatable) Specifies the vulnerability type.
+  The valid values are as follows:
+  + **linux_vul**: Linux vulnerability.
+  + **windows_vul**: Windows vulnerability.
+  + **web_cms**: Web-CMS vulnerability.
+  + **app_vul**: Application vulnerability.
+  + **urgent_vul**: Emergency vulnerability.
+
+* `group_name` - (Optional, String, NonUpdatable) Specifies the server group name.
+
+* `handle_cycle` - (Optional, String, NonUpdatable) Specifies the vulnerability handling cycle.
+  The valid values are as follows:
+  + **today**: Query data handled today.
+  + **all**: Query all handled data.
+
+* `export_size` - (Optional, Int, NonUpdatable) Specifies the number of data records to export.
+
+* `specific_vuls` - (Optional, List, NonUpdatable) Specifies the specific vulnerabilities to export.
+  The [specific_vuls](#specific_vuls_object) structure is documented below.
+
+<a name="specific_vuls_object"></a>
+The `specific_vuls` block supports:
+
+* `host_id` - (Optional, String) Specifies the host ID.
+
+* `vul_id` - (Optional, String) Specifies the vulnerability ID.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (also task ID).
+
+* `task_name` - The task name.
+
+* `task_status` - The task status.
+  + **success**: The task is successful.
+  + **failure**: The task fails.
+
+* `file_id` - The file ID.
+
+* `file_name` - The file name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2777,6 +2777,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_switch_honeypot_port_policy":                    hss.ResourceSwitchHoneypotPortPolicy(),
 			"huaweicloud_hss_vulnerability_information_export":               hss.ResourceVulnerabilityInformationExport(),
 			"huaweicloud_hss_vulnerability_task_user_trace":                  hss.ResourceVulnerabilityTaskUserTrace(),
+			"huaweicloud_hss_vulnerability_history_export_task":              hss.ResourceVulnerabilityHistoryExportTask(),
 			"huaweicloud_hss_file_download":                                  hss.ResourceFileDownload(),
 			"huaweicloud_hss_ignore_failed_pcc":                              hss.ResourceIgnoreFailedPCC(),
 			"huaweicloud_hss_antivirus_create_virus_scan_task":               hss.ResourceCreateVirusScanTask(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_vulnerability_history_export_task_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_vulnerability_history_export_task_test.go
@@ -1,0 +1,40 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccVulnerabilityHistoryExportTask_basic(t *testing.T) {
+	rName := "huaweicloud_hss_vulnerability_history_export_task.test"
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testVulnerabilityHistoryExportTask_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "task_status", "success"),
+					resource.TestCheckResourceAttrSet(rName, "task_name"),
+					resource.TestCheckResourceAttrSet(rName, "file_id"),
+					resource.TestCheckResourceAttrSet(rName, "file_name"),
+				),
+			},
+		},
+	})
+}
+
+const testVulnerabilityHistoryExportTask_basic = `
+resource "huaweicloud_hss_vulnerability_history_export_task" "test" {
+  type                  = "linux_vul"
+  handle_cycle          = "all"
+  export_headers        = [["vul_name", "漏洞名称"], ["status", "状态"]]
+  enterprise_project_id = "0"
+}
+`

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_vulnerability_history_export_task.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_vulnerability_history_export_task.go
@@ -1,0 +1,336 @@
+package hss
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS POST /v5/{project_id}/vulnerability/history/export-task
+// @API HSS GET /v5/{project_id}/export-task/{task_id}
+func ResourceVulnerabilityHistoryExportTask() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVulnerabilityHistoryExportTaskCreate,
+		ReadContext:   resourceVulnerabilityHistoryExportTaskRead,
+		UpdateContext: resourceVulnerabilityHistoryExportTaskUpdate,
+		DeleteContext: resourceVulnerabilityHistoryExportTaskDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"export_headers",
+			"enterprise_project_id",
+			"vul_name",
+			"repair_priority",
+			"host_name",
+			"host_ip",
+			"is_affect_business",
+			"status",
+			"asset_value",
+			"label",
+			"type",
+			"group_name",
+			"handle_cycle",
+			"specific_vuls",
+			"specific_vuls.*.host_id",
+			"specific_vuls.*.vul_id",
+			"export_size",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"export_headers": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeList,
+					Elem: &schema.Schema{Type: schema.TypeString},
+				},
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vul_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"repair_priority": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"host_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"host_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"is_affect_business": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"asset_value": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"label": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"handle_cycle": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"specific_vuls": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     historyExportSpecificVulsSchema(),
+			},
+			"export_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"task_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"task_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"file_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"file_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func historyExportSpecificVulsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"host_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vul_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func buildVulnerabilityHistoryExportTaskQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%v", epsId)
+	}
+
+	return ""
+}
+
+func buildCreateExportTaskSpecificVulsBodyParams(rawArray []interface{}) []map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"host_id": rawMap["host_id"],
+			"vul_id":  rawMap["vul_id"],
+		})
+	}
+
+	return rst
+}
+
+func buildVulnerabilityHistoryExportTaskBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"export_headers":     d.Get("export_headers"),
+		"vul_name":           utils.ValueIgnoreEmpty(d.Get("vul_name")),
+		"repair_priority":    utils.ValueIgnoreEmpty(d.Get("repair_priority")),
+		"host_name":          utils.ValueIgnoreEmpty(d.Get("host_name")),
+		"host_ip":            utils.ValueIgnoreEmpty(d.Get("host_ip")),
+		"is_affect_business": d.Get("is_affect_business"),
+		"status":             utils.ValueIgnoreEmpty(d.Get("status")),
+		"asset_value":        utils.ValueIgnoreEmpty(d.Get("asset_value")),
+		"label":              utils.ValueIgnoreEmpty(d.Get("label")),
+		"type":               utils.ValueIgnoreEmpty(d.Get("type")),
+		"group_name":         utils.ValueIgnoreEmpty(d.Get("group_name")),
+		"handle_cycle":       utils.ValueIgnoreEmpty(d.Get("handle_cycle")),
+		"specific_vuls":      buildCreateExportTaskSpecificVulsBodyParams(d.Get("specific_vuls").([]interface{})),
+		"export_size":        utils.ValueIgnoreEmpty(d.Get("export_size")),
+	}
+}
+
+func getExportTask(client *golangsdk.ServiceClient, taskId, epsID string) (interface{}, error) {
+	requestPath := client.Endpoint + "v5/{project_id}/export-task/{task_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{task_id}", taskId)
+	requestPath += buildVulnerabilityHistoryExportTaskQueryParams(epsID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func waitingForExportTaskFinished(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration, epsID string) (interface{}, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			respBody, err := getExportTask(client, d.Id(), epsID)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			taskStatus := utils.PathSearch("task_status", respBody, "").(string)
+			if taskStatus == "" {
+				return nil, "ERROR", errors.New("task_status is not found in list API response")
+			}
+
+			// When the state enters the final state, safely exit the training logic.
+			if taskStatus == "success" || taskStatus == "failure" {
+				return respBody, "COMPLETED", nil
+			}
+
+			return respBody, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	return stateConf.WaitForStateContext(ctx)
+}
+
+func resourceVulnerabilityHistoryExportTaskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v5/{project_id}/vulnerability/history/export-task"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildVulnerabilityHistoryExportTaskQueryParams(epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildVulnerabilityHistoryExportTaskBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating HSS vulnerability export task: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	taskId := utils.PathSearch("task_id", respBody, "").(string)
+	if taskId == "" {
+		return diag.Errorf("unable to find task_id in response")
+	}
+
+	d.SetId(taskId)
+
+	taskRespBody, err := waitingForExportTaskFinished(ctx, client, d, d.Timeout(schema.TimeoutCreate), epsId)
+	if err != nil {
+		return diag.Errorf("error waiting for HSS vulnerability export task %s complete: %s", taskId, err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("task_name", utils.PathSearch("task_name", taskRespBody, nil)),
+		d.Set("task_status", utils.PathSearch("task_status", taskRespBody, nil)),
+		d.Set("file_id", utils.PathSearch("file_id", taskRespBody, nil)),
+		d.Set("file_name", utils.PathSearch("file_name", taskRespBody, nil)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting HSS vulnerability export task attributes: %s", err)
+	}
+
+	return resourceVulnerabilityHistoryExportTaskRead(ctx, d, meta)
+}
+
+func resourceVulnerabilityHistoryExportTaskRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceVulnerabilityHistoryExportTaskUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceVulnerabilityHistoryExportTaskDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to create HSS vulnerability export task. Deleting this resource
+	will not clear the corresponding request record, but will only remove the resource information from the tf state
+    file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to export vulnerability history task.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccVulnerabilityHistoryExportTask_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccVulnerabilityHistoryExportTask_basic -timeout 360m -parallel 10
=== RUN   TestAccVulnerabilityHistoryExportTask_basic
=== PAUSE TestAccVulnerabilityHistoryExportTask_basic
=== CONT  TestAccVulnerabilityHistoryExportTask_basic
--- PASS: TestAccVulnerabilityHistoryExportTask_basic (14.86s)
PASS
coverage: 3.6% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       14.956s coverage: 3.6% of statements in ./huaweicloud/services/hss
```
<img width="1378" height="79" alt="image" src="https://github.com/user-attachments/assets/96b8b54f-2ed4-40d4-bde1-28740caee888" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
