### PR TITLE
feat(hss): support `hss_webtamper_host_management_hosts` data source

### DIFF
--- a/docs/data-sources/hss_webtamper_host_management_hosts.md
+++ b/docs/data-sources/hss_webtamper_host_management_hosts.md
@@ -1,0 +1,79 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_webtamper_host_management_hosts"
+description: |-
+  Use this data source to get the list of HSS web tamper host management hosts within HuaweiCloud.
+---
+
+# huaweicloud_hss_webtamper_host_management_hosts
+
+Use this data source to get the list of HSS web tamper host management hosts within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_webtamper_host_management_hosts" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `host_id` - (Optional, String) Specifies the host ID.
+
+* `host_name` - (Optional, String) Specifies the host name.
+
+* `private_ip` - (Optional, String) Specifies the private IP of the host.
+
+* `public_ip` - (Optional, String) Specifies the public IP of the host.
+
+* `group_id` - (Optional, String) Specifies the group ID.
+
+* `os_type` - (Optional, String) Specifies the OS type. Valid values are:
+  + **Linux**
+  + **Windows**
+
+* `web_app_name` - (Optional, String) Specifies the web application name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `data_list` - The list of web tamper host management hosts.
+
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `host_id` - The host ID.
+
+* `host_name` - The host name.
+
+* `public_ip` - The public IP address.
+
+* `private_ip` - The private IP address.
+
+* `agent_id` - The agent ID.
+
+* `os_type` - The OS type.
+
+* `asset_value` - The importance of assets. Valid values are:
+  + **important**: Important assets.
+  + **common**: Common assets.
+  + **test**: Test assets.
+
+* `web_app_list` - The web application list.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1333,6 +1333,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_vulnerability_hosts":                        hss.DataSourceVulnerabilityHosts(),
 			"huaweicloud_hss_vulnerability_statistics":                   hss.DataSourceVulnerabilityStatistics(),
 			"huaweicloud_hss_webtamper_hosts":                            hss.DataSourceWebTamperHosts(),
+			"huaweicloud_hss_webtamper_host_management_hosts":            hss.DataSourceWebTamperHostManagementHosts(),
 			"huaweicloud_hss_webtamper_rasp_path":                        hss.DataSourceWebtamperRaspPath(),
 			"huaweicloud_hss_webtamper_policy":                           hss.DataSourceWebTamperPolicy(),
 			"huaweicloud_hss_antivirus_custom_scan_policies":             hss.DataSourceAntivirusCustomScanPolicies(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_webtamper_host_management_hosts_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_webtamper_host_management_hosts_test.go
@@ -1,0 +1,41 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Due to testing environment limitations, this test case can only test the scenario with empty `data_list`.
+func TestAccDataSourceWebTamperHostManagementHosts_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_webtamper_host_management_hosts.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceWebTamperHostManagementHosts_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceWebTamperHostManagementHosts_basic() string {
+	return `
+data "huaweicloud_hss_webtamper_host_management_hosts" "test" {
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_webtamper_host_management_hosts.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_webtamper_host_management_hosts.go
@@ -1,0 +1,217 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/webtamper/host-management/hosts
+func DataSourceWebTamperHostManagementHosts() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceWebTamperHostManagementHostsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"host_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"private_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"public_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"os_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"web_app_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"host_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"public_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"private_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"agent_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"os_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"asset_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"web_app_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildWebTamperHostManagementHostsQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=200"
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("host_id"); ok {
+		queryParams = fmt.Sprintf("%s&host_id=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("host_name"); ok {
+		queryParams = fmt.Sprintf("%s&host_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("private_ip"); ok {
+		queryParams = fmt.Sprintf("%s&private_ip=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("public_ip"); ok {
+		queryParams = fmt.Sprintf("%s&public_ip=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("group_id"); ok {
+		queryParams = fmt.Sprintf("%s&group_id=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("os_type"); ok {
+		queryParams = fmt.Sprintf("%s&os_type=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("web_app_name"); ok {
+		queryParams = fmt.Sprintf("%s&web_app_name=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceWebTamperHostManagementHostsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		product = "hss"
+		httpUrl = "v5/{project_id}/webtamper/host-management/hosts"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildWebTamperHostManagementHostsQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", currentPath, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS web tamper host management hosts: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataResp := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataResp) == 0 {
+			break
+		}
+
+		result = append(result, dataResp...)
+		offset += len(dataResp)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data_list", flattenWebTamperHostManagementHosts(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenWebTamperHostManagementHosts(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"host_id":      utils.PathSearch("host_id", v, nil),
+			"host_name":    utils.PathSearch("host_name", v, nil),
+			"public_ip":    utils.PathSearch("public_ip", v, nil),
+			"private_ip":   utils.PathSearch("private_ip", v, nil),
+			"agent_id":     utils.PathSearch("agent_id", v, nil),
+			"os_type":      utils.PathSearch("os_type", v, nil),
+			"asset_value":  utils.PathSearch("asset_value", v, nil),
+			"web_app_list": utils.ExpandToStringList(utils.PathSearch("web_app_list", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_webtamper_host_management_hosts` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_webtamper_host_management_hosts` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceWebTamperHostManagementHosts_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceWebTamperHostManagementHosts_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWebTamperHostManagementHosts_basic
=== PAUSE TestAccDataSourceWebTamperHostManagementHosts_basic
=== CONT  TestAccDataSourceWebTamperHostManagementHosts_basic
--- PASS: TestAccDataSourceWebTamperHostManagementHosts_basic (9.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       9.865s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
