### PR TITLE
feat(hss): support `hss_antivirus_create_pay_per_scan_task` resource

### DIFF
--- a/docs/resources/hss_antivirus_create_pay_per_scan_task.md
+++ b/docs/resources/hss_antivirus_create_pay_per_scan_task.md
@@ -1,0 +1,90 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_antivirus_create_pay_per_scan_task"
+description: |-
+  Manages an HSS antivirus pay-per-scan task creation resource within HuaweiCloud.
+---
+
+# huaweicloud_hss_antivirus_create_pay_per_scan_task
+
+Manages an HSS antivirus pay-per-scan task creation resource within HuaweiCloud.
+
+-> This resource is a one-time action resource using to create HSS antivirus pay-per-scan task. Deleting this resource
+  will not clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "task_name" {}
+variable "scan_type" {}
+variable "action" {}
+variable "host_ids" {
+  type = list(string)
+}
+variable "file_types" {
+  type = list(int)
+}
+
+resource "huaweicloud_hss_antivirus_create_pay_per_scan_task" "test" {
+  task_name  = var.task_name
+  scan_type  = var.scan_type
+  action     = var.action
+  host_ids   = var.host_ids
+  file_types = var.file_types
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `task_name` - (Required, String, NonUpdatable) Specifies the task name.
+
+* `scan_type` - (Required, String, NonUpdatable) Specifies the task type.  
+  The valid values are as follows:
+  + **quick**: Quick scan.
+  + **full**: Full scan.
+  + **custom**: Custom scan.
+
+* `action` - (Required, String, NonUpdatable) Specifies disposal action.  
+  The valid values are as follows:
+  + **auto**: Automatic disposal.
+  + **manual**: Manual disposal.
+
+* `host_ids` - (Required, List, NonUpdatable) Specifies the host IDs.
+
+* `file_types` - (Optional, List, NonUpdatable) Specifies a set of file types.  
+  The valid values are as follows:
+  + **0**: All.
+  + **1**: Executable.
+  + **2**: Compress.
+  + **3**: Script.
+  + **4**: Document.
+  + **5**: Image.
+  + **6**: Audio and video.
+
+* `task_id` - (Optional, String, NonUpdatable) Specifies the task ID. When creating a virus scanning task, the `task_id`
+  is null, when rescanning, the `task_id` is not null, it is the ID of the current task.
+
+* `scan_dir` - (Optional, String, NonUpdatable) Specifies scanning directory, separate multiple directories with
+  semicolons.
+
+* `ignore_dir` - (Optional, String, NonUpdatable) Specifies exclusion directory, separate multiple directories with
+  semicolons.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2850,6 +2850,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_file_download":                                  hss.ResourceFileDownload(),
 			"huaweicloud_hss_ignore_failed_pcc":                              hss.ResourceIgnoreFailedPCC(),
 			"huaweicloud_hss_antivirus_create_virus_scan_task":               hss.ResourceCreateVirusScanTask(),
+			"huaweicloud_hss_antivirus_create_pay_per_scan_task":             hss.ResourceAntivirusCreatePayPerScanTask(),
 			"huaweicloud_hss_app_whitelist_policy_process":                   hss.ResourceAppWhitelistPolicyProcess(),
 
 			"huaweicloud_identity_access_key":            iam.ResourceIdentityKey(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_antivirus_create_pay_per_scan_task_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_antivirus_create_pay_per_scan_task_test.go
@@ -1,0 +1,43 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccAntivirusCreatePayPerScanTask_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting a host ID with host protection enabled,
+			// and the host is under the default enterprise project.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAntivirusCreatePayPerScanTask_basic(),
+			},
+		},
+	})
+}
+
+func testAntivirusCreatePayPerScanTask_basic() string {
+	taskName := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_hss_antivirus_create_pay_per_scan_task" "test" {
+  task_name             = "%[1]s"
+  scan_type             = "quick"
+  action                = "auto"
+  host_ids              = ["%[2]s"]
+  file_types            = [0]
+  enterprise_project_id = "0"
+}
+`, taskName, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
+}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_antivirus_create_pay_per_scan_task.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_antivirus_create_pay_per_scan_task.go
@@ -1,0 +1,176 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var antivirusCreatePayPerScanTaskNonUpdatableParams = []string{
+	"task_name",
+	"scan_type",
+	"action",
+	"host_ids",
+	"file_types",
+	"scan_dir",
+	"ignore_dir",
+	"task_id",
+	"enterprise_project_id",
+}
+
+// @API HSS POST /v5/{project_id}/antivirus/pay-per-scan/tasks
+func ResourceAntivirusCreatePayPerScanTask() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAntivirusCreatePayPerScanTaskCreate,
+		ReadContext:   resourceAntivirusCreatePayPerScanTaskRead,
+		UpdateContext: resourceAntivirusCreatePayPerScanTaskUpdate,
+		DeleteContext: resourceAntivirusCreatePayPerScanTaskDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(antivirusCreatePayPerScanTaskNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"task_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"scan_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"host_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"file_types": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+			"scan_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ignore_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"task_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildAntivirusCreatePayPerScanTaskQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%v", epsId)
+	}
+
+	return ""
+}
+
+func buildAntivirusCreatePayPerScanTaskBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"task_name":  d.Get("task_name"),
+		"scan_type":  d.Get("scan_type"),
+		"action":     d.Get("action"),
+		"host_ids":   utils.ExpandToStringList(d.Get("host_ids").([]interface{})),
+		"file_types": utils.ValueIgnoreEmpty(utils.ExpandToStringList(d.Get("file_types").([]interface{}))),
+		"scan_dir":   utils.ValueIgnoreEmpty(d.Get("scan_dir")),
+		"ignore_dir": utils.ValueIgnoreEmpty(d.Get("ignore_dir")),
+		"task_id":    utils.ValueIgnoreEmpty(d.Get("task_id")),
+	}
+
+	return bodyParams
+}
+
+func resourceAntivirusCreatePayPerScanTaskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v5/{project_id}/antivirus/pay-per-scan/tasks"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildAntivirusCreatePayPerScanTaskQueryParams(epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": region},
+		JSONBody:         utils.RemoveNil(buildAntivirusCreatePayPerScanTaskBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating HSS antivirus pay-per-scan task: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return resourceAntivirusCreatePayPerScanTaskRead(ctx, d, meta)
+}
+
+func resourceAntivirusCreatePayPerScanTaskRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceAntivirusCreatePayPerScanTaskUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceAntivirusCreatePayPerScanTaskDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to create HSS antivirus pay-per-scan task. Deleting
+    this resource will not clear the corresponding request record, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_antivirus_create_pay_per_scan_task` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_antivirus_create_pay_per_scan_task` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccAntivirusCreatePayPerScanTask_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccAntivirusCreatePayPerScanTask_basic -timeout 360m -parallel 4
=== RUN   TestAccAntivirusCreatePayPerScanTask_basic
=== PAUSE TestAccAntivirusCreatePayPerScanTask_basic
=== CONT  TestAccAntivirusCreatePayPerScanTask_basic
--- PASS: TestAccAntivirusCreatePayPerScanTask_basic (15.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       15.197s

```
<img width="972" height="38" alt="image" src="https://github.com/user-attachments/assets/3a80bbf0-8acb-49d8-96a6-c1dba833fdf8" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
