### PR TITLE
feat(dew): new resource to manage cpcs app access key

### DIFF
--- a/docs/resources/cpcs_app_access_key.md
+++ b/docs/resources/cpcs_app_access_key.md
@@ -1,0 +1,89 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cpcs_app_access_key"
+description: |-
+  Manages a CPCS application access key resource within HuaweiCloud.
+---
+
+# huaweicloud_cpcs_app_access_key
+
+Manages a CPCS application access key resource within HuaweiCloud.
+
+-> Currently, this resource is valid only in cn-north-9 region.
+
+## Example Usage
+
+```hcl
+variable "app_id" {}
+variable "key_name" {}
+
+resource "huaweicloud_cpcs_app_access_key" "test" {
+  app_id   = var.app_id
+  key_name = var.key_name
+  status   = "enable"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `app_id` - (Required, String, NonUpdatable) Specifies the application ID to which the access key belongs.
+
+* `key_name` - (Required, String, NonUpdatable) Specifies the access key name. The name must be unique within the
+  application.
+
+* `access_key` - (Optional, String, Sensitive, NonUpdatable) Specifies the access key AK. If omitted, the system will
+  automatically generate it.
+
+* `secret_key` - (Optional, String, Sensitive, NonUpdatable) Specifies the access key SK. If omitted, the system will
+  automatically generate it.
+
+* `status` - (Optional, String) Specifies the status of the access key. Valid values are **enable** and **disable**.
+  Defaults to **enable**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (access key ID).
+
+* `app_name` - The name of the application to which the access key belongs.
+
+* `create_time` - The creation time of the access key, UNIX timestamp in milliseconds.
+
+* `download_time` - The time when the access key was downloaded, UNIX timestamp in milliseconds.
+
+* `is_downloaded` - Whether the access key has been downloaded.
+
+* `is_imported` - Whether the access key is imported.
+
+## Import
+
+The CPCS application access key resource can be imported using the `app_id` and `key_name`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_cpcs_app_access_key.test <app_id>/<key_name>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `secret_key`.
+It is generally recommended running `terraform plan` after importing a cluster.
+You can then decide if changes should be applied to the cluster, or the resource definition
+should be updated to align with the cluster. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_cpcs_app_access_key" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      secret_key,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2459,7 +2459,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_cse_microservice_instance":             cse.ResourceMicroserviceInstance(),
 			"huaweicloud_cse_nacos_namespace":                   cse.ResourceNacosNamespace(),
 
-			"huaweicloud_cpcs_app": dew.ResourceCpcsApp(),
+			"huaweicloud_cpcs_app_access_key": dew.ResourceCpcsAppAccessKey(),
+			"huaweicloud_cpcs_app":            dew.ResourceCpcsApp(),
 
 			"huaweicloud_csms_event":                        dew.ResourceCsmsEvent(),
 			"huaweicloud_csms_secret":                       dew.ResourceSecret(),

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_cpcs_app_access_key_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_cpcs_app_access_key_test.go
@@ -1,0 +1,119 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dew"
+)
+
+func getCpcsAppAccessKeyResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("kms", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DEW client: %s", err)
+	}
+
+	appId := state.Primary.Attributes["app_id"]
+	keyName := state.Primary.Attributes["key_name"]
+	return dew.QueryCpcsAppAccessKeyByAppIdAndKeyName(client, appId, keyName)
+}
+
+// Currently, this resource is valid only in cn-north-9 region.
+func TestAccCpcsAppAccessKey_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_cpcs_app_access_key.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getCpcsAppAccessKeyResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCpcsAppAccessKey_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "key_name", name),
+					resource.TestCheckResourceAttr(rName, "status", "disable"),
+					resource.TestCheckResourceAttrSet(rName, "app_id"),
+					resource.TestCheckResourceAttrSet(rName, "access_key"),
+					resource.TestCheckResourceAttrSet(rName, "create_time"),
+					resource.TestCheckResourceAttrSet(rName, "download_time"),
+					resource.TestCheckResourceAttrSet(rName, "is_downloaded"),
+					resource.TestCheckResourceAttrSet(rName, "is_imported"),
+				),
+			},
+			{
+				Config: testCpcsAppAccessKey_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "status", "enable"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testCpcsAppAccessKeyImportState(rName),
+			},
+		},
+	})
+}
+
+func testCpcsAppAccessKey_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cpcs_app_access_key" "test" {
+  app_id   = huaweicloud_cpcs_app.test.id
+  key_name = "%[2]s"
+  status   = "disable"
+}
+`, testCpcsApp_basic(name), name)
+}
+
+func testCpcsAppAccessKey_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cpcs_app_access_key" "test" {
+  app_id   = huaweicloud_cpcs_app.test.id
+  key_name = "%[2]s"
+  status   = "enable"
+}
+`, testCpcsApp_basic(name), name)
+}
+
+func testCpcsAppAccessKeyImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+		if rs.Primary.Attributes["app_id"] == "" {
+			return "", fmt.Errorf("attribute (app_id) of resource (%s) not found", name)
+		}
+		if rs.Primary.Attributes["key_name"] == "" {
+			return "", fmt.Errorf("attribute (key_name) of resource (%s) not found", name)
+		}
+
+		appId := rs.Primary.Attributes["app_id"]
+		keyName := rs.Primary.Attributes["key_name"]
+		return fmt.Sprintf("%s/%s", appId, keyName), nil
+	}
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_cpcs_app_access_key.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_cpcs_app_access_key.go
@@ -1,0 +1,327 @@
+package dew
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW POST /v1/{project_id}/dew/cpcs/apps/{app_id}/access-keys
+// @API DEW GET /v1/{project_id}/dew/cpcs/apps/{app_id}/access-keys
+// @API DEW DELETE /v1/{project_id}/dew/cpcs/apps/{app_id}/access-keys/{access_key_id}
+// @API DEW POST /v1/{project_id}/dew/cpcs/apps/{app_id}/access-keys/enable
+// @API DEW POST /v1/{project_id}/dew/cpcs/apps/{app_id}/access-keys/disable
+func ResourceCpcsAppAccessKey() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCpcsAppAccessKeyCreate,
+		ReadContext:   resourceCpcsAppAccessKeyRead,
+		UpdateContext: resourceCpcsAppAccessKeyUpdate,
+		DeleteContext: resourceCpcsAppAccessKeyDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceCpcsAppAccessKeyImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"app_id",
+			"key_name",
+			"access_key",
+			"secret_key",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"app_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the application ID to which the access key belongs.`,
+			},
+			"key_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the access key name.`,
+			},
+			"access_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Sensitive:   true,
+				Description: `Specifies the access key AK. If omitted, the system will automatically generate it.`,
+			},
+			"secret_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Sensitive:   true,
+				Description: `Specifies the access key SK. If omitted, the system will automatically generate it.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the status of the access key.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"app_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the application to which the access key belongs.`,
+			},
+			"create_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The creation time of the access key, UNIX timestamp in milliseconds.`,
+			},
+			"download_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The time when the access key was downloaded, UNIX timestamp in milliseconds.`,
+			},
+			"is_downloaded": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the access key has been downloaded.`,
+			},
+			"is_imported": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the access key is imported.`,
+			},
+		},
+	}
+}
+
+func buildCreateAppAccessKeyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"key_name":   d.Get("key_name"),
+		"access_key": utils.ValueIgnoreEmpty(d.Get("access_key")),
+		"secret_key": utils.ValueIgnoreEmpty(d.Get("secret_key")),
+	}
+	return bodyParams
+}
+
+func updateCpcsAppAccessKeyStatus(client *golangsdk.ServiceClient, d *schema.ResourceData, status string) error {
+	httpUrl := ""
+	switch status {
+	case "disable":
+		httpUrl = "v1/{project_id}/dew/cpcs/apps/{app_id}/access-keys/disable"
+	case "enable":
+		httpUrl = "v1/{project_id}/dew/cpcs/apps/{app_id}/access-keys/enable"
+	default:
+		return fmt.Errorf("invalid status: %s", status)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{app_id}", d.Get("app_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"access_key_ids": []string{d.Id()},
+		},
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	return err
+}
+
+func resourceCpcsAppAccessKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/dew/cpcs/apps/{app_id}/access-keys"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{app_id}", d.Get("app_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateAppAccessKeyBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating DEW CPCS application access key: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	accessKeyId := utils.PathSearch("access_key_id", respBody, "").(string)
+	if accessKeyId == "" {
+		return diag.Errorf("unable to find the DEW CPCS application access key ID from the API response")
+	}
+	d.SetId(accessKeyId)
+
+	if d.Get("status").(string) == "disable" {
+		if err := updateCpcsAppAccessKeyStatus(client, d, "disable"); err != nil {
+			return diag.Errorf("error disabling DEW CPCS application access key in create operation: %s", err)
+		}
+	}
+
+	return resourceCpcsAppAccessKeyRead(ctx, d, meta)
+}
+
+// The value of `key_name` can be used to accurately find the target value.
+func QueryCpcsAppAccessKeyByAppIdAndKeyName(client *golangsdk.ServiceClient, appId, keyName string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/dew/cpcs/apps/{app_id}/access-keys"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{app_id}", appId)
+	requestPath += fmt.Sprintf("?key_name=%s", keyName)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	accessKeyDetail := utils.PathSearch("result|[0]", respBody, nil)
+	if accessKeyDetail == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return accessKeyDetail, nil
+}
+
+func resourceCpcsAppAccessKeyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "kms"
+		appId   = d.Get("app_id").(string)
+		keyName = d.Get("key_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	accessKeyDetail, err := QueryCpcsAppAccessKeyByAppIdAndKeyName(client, appId, keyName)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DEW CPCS application access key")
+	}
+
+	// Make sure that the ID value can be written back normally when importing.
+	d.SetId(utils.PathSearch("access_key_id", accessKeyDetail, "").(string))
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("key_name", utils.PathSearch("key_name", accessKeyDetail, nil)),
+		d.Set("access_key", utils.PathSearch("access_key", accessKeyDetail, nil)),
+		d.Set("app_name", utils.PathSearch("app_name", accessKeyDetail, nil)),
+		d.Set("status", utils.PathSearch("status", accessKeyDetail, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", accessKeyDetail, nil)),
+		d.Set("download_time", utils.PathSearch("download_time", accessKeyDetail, nil)),
+		d.Set("is_downloaded", utils.PathSearch("is_downloaded", accessKeyDetail, nil)),
+		d.Set("is_imported", utils.PathSearch("is_imported", accessKeyDetail, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceCpcsAppAccessKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "kms"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	if d.HasChange("status") {
+		if err := updateCpcsAppAccessKeyStatus(client, d, d.Get("status").(string)); err != nil {
+			return diag.Errorf("error updating DEW CPCS application access key status in update operation: %s", err)
+		}
+	}
+
+	return resourceCpcsAppAccessKeyRead(ctx, d, meta)
+}
+
+func resourceCpcsAppAccessKeyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/dew/cpcs/apps/{app_id}/access-keys/{access_key_id}"
+		product = "kms"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	// Disable the key first and then delete it.
+	if d.Get("status").(string) == "enable" {
+		if err := updateCpcsAppAccessKeyStatus(client, d, "disable"); err != nil {
+			return diag.Errorf("error updating DEW CPCS application access key status in delete operation: %s", err)
+		}
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{app_id}", d.Get("app_id").(string))
+	requestPath = strings.ReplaceAll(requestPath, "{access_key_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DEW CPCS application access key: %s", err)
+	}
+
+	return nil
+}
+
+func resourceCpcsAppAccessKeyImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format for import ID, want '<app_id>/<key_name>', but got '%s'", d.Id())
+	}
+
+	mErr := multierror.Append(
+		d.Set("app_id", parts[0]),
+		d.Set("key_name", parts[1]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to manage cpcs app access key

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccCpcsAppAccessKey_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccCpcsAppAccessKey_basic -timeout 360m -parallel 10
=== RUN   TestAccCpcsAppAccessKey_basic
=== PAUSE TestAccCpcsAppAccessKey_basic
=== CONT  TestAccCpcsAppAccessKey_basic
--- PASS: TestAccCpcsAppAccessKey_basic (36.42s)
PASS
coverage: 7.9% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       36.517s coverage: 7.9% of statements in ./huaweicloud/services/dew
```
<img width="1288" height="81" alt="image" src="https://github.com/user-attachments/assets/754cbf7c-b39c-4da5-a577-c87816116cc7" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="933" height="194" alt="image" src="https://github.com/user-attachments/assets/f337dafe-1b5c-4ff2-a24c-a4fd2ba9254a" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
