### PR TITLE
feat(hss): new datasource to query app policy process extend

### DIFF
--- a/docs/data-sources/hss_app_whitelist_policy_process_extend.md
+++ b/docs/data-sources/hss_app_whitelist_policy_process_extend.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_app_whitelist_policy_process_extend"
+description: |-
+  Use this data source to get the process extend list of HSS app whitelist policy within HuaweiCloud.
+---
+
+# huaweicloud_hss_app_whitelist_policy_process_extend
+
+Use this data source to get the process extend list of HSS app whitelist policy within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "policy_id" {}
+variable "host_id" {}
+
+data "huaweicloud_hss_app_whitelist_policy_process_extend" "test" {
+  policy_id = var.policy_id
+  host_id   = var.host_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `policy_id` - (Required, String) Specifies the policy ID.
+
+* `host_id` - (Required, String) Specifies the host ID.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `data_list` - The list of process extend information.
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `process_name` - The process name.
+
+* `process_path` - The process path.
+
+* `process_hash` - The process hash.
+
+* `container_id` - The container ID.
+
+* `cmdline` - The process command line.
+
+* `file_size` - The file size.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1279,6 +1279,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_app_whitelist_associate_hosts":              hss.DataSourceAppWhitelistAssociateHosts(),
 			"huaweicloud_hss_app_whitelist_optional_hosts":               hss.DataSourceAppWhitelistOptionalHosts(),
 			"huaweicloud_hss_app_whitelist_policies":                     hss.DataSourceAppWhitelistPolicies(),
+			"huaweicloud_hss_app_whitelist_policy_process_extend":        hss.DataSourceAppWhitelistPolicyProcessExtend(),
 			"huaweicloud_hss_asset_apps":                                 hss.DataSourceAssetApps(),
 			"huaweicloud_hss_asset_assign_task":                          hss.DataSourceAssetAssignTask(),
 			"huaweicloud_hss_asset_kernel_module_hosts":                  hss.DataSourceAssetKernelModuleHosts(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_app_whitelist_policy_process_extend_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_app_whitelist_policy_process_extend_test.go
@@ -1,0 +1,35 @@
+package hss
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAppWhitelistPolicyProcessExtend_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAppWhitelistPolicyProcessExtend_basic(),
+				ExpectError: regexp.MustCompile(`Access denied.`),
+			},
+		},
+	})
+}
+
+// The values ​​of policy_id and host_id are fake data.
+func testAccDataSourceAppWhitelistPolicyProcessExtend_basic() string {
+	return `
+data "huaweicloud_hss_app_whitelist_policy_process_extend" "test" {
+  policy_id = "3bd2a82c-4b37-47f3-952b-fa323c22c8e6"
+  host_id   = "3bd2a82c-4b37-47f3-952b-fa323c22c8e6"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_app_whitelist_policy_process_extend.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_app_whitelist_policy_process_extend.go
@@ -1,0 +1,155 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/app/{policy_id}/process-extend
+func DataSourceAppWhitelistPolicyProcessExtend() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppWhitelistPolicyProcessExtendRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"process_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"process_path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"process_hash": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"container_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cmdline": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"file_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAppWhitelistPolicyProcessExtendQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := fmt.Sprintf("?host_id=%s", d.Get("host_id").(string))
+
+	if epsId != "" {
+		queryParams += fmt.Sprintf("&enterprise_project_id=%s", epsId)
+	}
+
+	return queryParams
+}
+
+func dataSourceAppWhitelistPolicyProcessExtendRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		epsId    = cfg.GetEnterpriseProjectID(d)
+		product  = "hss"
+		httpUrl  = "v5/{project_id}/app/{policy_id}/process-extend"
+		policyId = d.Get("policy_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{policy_id}", policyId)
+	requestPath += buildAppWhitelistPolicyProcessExtendQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS app whitelist policy process extend: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data_list", flattenAppWhitelistPolicyProcessExtendDataList(respBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAppWhitelistPolicyProcessExtendDataList(resp interface{}) []interface{} {
+	dataList := utils.PathSearch("data_list", resp, make([]interface{}, 0)).([]interface{})
+	if len(dataList) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(dataList))
+	for _, v := range dataList {
+		rst = append(rst, map[string]interface{}{
+			"process_name": utils.PathSearch("process_name", v, nil),
+			"process_path": utils.PathSearch("process_path", v, nil),
+			"process_hash": utils.PathSearch("process_hash", v, nil),
+			"container_id": utils.PathSearch("container_id", v, nil),
+			"cmdline":      utils.PathSearch("cmdline", v, nil),
+			"file_size":    utils.PathSearch("file_size", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query app policy process extend.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccDataSourceAppWhitelistPolicyProcessExtend_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccDataSourceAppWhitelistPolicyProcessExtend_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAppWhitelistPolicyProcessExtend_basic
=== PAUSE TestAccDataSourceAppWhitelistPolicyProcessExtend_basic
=== CONT  TestAccDataSourceAppWhitelistPolicyProcessExtend_basic
--- PASS: TestAccDataSourceAppWhitelistPolicyProcessExtend_basic (2.27s)
PASS
coverage: 2.9% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       2.372s  coverage: 2.9% of statements in ./huaweicloud/services/hss
```
<img width="1389" height="83" alt="image" src="https://github.com/user-attachments/assets/19680340-3de4-4845-8252-d15f623d3e87" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
