### PR TITLE
feat(hss): support `hss_antivirus_pay_per_scan_hosts` data source

### DIFF
--- a/docs/data-sources/hss_antivirus_pay_per_scan_hosts.md
+++ b/docs/data-sources/hss_antivirus_pay_per_scan_hosts.md
@@ -1,0 +1,85 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_antivirus_pay_per_scan_hosts"
+description: |-
+  Use this data source to get the list of HSS antivirus pay-per-scan hosts within HuaweiCloud.
+---
+
+# huaweicloud_hss_antivirus_pay_per_scan_hosts
+
+Use this data source to get the list of HSS antivirus pay-per-scan hosts within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "scan_type" {}
+variable "start_type" {}
+
+data "huaweicloud_hss_antivirus_pay_per_scan_hosts" "test" {
+  scan_type  = var.scan_type
+  start_type = var.start_type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `scan_type` - (Required, String) Specifies the scan type.  
+  The valid values are as follows:
+  + **quick**: Quick scan.
+  + **full**: Full scan.
+  + **custom**: Custom scan.
+
+* `start_type` - (Required, String) Specifies the start type.  
+  The valid values are as follows:
+  + **now**: Start immediately.
+  + **period**: Periodic start.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need to set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `host_id` - (Optional, String) Specifies the host ID.
+
+* `host_name` - (Optional, String) Specifies the host name.
+
+* `private_ip` - (Optional, String) Specifies the private IP.
+
+* `public_ip` - (Optional, String) Specifies the public IP.
+
+* `group_id` - (Optional, String) Specifies the group ID.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `data_list` - The list of hosts.
+
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `host_id` - The host ID.
+
+* `host_name` - The host name.
+
+* `group_id` - The group ID.
+
+* `public_ip` - The public IP address.
+
+* `private_ip` - The private IP address.
+
+* `agent_id` - The agent ID.
+
+* `os_type` - The operating system type. The valid values are **Linux** and **Windows**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1379,6 +1379,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_antivirus_pay_per_scan_switch_status":       hss.DataSourceAntivirusPayPerScanSwitchStatus(),
 			"huaweicloud_hss_antivirus_pay_per_scan_free_quotas":         hss.DataSourceAntivirusPayPerScanFreeQuotas(),
 			"huaweicloud_hss_antivirus_virus_scan_tasks":                 hss.DataSourceAntivirusVirusScanTasks(),
+			"huaweicloud_hss_antivirus_pay_per_scan_hosts":               hss.DataSourceAntivirusPayPerScanHosts(),
 			"huaweicloud_hss_backup_policy":                              hss.DataSourceBackupPolicy(),
 			"huaweicloud_hss_cicd_configurations":                        hss.DataSourceCiCdConfigurations(),
 			"huaweicloud_hss_page_notices":                               hss.DataSourcePageNotices(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_antivirus_pay_per_scan_hosts_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_antivirus_pay_per_scan_hosts_test.go
@@ -1,0 +1,115 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAntivirusPayPerScanHosts_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_antivirus_pay_per_scan_hosts.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires the preparation of a host ID that has completed the paid virus quick scan.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAntivirusPayPerScanHosts_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.host_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.host_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.private_ip"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.agent_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.os_type"),
+
+					resource.TestCheckOutput("is_host_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_host_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_private_ip_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceAntivirusPayPerScanHosts_basic() string {
+	return `
+data "huaweicloud_hss_antivirus_pay_per_scan_hosts" "test" {
+  scan_type  = "quick"
+  start_type = "now"
+}
+
+# Filter using host_id.
+locals {
+  host_id = data.huaweicloud_hss_antivirus_pay_per_scan_hosts.test.data_list[0].host_id
+}
+
+data "huaweicloud_hss_antivirus_pay_per_scan_hosts" "host_id_filter" {
+  scan_type  = "quick"
+  start_type = "now"
+  host_id    = local.host_id
+}
+
+output "is_host_id_filter_useful" {
+  value = length(data.huaweicloud_hss_antivirus_pay_per_scan_hosts.host_id_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_antivirus_pay_per_scan_hosts.host_id_filter.data_list[*].host_id : v == local.host_id]
+  )
+}
+
+# Filter using host_name.
+locals {
+  host_name = data.huaweicloud_hss_antivirus_pay_per_scan_hosts.test.data_list[0].host_name
+}
+
+data "huaweicloud_hss_antivirus_pay_per_scan_hosts" "host_name_filter" {
+  scan_type  = "quick"
+  start_type = "now"
+  host_name  = local.host_name
+}
+
+output "is_host_name_filter_useful" {
+  value = length(data.huaweicloud_hss_antivirus_pay_per_scan_hosts.host_name_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_antivirus_pay_per_scan_hosts.host_name_filter.data_list[*].host_name : v == local.host_name]
+  )
+}
+
+# Filter using private_ip.
+locals {
+  private_ip = data.huaweicloud_hss_antivirus_pay_per_scan_hosts.test.data_list[0].private_ip
+}
+
+data "huaweicloud_hss_antivirus_pay_per_scan_hosts" "private_ip_filter" {
+  scan_type  = "quick"
+  start_type = "now"
+  private_ip = local.private_ip
+}
+
+output "is_private_ip_filter_useful" {
+  value = length(data.huaweicloud_hss_antivirus_pay_per_scan_hosts.private_ip_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_antivirus_pay_per_scan_hosts.private_ip_filter.data_list[*].private_ip : v == local.private_ip]
+  )
+}
+
+# Filter using non existent host_name.
+data "huaweicloud_hss_antivirus_pay_per_scan_hosts" "not_found" {
+  scan_type  = "quick"
+  start_type = "now"
+  host_name  = "resource_not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_hss_antivirus_pay_per_scan_hosts.not_found.data_list) == 0
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_antivirus_pay_per_scan_hosts.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_antivirus_pay_per_scan_hosts.go
@@ -1,0 +1,213 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/antivirus/pay-per-scan/hosts
+func DataSourceAntivirusPayPerScanHosts() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAntivirusPayPerScanHostsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"scan_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"start_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"host_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"private_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"public_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"host_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"public_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"private_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"agent_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"os_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAntivirusPayPerScanHostsQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=200"
+	queryParams = fmt.Sprintf("%s&scan_type=%s", queryParams, d.Get("scan_type"))
+	queryParams = fmt.Sprintf("%s&start_type=%v", queryParams, d.Get("start_type"))
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("host_id"); ok {
+		queryParams = fmt.Sprintf("%s&host_id=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("host_name"); ok {
+		queryParams = fmt.Sprintf("%s&host_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("private_ip"); ok {
+		queryParams = fmt.Sprintf("%s&private_ip=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("public_ip"); ok {
+		queryParams = fmt.Sprintf("%s&public_ip=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("group_id"); ok {
+		queryParams = fmt.Sprintf("%s&group_id=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceAntivirusPayPerScanHostsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		result  = make([]interface{}, 0)
+		offset  = 0
+		httpUrl = "v5/{project_id}/antivirus/pay-per-scan/hosts"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildAntivirusPayPerScanHostsQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS antivirus pay-per-scan hosts: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataList := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataList) == 0 {
+			break
+		}
+
+		result = append(result, dataList...)
+
+		totalNum := utils.PathSearch("total_num", respBody, float64(0)).(float64)
+		if int(totalNum) == len(result) {
+			break
+		}
+
+		offset += len(dataList)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data_list", flattenAntivirusPayPerScanHostsDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAntivirusPayPerScanHostsDataList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"host_id":    utils.PathSearch("host_id", v, nil),
+			"host_name":  utils.PathSearch("host_name", v, nil),
+			"group_id":   utils.PathSearch("group_id", v, nil),
+			"public_ip":  utils.PathSearch("public_ip", v, nil),
+			"private_ip": utils.PathSearch("private_ip", v, nil),
+			"agent_id":   utils.PathSearch("agent_id", v, nil),
+			"os_type":    utils.PathSearch("os_type", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_antivirus_pay_per_scan_hosts` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_antivirus_pay_per_scan_hosts` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceAntivirusPayPerScanHosts_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceAntivirusPayPerScanHosts_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAntivirusPayPerScanHosts_basic
=== PAUSE TestAccDataSourceAntivirusPayPerScanHosts_basic
=== CONT  TestAccDataSourceAntivirusPayPerScanHosts_basic
--- PASS: TestAccDataSourceAntivirusPayPerScanHosts_basic (14.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       14.551s
```
<img width="951" height="32" alt="image" src="https://github.com/user-attachments/assets/47f0c4e6-7b0f-4bde-aa19-505578aeb95d" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
