### PR TITLE
feat(hss): new datasource to query kubernetes pod detail

### DIFF
--- a/docs/data-sources/hss_kubernetes_pod_detail.md
+++ b/docs/data-sources/hss_kubernetes_pod_detail.md
@@ -1,0 +1,137 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_kubernetes_pod_detail"
+description: |-
+  Use this data source to get the kubernetes pod detail of HSS within HuaweiCloud.
+---
+
+# huaweicloud_hss_kubernetes_pod_detail
+
+Use this data source to get the kubernetes pod detail of HSS within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "pod_name" {}
+
+data "huaweicloud_hss_kubernetes_pod_detail" "test" {
+  pod_name = var.pod_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `pod_name` - (Required, String) Specifies the pod name.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `pod_name_attr` - The pod name.
+
+* `namespace_name` - The namespace name.
+
+* `cluster_name` - The cluster name.
+
+* `node_name` - The node name.
+
+* `label` - The pod label.
+
+* `cpu` - The CPU usage.
+
+* `memory` - The memory usage.
+
+* `cpu_limit` - The CPU limit.
+
+* `memory_limit` - The memory limit.
+
+* `node_ip` - The node IP address.
+
+* `pod_ip` - The pod IP address.
+
+* `status` - The pod status.
+  The valid values are as follows:
+  + **Pending**: The pod has been accepted by the Kubernetes system, but one or more container images have not been created.
+  + **Running**: The pod has been bound to a node and all of the containers have been created.
+  + **Succeeded**: All containers in the pod have voluntarily terminated with a container exit code of 0,
+    and will not be restarted.
+  + **Failed**: All containers in the pod have terminated, and at least one container has terminated in a failure state.
+  + **Unknown**: For some reason the state of the pod could not be obtained.
+
+* `create_time` - The creation timestamp.
+
+* `containers` - The container list.
+
+  The [containers](#containers_struct) structure is documented below.
+
+<a name="containers_struct"></a>
+The `containers` block supports:
+
+* `id` - The container ID.
+
+* `region_id` - The region ID.
+
+* `container_id` - The container ID.
+
+* `container_name` - The container name.
+
+* `image_name` - The image name.
+
+* `status` - The container status.
+  The valid values are as follows:
+  + **Running**: Running.
+  + **Terminated**: Terminated.
+  + **Waiting**: Waiting.
+
+* `create_time` - The creation timestamp.
+
+* `cpu_limit` - The CPU limit.
+
+* `memory_limit` - The memory limit.
+
+* `restart_count` - The restart count.
+
+* `pod_name` - The pod name.
+
+* `cluster_name` - The cluster name.
+
+* `cluster_id` - The cluster ID.
+
+* `cluster_type` - The cluster type.
+  The valid values are as follows:
+  + **k8s**: Native cluster.
+  + **cce**: CCE cluster.
+  + **ali**: Alibaba Cloud cluster.
+  + **tencent**: Tencent Cloud cluster.
+  + **azure**: Microsoft Azure cluster.
+  + **aws**: Amazon cluster.
+  + **self_built_hw**: Huawei Cloud self-built cluster.
+  + **self_built_idc**: IDC self-built cluster.
+
+* `risky` - Whether there is a risk.
+  The valid values are as follows:
+  + **true**: There is a risk.
+  + **false**: No risk.
+
+* `low_risk` - The number of low-risk vulnerabilities.
+
+* `medium_risk` - The number of medium-risk vulnerabilities.
+
+* `high_risk` - The number of high-risk vulnerabilities.
+
+* `fatal_risk` - The number of fatal-risk vulnerabilities.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1321,6 +1321,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_host_vulnerabilities":                       hss.DataSourceHssHostVulnerabilities(),
 			"huaweicloud_hss_hosts":                                      hss.DataSourceHosts(),
 			"huaweicloud_hss_kubernetes_services":                        hss.DataSourceKubernetesServices(),
+			"huaweicloud_hss_kubernetes_pod_detail":                      hss.DataSourceKubernetesPodDetail(),
 			"huaweicloud_hss_policy_groups":                              hss.DataSourcePolicyGroups(),
 			"huaweicloud_hss_product_infos":                              hss.DataSourceProductInfos(),
 			"huaweicloud_hss_quotas":                                     hss.DataSourceQuotas(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_kubernetes_pod_detail_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_kubernetes_pod_detail_test.go
@@ -1,0 +1,39 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceKubernetesPodDetail_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_kubernetes_pod_detail.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceKubernetesPodDetail_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "containers.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceKubernetesPodDetail_basic = `
+data "huaweicloud_hss_kubernetes_pod_detail" "test" {
+  pod_name              = "non-exist"
+  enterprise_project_id = "0"
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_kubernetes_pod_detail.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_kubernetes_pod_detail.go
@@ -1,0 +1,279 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/kubernetes/{pod_name}/pod/detail
+func DataSourceKubernetesPodDetail() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceKubernetesPodDetailRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"pod_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"pod_name_attr": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"namespace_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"node_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"label": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cpu": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"memory": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cpu_limit": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"memory_limit": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"node_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"pod_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"containers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"container_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"container_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"image_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"cpu_limit": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"memory_limit": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"restart_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"pod_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"risky": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"low_risk": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"medium_risk": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"high_risk": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"fatal_risk": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildKubernetesPodDetailQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%v", epsId)
+	}
+
+	return ""
+}
+
+func dataSourceKubernetesPodDetailRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		product = "hss"
+		podName = d.Get("pod_name").(string)
+		httpUrl = "v5/{project_id}/kubernetes/{pod_name}/pod/detail"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{pod_name}", podName)
+	requestPath += buildKubernetesPodDetailQueryParams(epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS kubernetes pod detail: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("pod_name_attr", utils.PathSearch("pod_name", respBody, nil)),
+		d.Set("namespace_name", utils.PathSearch("namespace_name", respBody, nil)),
+		d.Set("cluster_name", utils.PathSearch("cluster_name", respBody, nil)),
+		d.Set("node_name", utils.PathSearch("node_name", respBody, nil)),
+		d.Set("label", utils.PathSearch("label", respBody, nil)),
+		d.Set("cpu", utils.PathSearch("cpu", respBody, nil)),
+		d.Set("memory", utils.PathSearch("memory", respBody, nil)),
+		d.Set("cpu_limit", utils.PathSearch("cpu_limit", respBody, nil)),
+		d.Set("memory_limit", utils.PathSearch("memory_limit", respBody, nil)),
+		d.Set("node_ip", utils.PathSearch("node_ip", respBody, nil)),
+		d.Set("pod_ip", utils.PathSearch("pod_ip", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", respBody, nil)),
+		d.Set("containers", flattenKubernetesPodDetailContainers(respBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenKubernetesPodDetailContainers(resp interface{}) []map[string]interface{} {
+	containersResp := utils.PathSearch("containers", resp, make([]interface{}, 0)).([]interface{})
+	if len(containersResp) == 0 {
+		return nil
+	}
+
+	containersResult := make([]map[string]interface{}, 0, len(containersResp))
+	for _, v := range containersResp {
+		containersResult = append(containersResult, map[string]interface{}{
+			"id":             utils.PathSearch("id", v, nil),
+			"region_id":      utils.PathSearch("region_id", v, nil),
+			"container_id":   utils.PathSearch("container_id", v, nil),
+			"container_name": utils.PathSearch("container_name", v, nil),
+			"image_name":     utils.PathSearch("image_name", v, nil),
+			"status":         utils.PathSearch("status", v, nil),
+			"create_time":    utils.PathSearch("create_time", v, nil),
+			"cpu_limit":      utils.PathSearch("cpu_limit", v, nil),
+			"memory_limit":   utils.PathSearch("memory_limit", v, nil),
+			"restart_count":  utils.PathSearch("restart_count", v, nil),
+			"pod_name":       utils.PathSearch("pod_name", v, nil),
+			"cluster_name":   utils.PathSearch("cluster_name", v, nil),
+			"cluster_id":     utils.PathSearch("cluster_id", v, nil),
+			"cluster_type":   utils.PathSearch("cluster_type", v, nil),
+			"risky":          utils.PathSearch("risky", v, nil),
+			"low_risk":       utils.PathSearch("low_risk", v, nil),
+			"medium_risk":    utils.PathSearch("medium_risk", v, nil),
+			"high_risk":      utils.PathSearch("high_risk", v, nil),
+			"fatal_risk":     utils.PathSearch("fatal_risk", v, nil),
+		})
+	}
+
+	return containersResult
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query kubernetes pod detail.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccDataSourceKubernetesPodDetail_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccDataSourceKubernetesPodDetail_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceKubernetesPodDetail_basic
=== PAUSE TestAccDataSourceKubernetesPodDetail_basic
=== CONT  TestAccDataSourceKubernetesPodDetail_basic
--- PASS: TestAccDataSourceKubernetesPodDetail_basic (11.84s)
PASS
coverage: 3.1% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       11.932s coverage: 3.1% of statements in ./huaweicloud/services/hss
```
<img width="1389" height="85" alt="image" src="https://github.com/user-attachments/assets/75dba108-fb7d-4d71-89a2-a8437d8c6ff5" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
