### PR TITLE
fix(eg): fix the parameter name to source_community_rocketmq_kafka

### DIFF
--- a/huaweicloud/services/eg/resource_huaweicloud_eg_event_stream.go
+++ b/huaweicloud/services/eg/resource_huaweicloud_eg_event_stream.go
@@ -279,7 +279,7 @@ func buildEventStreamSource(eventSources []interface{}) interface{} {
 			utils.PathSearch("kafka", newSource, "").(string))),
 		"source_mobile_rocketmq": utils.ValueIgnoreEmpty(unmarshalJsonFormatParamster("mobile RocketMQ configuration",
 			utils.PathSearch("mobile_rocketmq", newSource, "").(string))),
-		"sourcesource_community_rocketmq_kafka": utils.ValueIgnoreEmpty(unmarshalJsonFormatParamster("community RocketMQ configuration",
+		"source_community_rocketmq_kafka": utils.ValueIgnoreEmpty(unmarshalJsonFormatParamster("community RocketMQ configuration",
 			utils.PathSearch("community_rocketmq", newSource, "").(string))),
 		"source_dms_rocketmq": utils.ValueIgnoreEmpty(unmarshalJsonFormatParamster("DMS RocketMQ configuration",
 			utils.PathSearch("dms_rocketmq", newSource, "").(string))),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix the parameter name to `source_community_rocketmq_kafka`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
