### PR TITLE
fix(cdn): remove `region` attribute in CDN global service provider

### DIFF
--- a/docs/data-sources/cdn_ip_information.md
+++ b/docs/data-sources/cdn_ip_information.md
@@ -24,8 +24,6 @@ data "huaweicloud_cdn_ip_information" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region where the queried IP attribution information are located.
-
 * `ips` - (Required, String) Specifies the list of IP addresses to be queried.  
   The maximum number of IPs that can be queried is 20, and multiple IPs are separated by commas (,).
 

--- a/docs/data-sources/cdn_quotas.md
+++ b/docs/data-sources/cdn_quotas.md
@@ -16,12 +16,6 @@ Use this data source to get the CDN resource quotas within HuaweiCloud.
 data "huaweicloud_cdn_quotas" "test" {}
 ```
 
-## Argument Reference
-
-The following arguments are supported:
-
-* `region` - (Optional, String) Specifies the region where the resource quotas are located.
-
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/data-sources/cdn_tags.md
+++ b/docs/data-sources/cdn_tags.md
@@ -24,8 +24,6 @@ data "huaweicloud_cdn_domain_tags" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region where the domain tags are located.
-
 * `resource_id` - (Required, String) Specifies the ID of the domain to query tags.
 
 ## Attribute Reference

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_billing_option_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_billing_option_test.go
@@ -13,12 +13,8 @@ import (
 )
 
 func getBillingOptionResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	var (
-		region      = acceptance.HW_REGION_NAME
-		product     = "cdn"
-		productType = state.Primary.Attributes["product_type"]
-	)
-	client, err := cfg.NewServiceClient(product, region)
+	productType := state.Primary.Attributes["product_type"]
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return nil, fmt.Errorf("error creating CDN client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_cache_preheat_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_cache_preheat_test.go
@@ -13,11 +13,7 @@ import (
 )
 
 func getCachePreheatResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	var (
-		region  = acceptance.HW_REGION_NAME
-		product = "cdn"
-	)
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return nil, fmt.Errorf("error creating CDN client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_cache_refresh_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_cache_refresh_test.go
@@ -13,11 +13,7 @@ import (
 )
 
 func getCacheRefreshResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	var (
-		region  = acceptance.HW_REGION_NAME
-		product = "cdn"
-	)
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return nil, fmt.Errorf("error creating CDN client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_rule_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_rule_test.go
@@ -13,12 +13,8 @@ import (
 )
 
 func getCdnDomainRuleFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	var (
-		domainName = state.Primary.Attributes["name"]
-		region     = acceptance.HW_REGION_NAME
-	)
-
-	client, err := cfg.NewServiceClient("cdn", region)
+	domainName := state.Primary.Attributes["name"]
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return nil, fmt.Errorf("error creating CDN client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -21,9 +21,9 @@ func getCdnDomainFunc(cfg *config.Config, state *terraform.ResourceState) (inter
 		epsID      = state.Primary.Attributes["enterprise_project_id"]
 	)
 
-	client, err := cfg.CdnV1Client(acceptance.HW_REGION_NAME)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
-		return nil, fmt.Errorf("error creating CDN v1 client: %s", err)
+		return nil, fmt.Errorf("error creating CDN client: %s", err)
 	}
 	return cdn.ReadCdnDomainDetail(client, domainName, epsID)
 }

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_billing_option.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_billing_option.go
@@ -75,13 +75,11 @@ func buildDataSourceBillingOptionQueryParams(d *schema.ResourceData) string {
 
 func dataSourceBillingOptionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		product = "cdn"
-		mErr    *multierror.Error
+		cfg  = meta.(*config.Config)
+		mErr *multierror.Error
 	)
 
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_cache_history_tasks.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_cache_history_tasks.go
@@ -161,15 +161,13 @@ func buildHistoryTaskQueryParams(d *schema.ResourceData, cfg *config.Config) str
 func resourceCacheHistoryTasksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg        = meta.(*config.Config)
-		region     = cfg.GetRegion(d)
-		product    = "cdn"
 		httpUrl    = "v1.0/cdn/historytasks"
 		pageNumber = 1
 		result     = make([]interface{}, 0)
 		mErr       *multierror.Error
 	)
 
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_cache_url_tasks.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_cache_url_tasks.go
@@ -145,15 +145,13 @@ func buildCacheUrlTasksQueryParams(d *schema.ResourceData) string {
 func resourceCacheUrlTasksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		product = "cdn"
 		httpUrl = "v1.0/cdn/contentgateway/url-tasks"
 		offset  = 0
 		result  = make([]interface{}, 0)
 		mErr    *multierror.Error
 	)
 
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_certificates.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_certificates.go
@@ -96,14 +96,12 @@ func buildCertificateQueryParams(conf *config.Config, d *schema.ResourceData) st
 func resourceDomainCertificatesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		conf         = meta.(*config.Config)
-		region       = conf.GetRegion(d)
 		mErr         *multierror.Error
 		httpUrl      = "v1.0/cdn/domains/https-certificate-info"
-		product      = "cdn"
 		currentTotal = 1
 		rst          = make([]interface{}, 0)
 	)
-	client, err := conf.NewServiceClient(product, region)
+	client, err := conf.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_statistics.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_statistics.go
@@ -97,12 +97,10 @@ func DataSourceStatistics() *schema.Resource {
 func resourceStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		conf    = meta.(*config.Config)
-		region  = conf.GetRegion(d)
 		mErr    *multierror.Error
 		httpUrl = "v1.0/cdn/statistics/domain-location-stats"
-		product = "cdn"
 	)
-	client, err := conf.NewServiceClient(product, region)
+	client, err := conf.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domains.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domains.go
@@ -194,14 +194,12 @@ func buildDomainsQueryParams(cfg *config.Config, d *schema.ResourceData) string 
 func datasourceDomainsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg          = meta.(*config.Config)
-		region       = cfg.GetRegion(d)
 		mErr         *multierror.Error
 		httpUrl      = "v1.0/cdn/domains"
-		product      = "cdn"
 		currentTotal = 1
 		rst          = make([]interface{}, 0)
 	)
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_ip_information.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_ip_information.go
@@ -21,13 +21,6 @@ func DataSourceIpInformation() *schema.Resource {
 		ReadContext: dataSourceIpInformationRead,
 
 		Schema: map[string]*schema.Schema{
-			"region": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: `The region where the queried IP attribution information are located.`,
-			},
-
 			// Required parameters.
 			"ips": {
 				Type:        schema.TypeString,
@@ -124,11 +117,10 @@ func flattenIpsInformation(items []interface{}) []map[string]interface{} {
 func dataSourceIpInformationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
 		httpUrl = "v1.0/cdn/ip-info"
 	)
 
-	client, err := cfg.NewServiceClient("cdn", region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}
@@ -160,7 +152,6 @@ func dataSourceIpInformationRead(_ context.Context, d *schema.ResourceData, meta
 	d.SetId(randomUUID)
 
 	mErr := multierror.Append(
-		d.Set("region", region),
 		d.Set("information", flattenIpsInformation(utils.PathSearch("cdn_ips", respBody,
 			make([]interface{}, 0)).([]interface{}))))
 	return diag.FromErr(mErr.ErrorOrNil())

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_quotas.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_quotas.go
@@ -20,13 +20,6 @@ func DataSourceQuotas() *schema.Resource {
 		ReadContext: dataSourceQuotasRead,
 
 		Schema: map[string]*schema.Schema{
-			"region": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: `The region where the resource quotas are located.`,
-			},
-
 			// Attributes.
 			"quotas": {
 				Type:     schema.TypeList,
@@ -104,12 +97,8 @@ func flattenQuotas(quotas []interface{}) []map[string]interface{} {
 }
 
 func dataSourceQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
-	)
-
-	client, err := cfg.NewServiceClient("cdn", region)
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}
@@ -126,7 +115,6 @@ func dataSourceQuotasRead(_ context.Context, d *schema.ResourceData, meta interf
 	d.SetId(randomUUID)
 
 	mErr := multierror.Append(
-		d.Set("region", region),
 		d.Set("quotas", flattenQuotas(resp)),
 	)
 	return diag.FromErr(mErr.ErrorOrNil())

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_tags.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_tags.go
@@ -21,13 +21,6 @@ func DataSourceDomainTags() *schema.Resource {
 		ReadContext: dataSourceDomainTagsRead,
 
 		Schema: map[string]*schema.Schema{
-			"region": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: `The region where the domain tags are located.`,
-			},
-
 			// Required parameters.
 			"resource_id": {
 				Type:        schema.TypeString,
@@ -103,11 +96,10 @@ func flattenTags(tags []interface{}) []map[string]interface{} {
 func dataSourceDomainTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg        = meta.(*config.Config)
-		region     = cfg.GetRegion(d)
 		resourceId = d.Get("resource_id").(string)
 	)
 
-	client, err := cfg.NewServiceClient("cdn", region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}
@@ -124,7 +116,6 @@ func dataSourceDomainTagsRead(_ context.Context, d *schema.ResourceData, meta in
 	d.SetId(randomUUID)
 
 	mErr := multierror.Append(
-		d.Set("region", region),
 		d.Set("tags", flattenTags(tags)),
 	)
 	return diag.FromErr(mErr.ErrorOrNil())

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_billing_option.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_billing_option.go
@@ -90,13 +90,8 @@ func changeBillingOption(client *golangsdk.ServiceClient, d *schema.ResourceData
 }
 
 func resourceBillingOptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		product = "cdn"
-	)
-
-	client, err := cfg.NewServiceClient(product, region)
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}
@@ -149,13 +144,11 @@ func GetBillingOptionDetail(client *golangsdk.ServiceClient, productType string)
 
 func resourceBillingOptionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		product = "cdn"
-		mErr    *multierror.Error
+		cfg  = meta.(*config.Config)
+		mErr *multierror.Error
 	)
 
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}
@@ -184,12 +177,8 @@ func flattenEffectiveTime(result interface{}) string {
 }
 
 func resourceBillingOptionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		product = "cdn"
-	)
-	client, err := cfg.NewServiceClient(product, region)
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_cache_preheat.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_cache_preheat.go
@@ -103,11 +103,9 @@ func buildCachePreheatBodyParams(d *schema.ResourceData) interface{} {
 func resourceCachePreheatCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg           = meta.(*config.Config)
-		region        = cfg.GetRegion(d)
-		product       = "cdn"
 		createHttpUrl = "v1.0/cdn/content/preheating-tasks"
 	)
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}
@@ -146,12 +144,10 @@ func resourceCachePreheatCreate(ctx context.Context, d *schema.ResourceData, met
 
 func resourceCachePreheatRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		product = "cdn"
-		mErr    *multierror.Error
+		cfg  = meta.(*config.Config)
+		mErr *multierror.Error
 	)
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_cache_refresh.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_cache_refresh.go
@@ -134,11 +134,9 @@ func buildCacheRefreshBodyParams(d *schema.ResourceData) interface{} {
 func resourceCacheRefreshCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg           = meta.(*config.Config)
-		region        = cfg.GetRegion(d)
-		product       = "cdn"
 		createHttpUrl = "v1.0/cdn/content/refresh-tasks"
 	)
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}
@@ -239,12 +237,10 @@ func GetCacheDetailById(client *golangsdk.ServiceClient, id string) (interface{}
 
 func resourceCacheRefreshRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		product = "cdn"
-		mErr    *multierror.Error
+		cfg  = meta.(*config.Config)
+		mErr *multierror.Error
 	)
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -1359,12 +1359,10 @@ func waitingForCdnDomainStatusOnline(ctx context.Context, client *golangsdk.Serv
 func resourceCdnDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
 		httpUrl = "v1.0/cdn/domains"
-		product = "cdn"
 	)
 
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}
@@ -2199,12 +2197,10 @@ func flattenConfigAttributes(configResp interface{}, d *schema.ResourceData) []m
 func resourceCdnDomainRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg        = meta.(*config.Config)
-		region     = cfg.GetRegion(d)
-		product    = "cdn"
 		domainName = getDomainName(d)
 		epsID      = cfg.GetEnterpriseProjectID(d)
 	)
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}
@@ -3040,12 +3036,8 @@ func updateCdnDomainTags(client *golangsdk.ServiceClient, d *schema.ResourceData
 }
 
 func resourceCdnDomainUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		product = "cdn"
-	)
-	client, err := cfg.NewServiceClient(product, region)
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}
@@ -3071,8 +3063,8 @@ func resourceCdnDomainUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		migrateOpts := config.MigrateResourceOpts{
 			ResourceId:   d.Id(),
 			ResourceType: "cdn",
-			RegionId:     region,
-			ProjectId:    cfg.GetProjectID(region),
+			RegionId:     "",
+			ProjectId:    d.Get("enterprise_project_id").(string),
 		}
 		if err := cfg.MigrateEnterpriseProject(ctx, d, migrateOpts); err != nil {
 			return diag.FromErr(err)
@@ -3205,13 +3197,11 @@ func waitingForCdnDomainStatusOffline(ctx context.Context, client *golangsdk.Ser
 
 func resourceCdnDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		product = "cdn"
-		epsID   = cfg.GetEnterpriseProjectID(d)
+		cfg   = meta.(*config.Config)
+		epsID = cfg.GetEnterpriseProjectID(d)
 	)
 
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain_rule.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain_rule.go
@@ -595,12 +595,10 @@ func updateCdnDomainRule(client *golangsdk.ServiceClient, d *schema.ResourceData
 func resourceCdnDomainRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg        = meta.(*config.Config)
-		region     = cfg.GetRegion(d)
-		product    = "cdn"
 		domainName = d.Get("name").(string)
 	)
 
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}
@@ -860,11 +858,9 @@ func flattenDomainRuleAttribute(respBody interface{}) []interface{} {
 func resourceCdnDomainRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg        = meta.(*config.Config)
-		region     = cfg.GetRegion(d)
-		product    = "cdn"
 		domainName = d.Get("name").(string)
 	)
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}
@@ -882,13 +878,8 @@ func resourceCdnDomainRuleRead(_ context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceCdnDomainRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		product = "cdn"
-	)
-
-	client, err := cfg.NewServiceClient(product, region)
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}
@@ -914,13 +905,8 @@ func resourceCdnDomainRuleUpdate(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceCdnDomainRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		product = "cdn"
-	)
-
-	client, err := cfg.NewServiceClient(product, region)
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("cdn", "")
 	if err != nil {
 		return diag.Errorf("error creating CDN client: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix(cdn): remove `region` attribute in CDN global service provider

**Which issue this PR fixes**:
HuaweiCloud CDN is global service , so there is no need to set region attribute.

**Special notes for your reviewer**:
the cdn_domain resource need region attribute to get project id.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove the region attribute in CDN service provider.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.