### PR TITLE
feat(hss): support `hss_rasp_statistics` data source

### DIFF
--- a/docs/data-sources/hss_rasp_statistics.md
+++ b/docs/data-sources/hss_rasp_statistics.md
@@ -1,0 +1,41 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_rasp_statistics"
+description: |-
+  Use this data source to get the HSS protection data statistics within HuaweiCloud.
+---
+
+# huaweicloud_hss_rasp_statistics
+
+Use this data source to get the HSS protection data statistics within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_rasp_statistics" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need to set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `protect_host_num` - The number of protected hosts.
+
+* `anti_tampering_num` - The number of anti-tampering attacks defended.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1363,6 +1363,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_rasp_rules":                                 hss.DataSourceRaspRules(),
 			"huaweicloud_hss_rasp_servers":                               hss.DataSourceRaspServers(),
 			"huaweicloud_hss_rasp_status":                                hss.DataSourceRaspStatus(),
+			"huaweicloud_hss_rasp_statistics":                            hss.DataSourceRaspStatistics(),
 			"huaweicloud_hss_resource_quotas":                            hss.DataSourceResourceQuotas(),
 			"huaweicloud_hss_setting_login_common_ips":                   hss.DataSourceSettingLoginCommonIps(),
 			"huaweicloud_hss_setting_login_common_locations":             hss.DataSourceSettingLoginCommonLocations(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_rasp_statistics_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_rasp_statistics_test.go
@@ -1,0 +1,41 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRaspStatistics_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_rasp_statistics.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceRaspStatistics_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "protect_host_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "anti_tampering_num"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceRaspStatistics_basic() string {
+	return `
+data "huaweicloud_hss_rasp_statistics" "test" {
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_rasp_statistics.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_rasp_statistics.go
@@ -1,0 +1,99 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/rasp/statistics
+func DataSourceRaspStatistics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRaspStatisticsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"protect_host_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"anti_tampering_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildRaspStatisticsQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%v", epsId)
+	}
+
+	return ""
+}
+
+func dataSourceRaspStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/rasp/statistics"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildRaspStatisticsQueryParams(epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS protection data statistics: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("protect_host_num", utils.PathSearch("protect_host_num", respBody, 0)),
+		d.Set("anti_tampering_num", utils.PathSearch("anti_tampering_num", respBody, 0)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_rasp_statistics` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_rasp_statistics` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceRaspStatistics_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceRaspStatistics_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRaspStatistics_basic
=== PAUSE TestAccDataSourceRaspStatistics_basic
=== CONT  TestAccDataSourceRaspStatistics_basic
--- PASS: TestAccDataSourceRaspStatistics_basic (16.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       16.265s
```
<img width="854" height="33" alt="image" src="https://github.com/user-attachments/assets/a1709319-869a-4cfe-b061-2539daa99db3" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
