### PR TITLE
feat(vpc): sync DataSources support to query interface and subnet by tags

### DIFF
--- a/docs/data-sources/vpc_network_interface_tags.md
+++ b/docs/data-sources/vpc_network_interface_tags.md
@@ -1,0 +1,41 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_vpc_network_interface_tags"
+description: |-
+  Use this data source to get the list of network interface project tags.
+---
+
+# huaweicloud_vpc_network_interface_tags
+
+Use this data source to get the list of network interface project tags.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_network_interface_tags" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tags` - The list of tags.
+
+  The [tags](#tags_struct) structure is documented below.
+
+<a name="tags_struct"></a>
+The `tags` block supports:
+
+* `key` - The tag key.
+
+* `values` - The tag values.

--- a/docs/data-sources/vpc_network_interfaces_by_tags.md
+++ b/docs/data-sources/vpc_network_interfaces_by_tags.md
@@ -1,0 +1,75 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_vpc_network_interfaces_by_tags"
+description: |-
+  Use this data source to get a list of network interfaces by tags.
+---
+
+# huaweicloud_vpc_network_interfaces_by_tags
+
+Use this data source to get a list of network interfaces by tags.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_vpc_network_interfaces_by_tags" "test" {
+  tags {
+    key    = "foo"
+    values = ["bar"]
+  }
+
+  tags {
+    key    = "key"
+    values = ["value_1", "value_2"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `tags` - (Optional, List) Specifies the tags to filter to resources.
+  The [tags](#tags) structure is documented below.
+
+* `matches` - (Optional, List) Specifies the matches to filter to resources.
+  The [matches](#matches) structure is documented below.
+
+<a name="tags"></a>
+The `tags` block supports:
+
+* `key` - (Required, String) Specifies the key of the tag.
+
+* `values` - (Required, List) Specifies the values of the tag.
+
+<a name="matches"></a>
+The `matches` block supports:
+
+* `key` - (Required, String) Specifies the key of the match. The value can be: **resource_name**.
+
+* `value` - (Required, String) Specifies the value of the match.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `resources` - The list of the network ACLs found. The [resources](#resources) structure is documented below.
+
+* `total_count` - The total count of the network ACLs found.
+
+<a name="resources"></a>
+The `resources` block supports:
+
+* `resource_name` - The name of the network interface.
+
+* `resource_id` - The ID of the network interface.
+
+* `resource_detail` - The detail of the network interface.
+
+* `tags` - The tags which associated with the network interface.

--- a/docs/data-sources/vpc_subnet_tags.md
+++ b/docs/data-sources/vpc_subnet_tags.md
@@ -1,0 +1,41 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_vpc_subnet_tags"
+description: |-
+  Use this data source to get the list of VPC subnet project tags.
+---
+
+# huaweicloud_vpc_subnet_tags
+
+Use this data source to get the list of VPC subnet project tags.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_vpc_subnet_tags" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tags` - The list of tags.
+
+  The [tags](#tags_struct) structure is documented below.
+
+<a name="tags_struct"></a>
+The `tags` block supports:
+
+* `key` - The tag key.
+
+* `values` - The tag values.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1881,6 +1881,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_subnet_ids":                  vpc.DataSourceVpcSubnetIdsV1(),
 			"huaweicloud_vpc_subnet_private_ips":          vpc.DataSourceVpcSubnetPrivateIps(),
 			"huaweicloud_vpc_subnets":                     vpc.DataSourceVpcSubnets(),
+			"huaweicloud_vpc_subnet_tags":                 vpc.DataSourceVpcSubnetTags(),
 			"huaweicloud_vpc_subnets_by_tags":             vpc.DataSourceVpcSubnetsByTags(),
 			"huaweicloud_vpc_traffic_mirror_filter_rules": vpc.DataSourceVpcTrafficMirrorFilterRules(),
 			"huaweicloud_vpc_traffic_mirror_filters":      vpc.DataSourceVpcTrafficMirrorFilters(),
@@ -1891,6 +1892,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_subnet_ip_availabilities":    vpc.DataSourceVpcSubnetIpAvailabilities(),
 			"huaweicloud_vpc_network_interfaces":          vpc.DataSourceVpcNetworkInterfaces(),
 			"huaweicloud_vpc_subnet_cidr_reservations":    vpc.DataSourceVpcSubnetCidrReservations(),
+			"huaweicloud_vpc_network_interface_tags":      vpc.DataSourceVpcNetworkInterfaceTags(),
+			"huaweicloud_vpc_network_interfaces_by_tags":  vpc.DataSourceNetworkInterfacesByTags(),
 
 			"huaweicloud_vpcep_endpoints":           vpcep.DataSourceVPCEPEndpoints(),
 			"huaweicloud_vpcep_public_services":     vpcep.DataSourceVPCEPPublicServices(),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_network_interface_tags_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_network_interface_tags_test.go
@@ -1,0 +1,46 @@
+package vpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceVpcNetworkInterfaceTags_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_vpc_network_interface_tags.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDataSourceVpcNetworkInterfaceTags_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_results_not_empty", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDataSourceVpcNetworkInterfaceTags_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_vpc_network_interface_tags" "test" {
+  depends_on = [ huaweicloud_vpc_network_interface.test ]
+}
+
+output "is_results_not_empty" {
+  value = length(data.huaweicloud_vpc_network_interface_tags.test.tags) > 0
+}
+`, testAccNetworkInterface_basic(name))
+}

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_network_interfaces_by_tags_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_network_interfaces_by_tags_test.go
@@ -1,0 +1,115 @@
+package vpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceNetworkInterfacesByTags_basic(t *testing.T) {
+	dataSource1 := "data.huaweicloud_vpc_network_interfaces_by_tags.basic"
+	dataSource2 := "data.huaweicloud_vpc_network_interfaces_by_tags.filter_by_tags"
+	dataSource3 := "data.huaweicloud_vpc_network_interfaces_by_tags.filter_by_matches"
+	rName := acceptance.RandomAccResourceName()
+	dc1 := acceptance.InitDataSourceCheck(dataSource1)
+	dc2 := acceptance.InitDataSourceCheck(dataSource2)
+	dc3 := acceptance.InitDataSourceCheck(dataSource3)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDataSourceNetworkInterfacesByTags_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc1.CheckResourceExists(),
+					dc2.CheckResourceExists(),
+					dc3.CheckResourceExists(),
+					resource.TestCheckOutput("is_results_not_empty", "true"),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
+					resource.TestCheckOutput("is_matches_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDataSourceNetworkInterfacesByTags_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s-vpc"
+  cidr = "192.168.0.0/16"
+}
+	
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id     = huaweicloud_vpc.test.id
+  name       = "%[1]s-subnet"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+}   
+
+resource "huaweicloud_vpc_network_interface" "test1" {
+  name      = "%[1]s-1"
+  subnet_id = huaweicloud_vpc_subnet.test.id
+
+  tags = {
+    foo = "%[1]s"
+    key = "%[1]s_1"
+  }
+}
+
+resource "huaweicloud_vpc_network_interface" "test2" {
+  name      = "%[1]s-2"
+  subnet_id = huaweicloud_vpc_subnet.test.id
+
+  tags = {
+    foo = "%[1]s"
+    key = "%[1]s_2"
+  }
+}
+
+data "huaweicloud_vpc_network_interfaces_by_tags" "basic" {
+  depends_on = [huaweicloud_vpc_network_interface.test1, huaweicloud_vpc_network_interface.test2]
+}
+
+data "huaweicloud_vpc_network_interfaces_by_tags" "filter_by_tags" {
+  tags {
+    key    = "foo"
+    values = ["%[1]s"]
+  }
+
+  tags {
+    key    = "key"
+    values = ["%[1]s_1", "%[1]s_2"]
+  }
+
+  depends_on = [huaweicloud_vpc_network_interface.test1, huaweicloud_vpc_network_interface.test2]
+}
+
+data "huaweicloud_vpc_network_interfaces_by_tags" "filter_by_matches" {
+  matches {
+    key   = "resource_name"
+    value = "%[1]s-1"
+  }
+
+  depends_on = [huaweicloud_vpc_network_interface.test1, huaweicloud_vpc_network_interface.test2]
+}
+
+output "is_results_not_empty" {
+  value = length(data.huaweicloud_vpc_network_interfaces_by_tags.basic.resources) > 0
+}
+
+output "is_tags_filter_useful" {
+  value = length(data.huaweicloud_vpc_network_interfaces_by_tags.filter_by_tags.resources) == 2
+}
+
+output "is_matches_filter_useful" {
+  value = length(data.huaweicloud_vpc_network_interfaces_by_tags.filter_by_matches.resources) == 1
+}
+`, name)
+}

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_subnet_tags_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_subnet_tags_test.go
@@ -1,0 +1,48 @@
+package vpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceVpcSubnetTags_basic(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	randCidr, randGatewayIp := acceptance.RandomCidrAndGatewayIp()
+	dataSourceName := "data.huaweicloud_vpc_subnet_tags.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceVpcSubnetTags_basic(randName, randCidr, randGatewayIp),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_results_not_empty", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceVpcSubnetTags_basic(rName, cidr, gatewayIp string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_vpc_subnet_tags" "test" {
+  depends_on = [ huaweicloud_vpc_subnet.test ]
+}
+
+output "is_results_not_empty" {
+  value = length(data.huaweicloud_vpc_subnet_tags.test.tags) > 0
+}
+`, testAccVpcSubnetsDataSource_Base(rName, cidr, gatewayIp))
+}

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_network_interface_tags.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_network_interface_tags.go
@@ -1,0 +1,115 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/tidwall/gjson"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/httphelper"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/schemas"
+)
+
+func DataSourceVpcNetworkInterfaceTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceVpcNetworkInterfaceTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Specifies the region in which to query the resource. If omitted, the provider-level region will be used.",
+			},
+			"tags": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of tags`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The tag key.`,
+						},
+						"values": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The tag values.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type NetworkInterfaceTagsDSWrapper struct {
+	*schemas.ResourceDataWrapper
+	Config *config.Config
+}
+
+func newNetworkInterfaceTagsDSWrapper(d *schema.ResourceData, meta interface{}) *NetworkInterfaceTagsDSWrapper {
+	return &NetworkInterfaceTagsDSWrapper{
+		ResourceDataWrapper: schemas.NewSchemaWrapper(d),
+		Config:              meta.(*config.Config),
+	}
+}
+
+func dataSourceVpcNetworkInterfaceTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	wrapper := newNetworkInterfaceTagsDSWrapper(d, meta)
+	listPortTagsRst, err := wrapper.ListPortTags()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	err = wrapper.ListPortTagsToSchema(listPortTagsRst)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+// @API VPC GET /v3/{project_id}/ports/tags
+func (w *NetworkInterfaceTagsDSWrapper) ListPortTags() (*gjson.Result, error) {
+	client, err := w.NewClient(w.Config, "vpc")
+	if err != nil {
+		return nil, err
+	}
+
+	uri := "/v3/{project_id}/ports/tags"
+	return httphelper.New(client).
+		Method("GET").
+		URI(uri).
+		OffsetPager("tags", "offset", "limit", 0).
+		Request().
+		Result()
+}
+
+func (w *NetworkInterfaceTagsDSWrapper) ListPortTagsToSchema(body *gjson.Result) error {
+	d := w.ResourceData
+	mErr := multierror.Append(nil,
+		d.Set("region", w.Config.GetRegion(w.ResourceData)),
+		d.Set("tags", schemas.SliceToList(body.Get("tags"),
+			func(tags gjson.Result) any {
+				return map[string]any{
+					"key":    tags.Get("key").Value(),
+					"values": schemas.SliceToStrList(tags.Get("values")),
+				}
+			},
+		)),
+	)
+	return mErr.ErrorOrNil()
+}

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_network_interfaces_by_tags.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_network_interfaces_by_tags.go
@@ -1,0 +1,219 @@
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API VPC POST /v3/{project_id}/ports/resource-instances/filter
+func DataSourceNetworkInterfacesByTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNetworkInterfacesByTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"matches": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_detail": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceNetworkInterfacesByTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	var (
+		listNetworkInterfacesByTagsHttpUrl = "v3/{project_id}/ports/resource-instances/filter"
+		listNetworkInterfacesByTagsProduct = "vpc"
+	)
+	client, err := cfg.NewServiceClient(listNetworkInterfacesByTagsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
+	}
+
+	listNetworkInterfacesByTagsPath := client.Endpoint + listNetworkInterfacesByTagsHttpUrl
+	listNetworkInterfacesByTagsPath = strings.ReplaceAll(listNetworkInterfacesByTagsPath, "{project_id}", client.ProjectID)
+
+	listNetworkInterfacesByTagsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	bodyParams := buildNetworkInterfacesByTagsBodyParams(d)
+	resources := make([]interface{}, 0)
+	offset := 0
+	totalCount := float64(0)
+	for {
+		listNetworkInterfacesByTagsReqPath := listNetworkInterfacesByTagsPath + fmt.Sprintf("?offset=%v", offset)
+		listNetworkInterfacesByTagsOpt.JSONBody = utils.RemoveNil(bodyParams)
+		listNetworkInterfacesByTagsResp, err := client.Request("POST", listNetworkInterfacesByTagsReqPath, &listNetworkInterfacesByTagsOpt)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		listNetworkInterfacesByTagsRespBody, err := utils.FlattenResponse(listNetworkInterfacesByTagsResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalCount = utils.PathSearch("total_count", listNetworkInterfacesByTagsRespBody, float64(0)).(float64)
+		data := utils.PathSearch("resources", listNetworkInterfacesByTagsRespBody, make([]interface{}, 0)).([]interface{})
+		if len(data) == 0 {
+			break
+		}
+
+		resources = append(resources, data...)
+
+		offset += len(data)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("resources", flattenNetworkInterfacesByTagsResponseBody(resources)),
+		d.Set("total_count", totalCount),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildInterfacesByTagsTagsBodyParams(d *schema.ResourceData) []map[string]interface{} {
+	v, ok := d.GetOk("tags")
+	if !ok {
+		return nil
+	}
+
+	bodyParams := make([]map[string]interface{}, len(v.([]interface{})))
+
+	for i, tag := range v.([]interface{}) {
+		bodyParams[i] = map[string]interface{}{
+			"key":    utils.PathSearch("key", tag, nil),
+			"values": utils.PathSearch("values", tag, nil),
+		}
+	}
+
+	return bodyParams
+}
+
+func buildInterfacesByTagsMatchesBodyParams(d *schema.ResourceData) []map[string]interface{} {
+	v, ok := d.GetOk("matches")
+	if !ok {
+		return nil
+	}
+
+	bodyParams := make([]map[string]interface{}, len(v.([]interface{})))
+
+	for i, match := range v.([]interface{}) {
+		bodyParams[i] = map[string]interface{}{
+			"key":   utils.PathSearch("key", match, nil),
+			"value": utils.PathSearch("value", match, nil),
+		}
+	}
+
+	return bodyParams
+}
+
+func buildNetworkInterfacesByTagsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"action":  d.Get("action"),
+		"tags":    buildInterfacesByTagsTagsBodyParams(d),
+		"matches": buildInterfacesByTagsMatchesBodyParams(d),
+	}
+
+	return bodyParams
+}
+
+func flattenNetworkInterfacesByTagsResponseBody(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	resources := make([]interface{}, len(resp))
+	for i, v := range resp {
+		resources[i] = map[string]interface{}{
+			"resource_name":   utils.PathSearch("resource_name", v, nil),
+			"resource_id":     utils.PathSearch("resource_id", v, nil),
+			"resource_detail": utils.JsonToString(utils.PathSearch("resource_detail", v, nil)),
+			"tags":            utils.FlattenTagsToMap(utils.PathSearch("tags", v, nil)),
+		}
+	}
+	return resources
+}

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnet_tags.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnet_tags.go
@@ -1,0 +1,114 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/tidwall/gjson"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/httphelper"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/schemas"
+)
+
+func DataSourceVpcSubnetTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceVpcSubnetTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"tags": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of tags`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The tag key.`,
+						},
+						"values": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The tag values.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type SubnetTagsDSWrapper struct {
+	*schemas.ResourceDataWrapper
+	Config *config.Config
+}
+
+func newSubnetTagsDSWrapper(d *schema.ResourceData, meta interface{}) *SubnetTagsDSWrapper {
+	return &SubnetTagsDSWrapper{
+		ResourceDataWrapper: schemas.NewSchemaWrapper(d),
+		Config:              meta.(*config.Config),
+	}
+}
+
+func dataSourceVpcSubnetTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	wrapper := newSubnetTagsDSWrapper(d, meta)
+	listSubnetTagRst, err := wrapper.ListSubnetTags()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	err = wrapper.listSubnetTagsToSchema(listSubnetTagRst)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+// @API VPC GET /v2.0/{project_id}/subnets/tags
+func (w *SubnetTagsDSWrapper) ListSubnetTags() (*gjson.Result, error) {
+	client, err := w.NewClient(w.Config, "vpc")
+	if err != nil {
+		return nil, err
+	}
+
+	uri := "/v2.0/{project_id}/subnets/tags"
+	return httphelper.New(client).
+		Method("GET").
+		URI(uri).
+		Request().
+		Result()
+}
+
+func (w *SubnetTagsDSWrapper) listSubnetTagsToSchema(body *gjson.Result) error {
+	d := w.ResourceData
+	mErr := multierror.Append(nil,
+		d.Set("region", w.Config.GetRegion(w.ResourceData)),
+		d.Set("tags", schemas.SliceToList(body.Get("tags"),
+			func(tags gjson.Result) any {
+				return map[string]any{
+					"key":    tags.Get("key").Value(),
+					"values": schemas.SliceToStrList(tags.Get("values")),
+				}
+			},
+		)),
+	)
+	return mErr.ErrorOrNil()
+}


### PR DESCRIPTION
Signed-off-by: daimengmeng

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
