### PR TITLE
chore(dew): kps keypairs datasource support new fields

### DIFF
--- a/docs/data-sources/kps_keypairs.md
+++ b/docs/data-sources/kps_keypairs.md
@@ -48,6 +48,8 @@ The `keypairs` block supports:
 
 * `name` - Indicates the name of the keypair.
 
+* `type` - Indicates the type of the keypair. The value can be **ssh** or **x509**.
+
 * `scope` - Indicates the scope of keypair. The value can be **account**or **user**.
 
 * `public_key` - Indicates the imported OpenSSH-formatted public key.
@@ -55,3 +57,16 @@ The `keypairs` block supports:
 * `fingerprint` - Indicates the fingerprint information about a keypair.
 
 * `is_managed` - Indicates whether the private key is managed by HuaweiCloud.
+
+* `frozen_state` - Indicates the frozen state of the keypair. Valid values are:
+  + **0**: Normal state
+  + **1**: General freeze
+  + **2**: Police freeze
+  + **3**: General freeze and police freeze
+  + **4**: Violation freeze
+  + **5**: General freeze and violation freeze
+  + **6**: Police freeze and violation freeze
+  + **7**: General freeze, police freeze and violation freeze
+  + **8**: Unverified identity freeze
+  + **9**: General freeze and unverified identity freeze
+  + **10**: Police freeze and unverified identity freeze

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_kps_keypairs_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_kps_keypairs_test.go
@@ -37,10 +37,12 @@ func TestAccDataKpsKeypairs_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(resourceName, "keypairs.0.name"),
+					resource.TestCheckResourceAttrSet(resourceName, "keypairs.0.type"),
 					resource.TestCheckResourceAttrSet(resourceName, "keypairs.0.public_key"),
 					resource.TestCheckResourceAttrSet(resourceName, "keypairs.0.scope"),
 					resource.TestCheckResourceAttrSet(resourceName, "keypairs.0.fingerprint"),
 					resource.TestCheckResourceAttrSet(resourceName, "keypairs.0.is_managed"),
+					resource.TestCheckResourceAttrSet(resourceName, "keypairs.0.frozen_state"),
 
 					dcByName.CheckResourceExists(),
 					resource.TestCheckOutput("is_name_filter_useful", "true"),

--- a/huaweicloud/services/dew/data_source_huaweicloud_kps_keypairs.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_kps_keypairs.go
@@ -53,6 +53,10 @@ func DataSourceKeypairs() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"scope": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -67,6 +71,10 @@ func DataSourceKeypairs() *schema.Resource {
 						},
 						"is_managed": {
 							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"frozen_state": {
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 					},
@@ -180,11 +188,13 @@ func flattenKeypairs(keypairs []interface{}) []interface{} {
 	result := make([]interface{}, 0, len(keypairs))
 	for _, v := range keypairs {
 		result = append(result, map[string]interface{}{
-			"name":        utils.PathSearch("name", v, nil),
-			"public_key":  utils.PathSearch("public_key", v, nil),
-			"fingerprint": utils.PathSearch("fingerprint", v, nil),
-			"is_managed":  utils.PathSearch("is_key_protection", v, nil),
-			"scope":       flattenDatasourceScopeAttribute(utils.PathSearch("scope", v, "").(string)),
+			"name":         utils.PathSearch("name", v, nil),
+			"type":         utils.PathSearch("type", v, nil),
+			"public_key":   utils.PathSearch("public_key", v, nil),
+			"fingerprint":  utils.PathSearch("fingerprint", v, nil),
+			"is_managed":   utils.PathSearch("is_key_protection", v, nil),
+			"scope":        flattenDatasourceScopeAttribute(utils.PathSearch("scope", v, "").(string)),
+			"frozen_state": utils.PathSearch("frozen_state", v, nil),
 		})
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

kps keypairs datasource support new fields

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccDataKpsKeypairs_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccDataKpsKeypairs_basic -timeout 360m -parallel 10
=== RUN   TestAccDataKpsKeypairs_basic
=== PAUSE TestAccDataKpsKeypairs_basic
=== CONT  TestAccDataKpsKeypairs_basic
--- PASS: TestAccDataKpsKeypairs_basic (13.37s)
PASS
coverage: 6.5% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       13.461s coverage: 6.5% of statements in ./huaweicloud/services/dew
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
