### PR TITLE
fix(dns/authorize): change the authorization resource to a one-time action resource

### DIFF
--- a/docs/resources/dns_zone_authorization.md
+++ b/docs/resources/dns_zone_authorization.md
@@ -10,10 +10,15 @@ description: |-
 
 Using this resource to request a sub-domain authorization request to the owner of the main-domain within HuaweiCloud.
 
--> This resource is used to request a sub-domain authorization when creating a sub-domain prompts this following error:
-   `domain conflicts with other tenants, you need to add TXT authorization verification`.
-   Deleting this resource will not clear the corresponding request record, but will only remove the resource information
-   from the tfstate file.
+-> This resource is a one-time action resource used to request a sub-domain authorization when creating a sub-domain
+   prompts this following error:
+   <br>`domain conflicts with other tenants, you need to add TXT authorization verification`.
+   <br>Deleting this resource will not clear the corresponding request record, but will only remove the resource
+   information from the tfstate file.
+
+-> After authorizing the sub-domain and receiving a **CREATED** status, you should use the `huaweicloud_dns_recordset`
+   resource to record the corresponding TXT record. Only then will the authorization be marked as **verified**.<br>
+   However, this one-time operation resource only returns the status at the time the request was sent.
 
 ## Example Usage
 
@@ -47,7 +52,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - The authorization status.
   + **CREATED**: Authorization has been created.
-  + **VERIFIED**: Authorization has been verified.
 
 * `created_at` - The creation time of the authorization, in RFC3339 format.
 

--- a/scripts/read_check_deleted_check/main.go
+++ b/scripts/read_check_deleted_check/main.go
@@ -35,7 +35,6 @@ var (
 		"resource_huaweicloud_cbh_asset_agency_authorization":     true,
 		"resource_huaweicloud_cdn_billing_option":                 true,
 		"resource_huaweicloud_css_manual_log_backup":              true,
-		"resource_huaweicloud_dns_zone_authorization":             true,
 		"resource_huaweicloud_identity_acl":                       true,
 		"resource_huaweicloud_identity_password_policy":           true,
 		"resource_huaweicloud_identity_user_token":                true,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

After sub-domain create, the corresponding authorization will be deleted, so the query logic cannot be in the ReadContext.
```
huaweicloud_dns_zone_authorization.test: Refreshing state... [id=ff80808298cd8e66019a345c260b0aa3]
╷
│ Error: error querying sub-domain authorization: Resource not found: [GET https://dns.myhuaweicloud.com/v2/authorize-txtrecord?zone_name=dev.myterraformtest2.xyz.], request_id: 15f6dd9e344d08aec30f48ffd3de6ff3, error message: {"code":"DNS.0224","encoded_authorization_message":null,"details":null,"message":"The authorize task not found."}
│ 
│   with huaweicloud_dns_zone_authorization.test,
│   on main.tf line 9, in resource "huaweicloud_dns_zone_authorization" "test":
│    9: resource "huaweicloud_dns_zone_authorization" "test" {
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
change the authorization resource to a one-time action resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

<img width="873" height="862" alt="image" src="https://github.com/user-attachments/assets/bf57fc29-6fe1-4e48-bd77-2c09efedfd23" />

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
