### PR TITLE
feat(hss): new resource to sync container network  policy

### DIFF
--- a/docs/resources/hss_container_network_policy_sync.md
+++ b/docs/resources/hss_container_network_policy_sync.md
@@ -1,0 +1,44 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_container_network_policy_sync"
+description: |-
+  Manages an HSS container network policy sync resource within HuaweiCloud.
+---
+
+# huaweicloud_hss_container_network_policy_sync
+
+Manages an HSS container network policy sync resource within HuaweiCloud.
+
+-> This resource is only a one-time action resource for synchronizing container network policies. Deleting this resource
+   will not affect the synchronization status, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+variable "enterprise_project_id" {}
+
+resource "huaweicloud_hss_container_network_policy_sync" "test" {
+  cluster_id            = var.cluster_id
+  enterprise_project_id = var.enterprise_project_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region to which the HSS container network policy sync resource belongs.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the cluster to synchronize network policies for.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  If omitted, the default enterprise project is used.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2789,6 +2789,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_container_kubernetes_sync_mccs":                 hss.ResourceContainerKubernetesSyncMccs(),
 			"huaweicloud_hss_container_kubernetes_cluster_daemonset":         hss.ResourceContainerKubernetesClusterDaemonset(),
 			"huaweicloud_hss_container_kubernetes_cluster_protection_enable": hss.ResourceContainerKubernetesClusterProtectionEnable(),
+			"huaweicloud_hss_container_network_policy_sync":                  hss.ResourceContainerNetworkPolicySync(),
 			"huaweicloud_hss_cicd_configuration":                             hss.ResourceCiCdConfiguration(),
 			"huaweicloud_hss_honeypot_port_policy":                           hss.ResourceHoneypotPortPolicy(),
 			"huaweicloud_hss_host_protection":                                hss.ResourceHostProtection(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_container_network_policy_sync_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_container_network_policy_sync_test.go
@@ -1,0 +1,31 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccContainerNetworkPolicySync_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testContainerNetworkPolicySync_basic,
+			},
+		},
+	})
+}
+
+const testContainerNetworkPolicySync_basic = `
+resource "huaweicloud_hss_container_network_policy_sync" "test" {
+  cluster_id            = "non-exist-id"
+  enterprise_project_id = "0"
+}
+`

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_container_network_policy_sync.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_container_network_policy_sync.go
@@ -1,0 +1,124 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var syncNetworkPolicyNonUpdatableParams = []string{
+	"cluster_id", "enterprise_project_id",
+}
+
+// @API HSS GET /v5/{project_id}/container-network/{cluster_id}/policy-sync
+func ResourceContainerNetworkPolicySync() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceContainerNetworkPolicySyncCreate,
+		ReadContext:   resourceContainerNetworkPolicySyncRead,
+		UpdateContext: resourceContainerNetworkPolicySyncUpdate,
+		DeleteContext: resourceContainerNetworkPolicySyncDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(syncNetworkPolicyNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Specifies the region where the resource is located. If omitted, the provider-level region will be used.",
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the ID of the cluster to synchronize network policies for.",
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the enterprise project ID.",
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildContainerNetworkPolicySyncQueryParams(d *schema.ResourceData, cfg *config.Config) string {
+	rst := ""
+	if epsID := cfg.GetEnterpriseProjectID(d); epsID != "" {
+		rst = fmt.Sprintf("?enterprise_project_id=%s", epsID)
+	}
+	return rst
+}
+
+func resourceContainerNetworkPolicySyncCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		product   = "hss"
+		clusterId = d.Get("cluster_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := "v5/{project_id}/container-network/{cluster_id}/policy-sync"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{cluster_id}", clusterId)
+	requestPath += buildContainerNetworkPolicySyncQueryParams(d, cfg)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("GET", client.Endpoint+requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error synchronizing container network policies for cluster %s: %s", clusterId, err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID: %s", err)
+	}
+	d.SetId(id)
+
+	return resourceContainerNetworkPolicySyncRead(ctx, d, meta)
+}
+
+func resourceContainerNetworkPolicySyncRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceContainerNetworkPolicySyncUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceContainerNetworkPolicySyncDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to synchronize container network policies. Deleting
+	this resource will not affect the synchronization status, but will only remove the resource information from
+	the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to sync container network  policy.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccContainerNetworkPolicySync_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccContainerNetworkPolicySync_basic -timeout 360m -parallel 10
=== RUN   TestAccContainerNetworkPolicySync_basic
=== PAUSE TestAccContainerNetworkPolicySync_basic
=== CONT  TestAccContainerNetworkPolicySync_basic
--- PASS: TestAccContainerNetworkPolicySync_basic (12.71s)
PASS
coverage: 3.0% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       12.840s coverage: 3.0% of statements in ./huaweicloud/services/hss
```
<img width="1388" height="130" alt="image" src="https://github.com/user-attachments/assets/06aa31c9-68d1-4e85-a9fc-1bf44cef6643" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
