### PR TITLE
feat(evs): support `evs_recycle_bin_policy` data source

### DIFF
--- a/docs/data-sources/evs_recycle_bin_policy.md
+++ b/docs/data-sources/evs_recycle_bin_policy.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Elastic Volume Service (EVS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_evs_recycle_bin_policy"
+description: |-
+  Use this data source to get the EVS recycle bin policy within HuaweiCloud.
+---
+
+# huaweicloud_evs_recycle_bin_policy
+
+Use this data source to get the EVS recycle bin policy within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_evs_recycle_bin_policy" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `switch` - Whether the recycle bin switch.  
+  The valid values are as follows:
+  + **true**: Open recycle bin.
+  + **false**: Close recycle bin.
+
+* `threshold_time` - The threshold time for the recycle bin, and how many days after the cloud
+  disk is created, it will be deleted before being placed in the recycle bin.  
+  The valid value range is `1` to `1,000`. The default value is `7`.
+
+* `keep_time` - The storage period (days) of the cloud disk in the designated recycle bin, and
+  how many days it will take for the cloud disk to be completely deleted after entering the recycle bin.  
+  The valid value range is `1` to `365`. The default value is `7`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1173,6 +1173,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_evs_snapshot_chains":           evs.DataSourceEvsSnapshotChains(),
 			"huaweicloud_evs_quotas":                    evs.DataSourceEvsQuotas(),
 			"huaweicloud_evsv3_quotas":                  evs.DataSourceEvsV3Quotas(),
+			"huaweicloud_evs_recycle_bin_policy":        evs.DataSourceRecycleBinPolicy(),
 
 			"huaweicloud_fgs_applications":                fgs.DataSourceApplications(),
 			"huaweicloud_fgs_application_templates":       fgs.DataSourceApplicationTemplates(),

--- a/huaweicloud/services/acceptance/evs/data_source_huaweicloud_evs_recycle_bin_policy_test.go
+++ b/huaweicloud/services/acceptance/evs/data_source_huaweicloud_evs_recycle_bin_policy_test.go
@@ -1,0 +1,40 @@
+package evs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRecycleBinPolicy_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_evs_recycle_bin_policy.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceRecycleBinPolicy_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "switch"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "threshold_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "keep_time"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceRecycleBinPolicy_basic() string {
+	return `
+data "huaweicloud_evs_recycle_bin_policy" "test" {}
+`
+}

--- a/huaweicloud/services/evs/data_source_huaweicloud_evs_recycle_bin_policy.go
+++ b/huaweicloud/services/evs/data_source_huaweicloud_evs_recycle_bin_policy.go
@@ -1,0 +1,89 @@
+package evs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EVS GET /v3/{project_id}/recycle-bin-volumes/policy
+func DataSourceRecycleBinPolicy() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRecycleBinPolicyRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"switch": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"threshold_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"keep_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceRecycleBinPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "evs"
+		httpUrl = "v3/{project_id}/recycle-bin-volumes/policy"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving EVS recycle bin policy: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("switch", utils.PathSearch("switch", respBody, nil)),
+		d.Set("threshold_time", utils.PathSearch("threshold_time", respBody, nil)),
+		d.Set("keep_time", utils.PathSearch("keep_time", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `evs_recycle_bin_policy` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `evs_recycle_bin_policy` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/evs" TESTARGS="-run TestAccDataSourceRecycleBinPolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccDataSourceRecycleBinPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRecycleBinPolicy_basic
=== PAUSE TestAccDataSourceRecycleBinPolicy_basic
=== CONT  TestAccDataSourceRecycleBinPolicy_basic
--- PASS: TestAccDataSourceRecycleBinPolicy_basic (14.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       14.503s
```
<img width="871" height="39" alt="image" src="https://github.com/user-attachments/assets/80209389-3e37-4627-ad6a-662be13b9f26" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
