### PR TITLE
feat(dew): new datasource to query cpcs cluster access keys

### DIFF
--- a/docs/data-sources/cpcs_cluster_access_keys.md
+++ b/docs/data-sources/cpcs_cluster_access_keys.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cpcs_cluster_access_keys"
+description: |-
+  Use this data source to get the access keys of a CPCS cluster.
+---
+
+# huaweicloud_cpcs_cluster_access_keys
+
+Use this data source to get the access keys of a CPCS cluster.
+
+-> Currently, this data source is valid only in cn-north-9 region.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_cpcs_cluster_access_keys" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the ID of the CPCS cluster.
+
+* `app_name` - (Optional, String) Specifies the name of the application to filter access keys.
+
+* `sort_key` - (Optional, String) Specifies the key for sorting the access keys. Defaults to **create_time**.
+
+* `sort_dir` - (Optional, String) Specifies the direction for sorting. Valid values are **ASC** and **DESC**.
+  Defaults to **DESC**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `access_keys` - The list of access keys.
+  The [access_keys](#access_keys_struct) structure is documented below.
+
+<a name="access_keys_struct"></a>
+The `access_keys` block supports:
+
+* `access_key_id` - The ID of the access key.
+
+* `status` - The status of the access key.
+
+* `app_name` - The name of the application that the access key belongs to.
+
+* `access_key` - The access key value.
+
+* `key_name` - The name of the access key.
+
+* `create_time` - The creation time of the access key, in milliseconds.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -926,11 +926,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_cse_microservice_instances":             cse.DataSourceMicroserviceInstances(),
 			"huaweicloud_cse_nacos_namespaces":                   cse.DataSourceNacosNamespaces(),
 
-			"huaweicloud_cpcs_apps":               dew.DataSourceCpcsApps(),
-			"huaweicloud_cpcs_app_access_keys":    dew.DataSourceCpcsAppAccessKeys(),
-			"huaweicloud_cpcs_availability_zones": dew.DataSourceAvailabilityZones(),
-			"huaweicloud_cpcs_resource_infos":     dew.DataSourceResourceInfos(),
-			"huaweicloud_cpcs_images":             dew.DataSourceCpcsImages(),
+			"huaweicloud_cpcs_apps":                dew.DataSourceCpcsApps(),
+			"huaweicloud_cpcs_app_access_keys":     dew.DataSourceCpcsAppAccessKeys(),
+			"huaweicloud_cpcs_availability_zones":  dew.DataSourceAvailabilityZones(),
+			"huaweicloud_cpcs_cluster_access_keys": dew.DataSourceCpcsClusterAccessKeys(),
+			"huaweicloud_cpcs_resource_infos":      dew.DataSourceResourceInfos(),
+			"huaweicloud_cpcs_images":              dew.DataSourceCpcsImages(),
 
 			"huaweicloud_csms_agencies":                 dew.DataSourceAgencies(),
 			"huaweicloud_csms_events":                   dew.DataSourceDewCsmsEvents(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -148,6 +148,8 @@ var (
 	HW_CSMS_TASK_ID              = os.Getenv("HW_CSMS_TASK_ID")
 	HW_CSMS_SECRET_ID            = os.Getenv("HW_CSMS_SECRET_ID")
 
+	HW_CPCS_CLUSTER_ID = os.Getenv("HW_CPCS_CLUSTER_ID")
+
 	HW_DEST_REGION          = os.Getenv("HW_DEST_REGION")
 	HW_DEST_PROJECT_ID      = os.Getenv("HW_DEST_PROJECT_ID")
 	HW_DEST_PROJECT_ID_TEST = os.Getenv("HW_DEST_PROJECT_ID_TEST")
@@ -4095,6 +4097,13 @@ func TestAccPrecheckDewFlag(t *testing.T) {
 func TestAccPrecheckCsmsTask(t *testing.T) {
 	if HW_CSMS_TASK_ID == "" {
 		t.Skip("HW_CSMS_TASK_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPrecheckCpcsClusterId(t *testing.T) {
+	if HW_CPCS_CLUSTER_ID == "" {
+		t.Skip("HW_CPCS_CLUSTER_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_cpcs_cluster_access_keys_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_cpcs_cluster_access_keys_test.go
@@ -1,0 +1,67 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCpcsClusterAccessKeys_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_cpcs_cluster_access_keys.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckCpcsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCpcsClusterAccessKeys_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "access_keys.0.access_key_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "access_keys.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "access_keys.0.app_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "access_keys.0.access_key"),
+					resource.TestCheckResourceAttrSet(dataSource, "access_keys.0.key_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "access_keys.0.create_time"),
+
+					resource.TestCheckOutput("is_app_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCpcsClusterAccessKeys_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cpcs_cluster_access_keys" "test" {
+  cluster_id = "%[1]s"
+}
+
+locals {
+  app_name = data.huaweicloud_cpcs_cluster_access_keys.test.access_keys.0.app_name
+}
+
+# Filter by app name
+data "huaweicloud_cpcs_cluster_access_keys" "app_name_filter" {
+  cluster_id = "%[1]s"
+  app_name   = local.app_name
+}
+
+locals {
+  app_name_filter_result = [
+    for v in data.huaweicloud_cpcs_cluster_access_keys.app_name_filter.access_keys[*].app_name : v == local.app_name
+  ]
+}
+
+output "is_app_name_filter_useful" {
+  value = length(local.app_name_filter_result) > 0 && alltrue(local.app_name_filter_result)
+}
+`, acceptance.HW_CPCS_CLUSTER_ID)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query cpcs cluster access keys

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccDataSourceCpcsClusterAccessKeys_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccDataSourceCpcsClusterAccessKeys_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCpcsClusterAccessKeys_basic
=== PAUSE TestAccDataSourceCpcsClusterAccessKeys_basic
=== CONT  TestAccDataSourceCpcsClusterAccessKeys_basic
--- PASS: TestAccDataSourceCpcsClusterAccessKeys_basic (9.88s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       9.972s  coverage: 4.2% of statements in ./huaweicloud/services/dew
```
<img width="1278" height="69" alt="image" src="https://github.com/user-attachments/assets/9d0ab026-9f1a-4928-bc61-e5cadb35ecce" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
