### PR TITLE
feat(dew): new resource to associate app and cluster

### DIFF
--- a/docs/resources/cpcs_app_cluster_association.md
+++ b/docs/resources/cpcs_app_cluster_association.md
@@ -1,0 +1,74 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cpcs_app_cluster_association"
+description: |-
+  Manages an association between a CPCS application and cluster within HuaweiCloud.
+---
+
+# huaweicloud_cpcs_app_cluster_association
+
+Manages an association between a CPCS application and cluster within HuaweiCloud.
+
+-> Currently, this resource is valid only in cn-north-9 region.
+
+## Example Usage
+
+```hcl
+variable "app_id" {}
+variable "cluster_id" {}
+
+resource "huaweicloud_cpcs_app_cluster_association" "test" {
+  app_id     = var.app_id
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `app_id` - (Required, String, NonUpdatable) Specifies the ID of the application to be associated with the cluster.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the cluster to associate with the application.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (Randomly generated UUID).
+
+* `cluster_name` - The name of the cluster.
+
+* `app_name` - The name of the application.
+
+* `vpc_name` - The name of the VPC where the application is located.
+
+* `subnet_name` - The name of the subnet where the application is located.
+
+* `cluster_server_type` - The type of the cluster server.
+
+* `vpcep_address` - The address of the VPC endpoint.
+
+* `update_time` - The update time of the association, UNIX timestamp in milliseconds.
+
+* `create_time` - The creation time of the association, UNIX timestamp in milliseconds.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The CPCS application cluster association resource can be imported using the `app_id` and `cluster_id`,
+separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_cpcs_app_cluster_association.test <app_id>/<cluster_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2488,8 +2488,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_cse_microservice_instance":             cse.ResourceMicroserviceInstance(),
 			"huaweicloud_cse_nacos_namespace":                   cse.ResourceNacosNamespace(),
 
-			"huaweicloud_cpcs_app_access_key": dew.ResourceCpcsAppAccessKey(),
-			"huaweicloud_cpcs_app":            dew.ResourceCpcsApp(),
+			"huaweicloud_cpcs_app_access_key":          dew.ResourceCpcsAppAccessKey(),
+			"huaweicloud_cpcs_app_cluster_association": dew.ResourceCpcsAppClusterAssociation(),
+			"huaweicloud_cpcs_app":                     dew.ResourceCpcsApp(),
 
 			"huaweicloud_csms_agency":                       dew.ResourceAgency(),
 			"huaweicloud_csms_event":                        dew.ResourceCsmsEvent(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -149,6 +149,7 @@ var (
 	HW_CSMS_SECRET_ID            = os.Getenv("HW_CSMS_SECRET_ID")
 
 	HW_CPCS_CLUSTER_ID = os.Getenv("HW_CPCS_CLUSTER_ID")
+	HW_CPCS_APP_ID     = os.Getenv("HW_CPCS_APP_ID")
 
 	HW_DEST_REGION          = os.Getenv("HW_DEST_REGION")
 	HW_DEST_PROJECT_ID      = os.Getenv("HW_DEST_PROJECT_ID")
@@ -4112,6 +4113,13 @@ func TestAccPrecheckCsmsTask(t *testing.T) {
 func TestAccPrecheckCpcsClusterId(t *testing.T) {
 	if HW_CPCS_CLUSTER_ID == "" {
 		t.Skip("HW_CPCS_CLUSTER_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPrecheckCpcsAppClusterAssociation(t *testing.T) {
+	if HW_CPCS_APP_ID == "" || HW_CPCS_CLUSTER_ID == "" {
+		t.Skip("HW_CPCS_APP_ID and HW_CPCS_CLUSTER_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_cpcs_app_cluster_association_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_cpcs_app_cluster_association_test.go
@@ -1,0 +1,93 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dew"
+)
+
+func getCpcsAppClusterAssociationResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("kms", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DEW client: %s", err)
+	}
+
+	appId := state.Primary.Attributes["app_id"]
+	clusterId := state.Primary.Attributes["cluster_id"]
+	return dew.QueryCpcsAppClusterAssociation(client, appId, clusterId)
+}
+
+// Currently, this resource is valid only in cn-north-9 region.
+func TestAccCpcsAppClusterAssociation_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_cpcs_app_cluster_association.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getCpcsAppClusterAssociationResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare an unbound App and Cluster, and configure the ID in the environment variables.
+			acceptance.TestAccPrecheckCpcsAppClusterAssociation(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCpcsAppClusterAssociation_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "app_id", acceptance.HW_CPCS_APP_ID),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_CPCS_CLUSTER_ID),
+					resource.TestCheckResourceAttrSet(rName, "app_name"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_name"),
+					resource.TestCheckResourceAttrSet(rName, "vpc_name"),
+					resource.TestCheckResourceAttrSet(rName, "subnet_name"),
+					resource.TestCheckResourceAttrSet(rName, "create_time"),
+					resource.TestCheckResourceAttrSet(rName, "update_time"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateIdFunc: testCpcsAppClusterAssociationImportState(rName),
+			},
+		},
+	})
+}
+
+func testCpcsAppClusterAssociation_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cpcs_app_cluster_association" "test" {
+  app_id     = "%s"
+  cluster_id = "%s"
+}
+`, acceptance.HW_CPCS_APP_ID, acceptance.HW_CPCS_CLUSTER_ID)
+}
+
+func testCpcsAppClusterAssociationImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+		if rs.Primary.Attributes["app_id"] == "" || rs.Primary.Attributes["cluster_id"] == "" {
+			return "", fmt.Errorf("required attributes (app_id, cluster_id) of resource (%s) not found", name)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["app_id"], rs.Primary.Attributes["cluster_id"]), nil
+	}
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_cpcs_app_cluster_association.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_cpcs_app_cluster_association.go
@@ -1,0 +1,325 @@
+package dew
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW POST /v1/{project_id}/dew/cpcs/associate-apps
+// @API DEW POST /v1/{project_id}/dew/cpcs/disassociate-apps
+// @API DEW GET /v1/{project_id}/dew/cpcs/associations
+func ResourceCpcsAppClusterAssociation() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCpcsAppClusterAssociationCreate,
+		ReadContext:   resourceCpcsAppClusterAssociationRead,
+		UpdateContext: resourceCpcsAppClusterAssociationUpdate,
+		DeleteContext: resourceCpcsAppClusterAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceCpcsAppClusterAssociationImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"app_id",
+			"cluster_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"app_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the application.`,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the cluster.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"cluster_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the cluster.`,
+			},
+			"app_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the application.`,
+			},
+			"vpc_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the VPC.`,
+			},
+			"subnet_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the subnet.`,
+			},
+			"cluster_server_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the cluster server.`,
+			},
+			"vpcep_address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The address of the VPC endpoint.`,
+			},
+			"update_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The update time of the association, UNIX timestamp in milliseconds.`,
+			},
+			"create_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The creation time of the association, UNIX timestamp in milliseconds.`,
+			},
+		},
+	}
+}
+
+func waitingForCpcsAppClusterAssociationSuccess(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration) error {
+	appId := d.Get("app_id").(string)
+	clusterId := d.Get("cluster_id").(string)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			associationDetail, err := QueryCpcsAppClusterAssociation(client, appId, clusterId)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			// Although the API documentation does not explicitly mention the existence of the `bind_status` field,
+			// we still need to use this field to guide the binding process.
+			bindStatus := utils.PathSearch("bind_status", associationDetail, "").(string)
+			if bindStatus == "BIND_SUCCESS" {
+				return associationDetail, "COMPLETED", nil
+			}
+
+			return associationDetail, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceCpcsAppClusterAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/dew/cpcs/associate-apps"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"app_id":     d.Get("app_id").(string),
+			"cluster_id": d.Get("cluster_id").(string),
+		},
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating the association between DEW CPCS application and cluster: %s", err)
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID: %s", err)
+	}
+	d.SetId(generateId)
+
+	if err := waitingForCpcsAppClusterAssociationSuccess(ctx, client, d, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("error waiting for DEW CPCS application cluster association to be created: %s", err)
+	}
+
+	return resourceCpcsAppClusterAssociationRead(ctx, d, meta)
+}
+
+func QueryCpcsAppClusterAssociation(client *golangsdk.ServiceClient, appId, clusterId string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/dew/cpcs/associations"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?app_id=%s&cluster_id=%s", appId, clusterId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	associationDetail := utils.PathSearch("result|[0]", respBody, nil)
+	if associationDetail == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return associationDetail, nil
+}
+
+func resourceCpcsAppClusterAssociationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		product   = "kms"
+		appId     = d.Get("app_id").(string)
+		clusterId = d.Get("cluster_id").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	associationDetail, err := QueryCpcsAppClusterAssociation(client, appId, clusterId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DEW CPCS application cluster association")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("cluster_id", utils.PathSearch("cluster_id", associationDetail, nil)),
+		d.Set("cluster_name", utils.PathSearch("cluster_name", associationDetail, nil)),
+		d.Set("app_id", utils.PathSearch("app_id", associationDetail, nil)),
+		d.Set("app_name", utils.PathSearch("app_name", associationDetail, nil)),
+		d.Set("vpc_name", utils.PathSearch("vpc_name", associationDetail, nil)),
+		d.Set("subnet_name", utils.PathSearch("subnet_name", associationDetail, nil)),
+		d.Set("cluster_server_type", utils.PathSearch("cluster_server_type", associationDetail, nil)),
+		d.Set("vpcep_address", utils.PathSearch("vpcep_address", associationDetail, nil)),
+		d.Set("update_time", utils.PathSearch("update_time", associationDetail, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", associationDetail, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceCpcsAppClusterAssociationUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func waitingForCpcsAppClusterAssociationDelete(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration) error {
+	appId := d.Get("app_id").(string)
+	clusterId := d.Get("cluster_id").(string)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			associationDetail, err := QueryCpcsAppClusterAssociation(client, appId, clusterId)
+			if err != nil {
+				var errDefault404 golangsdk.ErrDefault404
+				if errors.As(err, &errDefault404) {
+					return "deleted", "COMPLETED", nil
+				}
+				return nil, "ERROR", err
+			}
+
+			return associationDetail, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceCpcsAppClusterAssociationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/dew/cpcs/disassociate-apps"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"app_ids":    []string{d.Get("app_id").(string)},
+			"cluster_id": d.Get("cluster_id").(string),
+		},
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DEW CPCS application cluster association: %s", err)
+	}
+
+	timeout := d.Timeout(schema.TimeoutDelete)
+	if err := waitingForCpcsAppClusterAssociationDelete(context.Background(), client, d, timeout); err != nil {
+		return diag.Errorf("error waiting for DEW CPCS application cluster association to be deleted: %s", err)
+	}
+
+	return nil
+}
+
+func resourceCpcsAppClusterAssociationImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, must be <app_id>/<cluster_id>, but got %s", d.Id())
+	}
+
+	mErr := multierror.Append(
+		d.Set("app_id", parts[0]),
+		d.Set("cluster_id", parts[1]),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to associate app and cluster

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccCpcsAppClusterAssociation_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccCpcsAppClusterAssociation_basic -timeout 360m -parallel 10
=== RUN   TestAccCpcsAppClusterAssociation_basic
=== PAUSE TestAccCpcsAppClusterAssociation_basic
=== CONT  TestAccCpcsAppClusterAssociation_basic
--- PASS: TestAccCpcsAppClusterAssociation_basic (32.29s)
PASS
coverage: 5.2% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       32.387s coverage: 5.2% of statements in ./huaweicloud/services/dew
```
<img width="1279" height="75" alt="image" src="https://github.com/user-attachments/assets/c37a21a0-e732-4072-b524-be784f104972" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="824" height="188" alt="image" src="https://github.com/user-attachments/assets/64f01b7b-4b8a-4f2a-9387-1e76516ba60a" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
