### PR TITLE
feat(cpcs): new resource to manage cpcs application

### DIFF
--- a/docs/resources/cpcs_app.md
+++ b/docs/resources/cpcs_app.md
@@ -1,0 +1,67 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cpcs_app"
+description: |-
+  Manages a CPCS application resource within HuaweiCloud.
+---
+
+# huaweicloud_cpcs_app
+
+Manages a CPCS application resource within HuaweiCloud.
+
+-> Currently, this resource is valid only in cn-north-9 region.
+
+## Example Usage
+
+```hcl
+variable "app_name" {}
+variable "vpc_id" {}
+variable "vpc_name" {}
+variable "subnet_id" {}
+variable "subnet_name" {}
+
+resource "huaweicloud_cpcs_app" "test" {
+  app_name    = var.app_name
+  vpc_id      = var.vpc_id
+  vpc_name    = var.vpc_name
+  subnet_id   = var.subnet_id
+  subnet_name = var.subnet_name
+  description = "test application"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `app_name` - (Required, String, NonUpdatable) Specifies the application name. The name must be unique.
+
+* `vpc_id` - (Required, String, NonUpdatable) Specifies the ID of the VPC to which the application belongs.
+
+* `vpc_name` - (Required, String, NonUpdatable) Specifies the name of the VPC to which the application belongs.
+
+* `subnet_id` - (Required, String, NonUpdatable) Specifies the ID of the subnet to which the application belongs.
+
+* `subnet_name` - (Required, String, NonUpdatable) Specifies the name of the subnet to which the application belongs.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the application description.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (same as app_id).
+
+* `create_time` - The creation time of the application, UNIX timestamp in milliseconds.
+
+## Import
+
+The CPCS application resource can be imported using the `app_name`, e.g.
+
+```bash
+$ terraform import huaweicloud_cpcs_app.test <app_name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2451,6 +2451,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_cse_microservice_instance":             cse.ResourceMicroserviceInstance(),
 			"huaweicloud_cse_nacos_namespace":                   cse.ResourceNacosNamespace(),
 
