### PR TITLE
feat(evs): support `evs_recycle_bin_policy` resource

### DIFF
--- a/docs/resources/evs_recycle_bin_policy.md
+++ b/docs/resources/evs_recycle_bin_policy.md
@@ -1,0 +1,50 @@
+---
+subcategory: "Elastic Volume Service (EVS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_evs_recycle_bin_policy"
+description: |-
+  Manages an EVS update recycle bin policy resource within HuaweiCloud.
+---
+
+# huaweicloud_evs_recycle_bin_policy
+
+Manages an EVS update recycle bin policy resource within HuaweiCloud.
+
+-> This resource is a one-time action resource using to update EVS recycle bin policy. Deleting this resource will not
+  clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_evs_recycle_bin_policy" "test" {
+  switch         = true
+  threshold_time = 7
+  keep_time      = 7
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `switch` - (Optional, Bool) Specifies whether the recycle bin switch.  
+  The valid values are as follows:
+  + **true**: Open recycle bin.
+  + **false**: Close recycle bin.
+
+* `threshold_time` - (Optional, Int) Specifies the threshold time for the recycle bin, and how many days after the cloud
+  disk is created, it will be deleted before being placed in the recycle bin.  
+  The valid value range is `1` to `1,000`. The default value is `7`.
+
+* `keep_time` - (Optional, Int) Specifies the storage period (days) of the cloud disk in the designated recycle bin, and
+  how many days it will take for the cloud disk to be completely deleted after entering the recycle bin.  
+  The valid value range is `1` to `365`. The default value is `7`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2698,6 +2698,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_evsv3_volume_transfer_accepter": evs.ResourceV3VolumeTransferAccepter(),
 			"huaweicloud_evs_unsubscribe_prepaid_volume": evs.ResourceUnsubscribePrepaidVolume(),
 			"huaweicloud_evs_volumes_batch_expand":       evs.ResourceVolumesBatchExpand(),
+			"huaweicloud_evs_recycle_bin_policy":         evs.ResourceRecycleBinPolicy(),
 
 			"huaweicloud_fgs_application":                    fgs.ResourceApplication(),
 			"huaweicloud_fgs_async_invoke_configuration":     fgs.ResourceAsyncInvokeConfiguration(),

--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_recycle_bin_policy_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_recycle_bin_policy_test.go
@@ -1,0 +1,35 @@
+package evs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccRecycleBinPolicy_basic(t *testing.T) {
+	// Avoid CheckDestroy because this resource is a one-time action resource and there is nothing in the destroy
+	// method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// One-time action resource do not need to be checked and no processing is performed in the Read method.
+				Config: testRecycleBinPolicy_basic(),
+			},
+		},
+	})
+}
+
+func testRecycleBinPolicy_basic() string {
+	return `
+resource "huaweicloud_evs_recycle_bin_policy" "test" {
+  switch         = true
+  threshold_time = 7
+  keep_time      = 7
+}
+`
+}

--- a/huaweicloud/services/evs/resource_huaweicloud_evs_recycle_bin_policy.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_recycle_bin_policy.go
@@ -1,0 +1,129 @@
+package evs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var recycleBinPolicyNonUpdatableParams = []string{
+	"switch",
+	"threshold_time",
+	"keep_time",
+}
+
+// @API EVS PUT /v3/{project_id}/recycle-bin-volumes/policy
+func ResourceRecycleBinPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRecycleBinPolicyCreate,
+		ReadContext:   resourceRecycleBinPolicyRead,
+		UpdateContext: resourceRecycleBinPolicyUpdate,
+		DeleteContext: resourceRecycleBinPolicyDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(recycleBinPolicyNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"switch": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"threshold_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"keep_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildRecycleBinPolicyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"switch":         d.Get("switch"),
+		"threshold_time": utils.ValueIgnoreEmpty(d.Get("threshold_time")),
+		"keep_time":      utils.ValueIgnoreEmpty(d.Get("keep_time")),
+	}
+
+	return bodyParams
+}
+
+func resourceRecycleBinPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/recycle-bin-volumes/policy"
+		product = "evs"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	createRecycleBinPolicyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildRecycleBinPolicyBodyParams(d)),
+	}
+
+	_, err = client.Request("PUT", requestPath, &createRecycleBinPolicyOpt)
+	if err != nil {
+		return diag.Errorf("error creating EVS recycle bin policy: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return resourceRecycleBinPolicyRead(ctx, d, meta)
+}
+
+func resourceRecycleBinPolicyRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceRecycleBinPolicyUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceRecycleBinPolicyDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to update EVS recycle bin policy. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information from the tf
+    state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `evs_recycle_bin_policy` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `evs_recycle_bin_policy` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/evs" TESTARGS="-run TestAccRecycleBinPolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccRecycleBinPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccRecycleBinPolicy_basic
=== PAUSE TestAccRecycleBinPolicy_basic
=== CONT  TestAccRecycleBinPolicy_basic
--- PASS: TestAccRecycleBinPolicy_basic (13.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       13.716s
```
<img width="850" height="35" alt="image" src="https://github.com/user-attachments/assets/bfcb7d21-4361-4d48-bcc8-d3fda52bc517" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
