### PR TITLE
feat(hss): add data source to get server change list

### DIFF
--- a/docs/data-sources/hss_files_change_hosts.md
+++ b/docs/data-sources/hss_files_change_hosts.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_files_change_hosts"
+description: |-
+  Use this data source to get the modify server list.
+---
+
+# huaweicloud_hss_files_change_hosts
+
+Use this data source to get the modify server list.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_files_change_hosts" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `begin_time` - (Optional, Int) Specifies the query start time.
+  The format is 13-digit timestamp in millisecond.
+
+* `end_time` - (Optional, Int) Specifies the query end time.
+  The format is 13-digit timestamp in millisecond.
+
+* `host_name` - (Optional, String) Specifies the server name.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the hosts belong.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data_list` - The list of change servers.
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `host_name` - The server name.
+
+* `host_id` - The server ID.
+
+* `change_total_num` - The total number of changes.
+
+* `change_file_num` - The change the number of files.
+
+* `change_registry_num` - The change the number of registry entries.
+
+* `latest_time` - The last modified time.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1314,6 +1314,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_event_login_white_lists":                    hss.DataSourceEventLoginWhiteLists(),
 			"huaweicloud_hss_event_alarm_white_lists":                    hss.DataSourceEventAlarmWhiteLists(),
 			"huaweicloud_hss_event_unblock_ips":                          hss.DataSourceEventUnblockIps(),
+			"huaweicloud_hss_files_change_hosts":                         hss.DataSourceFilesChangeHosts(),
 			"huaweicloud_hss_files_statistic":                            hss.DataSourceFilesStatistic(),
 			"huaweicloud_hss_honeypot_port_policies":                     hss.DataSourceHoneypotPortPolicies(),
 			"huaweicloud_hss_host_groups":                                hss.DataSourceHostGroups(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_files_change_hosts_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_files_change_hosts_test.go
@@ -1,0 +1,37 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceFilesChangeHosts_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_files_change_hosts.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			// Because there is no available data for testing, the test case is only
+			// used to verify that the API can be invoked.
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceFilesChangeHosts_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceFilesChangeHosts_basic string = `data "huaweicloud_hss_files_change_hosts" "test" {}`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_files_change_hosts.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_files_change_hosts.go
@@ -1,0 +1,185 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/files/change-host
+func DataSourceFilesChangeHosts() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceFilesChangeHostsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"begin_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"end_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"host_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"host_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"change_total_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"change_file_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"change_registry_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"latest_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildFilesChangeHostsQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=200"
+
+	if v, ok := d.GetOk("begin_time"); ok {
+		queryParams = fmt.Sprintf("%s&begin_time=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("end_time"); ok {
+		queryParams = fmt.Sprintf("%s&end_time=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("host_name"); ok {
+		queryParams = fmt.Sprintf("%s&host_name=%v", queryParams, v)
+	}
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+
+	return queryParams
+}
+
+func dataSourceFilesChangeHostsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		httpUrl  = "v5/{project_id}/files/change-host"
+		epsId    = cfg.GetEnterpriseProjectID(d)
+		offset   = 0
+		result   = make([]interface{}, 0)
+		totalNum float64
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildFilesChangeHostsQueryParams(d, epsId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", getPath, offset)
+		getResp, err := client.Request("GET", currentPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving change servers: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataResp := utils.PathSearch("data_list", getRespBody, make([]interface{}, 0)).([]interface{})
+		if len(dataResp) == 0 {
+			break
+		}
+
+		result = append(result, dataResp...)
+
+		totalNum = utils.PathSearch("total_num", getRespBody, float64(0)).(float64)
+		if int(totalNum) == len(result) {
+			break
+		}
+
+		offset += len(dataResp)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data_list", flattenFilesChangeHostsDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenFilesChangeHostsDataList(dataResp []interface{}) []interface{} {
+	if len(dataResp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(dataResp))
+	for _, v := range dataResp {
+		result = append(result, map[string]interface{}{
+			"host_name":           utils.PathSearch("host_name", v, nil),
+			"host_id":             utils.PathSearch("host_id", v, nil),
+			"change_total_num":    utils.PathSearch("change_total_num", v, nil),
+			"change_file_num":     utils.PathSearch("change_file_num", v, nil),
+			"change_registry_num": utils.PathSearch("change_registry_num", v, nil),
+			"latest_time":         utils.PathSearch("latest_time", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add data source to get server change list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceFilesChangeHosts_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceFilesChangeHosts_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceFilesChangeHosts_basic
=== PAUSE TestAccDataSourceFilesChangeHosts_basic
=== CONT  TestAccDataSourceFilesChangeHosts_basic
--- PASS: TestAccDataSourceFilesChangeHosts_basic (12.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       12.657s
```
<img width="1142" height="19" alt="image" src="https://github.com/user-attachments/assets/035dde28-0cac-43ab-a0ce-89e013768304" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
