### PR TITLE
feat(hss): support `hss_antivirus_pay_per_scan_switch_status` resource

### DIFF
--- a/docs/resources/hss_antivirus_pay_per_scan_switch_status.md
+++ b/docs/resources/hss_antivirus_pay_per_scan_switch_status.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_antivirus_pay_per_scan_switch_status"
+description: |-
+  Manages an HSS update antivirus pay-per-scan switch status resource within HuaweiCloud.
+---
+
+# huaweicloud_hss_antivirus_pay_per_scan_switch_status
+
+Manages an HSS update antivirus pay-per-scan switch status resource within HuaweiCloud.
+
+-> This resource is a one-time action resource using to update HSS antivirus pay-per-scan switch status. Deleting this
+  resource will not clear the corresponding request record, but will only remove the resource information from the tf
+  state file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_hss_antivirus_pay_per_scan_switch_status" "test" {
+  enabled = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `enabled` - (Required, Bool, NonUpdatable) Specifies whether to enable virus scanning and billing per use function.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset  under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2850,6 +2850,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_vulnerability_history_export_task":              hss.ResourceVulnerabilityHistoryExportTask(),
 			"huaweicloud_hss_file_download":                                  hss.ResourceFileDownload(),
 			"huaweicloud_hss_ignore_failed_pcc":                              hss.ResourceIgnoreFailedPCC(),
+			"huaweicloud_hss_antivirus_pay_per_scan_switch_status":           hss.ResourceAntivirusPayPerScanSwitchStatus(),
 			"huaweicloud_hss_antivirus_create_virus_scan_task":               hss.ResourceCreateVirusScanTask(),
 			"huaweicloud_hss_app_whitelist_policy_process":                   hss.ResourceAppWhitelistPolicyProcess(),
 

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_antivirus_pay_per_scan_switch_status_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_antivirus_pay_per_scan_switch_status_test.go
@@ -1,0 +1,33 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccAntivirusPayPerScanSwitchStatus_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAntivirusPayPerScanSwitchStatus_basic(),
+			},
+		},
+	})
+}
+
+func testAntivirusPayPerScanSwitchStatus_basic() string {
+	return `
+resource "huaweicloud_hss_antivirus_pay_per_scan_switch_status" "test" {
+  enabled               = true
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_antivirus_pay_per_scan_switch_status.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_antivirus_pay_per_scan_switch_status.go
@@ -1,0 +1,129 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var antivirusPayPerScanSwitchStatusNonUpdatableParams = []string{
+	"enabled",
+	"enterprise_project_id",
+}
+
+// @API HSS PUT /v5/{project_id}/antivirus/pay-per-scan
+func ResourceAntivirusPayPerScanSwitchStatus() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAntivirusPayPerScanSwitchStatusCreate,
+		ReadContext:   resourceAntivirusPayPerScanSwitchStatusRead,
+		UpdateContext: resourceAntivirusPayPerScanSwitchStatusUpdate,
+		DeleteContext: resourceAntivirusPayPerScanSwitchStatusDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(antivirusPayPerScanSwitchStatusNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildCreateAntivirusPayPerScanSwitchStatusQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%v", epsId)
+	}
+
+	return ""
+}
+
+func buildCreateAntivirusPayPerScanSwitchStatusBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"enabled": d.Get("enabled"),
+	}
+}
+
+func resourceAntivirusPayPerScanSwitchStatusCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + "v5/{project_id}/antivirus/pay-per-scan"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildCreateAntivirusPayPerScanSwitchStatusQueryParams(epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildCreateAntivirusPayPerScanSwitchStatusBodyParams(d),
+	}
+
+	_, err = client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error update HSS antivirus pay-per-scan switch status: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return resourceAntivirusPayPerScanSwitchStatusRead(ctx, d, meta)
+}
+
+func resourceAntivirusPayPerScanSwitchStatusRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceAntivirusPayPerScanSwitchStatusUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceAntivirusPayPerScanSwitchStatusDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to update HSS antivirus pay-per-scan switch status.
+    Deleting this resource will not clear the corresponding request record, but will only remove the resource
+    information from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_antivirus_pay_per_scan_switch_status` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_antivirus_pay_per_scan_switch_status` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccAntivirusPayPerScanSwitchStatus_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccAntivirusPayPerScanSwitchStatus_basic -timeout 360m -parallel 4
=== RUN   TestAccAntivirusPayPerScanSwitchStatus_basic
=== PAUSE TestAccAntivirusPayPerScanSwitchStatus_basic
=== CONT  TestAccAntivirusPayPerScanSwitchStatus_basic
--- PASS: TestAccAntivirusPayPerScanSwitchStatus_basic (12.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       12.615s

```
<img width="980" height="35" alt="image" src="https://github.com/user-attachments/assets/5dd98588-450b-4c0c-8553-2d712be60996" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
