### PR TITLE
feat(dew): new resource to batch export kps private key

### DIFF
--- a/docs/resources/kps_batch_export_private_key.md
+++ b/docs/resources/kps_batch_export_private_key.md
@@ -1,0 +1,91 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_kps_batch_export_private_key"
+description: |-
+  Manages a KPS batch export private key resource within HuaweiCloud.
+---
+
+# huaweicloud_kps_batch_export_private_key
+
+Manages a KPS batch export private key resource within HuaweiCloud.
+
+-> The current resource is a one-time resource, and destroying this resource will not recover the exported keys,
+but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_kps_keypairs" "test" {}
+
+locals {
+  name              = data.huaweicloud_kps_keypairs.test.keypairs.0.name
+  type              = data.huaweicloud_kps_keypairs.test.keypairs.0.type
+  scope             = data.huaweicloud_kps_keypairs.test.keypairs.0.scope
+  public_key        = data.huaweicloud_kps_keypairs.test.keypairs.0.public_key
+  fingerprint       = data.huaweicloud_kps_keypairs.test.keypairs.0.fingerprint
+  is_key_protection = data.huaweicloud_kps_keypairs.test.keypairs.0.is_managed
+  frozen_state      = data.huaweicloud_kps_keypairs.test.keypairs.0.frozen_state
+}
+
+resource "huaweicloud_kps_batch_export_private_key" "test" {
+  export_file_name = "./keypairs.zip"
+
+  keypairs {
+    name              = local.name
+    type              = local.type
+    scope             = local.scope == "account" ? "domain" : local.scope
+    public_key        = local.public_key
+    fingerprint       = local.fingerprint
+    is_key_protection = local.is_key_protection
+    frozen_state      = local.frozen_state
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `export_file_name` - (Required, String, NonUpdatable) Specifies the directory file for storing exported key pairs,
+  and requires the file ending in `.zip`.
+
+* `keypairs` - (Required, List, NonUpdatable) Specifies the list of keypairs to export.
+  The [keypairs](#keypairs) structure is documented below.
+
+<a name="keypairs"></a>
+The `keypairs` block supports:
+
+* `name` - (Optional, String, NonUpdatable) Specifies the SSH keypair name.
+
+* `type` - (Optional, String, NonUpdatable) Specifies the SSH keypair type. Valid values are **ssh** and **x509**.
+
+* `scope` - (Optional, String, NonUpdatable) Specifies the scope of the keypair. Valid values are **domain** and **user**.
+
+* `public_key` - (Optional, String, NonUpdatable) Specifies the imported OpenSSH-formatted public key.
+
+* `fingerprint` - (Optional, String, NonUpdatable) Specifies the fingerprint of the keypair.
+
+* `is_key_protection` - (Optional, Bool, NonUpdatable) Specifies whether the key is protected.
+
+* `frozen_state` - (Optional, String, NonUpdatable) Specifies the frozen state of the keypair. Valid values are:
+  + **0**: normal, not frozen
+  + **1**: frozen due to common causes
+  + **2**: frozen by the public security bureau
+  + **3**: frozen due to common causes and by the public security bureau
+  + **4**: frozen due to violations
+  + **5**: frozen due to common causes and violations
+  + **6**: frozen by the public security bureau and due to violations
+  + **7**: frozen by the public security bureau and due to common causes and violations
+  + **8**: frozen due to lack of real-name authentication
+  + **9**: frozen due to common causes and lack of real-name authentication
+  + **10**: frozen by the public security bureau and due to lack of real-name authentication
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2947,10 +2947,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_datakey_without_plaintext": dew.ResourceKmsDatakeyWithoutPlaintext(),
 			"huaweicloud_kms_cancel_key_deletion":       dew.ResourceKmsCancelKeyDeletion(),
 
-			"huaweicloud_kps_keypair_disassociate": dew.ResourceKpsKeypairDisassociate(),
-			"huaweicloud_kps_keypair_associate":    dew.ResourceKpsKeypairAssociate(),
-			"huaweicloud_kps_failed_tasks_delete":  dew.ResourceKpsFailedTasksDelete(),
-			"huaweicloud_kps_failed_task_delete":   dew.ResourceKpsFailedTaskDelete(),
+			"huaweicloud_kps_keypair_disassociate":     dew.ResourceKpsKeypairDisassociate(),
+			"huaweicloud_kps_keypair_associate":        dew.ResourceKpsKeypairAssociate(),
+			"huaweicloud_kps_failed_tasks_delete":      dew.ResourceKpsFailedTasksDelete(),
+			"huaweicloud_kps_batch_export_private_key": dew.ResourceKpsBatchExportPrivateKey(),
+			"huaweicloud_kps_failed_task_delete":       dew.ResourceKpsFailedTaskDelete(),
 
 			"huaweicloud_lb_certificate":  lb.ResourceCertificateV2(),
 			"huaweicloud_lb_l7policy":     lb.ResourceL7PolicyV2(),

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_batch_export_private_key_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_batch_export_private_key_test.go
@@ -1,0 +1,79 @@
+package dew
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccKpsBatchExportPrivateKey_basic(t *testing.T) {
+	exportFileName := fmt.Sprintf("./%s.zip", acceptance.RandomAccResourceName())
+	defer func() {
+		if err := os.Remove(exportFileName); err != nil {
+			log.Printf("error deleting testing file %s: %s", exportFileName, err)
+		}
+	}()
+
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please ensure that there is at least one available keypair in the test environment.
+			acceptance.TestAccPreCheckKpsEnable(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKpsBatchExportPrivateKey_basic(exportFileName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKpsBatchExportPrivateKeyFileExists(exportFileName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckKpsBatchExportPrivateKeyFileExists(exportFileName string) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		if _, err := os.Stat(exportFileName); os.IsNotExist(err) {
+			return fmt.Errorf("exported file %s does not exist", exportFileName)
+		}
+		return nil
+	}
+}
+
+func testAccKpsBatchExportPrivateKey_basic(exportFileName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_kps_keypairs" "test" {}
+
+locals {
+  name              = data.huaweicloud_kps_keypairs.test.keypairs.0.name
+  type              = data.huaweicloud_kps_keypairs.test.keypairs.0.type
+  scope             = data.huaweicloud_kps_keypairs.test.keypairs.0.scope
+  public_key        = data.huaweicloud_kps_keypairs.test.keypairs.0.public_key
+  fingerprint       = data.huaweicloud_kps_keypairs.test.keypairs.0.fingerprint
+  is_key_protection = data.huaweicloud_kps_keypairs.test.keypairs.0.is_managed
+  frozen_state      = data.huaweicloud_kps_keypairs.test.keypairs.0.frozen_state
+}
+
+resource "huaweicloud_kps_batch_export_private_key" "test" {
+  export_file_name = "%[1]s"
+
+  keypairs {
+    name              = local.name
+    type              = local.type
+    scope             = local.scope == "account" ? "domain" : local.scope
+    public_key        = local.public_key
+    fingerprint       = local.fingerprint
+    is_key_protection = local.is_key_protection
+    frozen_state      = local.frozen_state
+  }
+}
+`, exportFileName)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_kps_batch_export_private_key.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kps_batch_export_private_key.go
@@ -1,0 +1,196 @@
+package dew
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var batchExportPrivateKeyNonUpdatableParams = []string{
+	"keypairs",
+	"keypairs.*.name",
+	"keypairs.*.type",
+	"keypairs.*.scope",
+	"keypairs.*.public_key",
+	"keypairs.*.fingerprint",
+	"keypairs.*.is_key_protection",
+	"keypairs.*.frozen_state",
+	"export_file_name",
+}
+
+// @API DEW POST /v3/{project_id}/keypairs/private-key/batch-export
+func ResourceKpsBatchExportPrivateKey() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKpsBatchExportPrivateKeyCreate,
+		ReadContext:   resourceKpsBatchExportPrivateKeyRead,
+		UpdateContext: resourceKpsBatchExportPrivateKeyUpdate,
+		DeleteContext: resourceKpsBatchExportPrivateKeyDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(batchExportPrivateKeyNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to create the resource.`,
+			},
+			"keypairs": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: `Specifies the list of keypairs to export.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the SSH keypair name.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the SSH keypair type.`,
+						},
+						"scope": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the scope of the keypair.`,
+						},
+						"public_key": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the public key of the keypair.`,
+						},
+						"fingerprint": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the fingerprint of the keypair.`,
+						},
+						"is_key_protection": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: `Specifies whether the key is protected.`,
+						},
+						"frozen_state": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the frozen state of the keypair.`,
+						},
+					},
+				},
+			},
+			"export_file_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the directory file for storing exported key pairs, and requires the file ending in .zip`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildBatchExportPrivateKeyRequestBody(d *schema.ResourceData) []map[string]interface{} {
+	keypairs := d.Get("keypairs").([]interface{})
+	rstArray := make([]map[string]interface{}, 0, len(keypairs))
+	for _, v := range keypairs {
+		keypairMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rstArray = append(rstArray, map[string]interface{}{
+			"keypair": map[string]interface{}{
+				"name":              utils.ValueIgnoreEmpty(keypairMap["name"]),
+				"type":              utils.ValueIgnoreEmpty(keypairMap["type"]),
+				"scope":             utils.ValueIgnoreEmpty(keypairMap["scope"]),
+				"public_key":        utils.ValueIgnoreEmpty(keypairMap["public_key"]),
+				"fingerprint":       utils.ValueIgnoreEmpty(keypairMap["fingerprint"]),
+				"is_key_protection": utils.ValueIgnoreEmpty(keypairMap["is_key_protection"]),
+				"frozen_state":      utils.ValueIgnoreEmpty(keypairMap["frozen_state"]),
+			},
+		})
+	}
+	return rstArray
+}
+
+func resourceKpsBatchExportPrivateKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		httpUrl        = "v3/{project_id}/keypairs/private-key/batch-export"
+		product        = "kms"
+		exportFileName = d.Get("export_file_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW KPS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildBatchExportPrivateKeyRequestBody(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error batch exporting DEW KPS private keys: %s", err)
+	}
+
+	defer resp.Body.Close()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return diag.Errorf("error reading response body: %s", err)
+	}
+
+	if err := os.WriteFile(exportFileName, bodyBytes, 0600); err != nil {
+		return diag.Errorf("failed to write zip file to (%s): %s", exportFileName, err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	return resourceKpsBatchExportPrivateKeyRead(ctx, d, meta)
+}
+
+func resourceKpsBatchExportPrivateKeyRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKpsBatchExportPrivateKeyUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKpsBatchExportPrivateKeyDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to batch export private keys. Deleting this resource
+	will not recover the exported keys, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to batch export kps private key

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccKpsBatchExportPrivateKey_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccKpsBatchExportPrivateKey_basic -timeout 360m -parallel 10
=== RUN   TestAccKpsBatchExportPrivateKey_basic
=== PAUSE TestAccKpsBatchExportPrivateKey_basic
=== CONT  TestAccKpsBatchExportPrivateKey_basic
--- PASS: TestAccKpsBatchExportPrivateKey_basic (14.59s)
PASS
coverage: 5.3% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       14.688s coverage: 5.3% of statements in ./huaweicloud/services/dew
```
<img width="1288" height="82" alt="image" src="https://github.com/user-attachments/assets/f0243d2a-0131-46ad-8106-5d29673ed04e" />




* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
