### PR TITLE
feat(dew): new datasource to query csms function templates

### DIFF
--- a/docs/data-sources/csms_function_templates.md
+++ b/docs/data-sources/csms_function_templates.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_csms_function_templates"
+description: |-
+  Use this data source to query CSMS secret rotation function templates within HuaweiCloud.
+---
+
+# huaweicloud_csms_function_templates
+
+Use this data source to query CSMS secret rotation function templates within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_csms_function_templates" "test" {
+  secret_type     = "GaussDB-FG"
+  secret_sub_type = "SingleUser"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `secret_type` - (Required, String) Specifies the secret type. Valid values are **GaussDB-FG** and **RDS-FG**.
+
+* `secret_sub_type` - (Required, String) Specifies the secret rotation account type.
+  The options are as follows:
+  + **SingleUser**: Single user mode rotation.
+  + **MultiUser**: Dual user mode rotation.
+
+* `engine` - (Optional, String) Specifies the database type. This parameter is mandatory when the secret type is
+  **RDS-FG**. The options are as follows:
+  + **mysql**
+  + **postgresql**
+  + **sqlserver**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `function_templates` - The secret rotation function templates.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -930,6 +930,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cpcs_images":          dew.DataSourceCpcsImages(),
 
 			"huaweicloud_csms_events":                   dew.DataSourceDewCsmsEvents(),
+			"huaweicloud_csms_function_templates":       dew.DataSourceCsmsFunctionTemplates(),
 			"huaweicloud_csms_secrets":                  dew.DataSourceDewCsmsSecrets(),
 			"huaweicloud_csms_secret_version":           dew.DataSourceDewCsmsSecret(),
 			"huaweicloud_csms_secret_versions":          dew.DataSourceDewCsmsSecretVersions(),

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_csms_function_templates_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_csms_function_templates_test.go
@@ -1,0 +1,39 @@
+package dew
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCsmsFunctionTemplates_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_csms_function_templates.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCsmsFunctionTemplates_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "function_templates"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceCsmsFunctionTemplates_basic = `
+data "huaweicloud_csms_function_templates" "test" {
+  secret_type     = "RDS-FG"
+  secret_sub_type = "SingleUser"
+  engine          = "mysql"
+}`

--- a/huaweicloud/services/dew/data_source_huaweicloud_csms_function_templates.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_csms_function_templates.go
@@ -1,0 +1,104 @@
+package dew
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW GET /v1/csms/function-templates
+func DataSourceCsmsFunctionTemplates() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCsmsFunctionTemplatesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource.`,
+			},
+			"secret_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the secret type.`,
+			},
+			"secret_sub_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the secret rotation account type.`,
+			},
+			"engine": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the database type.`,
+			},
+			"function_templates": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The secret rotation function templates.`,
+			},
+		},
+	}
+}
+
+func buildCsmsFunctionTemplatesQueryParams(d *schema.ResourceData) string {
+	rst := fmt.Sprintf("?secret_type=%v&secret_sub_type=%v", d.Get("secret_type"), d.Get("secret_sub_type"))
+
+	if engine, ok := d.GetOk("engine"); ok {
+		rst += fmt.Sprintf("&engine=%v", engine)
+	}
+	return rst
+}
+
+func dataSourceCsmsFunctionTemplatesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		getHttpUrl = "v1/csms/function-templates"
+		product    = "kms"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + getHttpUrl
+	requestPath += buildCsmsFunctionTemplatesQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DEW CSMS function templates: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("function_templates", utils.PathSearch("function_templates", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query csms function templates

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccDataSourceCsmsFunctionTemplates_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccDataSourceCsmsFunctionTemplates_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCsmsFunctionTemplates_basic
=== PAUSE TestAccDataSourceCsmsFunctionTemplates_basic
=== CONT  TestAccDataSourceCsmsFunctionTemplates_basic
--- PASS: TestAccDataSourceCsmsFunctionTemplates_basic (10.23s)
PASS
coverage: 3.5% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       10.328s coverage: 3.5% of statements in ./huaweicloud/services/dew
```
<img width="1288" height="69" alt="image" src="https://github.com/user-attachments/assets/7ab14771-48a0-468b-8322-ae232cf17b9e" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
