### PR TITLE
feat(dns): add new data source to query name servers under a zone

### DIFF
--- a/docs/data-sources/dns_zone_nameservers.md
+++ b/docs/data-sources/dns_zone_nameservers.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Domain Name Service (DNS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dns_zone_nameservers"
+description: |-
+  Use this data source to get the list of name servers for a public zone.
+---
+
+# huaweicloud_dns_zone_nameservers
+
+Use this data source to get the list of name servers for a public zone.
+
+## Example Usage
+
+```hcl
+variable "zone_id" {}
+
+data "huaweicloud_dns_zone_nameservers" "test" {
+  zone_id = var.zone_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `zone_id` - (Required, String) Specifies the ID of the public zone to which the name servers belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `nameservers` - The list of name servers of the public zone.
+  The [nameservers](#dns_zone_nameservers_attr) structure is documented below.
+
+<a name="dns_zone_nameservers_attr"></a>
+The `nameservers` block supports:
+
+* `hostname` - The host name of the name server.
+
+* `priority` - The priority of the name server.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1122,6 +1122,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_recordsets":          dns.DataSourceRecordsets(),
 			"huaweicloud_dns_resolver_rules":      dns.DataSourceDNSResolverRules(),
 			"huaweicloud_dns_zones":               dns.DataSourceZones(),
+			"huaweicloud_dns_zone_nameservers":    dns.DataSourceZoneNameservers(),
 			"huaweicloud_dns_public_zone_lines":   dns.DataSourceDNSPublicZoneLines(),
 			"huaweicloud_dns_tags":                dns.DataSourceDNSTags(),
 			"huaweicloud_dns_tags_filter":         dns.DataSourceDNSTagsFilter(),

--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_zone_nameservers_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_zone_nameservers_test.go
@@ -1,0 +1,65 @@
+package dns
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataZoneNameservers_basic(t *testing.T) {
+	var (
+		name = fmt.Sprintf("acpttest-zone-%s.com.", acctest.RandString(5))
+
+		dataSource = "data.huaweicloud_dns_zone_nameservers.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataZoneNameservers_notFound(),
+				ExpectError: regexp.MustCompile(`This zone does not exist`),
+			},
+			{
+				Config: testAccDataZoneNameservers_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "nameservers.#", regexp.MustCompile(`[1-9][0-9]*`)),
+					resource.TestCheckResourceAttrSet(dataSource, "nameservers.0.hostname"),
+					resource.TestCheckResourceAttrSet(dataSource, "nameservers.0.priority"),
+					resource.TestMatchResourceAttr(dataSource, "nameservers.0.hostname", regexp.MustCompile(`.+\.`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataZoneNameservers_notFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dns_zone_nameservers" "invalid_zone_id" {
+  zone_id = "%[1]s"
+}
+`, randomId)
+}
+
+func testAccDataZoneNameservers_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dns_zone" "test" {
+  name      = "%[1]s"
+  zone_type = "public"
+}
+
+data "huaweicloud_dns_zone_nameservers" "test" {
+  zone_id = huaweicloud_dns_zone.test.id
+}
+`, name)
+}

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_zone_nameservers.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_zone_nameservers.go
@@ -1,0 +1,108 @@
+package dns
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DNS GET /v2/zones/{zone_id}/nameservers
+func DataSourceZoneNameservers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceZoneNameserversRead,
+
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"zone_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the public zone to be queried.`,
+			},
+
+			// Attributes.
+			"nameservers": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the name servers of the public zone.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"hostname": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The host name of the name server.`,
+						},
+						"priority": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The priority of the name server.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceZoneNameserversRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+
+	client, err := cfg.NewServiceClient("dns", "")
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	respBody, err := getZoneNameservers(client, d.Get("zone_id").(string))
+	if err != nil {
+		return diag.Errorf("error querying DNS zone nameservers: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("nameservers", flattenZoneNameservers(utils.PathSearch("nameservers",
+			respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func getZoneNameservers(client *golangsdk.ServiceClient, zoneId string) (interface{}, error) {
+	var (
+		httpUrl = "v2/zones/{zone_id}/nameservers"
+	)
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{zone_id}", zoneId)
+
+	reqOpt := golangsdk.RequestOpts{KeepResponseBody: true}
+	requestResp, err := client.Request("GET", getPath, &reqOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func flattenZoneNameservers(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"hostname": utils.PathSearch("hostname", item, nil),
+			"priority": utils.PathSearch("priority", item, nil),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports new data source that used to query name servers under a zone.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query nameservers under a zone
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccDataZoneNameservers_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDataZoneNameservers_basic -timeout 360m -parallel 10
=== RUN   TestAccDataZoneNameservers_basic
=== PAUSE TestAccDataZoneNameservers_basic
=== CONT  TestAccDataZoneNameservers_basic
--- PASS: TestAccDataZoneNameservers_basic (27.51s)
PASS
coverage: 6.7% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       27.607s coverage: 6.7% of statements in ./huaweicloud/services/dns
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
