### PR TITLE
feat(cdn): add new resource for batch domain copy

### DIFF
--- a/docs/resources/cdn_domain_batch_copy.md
+++ b/docs/resources/cdn_domain_batch_copy.md
@@ -1,0 +1,61 @@
+---
+subcategory: "Content Delivery Network (CDN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cdn_domain_batch_copy"
+description: |-
+  Use this resource to batch copy the configurations of domain within HuaweiCloud.
+---
+
+# huaweicloud_cdn_domain_batch_copy
+
+Use this resource to batch copy the configurations of domain within HuaweiCloud.
+
+-> This resource is only a one-time action resource for performing domain batch copy operation. Deleting this resource
+   will not clear the corresponding request record, but will only remove the resource information from the tfstate
+   file.
+
+## Example Usage
+
+```hcl
+variable "source_domain" {}
+variable "target_domains" {}
+variable "config_list" {
+  type = list(string)
+}
+
+resource "huaweicloud_cdn_domain_batch_copy" "test" {
+  source_domain  = var.source_domain
+  target_domains = var.target_domain
+  config_list    = var.config_list
+}
+```
+
+## Argument Reference
+
+* `source_domain` - (Required, String, NonUpdatable) Specifies the source domain whose configuration will be copied.
+
+* `target_domains` - (Required, String, NonUpdatable) Specifies the target domain names to which configurations will be
+  copied.
+
+* `config_list` - (Required, List, NonUpdatable) Specifies the configuration items to copy.  
+  The valid values are as follows:
+  + **origin_request_header**
+  + **http_response_header**
+  + **url_auth**
+  + **user_agent_black_and_white_list**
+  + **ipv6Accelerate**
+  + **range_status**
+  + **cache_rules**
+  + **follow_302_status**
+  + **sources**
+  + **compress**
+  + **referer**
+  + **ip_black_and_white_list**
+  + **browserCacheRules**
+  + **cacheValidErrorCode**
+
+## Attributes Reference
+
+In addition to the above arguments, the following attributes are exported:
+
+* `id` - The ID of resource.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2324,6 +2324,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdn_cache_preheat":                 cdn.ResourceCachePreheat(),
 			"huaweicloud_cdn_cache_refresh":                 cdn.ResourceCacheRefresh(),
 			"huaweicloud_cdn_certificate_associate_domains": cdn.ResourceCertificateAssociateDomains(),
