### PR TITLE
feat(hss): add data source to get historical change records of software

### DIFF
--- a/docs/data-sources/hss_asset_app_change_history.md
+++ b/docs/data-sources/hss_asset_app_change_history.md
@@ -1,0 +1,90 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_asset_app_change_history"
+description: |-
+  Use this data source to get the historical change records of software information.
+---
+
+# huaweicloud_hss_asset_app_change_history
+
+Use this data source to get the historical change records of software information.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_asset_app_change_history" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `host_id` - (Optional, String) Specifies the host ID.
+
+* `host_ip` - (Optional, String) Specifies the host IP address.
+
+* `host_name` - (Optional, String) Specifies the host name.
+
+* `app_name` - (Optional, String) Specifies the software name.
+
+* `variation_type` - (Optional, String) Specifies the change type.
+  The valid values are as follows:
+  + **add**
+  + **delete**
+  + **modify**
+
+* `start_time` - (Optional, Int) Specifies the query start time.
+  The format is 13-digit timestamp in millisecond.
+
+* `end_time` - (Optional, Int) Specifies the query end time.
+  The format is 13-digit timestamp in millisecond.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the hosts belong.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `sort_key` - (Optional, String) Specifies the sort key.
+  Currently, data can only be sorted by `recent_scan_time`.
+
+* `sort_dir` - (Optional, String) Specifies the sort order. The default value is **desc**.
+  The valid values are as follows:
+  + **asc**
+  + **desc**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data_list` - The list of software change history.
+
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `agent_id` - The agent ID.
+
+* `variation_type` - The change type.
+
+* `host_id` - The host Id.
+
+* `app_name` - The software name.
+
+* `host_name` - The host name.
+
+* `host_ip` - The host IP address.
+
+* `version` - The software version.
+
+* `update_time` - The software update time.
+
+* `recent_scan_time` - The last scan time.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1286,6 +1286,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_app_whitelist_optional_hosts":               hss.DataSourceAppWhitelistOptionalHosts(),
 			"huaweicloud_hss_app_whitelist_policies":                     hss.DataSourceAppWhitelistPolicies(),
 			"huaweicloud_hss_app_whitelist_policy_process_extend":        hss.DataSourceAppWhitelistPolicyProcessExtend(),
+			"huaweicloud_hss_asset_app_change_history":                   hss.DataSourceAssetAppChangeHistory(),
 			"huaweicloud_hss_asset_apps":                                 hss.DataSourceAssetApps(),
 			"huaweicloud_hss_asset_assign_task":                          hss.DataSourceAssetAssignTask(),
 			"huaweicloud_hss_asset_kernel_module_hosts":                  hss.DataSourceAssetKernelModuleHosts(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_asset_app_change_history_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_asset_app_change_history_test.go
@@ -1,0 +1,37 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAssetAppChangeHistory_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_asset_app_change_history.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			// Because there is no available data for testing, the test case is only
+			// used to verify that the API can be invoked.
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAssetAppChangeHistory_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAssetAppChangeHistory_basic string = `data "huaweicloud_hss_asset_app_change_history" "test" {}`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_asset_app_change_history.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_asset_app_change_history.go
@@ -1,0 +1,241 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/asset/app/change-history
+func DataSourceAssetAppChangeHistory() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAssetAppChangeHistoryRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"host_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"host_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"app_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"variation_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"start_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"end_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"agent_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"variation_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"app_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"recent_scan_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAssetAppChangeHistoryQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=200"
+
+	if v, ok := d.GetOk("host_id"); ok {
+		queryParams = fmt.Sprintf("%s&host_id=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("host_ip"); ok {
+		queryParams = fmt.Sprintf("%s&host_ip=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("host_name"); ok {
+		queryParams = fmt.Sprintf("%s&host_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("app_name"); ok {
+		queryParams = fmt.Sprintf("%s&app_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("variation_type"); ok {
+		queryParams = fmt.Sprintf("%s&variation_type=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("start_time"); ok {
+		queryParams = fmt.Sprintf("%s&start_time=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("end_time"); ok {
+		queryParams = fmt.Sprintf("%s&end_time=%v", queryParams, v)
+	}
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("sort_key"); ok {
+		queryParams = fmt.Sprintf("%s&sort_key=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("sort_dir"); ok {
+		queryParams = fmt.Sprintf("%s&sort_dir=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceAssetAppChangeHistoryRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		epsId    = cfg.GetEnterpriseProjectID(d)
+		httpUrl  = "v5/{project_id}/asset/app/change-history"
+		offset   = 0
+		result   = make([]interface{}, 0)
+		totalNum float64
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildAssetAppChangeHistoryQueryParams(d, epsId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", getPath, offset)
+		getResp, err := client.Request("GET", currentPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving historical change records of software information: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataResp := utils.PathSearch("data_list", getRespBody, make([]interface{}, 0)).([]interface{})
+		if len(dataResp) == 0 {
+			break
+		}
+
+		result = append(result, dataResp...)
+
+		totalNum = utils.PathSearch("total_num", getRespBody, float64(0)).(float64)
+		if int(totalNum) == len(result) {
+			break
+		}
+
+		offset += len(dataResp)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data_list", flattenAssetAppChangeHistory(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAssetAppChangeHistory(appInfos []interface{}) []interface{} {
+	if len(appInfos) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(appInfos))
+	for _, v := range appInfos {
+		rst = append(rst, map[string]interface{}{
+			"agent_id":         utils.PathSearch("agent_id", v, nil),
+			"variation_type":   utils.PathSearch("variation_type", v, nil),
+			"host_id":          utils.PathSearch("host_id", v, nil),
+			"app_name":         utils.PathSearch("app_name", v, nil),
+			"host_name":        utils.PathSearch("host_name", v, nil),
+			"host_ip":          utils.PathSearch("host_ip", v, nil),
+			"version":          utils.PathSearch("version", v, nil),
+			"update_time":      utils.PathSearch("update_time", v, nil),
+			"recent_scan_time": utils.PathSearch("recent_scan_time", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get historical change records of software.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceAssetAppChangeHistory_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceAssetAppChangeHistory_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAssetAppChangeHistory_basic
=== PAUSE TestAccDataSourceAssetAppChangeHistory_basic
=== CONT  TestAccDataSourceAssetAppChangeHistory_basic
--- PASS: TestAccDataSourceAssetAppChangeHistory_basic (12.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       12.262s
```
<img width="1143" height="18" alt="image" src="https://github.com/user-attachments/assets/1d5d7771-26ac-4d99-8c90-c17602a4db95" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
