### PR TITLE
feat(hss): support `hss_antivirus_pay_per_scan_free_quotas` data source

### DIFF
--- a/docs/data-sources/hss_antivirus_pay_per_scan_free_quotas.md
+++ b/docs/data-sources/hss_antivirus_pay_per_scan_free_quotas.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_antivirus_pay_per_scan_free_quotas"
+description: |-
+  Use this data source to get the HSS antivirus pay per scan free quotas within HuaweiCloud.
+---
+
+# huaweicloud_hss_antivirus_pay_per_scan_free_quotas
+
+Use this data source to get the HSS antivirus pay per scan free quotas within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_antivirus_pay_per_scan_free_quotas" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `free_quota` - The free quota for antivirus scanning.
+
+* `occupied_free_quota` - The occupied free quota for current scanning tasks.
+
+* `antivirus_already_given` - Whether the antivirus interface has already given free quota.
+
+* `antivirus_free_quota` - The free quota that should be given by the antivirus interface.
+
+* `report_already_given` - Whether the monthly report interface has already given free quota.
+
+* `report_free_quota` - The free quota that should be given by the monthly report interface.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1344,6 +1344,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_antivirus_available_hosts":                  hss.DataSourceAntivirusAvailableHosts(),
 			"huaweicloud_hss_antivirus_statistic":                        hss.DataSourceAntivirusStatistic(),
 			"huaweicloud_hss_antivirus_pay_per_scan_switch_status":       hss.DataSourceAntivirusPayPerScanSwitchStatus(),
+			"huaweicloud_hss_antivirus_pay_per_scan_free_quotas":         hss.DataSourceAntivirusPayPerScanFreeQuotas(),
 			"huaweicloud_hss_antivirus_virus_scan_tasks":                 hss.DataSourceAntivirusVirusScanTasks(),
 			"huaweicloud_hss_backup_policy":                              hss.DataSourceBackupPolicy(),
 			"huaweicloud_hss_cicd_configurations":                        hss.DataSourceCiCdConfigurations(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_antivirus_pay_per_scan_free_quotas_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_antivirus_pay_per_scan_free_quotas_test.go
@@ -1,0 +1,43 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAntivirusPayPerScanFreeQuotas_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_hss_antivirus_pay_per_scan_free_quotas.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAntivirusPayPerScanFreeQuotas_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "free_quota"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "occupied_free_quota"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "antivirus_already_given"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "antivirus_free_quota"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "report_already_given"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "report_free_quota"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAntivirusPayPerScanFreeQuotas_basic() string {
+	return `
+data "huaweicloud_hss_antivirus_pay_per_scan_free_quotas" "test" {
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_antivirus_pay_per_scan_free_quotas.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_antivirus_pay_per_scan_free_quotas.go
@@ -1,0 +1,121 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/antivirus/pay-per-scan/free-quotas
+func DataSourceAntivirusPayPerScanFreeQuotas() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAntivirusPayPerScanFreeQuotasRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"free_quota": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"occupied_free_quota": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"antivirus_already_given": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"antivirus_free_quota": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"report_already_given": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"report_free_quota": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildAntivirusPayPerScanFreeQuotasQueryParams(epsId string) string {
+	queryParams := ""
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("?enterprise_project_id=%v", epsId)
+	}
+
+	return queryParams
+}
+
+func dataSourceAntivirusPayPerScanFreeQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		product = "hss"
+		httpUrl = "v5/{project_id}/antivirus/pay-per-scan/free-quotas"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildAntivirusPayPerScanFreeQuotasQueryParams(epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS antivirus pay-per-scan free quotas: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("free_quota", utils.PathSearch("free_quota", respBody, nil)),
+		d.Set("occupied_free_quota", utils.PathSearch("occupied_free_quota", respBody, nil)),
+		d.Set("antivirus_already_given", utils.PathSearch("antivirus_already_given", respBody, nil)),
+		d.Set("antivirus_free_quota", utils.PathSearch("antivirus_free_quota", respBody, nil)),
+		d.Set("report_already_given", utils.PathSearch("report_already_given", respBody, nil)),
+		d.Set("report_free_quota", utils.PathSearch("report_free_quota", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_antivirus_pay_per_scan_free_quotas` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_antivirus_pay_per_scan_free_quotas` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceAntivirusPayPerScanFreeQuotas_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceAntivirusPayPerScanFreeQuotas_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAntivirusPayPerScanFreeQuotas_basic
=== PAUSE TestAccDataSourceAntivirusPayPerScanFreeQuotas_basic
=== CONT  TestAccDataSourceAntivirusPayPerScanFreeQuotas_basic
--- PASS: TestAccDataSourceAntivirusPayPerScanFreeQuotas_basic (10.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       10.253s

```
<img width="989" height="46" alt="image" src="https://github.com/user-attachments/assets/705040c6-eb0f-46de-9b6b-46821606ee92" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
