### PR TITLE
feat(hss): new datasource to query kubernetes services

### DIFF
--- a/docs/data-sources/hss_kubernetes_services.md
+++ b/docs/data-sources/hss_kubernetes_services.md
@@ -1,0 +1,79 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_kubernetes_services"
+description: |-
+  Use this data source to get the list of HSS kubernetes services within HuaweiCloud.
+---
+
+# huaweicloud_hss_kubernetes_services
+
+Use this data source to get the list of HSS kubernetes services within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_kubernetes_services" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `name` - (Optional, String) Specifies the service name.
+
+* `cluster_name` - (Optional, String) Specifies the cluster name.
+
+* `namespace` - (Optional, String) Specifies the namespace.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `service_info_list` - The list of kubernetes services.
+
+  The [service_info_list](#service_info_list_struct) structure is documented below.
+
+<a name="service_info_list_struct"></a>
+The `service_info_list` block supports:
+
+* `id` - The service ID.
+
+* `name` - The service name.
+
+* `endpoint_name` - The endpoint name.
+
+* `namespace` - The namespace.
+
+* `creation_timestamp` - The creation timestamp.
+
+* `type` - The service type. Valid values are:
+  + **ClusterIP**: Services that are only accessible within the cluster.
+  + **NodePort**: Services that are exposed through NodePort.
+  + **LoadBalancer**: Services that are exposed through LoadBalancer.
+
+* `cluster_ip` - The cluster IP.
+
+* `cluster_name` - The cluster name.
+
+* `cluster_type` - The cluster type. Valid values are:
+  + **k8s**: Native cluster.
+  + **cce**: CCE cluster.
+  + **ali**: Alibaba Cloud cluster.
+  + **tencent**: Tencent Cloud cluster.
+  + **azure**: Microsoft Azure cluster.
+  + **aws**: Amazon cluster.
+  + **self_built_hw**: Huawei Cloud self-built cluster.
+  + **self_built_idc**: IDC self-built cluster.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1320,6 +1320,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_host_groups":                                hss.DataSourceHostGroups(),
 			"huaweicloud_hss_host_vulnerabilities":                       hss.DataSourceHssHostVulnerabilities(),
 			"huaweicloud_hss_hosts":                                      hss.DataSourceHosts(),
+			"huaweicloud_hss_kubernetes_services":                        hss.DataSourceKubernetesServices(),
 			"huaweicloud_hss_policy_groups":                              hss.DataSourcePolicyGroups(),
 			"huaweicloud_hss_product_infos":                              hss.DataSourceProductInfos(),
 			"huaweicloud_hss_quotas":                                     hss.DataSourceQuotas(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_kubernetes_services_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_kubernetes_services_test.go
@@ -1,0 +1,39 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Due to testing environment limitations, this test case can only test the scenario with empty `service_info_list`.
+func TestAccDataSourceKubernetesServices_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_kubernetes_services.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceKubernetesServices_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "service_info_list.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceKubernetesServices_basic = `
+data "huaweicloud_hss_kubernetes_services" "test" {
+  enterprise_project_id = "0"
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_kubernetes_services.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_kubernetes_services.go
@@ -1,0 +1,193 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/kubernetes/services
+func DataSourceKubernetesServices() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceKubernetesServicesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cluster_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"namespace": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"service_info_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"endpoint_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"namespace": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_timestamp": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildKubernetesServicesQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=200"
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		queryParams = fmt.Sprintf("%s&name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("cluster_name"); ok {
+		queryParams = fmt.Sprintf("%s&cluster_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("namespace"); ok {
+		queryParams = fmt.Sprintf("%s&namespace=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceKubernetesServicesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		product = "hss"
+		httpUrl = "v5/{project_id}/kubernetes/services"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildKubernetesServicesQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", currentPath, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS kubernetes services: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		serviceInfoList := utils.PathSearch("service_info_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(serviceInfoList) == 0 {
+			break
+		}
+
+		result = append(result, serviceInfoList...)
+		offset += len(serviceInfoList)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("service_info_list", flattenKubernetesServices(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenKubernetesServices(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"id":                 utils.PathSearch("id", v, nil),
+			"name":               utils.PathSearch("name", v, nil),
+			"endpoint_name":      utils.PathSearch("endpoint_name", v, nil),
+			"namespace":          utils.PathSearch("namespace", v, nil),
+			"creation_timestamp": utils.PathSearch("creation_timestamp", v, nil),
+			"type":               utils.PathSearch("type", v, nil),
+			"cluster_ip":         utils.PathSearch("cluster_ip", v, nil),
+			"cluster_name":       utils.PathSearch("cluster_name", v, nil),
+			"cluster_type":       utils.PathSearch("cluster_type", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query kubernetes services.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccDataSourceKubernetesServices_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccDataSourceKubernetesServices_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceKubernetesServices_basic
=== PAUSE TestAccDataSourceKubernetesServices_basic
=== CONT  TestAccDataSourceKubernetesServices_basic
--- PASS: TestAccDataSourceKubernetesServices_basic (10.10s)
PASS
coverage: 3.2% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       10.230s coverage: 3.2% of statements in ./huaweicloud/services/hss
```
<img width="1378" height="80" alt="image" src="https://github.com/user-attachments/assets/aa9e2ede-d61c-43a9-a200-a5cf8406c84e" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
