### PR TITLE
feat(dew/cpcs): add new data source to get list of availability zones

### DIFF
--- a/docs/data-sources/cpcs_availability_zones.md
+++ b/docs/data-sources/cpcs_availability_zones.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cpcs_availability_zones"
+description: |-
+  Use this data source to get the list of availability zones for creating password service cludters.
+---
+
+# huaweicloud_cpcs_availability_zones
+
+Use this data source to get the list of availability zones for creating password service cludters.
+
+-> Currently, this data source is valid only in cn-north-9 region.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cpcs_availability_zones" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `availability_zone` - The list of availability zones.
+  The [availability_zone](#availability_zones_struct) structure is documented below.
+
+<a name="availability_zones_struct"></a>
+The `availability_zone` block supports:
+
+* `id` - The availability zone ID.
+
+* `display_name` - The display name.
+
+* `locales` - The availability zone name.
+  The [locales](#locales_struct) structure is documented below.
+
+* `type` - The availability zone type.
+
+* `region_id` - The region ID.
+
+* `status` - The availability zone status.
+
+<a name="locales_struct"></a>
+The `locales` block supports:
+
+* `en_us` - The English name.
+
+* `zh_cn` - The Chinese name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -924,10 +924,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_cse_microservice_instances":             cse.DataSourceMicroserviceInstances(),
 			"huaweicloud_cse_nacos_namespaces":                   cse.DataSourceNacosNamespaces(),
 
-			"huaweicloud_cpcs_apps":            dew.DataSourceCpcsApps(),
-			"huaweicloud_cpcs_app_access_keys": dew.DataSourceCpcsAppAccessKeys(),
-			"huaweicloud_cpcs_resource_infos":  dew.DataSourceResourceInfos(),
-			"huaweicloud_cpcs_images":          dew.DataSourceCpcsImages(),
+			"huaweicloud_cpcs_apps":               dew.DataSourceCpcsApps(),
+			"huaweicloud_cpcs_app_access_keys":    dew.DataSourceCpcsAppAccessKeys(),
+			"huaweicloud_cpcs_availability_zones": dew.DataSourceAvailabilityZones(),
+			"huaweicloud_cpcs_resource_infos":     dew.DataSourceResourceInfos(),
+			"huaweicloud_cpcs_images":             dew.DataSourceCpcsImages(),
 
 			"huaweicloud_csms_agencies":                 dew.DataSourceAgencies(),
 			"huaweicloud_csms_events":                   dew.DataSourceDewCsmsEvents(),

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_cpcs_availability_zones_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_cpcs_availability_zones_test.go
@@ -1,0 +1,44 @@
+package dew
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAvailabilityZones_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_cpcs_availability_zones.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDewFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+
+			{
+				Config: testAccDataSourceAvailabilityZones_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "availability_zone.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "availability_zone.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "availability_zone.0.display_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "availability_zone.0.locales.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "availability_zone.0.locales.0.en_us"),
+					resource.TestCheckResourceAttrSet(dataSource, "availability_zone.0.locales.0.zh_cn"),
+					resource.TestCheckResourceAttrSet(dataSource, "availability_zone.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "availability_zone.0.region_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "availability_zone.0.status"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAvailabilityZones_basic = `data "huaweicloud_cpcs_availability_zones" "test" {}`

--- a/huaweicloud/services/dew/data_source_huaweicloud_cpcs_availability_zones.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_cpcs_availability_zones.go
@@ -1,0 +1,153 @@
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW GET /v1/{project_id}/dew/cpcs/az
+func DataSourceAvailabilityZones() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceAvailabilityZonesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"display_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"locales": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"en_us": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"zh_cn": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAvailabilityZonesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/dew/cpcs/az"
+	)
+
+	client, err := cfg.NewServiceClient("kms", region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving availability zones: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	availabilityZones := utils.PathSearch("availability_zone", respBody, make([]interface{}, 0)).([]interface{})
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("availability_zone", flattenAvailabilityZones(availabilityZones)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAvailabilityZones(availabilityZones []interface{}) []interface{} {
+	if len(availabilityZones) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(availabilityZones))
+	for _, availabilityZone := range availabilityZones {
+		result = append(result, map[string]interface{}{
+			"id":           utils.PathSearch("id", availabilityZone, nil),
+			"display_name": utils.PathSearch("display_name", availabilityZone, nil),
+			"locales":      flattenZonesLocales(utils.PathSearch("locales", availabilityZone, nil)),
+			"type":         utils.PathSearch("type", availabilityZone, nil),
+			"region_id":    utils.PathSearch("region_id", availabilityZone, nil),
+			"status":       utils.PathSearch("status", availabilityZone, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenZonesLocales(localesData interface{}) []map[string]interface{} {
+	if localesData == nil {
+		return nil
+	}
+
+	result := map[string]interface{}{
+		"en_us": utils.PathSearch(`"en-us"`, localesData, nil),
+		"zh_cn": utils.PathSearch(`"zh-cn"`, localesData, nil),
+	}
+
+	return []map[string]interface{}{result}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get list of availability zones.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dew" TESTARGS="-run TestAccDataSourceAvailabilityZones_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccDataSourceAvailabilityZones_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAvailabilityZones_basic
=== PAUSE TestAccDataSourceAvailabilityZones_basic
=== CONT  TestAccDataSourceAvailabilityZones_basic
--- PASS: TestAccDataSourceAvailabilityZones_basic (11.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       11.121s
```
<img width="1142" height="21" alt="image" src="https://github.com/user-attachments/assets/3fb8b815-e02e-427b-a4e4-3b8f2239eca2" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