+			"huaweicloud_cdn_domain_batch_copy":             cdn.ResourceDomainBatchCopy(),
 
 			"huaweicloud_ces_alarmrule":                                     ces.ResourceAlarmRule(),
 			"huaweicloud_ces_alarm_template":                                ces.ResourceCesAlarmTemplate(),

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_batch_copy_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_batch_copy_test.go
@@ -1,0 +1,148 @@
+package cdn
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDomainBatchCopy_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCDNURL(t)
+			acceptance.TestAccPreCheckCDNTargetDomainUrls(t, 1)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainBatchCopy_basic_step1(),
+			},
+			{
+				Config:      testAccDomainBatchCopy_basic_step2(),
+				ExpectError: regexp.MustCompile("Parameter invalidProperty is invalid. Reason: the config don`t support copy."),
+			},
+		},
+	})
+}
+
+func testAccDomainBatchCopy_base() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_domain" "source" {
+  name         = "%[1]s"
+  type         = "web"
+  service_area = "outside_mainland_china"
+
+  configs {
+    origin_protocol = "http"
+
+    http_response_header {
+      name   = "test-name"
+      value  = "test-val"
+      action = "set"
+    }
+  }
+
+  sources {
+    active      = 1
+    origin      = "100.254.53.75"
+    origin_type = "ipaddr"
+    http_port   = 80
+    https_port  = 443
+  }
+
+  cache_settings {
+    rules {
+      rule_type           = "all"
+      ttl                 = 365
+      ttl_type            = "d"
+      priority            = 2
+      url_parameter_type  = "del_params"
+      url_parameter_value = "test_value"
+    }
+  }
+
+  tags = {
+    key = "val"
+    foo = "bar"
+  }
+}
+
+resource "huaweicloud_cdn_domain" "target" {
+  name         = "%[2]s"
+  type         = "web"
+  service_area = "outside_mainland_china"
+
+  configs {
+    origin_protocol = "http"
+  }
+
+  sources {
+    active      = 1
+    origin      = "100.254.53.75"
+    origin_type = "ipaddr"
+    http_port   = 80
+    https_port  = 443
+  }
+
+  cache_settings {
+    rules {
+      rule_type           = "all"
+      ttl                 = 365
+      ttl_type            = "d"
+      priority            = 2
+      url_parameter_type  = "del_params"
+      url_parameter_value = "test_value"
+    }
+  }
+
+  tags = {
+    key = "val"
+    foo = "bar"
+  }
+}
+`, acceptance.HW_CDN_DOMAIN_URL, acceptance.HW_CDN_TARGET_DOMAIN_URLS)
+}
+
+func testAccDomainBatchCopy_basic_step1() string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cdn_domain_batch_copy" "test" {
+  source_domain  = "%[2]s"
+  target_domains = "%[3]s"
+  config_list    = ["http_response_header"]
+
+  depends_on = [
+    huaweicloud_cdn_domain.source,
+    huaweicloud_cdn_domain.target,
+  ]
+}
+`, testAccDomainBatchCopy_base(),
+		acceptance.HW_CDN_DOMAIN_URL, acceptance.HW_CDN_TARGET_DOMAIN_URLS)
+}
+
+func testAccDomainBatchCopy_basic_step2() string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cdn_domain_batch_copy" "test_with_invalid_property" {
+  source_domain  = "%[2]s"
+  target_domains = "%[3]s"
+  config_list    = ["invalid_property"]
+
+  depends_on = [
+    huaweicloud_cdn_domain.source,
+    huaweicloud_cdn_domain.target,
+  ]
+}
+`, testAccDomainBatchCopy_base(),
+		acceptance.HW_CDN_DOMAIN_URL, acceptance.HW_CDN_TARGET_DOMAIN_URLS)
+}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain_batch_copy.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain_batch_copy.go
@@ -1,0 +1,152 @@
+package cdn
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var domainBatchCopyNonUpdatableParams = []string{"source_domain", "target_domains", "config_list"}
+
+// @API CDN POST /v1.0/cdn/configuration/domains/batch-copy
+func ResourceDomainBatchCopy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDomainBatchCopyCreate,
+		ReadContext:   resourceDomainBatchCopyRead,
+		UpdateContext: resourceDomainBatchCopyUpdate,
+		DeleteContext: resourceDomainBatchCopyDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(domainBatchCopyNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"source_domain": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The source domain whose configuration will be copied.`,
+			},
+			"target_domains": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The target domain names to which configurations will be copied.`,
+			},
+			"config_list": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The configuration items to copy.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildDomainBatchCopyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"configs": map[string]interface{}{
+			"target_domain": d.Get("target_domains"),
+			"source_domain": d.Get("source_domain"),
+			"config_list":   utils.ExpandToStringList(d.Get("config_list").([]interface{})),
+		},
+	}
+}
+
+func collectBatchCopyErrors(results []interface{}) error {
+	var errors []string
+
+	for _, result := range results {
+		status := utils.PathSearch("status", result, "").(string)
+		domainName := utils.PathSearch("domain_name", result, "").(string)
+		reason := utils.PathSearch("reason", result, "").(string)
+
+		if status != "success" && status != "completed" && status != "" {
+			errorMsg := fmt.Sprintf("domain '%s' failed with status '%s', reason: '%s'", domainName, status, reason)
+			if reason != "" {
+				errors = append(errors, errorMsg)
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("batch copy operation failed for %d domain(s): %s", len(errors), strings.Join(errors, "; "))
+	}
+	return nil
+}
+
+func resourceDomainBatchCopyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v1.0/cdn/configuration/domains/batch-copy"
+	)
+
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildDomainBatchCopyBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return diag.Errorf("error performing domain batch copy: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	results := utils.PathSearch("result", respBody, make([]interface{}, 0)).([]interface{})
+	if err := collectBatchCopyErrors(results); err != nil {
+		return diag.Errorf("error in batch copy operation: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceDomainBatchCopyRead(ctx, d, meta)
+}
+
+func resourceDomainBatchCopyRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDomainBatchCopyUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDomainBatchCopyDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for performing domain batch copy operation. Deleting this 
+resource will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(cdn): add new resource for batch domain copy

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
test case failed was due to the domain resource destroy action failed, rather than the batch copy operation failed.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccCdnDomainBatchCopy_basic -timeout 360m -parallel 10
=== RUN   TestAccCdnDomainBatchCopy_basic
=== PAUSE TestAccCdnDomainBatchCopy_basic
=== CONT  TestAccCdnDomainBatchCopy_basic
    testing_new.go:84: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: error deleting CDN domain (dc07946533484d7698516c1b6e57f638): error_code (CDN.0126), error_msg (Only domain names that are in the disabled or error state can be deleted.)
        
--- FAIL: TestAccCdnDomainBatchCopy_basic (436.21s)
FAIL
coverage: 27.8% of statements in ./huaweicloud/services/cdn
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       436.336s
FAIL
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.