### PR TITLE
chore(dns): zone resource and data source deprecate masters field

### DIFF
--- a/docs/data-sources/dns_zones.md
+++ b/docs/data-sources/dns_zones.md
@@ -96,8 +96,6 @@ The `zones` block supports:
 
 * `record_num` - The number of record sets in the zone.
 
-* `masters` - The master DNS servers, from which the slave servers get DNS information.
-
 * `tags` - The key/value pairs to associate with the zone.
 
 * `routers` - The list of VPCs associated with the zone. This attribute is only valid when `zone_type` is **private**.

--- a/docs/resources/dns_zone.md
+++ b/docs/resources/dns_zone.md
@@ -124,8 +124,6 @@ In addition to all arguments above, the following attributes are exported:
 * `dnssec_infos` - Indicates the DNSSEC infos.
   The [dnssec_infos](#attrblock--dnssec_infos) structure is documented below.
 
-* `masters` - The list of the masters of the DNS server.
-
 <a name="attrblock--dnssec_infos"></a>
 The `dnssec_infos` block supports:
 

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_zones.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_zones.go
@@ -142,10 +142,15 @@ func zoneSchema() *schema.Resource {
 				Description: `The number of record sets in the zone.`,
 			},
 			"masters": {
-				Type:        schema.TypeList,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Computed:    true,
-				Description: `The master DNS servers, from which the slave servers get DNS information.`,
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`The master DNS servers, from which the slave servers get DNS information.`,
+					utils.SchemaDescInput{
+						Deprecated: true,
+					},
+				),
 			},
 			"routers": {
 				Type:        schema.TypeList,

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_zone.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_zone.go
@@ -155,10 +155,15 @@ func ResourceDNSZone() *schema.Resource {
 				Description: `Indicates the DNSSEC infos.`,
 			},
 			"masters": {
-				Type:        schema.TypeSet,
-				Computed:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: `The list of the masters of the DNS server.`,
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Description: utils.SchemaDesc(
+					`The list of the masters of the DNS server.`,
+					utils.SchemaDescInput{
+						Deprecated: true,
+					},
+				),
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The masters field is no meaning because this field has been deprecated by DNS service.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
zone resource and data source deprecate masters field
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
