### PR TITLE
fix(fgs): cancel the conflict between custom_image and code_type

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -32,7 +32,7 @@ resource "huaweicloud_fgs_function" "test" {
   name        = var.function_name
   app         = "default"
   agency      = var.agency_name
-  description = "fuction test"
+  description = "function test"
   handler     = "test.handler"
   memory_size = 128
   timeout     = 3
@@ -228,7 +228,7 @@ resource "huaweicloud_fgs_function" "test" {
   name        = var.function_name
   app         = "default"
   agency      = "test"
-  description = "fuction test"
+  description = "function test"
   handler     = "test.handler"
   memory_size = 128
   timeout     = 3
@@ -258,7 +258,7 @@ resource "huaweicloud_fgs_function" "test" {
   name                  = var.function_name
   app                   = "default"
   agency                = var.agency_name
-  description           = "fuction test"
+  description           = "function test"
   handler               = "test.handler"
   memory_size           = 128
   timeout               = 3
@@ -359,6 +359,8 @@ The following arguments are supported:
   + **jar**: JAR file or java functions.
   + **obs**: function code stored in an OBS bucket.
   + **Custom-Image-Swr**: function code comes from the SWR custom image.
+
+  -> The parameter `custom_image` is **Required** if `code_type` is **Custom-Image-Swr**.
 
 * `handler` - (Required, String) Specifies the entry point of the function.
 

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -320,9 +320,6 @@ func ResourceFgsFunction() *schema.Resource {
 						},
 					},
 				},
-				ConflictsWith: []string{
-					"code_type",
-				},
 				Description: `The custom image configuration of the function.`,
 			},
 			"max_instance_num": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- cancel the conflict between `custom_image` and `code_type`
- fix the description and error of docs


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
