### PR TITLE
feat(evs): support `evs_recycle_bin_volume_revert` resource

### DIFF
--- a/docs/resources/evs_recycle_bin_volume_revert.md
+++ b/docs/resources/evs_recycle_bin_volume_revert.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Elastic Volume Service (EVS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_evs_recycle_bin_volume_revert"
+description: |-
+  Manages an EVS revert recycle bin volume resource within HuaweiCloud.
+---
+
+# huaweicloud_evs_recycle_bin_volume_revert
+
+Manages an EVS revert recycle bin volume resource within HuaweiCloud.
+
+-> This resource is a one-time action resource using to revert EVS recycle bin volume. Deleting this resource will not
+  clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "volume_id" {}
+
+resource "huaweicloud_evs_recycle_bin_volume_revert" "test" {
+  volume_id = var.volume_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `volume_id` - (Required, String, NonUpdatable) Specifies the disk ID.
+  For its values, can be obtained using `huaweicloud_evs_volumes` dataSource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `volume_id`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2724,6 +2724,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_evs_volumes_batch_expand":       evs.ResourceVolumesBatchExpand(),
 			"huaweicloud_evs_recycle_bin_policy":         evs.ResourceRecycleBinPolicy(),
 			"huaweicloud_evs_recycle_bin_volume_delete":  evs.ResourceRecycleBinVolumeDelete(),
+			"huaweicloud_evs_recycle_bin_volume_revert":  evs.ResourceRecycleBinVolumeRevert(),
 
 			"huaweicloud_fgs_application":                    fgs.ResourceApplication(),
 			"huaweicloud_fgs_async_invoke_configuration":     fgs.ResourceAsyncInvokeConfiguration(),

--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_recycle_bin_volume_revert_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_recycle_bin_volume_revert_test.go
@@ -1,0 +1,38 @@
+package evs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccRecycleBinVolumeRevert_basic(t *testing.T) {
+	// Avoid CheckDestroy because this resource is a one-time action resource and there is nothing in the destroy
+	// method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting a volume ID that is in the recycle bin.
+			acceptance.TestAccPreCheckEVSRecycleBinVolumeId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// One-time action resource do not need to be checked and no processing is performed in the Read method.
+				Config: testRecycleBinVolumeRevert_basic(),
+			},
+		},
+	})
+}
+
+func testRecycleBinVolumeRevert_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_evs_recycle_bin_volume_revert" "test" {
+  volume_id = "%s"
+}
+`, acceptance.HW_EVS_RECYCLE_BIN_VOLUME_ID)
+}

--- a/huaweicloud/services/evs/resource_huaweicloud_evs_recycle_bin_volume_revert.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_recycle_bin_volume_revert.go
@@ -1,0 +1,105 @@
+package evs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var recycleBinVolumeRevertNonUpdatableParams = []string{
+	"volume_id",
+}
+
+// @API EVS POST /v3/{project_id}/recycle-bin-volumes/{volume_id}/revert
+func ResourceRecycleBinVolumeRevert() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRecycleBinVolumeRevertCreate,
+		ReadContext:   resourceRecycleBinVolumeRevertRead,
+		UpdateContext: resourceRecycleBinVolumeRevertUpdate,
+		DeleteContext: resourceRecycleBinVolumeRevertDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(recycleBinVolumeRevertNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceRecycleBinVolumeRevertCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		httpUrl  = "v3/{project_id}/recycle-bin-volumes/{volume_id}/revert"
+		product  = "evs"
+		volumeId = d.Get("volume_id").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{volume_id}", volumeId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200, 201, 202, 204,
+		},
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error reverting EVS recycle bin volume: %s", err)
+	}
+
+	d.SetId(volumeId)
+
+	return resourceRecycleBinVolumeRevertRead(ctx, d, meta)
+}
+
+func resourceRecycleBinVolumeRevertRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceRecycleBinVolumeRevertUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceRecycleBinVolumeRevertDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to revert EVS recycle bin volume. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information from the tf
+    state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `evs_recycle_bin_volume_revert` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `evs_recycle_bin_volume_revert` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/evs" TESTARGS="-run TestAccRecycleBinVolumeRevert_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccRecycleBinVolumeRevert_basic -timeout 360m -parallel 4
=== RUN   TestAccRecycleBinVolumeRevert_basic
=== PAUSE TestAccRecycleBinVolumeRevert_basic
=== CONT  TestAccRecycleBinVolumeRevert_basic
--- PASS: TestAccRecycleBinVolumeRevert_basic (13.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       13.512s

```
<img width="906" height="33" alt="image" src="https://github.com/user-attachments/assets/c48ad88f-a36d-4c02-9ed6-f9829da1b022" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
