### PR TITLE
feat(dew/csms): add new data source to check whether a agency exists

### DIFF
--- a/docs/data-sources/csms_agencies.md
+++ b/docs/data-sources/csms_agencies.md
@@ -1,0 +1,41 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_csms_agencies"
+description: |-
+  Use this data source to check whether a agency exists.
+---
+
+# huaweicloud_csms_agencies
+
+Use this data source to check whether a agency exists.
+
+## Example Usage
+
+```hcl
+variable "secret_type" {}
+
+data "huaweicloud_csms_agencies" "test" {
+  secret_type = var.secret_type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `secret_type` - (Required, String) Specifies the secret type.
+  The valid values are as follows:
+  + **RDS-FG**
+  + **GaussDB-FG**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `agency_granted` - Whether the agency exists.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -927,6 +927,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cpcs_apps":            dew.DataSourceCpcsApps(),
 			"huaweicloud_cpcs_app_access_keys": dew.DataSourceCpcsAppAccessKeys(),
 
+			"huaweicloud_csms_agencies":                 dew.DataSourceAgencies(),
 			"huaweicloud_csms_events":                   dew.DataSourceDewCsmsEvents(),
 			"huaweicloud_csms_secrets":                  dew.DataSourceDewCsmsSecrets(),
 			"huaweicloud_csms_secret_version":           dew.DataSourceDewCsmsSecret(),

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_csms_agencies_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_csms_agencies_test.go
@@ -1,0 +1,40 @@
+package dew
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAgencies_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_csms_agencies.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Before running the test, ensure that there is a corresponding secret agency.
+			acceptance.TestAccPrecheckDewFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAgencies_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "agency_granted"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAgencies_basic = `
+data "huaweicloud_csms_agencies" "test" {
+  secret_type = "RDS-FG"
+}
+`

--- a/huaweicloud/services/dew/data_source_huaweicloud_csms_agencies.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_csms_agencies.go
@@ -1,0 +1,83 @@
+package dew
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW GET /v1/csms/agencies
+func DataSourceAgencies() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceAgenciesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"secret_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"agency_granted": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAgenciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v1/csms/agencies"
+		secretType = d.Get("secret_type").(string)
+	)
+
+	client, err := cfg.NewServiceClient("kms", region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = fmt.Sprintf("%s?secret_type=%s", getPath, secretType)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the agency: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("agency_granted", utils.PathSearch("agency_granted", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to check whether a agency exists.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dew" TESTARGS="-run TestAccDataSourceAgencies_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccDataSourceAgencies_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAgencies_basic
--- PASS: TestAccDataSourceAgencies_basic (12.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       12.937s
```
<img width="1146" height="17" alt="image" src="https://github.com/user-attachments/assets/c4463835-6582-462a-b7c6-d8ec44a7be86" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
