### PR TITLE
feat(SWR): support enterprise domain name management

### DIFF
--- a/docs/resources/swr_enterprise_domain_name.md
+++ b/docs/resources/swr_enterprise_domain_name.md
@@ -1,0 +1,61 @@
+---
+subcategory: "Software Repository for Container (SWR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_swr_enterprise_domain_name"
+description: |-
+  Manages a SWR enterprise instance domain name resource within HuaweiCloud.
+---
+
+# huaweicloud_swr_enterprise_domain_name
+
+Manages a SWR enterprise instance domain name resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "domain_name" {}
+variable "certificate_id" {}
+
+resource "huaweicloud_swr_enterprise_domain_name" "test" {
+  instance_id    = var.instance_id
+  domain_name    = var.domain_name
+  certificate_id = var.certificate_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the enterprise instance ID.
+
+* `domain_name` - (Required, String, NonUpdatable) Specifies the domain name.
+
+* `certificate_id` - (Required, String) Specifies the SCM certificate ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `domain_name_id` - Indicates the domain name ID.
+
+* `type` - Indicates the domain name type.
+
+* `created_at` - Indicates the creation time.
+
+* `updated_at` - Indicates the last update time.
+
+## Import
+
+The domain name can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_swr_enterprise_domain_name.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3254,6 +3254,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_swr_enterprise_image_signature_policy":         swrenterprise.ResourceSwrEnterpriseImageSignaturePolicy(),
 			"huaweicloud_swr_enterprise_image_signature_policy_execute": swrenterprise.ResourceSwrEnterpriseImageSignaturePolicyExecute(),
 			"huaweicloud_swr_enterprise_job_delete":                     swrenterprise.ResourceSwrEnterpriseJobDelete(),
+			"huaweicloud_swr_enterprise_domain_name":                    swrenterprise.ResourceSwrEnterpriseDomainName(),
 			"huaweicloud_swr_enterprise_long_term_credential":           swrenterprise.ResourceSwrEnterpriseLongTermCredential(),
 			"huaweicloud_swr_enterprise_temporary_credential":           swrenterprise.ResourceSwrEnterpriseTemporaryCredential(),
 			"huaweicloud_swr_enterprise_private_network_access_control": swrenterprise.ResourceSwrEnterprisePrivateNetworkAccessControl(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -421,6 +421,9 @@ var (
 	// The repository of SWR image tag
 	HW_SWR_REPOSITORY = os.Getenv("HW_SWR_REPOSITORY")
 
+	HW_SCM_CERTIFICATE_ID          = os.Getenv("HW_SCM_CERTIFICATE_ID")
+	HW_SCM_CERTIFICATE_DOMAIN_NAME = os.Getenv("HW_SCM_CERTIFICATE_DOMAIN_NAME")
+
 	// The ID of the CBR vault
 	HW_IMS_VAULT_ID = os.Getenv("HW_IMS_VAULT_ID")
 	// The ID of the CBR backup
@@ -2403,6 +2406,20 @@ func TestAccPreCheckSwrOrigination(t *testing.T) {
 func TestAccPreCheckSwrRepository(t *testing.T) {
 	if HW_SWR_REPOSITORY == "" {
 		t.Skip("HW_SWR_REPOSITORY must be set for SWR image tags tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckScmCertificateId(t *testing.T) {
+	if HW_SCM_CERTIFICATE_ID == "" {
+		t.Skip("HW_SCM_CERTIFICATE_ID must be set for tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckScmCertificateDomainName(t *testing.T) {
+	if HW_SCM_CERTIFICATE_DOMAIN_NAME == "" {
+		t.Skip("HW_SCM_CERTIFICATE_DOMAIN_NAME must be set for tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/swrenterprise/resource_huaweicloud_swr_enterprise_domain_name_test.go
+++ b/huaweicloud/services/acceptance/swrenterprise/resource_huaweicloud_swr_enterprise_domain_name_test.go
@@ -1,0 +1,98 @@
+package swrenterprise
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getResourceSwrEnterpriseDomainName(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("swr", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SWR client: %s", err)
+	}
+
+	getHttpUrl := "v2/{project_id}/instances/{instance_id}/domainname?uid={domain_name_id}"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", state.Primary.Attributes["instance_id"])
+	getPath = strings.ReplaceAll(getPath, "{domain_name_id}", state.Primary.Attributes["domain_name_id"])
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	domainName := utils.PathSearch("domain_name_infos[0]", getRespBody, nil)
+	if domainName == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return domainName, nil
+}
+
+func TestAccSwrEnterpriseDomainName_basic(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_swr_enterprise_domain_name.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getResourceSwrEnterpriseDomainName,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckScmCertificateId(t)
+			acceptance.TestAccPreCheckScmCertificateDomainName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSwrEnterpriseDomainName_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", acceptance.HW_SCM_CERTIFICATE_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(resourceName, "certificate_id", acceptance.HW_SCM_CERTIFICATE_ID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSwrEnterpriseDomainName_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_swr_enterprise_domain_name" "test" {
+  instance_id    = huaweicloud_swr_enterprise_instance.test.id
+  domain_name    = "%[2]s"
+  certificate_id = "%[3]s"
+}
+`, testAccSwrEnterpriseInstance_update(rName), acceptance.HW_SCM_CERTIFICATE_DOMAIN_NAME, acceptance.HW_SCM_CERTIFICATE_ID)
+}

--- a/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_domain_name.go
+++ b/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_domain_name.go
@@ -1,0 +1,251 @@
+package swrenterprise
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var enterpriseDomainNameNonUpdatableParams = []string{
+	"instance_id", "domain_name",
+}
+
+// @API SWR POST /v2/{project_id}/instances/{instance_id}/domainname
+// @API SWR GET /v2/{project_id}/instances/{instance_id}/domainname
+// @API SWR PUT /v2/{project_id}/instances/{instance_id}/domainname/{domainname_id}
+// @API SWR DELETE /v2/{project_id}/instances/{instance_id}/domainname/{domainname_id}
+func ResourceSwrEnterpriseDomainName() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSwrEnterpriseDomainNameCreate,
+		UpdateContext: resourceSwrEnterpriseDomainNameUpdate,
+		ReadContext:   resourceSwrEnterpriseDomainNameRead,
+		DeleteContext: resourceSwrEnterpriseDomainNameDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(enterpriseDomainNameNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the enterprise instance ID.`,
+			},
+			"domain_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the domain name.`,
+			},
+			"certificate_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the SCM certificate ID.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the domain name type.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the creation time.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the last update time.`,
+			},
+			"domain_name_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the domain name ID.`,
+			},
+		},
+	}
+}
+
+func resourceSwrEnterpriseDomainNameCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("swr", region)
+	if err != nil {
+		return diag.Errorf("error creating SWR client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	createHttpUrl := "v2/{project_id}/instances/{instance_id}/domainname"
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateSwrEnterpriseDomainNameBodyParams(d)),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating SWR domain name: %s", err)
+	}
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("domain_name_info.uid", createRespBody, "").(string)
+	if id == "" {
+		return diag.Errorf("unable to find SWR instance domain name ID from the API response")
+	}
+
+	d.SetId(instanceId + "/" + id)
+
+	return resourceSwrEnterpriseDomainNameRead(ctx, d, meta)
+}
+
+func buildCreateSwrEnterpriseDomainNameBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"domain_name":    d.Get("domain_name"),
+		"certificate_id": d.Get("certificate_id"),
+	}
+
+	return bodyParams
+}
+
+func resourceSwrEnterpriseDomainNameRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("swr", region)
+	if err != nil {
+		return diag.Errorf("error creating SWR client: %s", err)
+	}
+
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return diag.Errorf("invalid ID format, want '<instance_id>/<domain_name_id>', but got '%s'", d.Id())
+	}
+	instanceId := parts[0]
+	id := parts[1]
+
+	getHttpUrl := "v2/{project_id}/instances/{instance_id}/domainname?uid={domain_name_id}"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getPath = strings.ReplaceAll(getPath, "{domain_name_id}", id)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error getting SWR domain name")
+	}
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.Errorf("error flattening SWR instance domain name response: %s", err)
+	}
+
+	domainName := utils.PathSearch("domain_name_infos[0]", getRespBody, nil)
+	if domainName == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error getting SWR domain name")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("instance_id", instanceId),
+		d.Set("domain_name_id", id),
+		d.Set("domain_name", utils.PathSearch("domain_name", domainName, nil)),
+		d.Set("type", utils.PathSearch("type", domainName, nil)),
+		d.Set("certificate_id", utils.PathSearch("certificate_id", domainName, nil)),
+		d.Set("created_at", utils.PathSearch("created_at", domainName, nil)),
+		d.Set("updated_at", utils.PathSearch("updated_at", domainName, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceSwrEnterpriseDomainNameUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("swr", region)
+	if err != nil {
+		return diag.Errorf("error creating SWR client: %s", err)
+	}
+
+	if d.HasChange("certificate_id") {
+		updateHttpUrl := "v2/{project_id}/instances/{instance_id}/domainname/{domainname_id}"
+		updatePath := client.Endpoint + updateHttpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
+		updatePath = strings.ReplaceAll(updatePath, "{domainname_id}", d.Get("domain_name_id").(string))
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody:         utils.RemoveNil(buildUpdateSwrEnterpriseDomainNameBodyParams(d)),
+		}
+
+		_, err = client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating SWR instance domain name: %s", err)
+		}
+	}
+
+	return resourceSwrEnterpriseDomainNameRead(ctx, d, meta)
+}
+
+func buildUpdateSwrEnterpriseDomainNameBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"certificate_id": d.Get("certificate_id"),
+	}
+
+	return bodyParams
+}
+
+func resourceSwrEnterpriseDomainNameDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("swr", region)
+	if err != nil {
+		return diag.Errorf("error creating SWR client: %s", err)
+	}
+
+	deleteHttpUrl := "v2/{project_id}/instances/{instance_id}/domainname/{domainname_id}"
+	deletePath := client.Endpoint + deleteHttpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", d.Get("instance_id").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{domainname_id}", d.Get("domain_name_id").(string))
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting SWR domain name")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support enterprise domain name management
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support enterprise domain name management
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/swrenterprise' TESTARGS='-run TestAccSwrEnterpriseDomainName_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swrenterprise -v -run TestAccSwrEnterpriseDomainName_basic -timeout 360m -parallel 4
=== RUN   TestAccSwrEnterpriseDomainName_basic
=== PAUSE TestAccSwrEnterpriseDomainName_basic
=== CONT  TestAccSwrEnterpriseDomainName_basic
--- PASS: TestAccSwrEnterpriseDomainName_basic (24.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swrenterprise     24.479s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
    <img width="1056" height="219" alt="image" src="https://github.com/user-attachments/assets/51d4a030-b942-4f61-bb74-54832aa7d3b1" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
    <img width="1543" height="198" alt="image" src="https://github.com/user-attachments/assets/522dd396-ba22-44d7-b706-6aa040d46f6e" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
