### PR TITLE
feat(hss): support `hss_container_cluster_statistics` resource

### DIFF
--- a/docs/data-sources/hss_container_cluster_statistics.md
+++ b/docs/data-sources/hss_container_cluster_statistics.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_container_cluster_statistics"
+description: |-
+  Use this data source to get the HSS container cluster statistics within HuaweiCloud.
+---
+
+# huaweicloud_hss_container_cluster_statistics
+
+Use this data source to get the HSS container cluster statistics within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_container_cluster_statistics" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `risk_cluster_num` - The number of clusters with risks.
+
+* `app_vul_cluster_num` - The number of clusters with application vulnerabilities.
+
+* `unscan_cluster_num` - The number of unscanned clusters.
+
+* `all_cluster_num` - The total number of clusters.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1321,6 +1321,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_container_node_statistics":                  hss.DataSourceContainerNodeStatistics(),
 			"huaweicloud_hss_container_cluster_risks":                    hss.DataSourceContainerClusterRisks(),
 			"huaweicloud_hss_container_cluster_risk_affected_resources":  hss.DataSourceContainerClusterRiskAffectedResources(),
+			"huaweicloud_hss_container_cluster_statistics":               hss.DataSourceContainerClusterStatistics(),
 			"huaweicloud_hss_container_network_policies":                 hss.DataSourceContainerNetworkPolicies(),
 			"huaweicloud_hss_container_iac_files":                        hss.DataSourceContainerIacFiles(),
 			"huaweicloud_hss_event_handle_history":                       hss.DataSourceEventHandleHistory(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_cluster_statistics_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_cluster_statistics_test.go
@@ -1,0 +1,43 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceContainerClusterStatistics_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_container_cluster_statistics.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceContainerClusterStatistics_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "risk_cluster_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "app_vul_cluster_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "unscan_cluster_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "all_cluster_num"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceContainerClusterStatistics_basic() string {
+	return `
+data "huaweicloud_hss_container_cluster_statistics" "test" {
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_container_cluster_statistics.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_container_cluster_statistics.go
@@ -1,0 +1,109 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/container/cluster/statistics
+func DataSourceContainerClusterStatistics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceContainerClusterStatisticsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"risk_cluster_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"app_vul_cluster_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"unscan_cluster_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"all_cluster_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildContainerClusterStatisticsQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%v", epsId)
+	}
+
+	return ""
+}
+
+func dataSourceContainerClusterStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		product = "hss"
+		httpUrl = "v5/{project_id}/container/cluster/statistics"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildContainerClusterStatisticsQueryParams(epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS container cluster statistics: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("risk_cluster_num", utils.PathSearch("risk_cluster_num", respBody, nil)),
+		d.Set("app_vul_cluster_num", utils.PathSearch("app_vul_cluster_num", respBody, nil)),
+		d.Set("unscan_cluster_num", utils.PathSearch("unscan_cluster_num", respBody, nil)),
+		d.Set("all_cluster_num", utils.PathSearch("all_cluster_num", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_container_cluster_statistics` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_container_cluster_statistics` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceContainerClusterStatistics_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceContainerClusterStatistics_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceContainerClusterStatistics_basic
=== PAUSE TestAccDataSourceContainerClusterStatistics_basic
=== CONT  TestAccDataSourceContainerClusterStatistics_basic
--- PASS: TestAccDataSourceContainerClusterStatistics_basic (9.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       10.032s

```
<img width="930" height="38" alt="image" src="https://github.com/user-attachments/assets/663d314b-bf7d-4a49-8886-26ead3bfed2e" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
