### PR TITLE
feat(dew/cpcs): add new data source to get list of associations

### DIFF
--- a/docs/data-sources/cpcs_associations.md
+++ b/docs/data-sources/cpcs_associations.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cpcs_associations"
+description: |-
+  Use this data source to get list of binding relationships between the password service clusters and the applications.
+---
+
+# huaweicloud_cpcs_associations
+
+Use this data source to get list of binding relationships between the password service clusters and the applications.
+
+-> Currently, this data source is valid only in cn-north-9 region.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cpcs_associations" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Optional, String) Specifies the cluster ID.
+
+* `app_id` - (Optional, String) Specifies the application ID.
+
+* `sort_key` - (Optional, String) Specifies the sort attribute.
+  The default value is **create_time**.
+
+* `sort_dir` - (Optional, String) Specifies the sort direction.
+  The default value is **DESC**. Valid values are **ASC** and **DESC**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `result` - Indicates the applications list.
+  The [result](#associations_result_struct) structure is documented below.
+
+<a name="associations_result_struct"></a>
+The `result` block supports:
+
+* `id` - The association ID.
+
+* `cluster_id` - The cluster ID.
+
+* `cluster_name` - The cluster name.
+
+* `app_id` - The application ID.
+
+* `app_name` - The application name.
+
+* `vpc_name` - The VPC name to which the application belongs.
+
+* `subnet_name` - The subnet name to which the application belongs.
+
+* `cluster_server_type` - The service type to which the cluster belongs.
+
+* `vpcep_address` - The access address.
+
+* `update_time` - The latest update time of the association, in UNIX timestamp format.
+
+* `create_time` - The creation time of the association, in UNIX timestamp format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -926,13 +926,14 @@ func Provider() *schema.Provider {
 			"huaweicloud_cse_microservice_instances":             cse.DataSourceMicroserviceInstances(),
 			"huaweicloud_cse_nacos_namespaces":                   cse.DataSourceNacosNamespaces(),
 
-			"huaweicloud_cpcs_apps":                dew.DataSourceCpcsApps(),
 			"huaweicloud_cpcs_app_access_keys":     dew.DataSourceCpcsAppAccessKeys(),
+			"huaweicloud_cpcs_apps":                dew.DataSourceCpcsApps(),
+			"huaweicloud_cpcs_associations":        dew.DataSourceAssociations(),
 			"huaweicloud_cpcs_availability_zones":  dew.DataSourceAvailabilityZones(),
 			"huaweicloud_cpcs_cluster_access_keys": dew.DataSourceCpcsClusterAccessKeys(),
-			"huaweicloud_cpcs_resource_infos":      dew.DataSourceResourceInfos(),
 			"huaweicloud_cpcs_images":              dew.DataSourceCpcsImages(),
 			"huaweicloud_cpcs_clusters":            dew.DataSourceCpcsClusters(),
+			"huaweicloud_cpcs_resource_infos":      dew.DataSourceResourceInfos(),
 
 			"huaweicloud_csms_agencies":                 dew.DataSourceAgencies(),
 			"huaweicloud_csms_events":                   dew.DataSourceDewCsmsEvents(),

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_cpcs_associations_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_cpcs_associations_test.go
@@ -1,0 +1,75 @@
+package dew
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAssociations_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_cpcs_associations.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Before running test, prepare a password service cluster bind an application.
+			acceptance.TestAccPrecheckDewFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAssociations_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.cluster_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.cluster_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.app_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.app_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.vpc_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.subnet_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.cluster_server_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.vpcep_address"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.update_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.create_time"),
+
+					resource.TestCheckOutput("cluster_id_filter_useful", "true"),
+					resource.TestCheckOutput("app_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceAssociations_basic = `
+data "huaweicloud_cpcs_associations" "test" {}
+
+locals {
+  cluster_id = data.huaweicloud_cpcs_associations.test.result.0.cluster_id
+  app_id     = data.huaweicloud_cpcs_associations.test.result.0.app_id
+}
+
+data "huaweicloud_cpcs_associations" "cluster_id_filter" {
+  cluster_id = local.cluster_id
+}
+
+output "cluster_id_filter_useful" {
+  value = length(data.huaweicloud_cpcs_associations.cluster_id_filter.result) > 0 && alltrue(
+    [for v in data.huaweicloud_cpcs_associations.cluster_id_filter.result[*].cluster_id : v == local.cluster_id]
+  )
+}
+
+data "huaweicloud_cpcs_associations" "app_id_filter" {
+  app_id = local.app_id
+}
+
+output "app_id_filter_useful" {
+  value = length(data.huaweicloud_cpcs_associations.app_id_filter.result) > 0 && alltrue(
+    [for v in data.huaweicloud_cpcs_associations.app_id_filter.result[*].app_id : v == local.app_id]
+  )
+}
+`

--- a/huaweicloud/services/dew/data_source_huaweicloud_cpcs_associations.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_cpcs_associations.go
@@ -1,0 +1,206 @@
+package dew
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW GET /v1/{project_id}/dew/cpcs/associations
+func DataSourceAssociations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAssociationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"app_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"result": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"app_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"app_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpc_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"subnet_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_server_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpcep_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAssociationsQueryParams(d *schema.ResourceData) string {
+	rst := "?page_size=10"
+
+	if v, ok := d.GetOk("cluster_id"); ok {
+		rst += fmt.Sprintf("&cluster_id=%v", v)
+	}
+
+	if v, ok := d.GetOk("app_id"); ok {
+		rst += fmt.Sprintf("&app_id=%v", v)
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		rst += fmt.Sprintf("&sort_key=%v", v)
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%v", v)
+	}
+
+	return rst
+}
+
+// The first page of page_num is `1`.
+func dataSourceAssociationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg             = meta.(*config.Config)
+		region          = cfg.GetRegion(d)
+		httpUrl         = "v1/{project_id}/dew/cpcs/associations"
+		pageNum         = 1
+		allAssociations = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("kms", region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildAssociationsQueryParams(d)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		getPathWithPageNum := fmt.Sprintf("%s&page_num=%d", getPath, pageNum)
+		resp, err := client.Request("GET", getPathWithPageNum, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving CPCS associations: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		results := utils.PathSearch("result", respBody, make([]interface{}, 0)).([]interface{})
+		if len(results) == 0 {
+			break
+		}
+
+		allAssociations = append(allAssociations, results...)
+
+		pageNum++
+	}
+
+	datasourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID: %s", err)
+	}
+
+	d.SetId(datasourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("result", flattenAssociationsResponseBody(allAssociations)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAssociationsResponseBody(results []interface{}) []interface{} {
+	if len(results) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(results))
+	for _, association := range results {
+		result = append(result, map[string]interface{}{
+			"id":                  utils.PathSearch("id", association, nil),
+			"cluster_id":          utils.PathSearch("cluster_id", association, nil),
+			"cluster_name":        utils.PathSearch("cluster_name", association, nil),
+			"app_id":              utils.PathSearch("app_id", association, nil),
+			"app_name":            utils.PathSearch("app_name", association, nil),
+			"vpc_name":            utils.PathSearch("vpc_name", association, nil),
+			"subnet_name":         utils.PathSearch("subnet_name", association, nil),
+			"cluster_server_type": utils.PathSearch("cluster_server_type", association, nil),
+			"vpcep_address":       utils.PathSearch("address", association, nil),
+			"update_time":         utils.PathSearch("update_time", association, nil),
+			"create_time":         utils.PathSearch("create_time", association, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get list of associations.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dew" TESTARGS="-run TestAccDataSourceAssociations_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccDataSourceAssociations_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAssociations_basic
=== PAUSE TestAccDataSourceAssociations_basic
=== CONT  TestAccDataSourceAssociations_basic
--- PASS: TestAccDataSourceAssociations_basic (12.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       12.431s
```
<img width="1209" height="17" alt="image" src="https://github.com/user-attachments/assets/e433516c-f887-489c-9a1e-8ca3189127ed" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
