### PR TITLE
feat(dew): new resource to batch import kps keypairs

### DIFF
--- a/docs/resources/kps_batch_import_keypair.md
+++ b/docs/resources/kps_batch_import_keypair.md
@@ -1,0 +1,136 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_kps_batch_import_keypair"
+description: |-
+  Manages a KPS batch import keypair resource within HuaweiCloud.
+---
+
+# huaweicloud_kps_batch_import_keypair
+
+Manages a KPS batch import keypair resource within HuaweiCloud.
+
+-> The current resource is a one-time resource, and destroying this resource will not recover the imported keypairs,
+but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+### Batch import keypair with private key
+
+```hcl
+variable "public_key" {}
+variable "private_key" {}
+
+resource "huaweicloud_kps_batch_import_keypair" "test" {
+  keypairs {
+    name       = "test-name"
+    type       = "ssh"
+    public_key = var.public_key
+    scope      = "domain"
+
+    key_protection {
+      private_key = var.private_key
+      encryption {
+        type = "default"
+      }
+    }
+  }
+}
+```
+
+### Batch import keypair without private key
+
+```hcl
+variable "public_key" {}
+
+resource "huaweicloud_kps_batch_import_keypair" "test" {
+  keypairs {
+    name       = "test-name"
+    type       = "ssh"
+    public_key = var.public_key
+    scope      = "domain"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `keypairs` - (Required, List, NonUpdatable) Specifies the list of keypairs to import.
+  The [keypairs](#Struct_keypairs) structure is documented below.
+
+<a name="Struct_keypairs"></a>
+The `keypairs` block supports:
+
+* `name` - (Required, String, NonUpdatable) Specifies the SSH keypair name.
+
+* `type` - (Optional, String, NonUpdatable) Specifies the SSH keypair type. Valid values are **ssh** and **x509**.
+
+* `public_key` - (Optional, String, NonUpdatable) Specifies the imported OpenSSH-formatted public key.
+
+* `scope` - (Optional, String, NonUpdatable) Specifies the scope of the keypair. Valid values are **domain** and **user**.
+
+* `user_id` - (Optional, String, NonUpdatable) Specifies the user ID of the keypair.
+
+* `key_protection` - (Optional, List, NonUpdatable) Specifies the key protection configuration.
+  This parameter can be configured with at most one element.
+  The [key_protection](#Struct_key_protection) structure is documented below.
+
+<a name="Struct_key_protection"></a>
+The `key_protection` block supports:
+
+* `private_key` - (Optional, String, NonUpdatable, Sensitive) Specifies the private key of the keypair.
+
+* `encryption` - (Required, List, NonUpdatable) Specifies the encryption configuration.
+  The [encryption](#Struct_encryption) structure is documented below.
+
+<a name="Struct_encryption"></a>
+The `encryption` block supports:
+
+* `type` - (Required, String, NonUpdatable) Specifies the encryption type. Valid values are **kms** and **default**.
+  + **default**: The default encryption mode. Applicable to sites where KMS is not deployed.
+  + **kms**: KMS encryption mode.
+
+* `kms_key_name` - (Optional, String, NonUpdatable) Specifies the KMS key name.
+
+* `kms_key_id` - (Optional, String, NonUpdatable) Specifies the KMS key ID.
+
+-> If `type` is set to **kms**, you must enter the KMS key name or ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `succeeded_keypairs` - The list of successfully imported keypairs.
+  The [succeeded_keypairs](#Struct_succeeded_keypairs) structure is documented below.
+
+* `failed_keypairs` - The list of failed imported keypairs.
+  The [failed_keypairs](#Struct_failed_keypairs) structure is documented below.
+
+<a name="Struct_succeeded_keypairs"></a>
+The `succeeded_keypairs` block supports:
+
+* `name` - The SSH keypair name.
+
+* `type` - The SSH keypair type.
+
+* `public_key` - The public key of the keypair.
+
+* `private_key` - The private key of the keypair.
+
+* `fingerprint` - The fingerprint of the keypair.
+
+* `user_id` - The user ID of the keypair.
+
+<a name="Struct_failed_keypairs"></a>
+The `failed_keypairs` block supports:
+
+* `keypair_name` - The SSH keypair name.
+
+* `failed_reason` - The failed reason.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2954,6 +2954,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kps_keypair_associate":        dew.ResourceKpsKeypairAssociate(),
 			"huaweicloud_kps_failed_tasks_delete":      dew.ResourceKpsFailedTasksDelete(),
 			"huaweicloud_kps_batch_export_private_key": dew.ResourceKpsBatchExportPrivateKey(),
+			"huaweicloud_kps_batch_import_keypair":     dew.ResourceKpsBatchImportKeypair(),
 			"huaweicloud_kps_failed_task_delete":       dew.ResourceKpsFailedTaskDelete(),
 
 			"huaweicloud_lb_certificate":  lb.ResourceCertificateV2(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -135,16 +135,18 @@ var (
 
 	HW_DBSS_INSATNCE_ID = os.Getenv("HW_DBSS_INSATNCE_ID")
 
-	HW_DEW_ENABLE_FLAG      = os.Getenv("HW_DEW_ENABLE_FLAG")
-	HW_KPS_KEY_FILE_PATH    = os.Getenv("HW_KPS_KEY_FILE_PATH")
-	HW_KPS_KEYPAIR_NAME_1   = os.Getenv("HW_KPS_KEYPAIR_NAME_1")
-	HW_KPS_KEYPAIR_NAME_2   = os.Getenv("HW_KPS_KEYPAIR_NAME_2")
-	HW_KPS_KEYPAIR_KEY_1    = os.Getenv("HW_KPS_KEYPAIR_KEY_1")
-	HW_KPS_KEYPAIR_SSH_PORT = os.Getenv("HW_KPS_KEYPAIR_SSH_PORT")
-	HW_KPS_ENABLE_FLAG      = os.Getenv("HW_KPS_ENABLE_FLAG")
-	HW_KPS_FAILED_TASK_ID   = os.Getenv("HW_KPS_FAILED_TASK_ID")
-	HW_CSMS_TASK_ID         = os.Getenv("HW_CSMS_TASK_ID")
-	HW_CSMS_SECRET_ID       = os.Getenv("HW_CSMS_SECRET_ID")
+	HW_DEW_ENABLE_FLAG           = os.Getenv("HW_DEW_ENABLE_FLAG")
+	HW_KPS_KEY_FILE_PATH         = os.Getenv("HW_KPS_KEY_FILE_PATH")
+	HW_KPS_KEYPAIR_NAME_1        = os.Getenv("HW_KPS_KEYPAIR_NAME_1")
+	HW_KPS_KEYPAIR_NAME_2        = os.Getenv("HW_KPS_KEYPAIR_NAME_2")
+	HW_KPS_KEYPAIR_KEY_1         = os.Getenv("HW_KPS_KEYPAIR_KEY_1")
+	HW_KPS_KEYPAIR_SSH_PORT      = os.Getenv("HW_KPS_KEYPAIR_SSH_PORT")
+	HW_KPS_ENABLE_FLAG           = os.Getenv("HW_KPS_ENABLE_FLAG")
+	HW_KPS_PUBLIC_KEY_FILE_PATH  = os.Getenv("HW_KPS_PUBLIC_KEY_FILE_PATH")
+	HW_KPS_PRIVATE_KEY_FILE_PATH = os.Getenv("HW_KPS_PRIVATE_KEY_FILE_PATH")
+	HW_KPS_FAILED_TASK_ID        = os.Getenv("HW_KPS_FAILED_TASK_ID")
+	HW_CSMS_TASK_ID              = os.Getenv("HW_CSMS_TASK_ID")
+	HW_CSMS_SECRET_ID            = os.Getenv("HW_CSMS_SECRET_ID")
 
 	HW_DEST_REGION          = os.Getenv("HW_DEST_REGION")
 	HW_DEST_PROJECT_ID      = os.Getenv("HW_DEST_PROJECT_ID")
@@ -2078,6 +2080,13 @@ func TestAccPreCheckKpsKeyPair(t *testing.T) {
 func TestAccPreCheckKpsEnable(t *testing.T) {
 	if HW_KPS_ENABLE_FLAG == "" {
 		t.Skip("HW_KPS_ENABLE_FLAG must be set for acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckKpsKeyFilePath(t *testing.T) {
+	if HW_KPS_PUBLIC_KEY_FILE_PATH == "" || HW_KPS_PRIVATE_KEY_FILE_PATH == "" {
+		t.Skip("HW_KPS_PUBLIC_KEY_FILE_PATH or HW_KPS_PRIVATE_KEY_FILE_PATH must be set for acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_batch_import_keypair_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_batch_import_keypair_test.go
@@ -1,0 +1,58 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccKpsBatchImportKeypair_basic(t *testing.T) {
+	rName := "huaweicloud_kps_batch_import_keypair.test"
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare public key and private key file path
+			acceptance.TestAccPreCheckKpsKeyFilePath(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKpsBatchImportKeypair_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rName, "succeeded_keypairs.#"),
+					resource.TestCheckResourceAttrSet(rName, "succeeded_keypairs.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "succeeded_keypairs.0.type"),
+					resource.TestCheckResourceAttrSet(rName, "succeeded_keypairs.0.public_key"),
+					resource.TestCheckResourceAttrSet(rName, "succeeded_keypairs.0.private_key"),
+					resource.TestCheckResourceAttrSet(rName, "succeeded_keypairs.0.fingerprint"),
+					resource.TestCheckResourceAttrSet(rName, "succeeded_keypairs.0.user_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKpsBatchImportKeypair_basic() string {
+	name := acceptance.RandomAccResourceName()
+	return fmt.Sprintf(`
+resource "huaweicloud_kps_batch_import_keypair" "test" {
+  keypairs {
+    name       = "%[1]s"
+    type       = "ssh"
+    public_key = file("%[2]s")
+    scope      = "domain"
+
+    key_protection {
+      private_key = file("%[3]s")
+      encryption {
+        type = "default"
+      }
+    }
+  }
+}
+`, name, acceptance.HW_KPS_PUBLIC_KEY_FILE_PATH, acceptance.HW_KPS_PRIVATE_KEY_FILE_PATH)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_kps_batch_import_keypair.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kps_batch_import_keypair.go
@@ -1,0 +1,361 @@
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var batchImportKeypairNonUpdatableParams = []string{
+	"keypairs",
+	"keypairs.*.name",
+	"keypairs.*.type",
+	"keypairs.*.public_key",
+	"keypairs.*.scope",
+	"keypairs.*.user_id",
+	"keypairs.*.key_protection",
+	"keypairs.*.key_protection.*.private_key",
+	"keypairs.*.key_protection.*.encryption",
+	"keypairs.*.key_protection.*.encryption.*.type",
+	"keypairs.*.key_protection.*.encryption.*.kms_key_name",
+	"keypairs.*.key_protection.*.encryption.*.kms_key_id",
+}
+
+// @API DEW POST /v3/{project_id}/keypairs/batch-import
+func ResourceKpsBatchImportKeypair() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKpsBatchImportKeypairCreate,
+		ReadContext:   resourceKpsBatchImportKeypairRead,
+		UpdateContext: resourceKpsBatchImportKeypairUpdate,
+		DeleteContext: resourceKpsBatchImportKeypairDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(batchImportKeypairNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to create the resource.`,
+			},
+			"keypairs": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: `Specifies the list of keypairs to import.`,
+				Elem:        batchImportKpsKeypairsSchema(),
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"succeeded_keypairs": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of successfully imported keypairs.`,
+				Elem:        batchImportKpsKeypairsSucceededKeypairsSchema(),
+			},
+			"failed_keypairs": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of failed imported keypairs.`,
+				Elem:        batchImportKpsKeypairsFailedKeypairsSchema(),
+			},
+		},
+	}
+}
+
+func batchImportKpsKeypairsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the SSH keypair name.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the SSH keypair type.`,
+			},
+			"public_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the public key of the keypair.`,
+			},
+			"scope": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the scope of the keypair.`,
+			},
+			"user_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the user ID of the keypair.`,
+			},
+			"key_protection": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: `Specifies the key protection configuration.`,
+				Elem:        keypairsKeyProtectionSchema(),
+			},
+		},
+	}
+}
+
+func keypairsKeyProtectionSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"private_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: `Specifies the private key of the keypair.`,
+			},
+			"encryption": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Description: `Specifies the encryption configuration.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `Specifies the encryption type.`,
+						},
+						"kms_key_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the KMS key name.`,
+						},
+						"kms_key_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Specifies the KMS key ID.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func batchImportKpsKeypairsFailedKeypairsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"keypair_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The SSH keypair name.`,
+			},
+			"failed_reason": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The failed reason.`,
+			},
+		},
+	}
+}
+
+func batchImportKpsKeypairsSucceededKeypairsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The SSH keypair name.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The SSH keypair type.`,
+			},
+			"public_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The public key of the keypair.`,
+			},
+			"private_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: `The private key of the keypair.`,
+			},
+			"fingerprint": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The fingerprint of the keypair.`,
+			},
+			"user_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The user ID of the keypair.`,
+			},
+		},
+	}
+}
+
+func buildImportKeypairEncryptionBodyParams(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"type":         rawMap["type"],
+		"kms_key_name": utils.ValueIgnoreEmpty(rawMap["kms_key_name"]),
+		"kms_key_id":   utils.ValueIgnoreEmpty(rawMap["kms_key_id"]),
+	}
+}
+
+func buildImportKeypairKeyProtectionBodyParams(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"private_key": utils.ValueIgnoreEmpty(rawMap["private_key"]),
+		"encryption":  buildImportKeypairEncryptionBodyParams(rawMap["encryption"].([]interface{})),
+	}
+}
+
+func buildImportKeypairsBodyParams(d *schema.ResourceData) []map[string]interface{} {
+	rawArray := d.Get("keypairs").([]interface{})
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		element := map[string]interface{}{
+			"name":           rawMap["name"],
+			"type":           utils.ValueIgnoreEmpty(rawMap["type"]),
+			"public_key":     utils.ValueIgnoreEmpty(rawMap["public_key"]),
+			"scope":          utils.ValueIgnoreEmpty(rawMap["scope"]),
+			"user_id":        utils.ValueIgnoreEmpty(rawMap["user_id"]),
+			"key_protection": buildImportKeypairKeyProtectionBodyParams(rawMap["key_protection"].([]interface{})),
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"keypair": utils.RemoveNil(element),
+		})
+	}
+
+	return rst
+}
+
+func flattenBatchImportSucceededKeypairs(respArray []interface{}) []map[string]interface{} {
+	rst := make([]map[string]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"name":        utils.PathSearch("keypair.keypair.name", v, nil),
+			"type":        utils.PathSearch("keypair.keypair.type", v, nil),
+			"public_key":  utils.PathSearch("keypair.keypair.public_key", v, nil),
+			"private_key": utils.PathSearch("keypair.keypair.private_key", v, nil),
+			"fingerprint": utils.PathSearch("keypair.keypair.fingerprint", v, nil),
+			"user_id":     utils.PathSearch("keypair.keypair.user_id", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenBatchImportFailedKeypairs(respArray []interface{}) []map[string]interface{} {
+	rst := make([]map[string]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"keypair_name":  utils.PathSearch("keypair_name", v, nil),
+			"failed_reason": utils.PathSearch("failed_reason", v, nil),
+		})
+	}
+	return rst
+}
+
+func resourceKpsBatchImportKeypairCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/keypairs/batch-import"
+		product = "kms"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW KPS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildImportKeypairsBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error batch importing DEW KPS keypairs: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.Errorf("error flattening response body: %s", err)
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID: %s", err)
+	}
+	d.SetId(generateId)
+
+	succeededKeypairs := utils.PathSearch("succeeded_keypairs", respBody, make([]interface{}, 0)).([]interface{})
+	failedKeypairs := utils.PathSearch("failed_keypairs", respBody, make([]interface{}, 0)).([]interface{})
+	mErr := multierror.Append(
+		d.Set("succeeded_keypairs", flattenBatchImportSucceededKeypairs(succeededKeypairs)),
+		d.Set("failed_keypairs", flattenBatchImportFailedKeypairs(failedKeypairs)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceKpsBatchImportKeypairRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKpsBatchImportKeypairUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKpsBatchImportKeypairDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to batch import keypairs. Deleting this resource
+	will not recover the imported keypairs, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to batch import kps keypairs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccKpsBatchImportKeypair_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccKpsBatchImportKeypair_basic -timeout 360m -parallel 10
=== RUN   TestAccKpsBatchImportKeypair_basic
=== PAUSE TestAccKpsBatchImportKeypair_basic
=== CONT  TestAccKpsBatchImportKeypair_basic
--- PASS: TestAccKpsBatchImportKeypair_basic (12.89s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       12.995s coverage: 4.5% of statements in ./huaweicloud/services/dew
```
<img width="1277" height="88" alt="image" src="https://github.com/user-attachments/assets/79770d5a-97c3-4e47-85c7-88f5a887fda2" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
