### PR TITLE
feat(dew): new datasource to query cpcs images

### DIFF
--- a/docs/data-sources/data_source_huaweicloud_cpcs_images.md
+++ b/docs/data-sources/data_source_huaweicloud_cpcs_images.md
@@ -1,0 +1,80 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cpcs_images"
+description: |-
+  Use this data source to get the list of CPCS images.
+---
+
+# huaweicloud_cpcs_images
+
+Use this data source to get the list of CPCS images.
+
+-> Currently, this data source is valid only in cn-north-9 region.
+
+## Example Usage
+
+```hcl
+variable "service_type" {}
+
+data "huaweicloud_cpcs_images" "test" {
+  service_type = var.service_type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `image_name` - (Optional, String) Specifies the name of the image.
+
+* `service_type` - (Optional, String) Specifies the service type of the image.
+  Valid values are **ENCRYPT_DECRYPT**, **SIGN_VERIFY**, **KMS**, **TIMESTAMP**, **COLLA_SIGN**, **OTP**,
+  **DB_ENCRYPT**, **FILE_ENCRYPT**, **DIGIT_SEAL** and **SSL_VPN**.
+
+* `sort_key` - (Optional, String) Specifies the sort attribute.
+  The default value is **create_time**.
+
+* `sort_dir` - (Optional, String) Specifies the sort direction.
+  The default value is **DESC**. Valid values are **ASC** and **DESC**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `images` - Indicates the images list.
+  The [images](#CPCS_images) structure is documented below.
+
+<a name="CPCS_images"></a>
+The `images` block supports:
+
+* `image_id` - The image ID.
+
+* `image_name` - The image name.
+
+* `service_type` - The service type of the image.
+
+* `arch_type` - The system architecture of the image. Valid values are **X86_64** and **ARRCH**.
+
+* `specification_id` - The specification ID.
+
+* `create_time` - The creation time of the image, in UNIX timestamp format.
+
+* `version_type` - The version type.
+
+* `trust_domain` - The domain whitelist.
+
+* `vendor_name` - The vendor name.
+
+* `vendor_image_version` - The vendor image version.
+
+* `ccsp_version_need` - The required platform version.
+
+* `hw_image_version` - The Huawei image version.
+
+* `description` - The description.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -927,6 +927,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cpcs_apps":            dew.DataSourceCpcsApps(),
 			"huaweicloud_cpcs_app_access_keys": dew.DataSourceCpcsAppAccessKeys(),
 			"huaweicloud_cpcs_resource_infos":  dew.DataSourceResourceInfos(),
+			"huaweicloud_cpcs_images":          dew.DataSourceCpcsImages(),
 
 			"huaweicloud_csms_events":                   dew.DataSourceDewCsmsEvents(),
 			"huaweicloud_csms_secrets":                  dew.DataSourceDewCsmsSecrets(),

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_cpcs_images_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_cpcs_images_test.go
@@ -1,0 +1,79 @@
+package dew
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCpcsImages_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_cpcs_images.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCpcsImages_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "images.0.image_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "images.0.image_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "images.0.service_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "images.0.arch_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "images.0.specification_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "images.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "images.0.version_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "images.0.vendor_name"),
+
+					resource.TestCheckOutput("is_image_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_service_type_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceCpcsImages_basic = `
+data "huaweicloud_cpcs_images" "test" {}
+
+locals {
+  image_name = data.huaweicloud_cpcs_images.test.images.0.image_name
+  service_type = data.huaweicloud_cpcs_images.test.images.0.service_type
+}
+
+# Filter by image_name
+data "huaweicloud_cpcs_images" "image_name_filter" {
+  image_name = local.image_name
+}
+
+locals {
+  image_name_filter_result = [
+    for v in data.huaweicloud_cpcs_images.image_name_filter.images[*].image_name : v == local.image_name
+  ]
+}
+
+output "is_image_name_filter_useful" {
+  value = length(local.image_name_filter_result) > 0 && alltrue(local.image_name_filter_result)
+}
+
+# Filter by service_type
+data "huaweicloud_cpcs_images" "service_type_filter" {
+  service_type = local.service_type
+}
+
+locals {
+  service_type_filter_result = [
+    for v in data.huaweicloud_cpcs_images.service_type_filter.images[*].service_type : v == local.service_type
+  ]
+}
+
+output "is_service_type_filter_useful" {
+  value = length(local.service_type_filter_result) > 0 && alltrue(local.service_type_filter_result)
+}
+`

--- a/huaweicloud/services/dew/data_source_huaweicloud_cpcs_images.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_cpcs_images.go
@@ -1,0 +1,239 @@
+package dew
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW GET /v1/{project_id}/dew/cpcs/images
+func DataSourceCpcsImages() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCpcsImagesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource.`,
+			},
+			"image_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the image name.`,
+			},
+			"service_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the service type of the image.`,
+			},
+			"sort_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the sort attribute.`,
+			},
+			"sort_dir": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the sort direction.`,
+			},
+			"images": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the images.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"image_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The image ID.`,
+						},
+						"image_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The image name.`,
+						},
+						"service_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The service type of the image.`,
+						},
+						"arch_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The system architecture of the image.`,
+						},
+						"specification_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The specification ID.`,
+						},
+						"create_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the image.`,
+						},
+						"version_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The version type.`,
+						},
+						"trust_domain": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The domain whitelist.`,
+						},
+						"vendor_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The vendor name.`,
+						},
+						"vendor_image_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The vendor image version.`,
+						},
+						"ccsp_version_need": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The required platform version.`,
+						},
+						"hw_image_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The Huawei image version.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildDataSourceCpcsImagesQueryParams(d *schema.ResourceData, pageNum int) string {
+	rst := fmt.Sprintf("?page_num=%d", pageNum)
+
+	if v, ok := d.GetOk("image_name"); ok {
+		rst += fmt.Sprintf("&image_name=%v", v)
+	}
+
+	if v, ok := d.GetOk("service_type"); ok {
+		rst += fmt.Sprintf("&service_type=%v", v)
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		rst += fmt.Sprintf("&sort_key=%v", v)
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%v", v)
+	}
+
+	return rst
+}
+
+// The first page of page_num is `1`. Because of the quality issues of the API, we need to add a quantitative comparison
+// of the value of `total_num`.
+func dataSourceCpcsImagesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		httpUrl   = "v1/{project_id}/dew/cpcs/images"
+		product   = "kms"
+		pageNum   = 1
+		allImages = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithPageNum := requestPath + buildDataSourceCpcsImagesQueryParams(d, pageNum)
+		resp, err := client.Request("GET", requestPathWithPageNum, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DEW CPCS images: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.Errorf("error flattening DEW CPCS images response: %s", err)
+		}
+
+		results := utils.PathSearch("result", respBody, make([]interface{}, 0)).([]interface{})
+		if len(results) == 0 {
+			break
+		}
+		allImages = append(allImages, results...)
+
+		totalNum := int(utils.PathSearch("total_num", respBody, float64(0)).(float64))
+		if len(allImages) >= totalNum {
+			break
+		}
+
+		pageNum++
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID: %s", err)
+	}
+	d.SetId(generateId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("images", flattenCpcsImagesResponseBody(allImages)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCpcsImagesResponseBody(images []interface{}) []interface{} {
+	if len(images) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(images))
+	for _, image := range images {
+		result = append(result, map[string]interface{}{
+			"image_id":             utils.PathSearch("image_id", image, nil),
+			"image_name":           utils.PathSearch("image_name", image, nil),
+			"service_type":         utils.PathSearch("service_type", image, nil),
+			"arch_type":            utils.PathSearch("arch_type", image, nil),
+			"specification_id":     utils.PathSearch("specification_id", image, nil),
+			"create_time":          utils.PathSearch("create_time", image, nil),
+			"version_type":         utils.PathSearch("version_type", image, nil),
+			"trust_domain":         utils.PathSearch("trust_domain", image, nil),
+			"vendor_name":          utils.PathSearch("vendor_name", image, nil),
+			"vendor_image_version": utils.PathSearch("vendor_image_version", image, nil),
+			"ccsp_version_need":    utils.PathSearch("ccsp_version_need", image, nil),
+			"hw_image_version":     utils.PathSearch("hw_image_version", image, nil),
+			"description":          utils.PathSearch("description", image, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query cpcs images.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccDataSourceCpcsImages_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccDataSourceCpcsImages_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCpcsImages_basic
=== PAUSE TestAccDataSourceCpcsImages_basic
=== CONT  TestAccDataSourceCpcsImages_basic
--- PASS: TestAccDataSourceCpcsImages_basic (10.04s)
PASS
coverage: 4.3% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       10.118s coverage: 4.3% of statements in ./huaweicloud/services/dew
```
<img width="1296" height="76" alt="image" src="https://github.com/user-attachments/assets/f3a63878-0840-4ca7-910b-b59897e5b091" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