+			"huaweicloud_cpcs_app": dew.ResourceCpcsApp(),
+
 			"huaweicloud_csms_event":                        dew.ResourceCsmsEvent(),
 			"huaweicloud_csms_secret":                       dew.ResourceSecret(),
 			"huaweicloud_csms_secret_version_state":         dew.ResourceSecretVersionState(),

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_cpcs_app_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_cpcs_app_test.go
@@ -1,0 +1,100 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dew"
+)
+
+func getCpcsAppResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("kms", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DEW client: %s", err)
+	}
+
+	return dew.QueryCpcsAppByAppName(client, state.Primary.Attributes["app_name"])
+}
+
+// Currently, this resource is valid only in cn-north-9 region.
+func TestAccCpcsApp_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_cpcs_app.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getCpcsAppResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCpcsApp_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "app_name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test application"),
+					resource.TestCheckResourceAttrSet(rName, "vpc_id"),
+					resource.TestCheckResourceAttrSet(rName, "vpc_name"),
+					resource.TestCheckResourceAttrSet(rName, "subnet_id"),
+					resource.TestCheckResourceAttrSet(rName, "subnet_name"),
+					resource.TestCheckResourceAttrSet(rName, "create_time"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testCpcsAppImportState(rName),
+			},
+		},
+	})
+}
+
+func testCpcsApp_basic(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_vpcs" "test" {}
+
+data "huaweicloud_vpc_subnets" "test" {
+  vpc_id = data.huaweicloud_vpcs.test.vpcs[0].id
+}
+
+resource "huaweicloud_cpcs_app" "test" {
+  app_name    = "%[2]s"
+  vpc_id      = data.huaweicloud_vpcs.test.vpcs[0].id
+  vpc_name    = data.huaweicloud_vpcs.test.vpcs[0].name
+  subnet_id   = data.huaweicloud_vpc_subnets.test.subnets[0].id
+  subnet_name = data.huaweicloud_vpc_subnets.test.subnets[0].name
+  description = "test application"
+}
+`, common.TestVpc(name), name)
+}
+
+func testCpcsAppImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+		if rs.Primary.Attributes["app_name"] == "" {
+			return "", fmt.Errorf("attribute (app_name) of resource (%s) not found", name)
+		}
+
+		return rs.Primary.Attributes["app_name"], nil
+	}
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_cpcs_app.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_cpcs_app.go
@@ -1,0 +1,237 @@
+package dew
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW POST /v1/{project_id}/dew/cpcs/apps
+// @API DEW GET /v1/{project_id}/dew/cpcs/apps
+// @API DEW DELETE /v1/{project_id}/dew/cpcs/apps/{app_id}
+func ResourceCpcsApp() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCpcsAppCreate,
+		ReadContext:   resourceCpcsAppRead,
+		UpdateContext: resourceCpcsAppUpdate,
+		DeleteContext: resourceCpcsAppDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceCpcsAppImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"app_name",
+			"vpc_id",
+			"vpc_name",
+			"subnet_id",
+			"subnet_name",
+			"description",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"app_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the application name.`,
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the VPC to which the application belongs.`,
+			},
+			"vpc_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the name of the VPC to which the application belongs.`,
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the subnet to which the application belongs.`,
+			},
+			"subnet_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the name of the subnet to which the application belongs.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the application description.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"create_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The creation time of the application, UNIX timestamp in milliseconds.`,
+			},
+		},
+	}
+}
+
+func buildCreateAppBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"app_name":    d.Get("app_name"),
+		"vpc_id":      d.Get("vpc_id"),
+		"vpc_name":    d.Get("vpc_name"),
+		"subnet_id":   d.Get("subnet_id"),
+		"subnet_name": d.Get("subnet_name"),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+	return bodyParams
+}
+
+func resourceCpcsAppCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/dew/cpcs/apps"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateAppBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating DEW CPCS application: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	appId := utils.PathSearch("app_id", respBody, "").(string)
+	if appId == "" {
+		return diag.Errorf("unable to find the DEW CPCS application ID from the API response")
+	}
+	d.SetId(appId)
+
+	return resourceCpcsAppRead(ctx, d, meta)
+}
+
+// The value of `app_name` can be used to accurately find the target value.
+func QueryCpcsAppByAppName(client *golangsdk.ServiceClient, appName string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/dew/cpcs/apps"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?app_name=%s", appName)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	appDetail := utils.PathSearch("result|[0]", respBody, nil)
+	if appDetail == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return appDetail, nil
+}
+
+func resourceCpcsAppRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	appDetail, err := QueryCpcsAppByAppName(client, d.Get("app_name").(string))
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DEW CPCS application")
+	}
+
+	// Make sure that the ID value can be written back normally when importing.
+	d.SetId(utils.PathSearch("app_id", appDetail, "").(string))
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("app_name", utils.PathSearch("app_name", appDetail, nil)),
+		d.Set("vpc_id", utils.PathSearch("vpc_id", appDetail, nil)),
+		d.Set("vpc_name", utils.PathSearch("vpc_name", appDetail, nil)),
+		d.Set("subnet_id", utils.PathSearch("subnet_id", appDetail, nil)),
+		d.Set("subnet_name", utils.PathSearch("subnet_name", appDetail, nil)),
+		d.Set("description", utils.PathSearch("description", appDetail, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", appDetail, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceCpcsAppUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceCpcsAppDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/dew/cpcs/apps/{app_id}"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{app_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DEW CPCS application: %s", err)
+	}
+
+	return nil
+}
+
+func resourceCpcsAppImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	return []*schema.ResourceData{d}, d.Set("app_name", d.Id())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to manage cpcs application

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccCpcsApp_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccCpcsApp_basic -timeout 360m -parallel 10
=== RUN   TestAccCpcsApp_basic
=== PAUSE TestAccCpcsApp_basic
=== CONT  TestAccCpcsApp_basic
--- PASS: TestAccCpcsApp_basic (20.33s)
PASS
coverage: 5.0% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       20.418s coverage: 5.0% of statements in ./huaweicloud/services/dew
```
<img width="1306" height="82" alt="image" src="https://github.com/user-attachments/assets/147db9db-7d91-4168-8c45-7f0d496b148c" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
