### PR TITLE
feat(ELB): add elb loadbalancers by tags data source

### DIFF
--- a/docs/data-sources/elb_loadbalancers_by_tags.md
+++ b/docs/data-sources/elb_loadbalancers_by_tags.md
@@ -1,0 +1,121 @@
+---
+subcategory: Dedicated Load Balance (Dedicated ELB)
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_elb_loadbalancers_by_tags"
+description: |-
+  Use this data source to get the list of ELB load balancers filtered by tags within HuaweiCloud.
+---
+
+
+# huaweicloud_elb_loadbalancers_by_tags
+
+Use this data source to get the list of ELB load balancers filtered by tags within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_elb_loadbalancers_by_tags" "test" {
+  action = "filter"
+  
+  tags = [
+    {
+      key    = "key_string"
+      values = ["value_string"]
+    }
+  ]
+
+  matches = [
+    {
+      key   = "resource_name"
+      value = "shared01"
+    }
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `action` - (Required, String) Specifies the action name. Possible values are **count** and **filter**.
+  + **count**: querying count of data filtered by tags.
+  + **filter**: querying details of data filtered by tags.
+
+* `tags` - (Optional, List) Specifies the list of included tags. Backups with these tags will be filtered.
+  The [tags](#tags_struct) structure is documented below.
+
+-> `tags` have limits as follows:
+  <br/>1. This list cannot be an empty list.
+  <br/>2. The list can contain up to `20` keys.
+  <br/>3. Keys in this list must be unique.
+  <br/>4. If no tag filtering condition is specified, full data is returned.
+
+* `matches` - (Optional, List) Specifies the matches supported by resources. Keys in this list must be unique.
+  Only two key is supported currently. Other key values will be available later.
+  The [matches](#matches_struct) structure is documented below.
+
+<a name="tags_struct"></a>
+The `tags` block supports:
+
+* `key` - (Required, String) Specifies the key of the resource tag. It contains a maximum of `127` unicode characters.
+  A tag key cannot be an empty string. Spaces before and after a key will be deprecated.
+
+* `values` - (Required, List) Specifies the list of values corresponding to the key.
+
+  -> The field has the following restrictions:
+    <br/>1. The list can contain up to `20` values.
+    <br/>2. A tag value contains up to `255` unicode characters. Spaces before and after a key will be deprecated.
+    <br/>3. Values in this list must be unique.
+    <br/>4. Values in this list are in an OR relationship.
+    <br/>5. This list can be empty and each value can be an empty character string.
+    <br/>6. If this list is left blank, it indicates that all values are included.
+    <br/>7. The asterisk (*) is a reserved character in the system.
+    If the value starts with (*), it indicates that fuzzy match is performed based on the value following (*).
+    The value cannot contain only asterisks.
+
+<a name="matches_struct"></a>
+The `matches` block supports:
+
+* `key` - (Required, String) Specifies the key of the resource tag.
+  Currently, only **resource_name**, **resource_id** for key is supported.
+
+* `value` - (Required, String) Specifies the value of the resource tag.
+  A value consists of up to `255` characters.
+  If key is **resource_name**, an empty string indicates exact match and any non-empty string indicates fuzzy match.
+  If key is **resource_id**, indicates exact match.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `total_count` - The total number of matched resources.
+
+* `resources` - List of matched resources.
+  The [resources](#elb_loadbalancers_resources) structure is documented below.
+
+<a name="elb_loadbalancers_resources"></a>
+The `resources` block supports:
+
+* `resource_id` - The resource ID.
+
+* `super_resource_id` - The parent resource ID.
+
+* `resource_name` - The resource name.
+
+* `resource_detail` - The detail of the matched resources. The value is a resource object used for extension.
+  This parameter is left blank by default.
+
+* `tags` - The tag list.
+  The [tags](#elb_loadbalancers_tags) structure is documented below.
+
+<a name="elb_loadbalancers_tags"></a>
+The `tags` block supports:
+
+* `key` - The tag key.
+
+* `value` - The tag value.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1521,6 +1521,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_elb_quotas":                              elb.DataSourceElbQuotas(),
 			"huaweicloud_elb_quota_details":                       elb.DataSourceElbQuotaDetails(),
 			"huaweicloud_elb_asynchronous_tasks":                  elb.DataSourceElbAsynchronousTasks(),
+			"huaweicloud_elb_loadbalancers_by_tags":               elb.DataSourceElbLoadbalancersByTags(),
 
 			"huaweicloud_nat_gateway":                  nat.DataSourcePublicGateway(),
 			"huaweicloud_nat_gateway_tags":             nat.DataSourceNatGatewayTags(),

--- a/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_loadbalancers_by_tags_test.go
+++ b/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_loadbalancers_by_tags_test.go
@@ -1,0 +1,156 @@
+package elb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceElbLoadbalancersByTags_basic(t *testing.T) {
+	var (
+		filterByTagsAll    = "data.huaweicloud_elb_loadbalancers_by_tags.filter_by_tags"
+		dcTags             = acceptance.InitDataSourceCheck(filterByTagsAll)
+		filterByMatchesAll = "data.huaweicloud_elb_loadbalancers_by_tags.filter_by_matches"
+		dcMatches          = acceptance.InitDataSourceCheck(filterByMatchesAll)
+		testName           = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceElbLoadbalancersByTags_basic(testName),
+				Check: resource.ComposeTestCheckFunc(
+					dcTags.CheckResourceExists(),
+					dcMatches.CheckResourceExists(),
+
+					resource.TestCheckResourceAttrSet(filterByTagsAll, "resources.#"),
+					resource.TestCheckResourceAttrSet(filterByTagsAll, "resources.0.resource_id"),
+					resource.TestCheckResourceAttr(filterByTagsAll, "resources.0.resource_name", testName),
+					resource.TestCheckResourceAttrSet(filterByTagsAll, "resources.0.tags.#"),
+					resource.TestCheckResourceAttr(filterByTagsAll, "resources.0.tags.0.key", "foo0"),
+					resource.TestCheckResourceAttr(filterByTagsAll, "resources.0.tags.0.value", "bar0"),
+					resource.TestCheckResourceAttr(filterByTagsAll, "resources.0.tags.1.key", "foo1"),
+					resource.TestCheckResourceAttr(filterByTagsAll, "resources.0.tags.1.value", "bar1"),
+
+					resource.TestCheckResourceAttrSet(filterByMatchesAll, "resources.#"),
+					resource.TestCheckResourceAttrSet(filterByMatchesAll, "resources.0.resource_id"),
+					resource.TestCheckResourceAttr(filterByMatchesAll, "resources.0.resource_name", testName),
+					resource.TestCheckResourceAttrSet(filterByMatchesAll, "resources.0.tags.#"),
+					resource.TestCheckResourceAttr(filterByMatchesAll, "resources.0.tags.0.key", "foo0"),
+					resource.TestCheckResourceAttr(filterByMatchesAll, "resources.0.tags.0.value", "bar0"),
+					resource.TestCheckResourceAttr(filterByMatchesAll, "resources.0.tags.1.key", "foo1"),
+					resource.TestCheckResourceAttr(filterByMatchesAll, "resources.0.tags.1.value", "bar1"),
+
+					resource.TestCheckOutput("tags_filter_is_useful", "true"),
+					resource.TestCheckOutput("matches_filter_is_useful", "true"),
+				),
+			},
+		},
+	},
+	)
+}
+
+func testDataSourceElbLoadbalancersByTags_base(name string) string {
+	return fmt.Sprintf(`
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
+
+resource "huaweicloud_elb_loadbalancer" "test" {
+  name           = "%[1]s"
+  vpc_id         = data.huaweicloud_vpc.test.id
+  ipv4_subnet_id = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
+
+  availability_zone = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+
+  backend_subnets = [
+    data.huaweicloud_vpc_subnet.test.id
+ ]
+
+  tags = {
+    "foo0" = "bar0"
+    "foo1" = "bar1"
+  }
+}
+
+`, name)
+}
+
+func testDataSourceElbLoadbalancersByTags_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_elb_loadbalancers_by_tags" "filter_by_tags" {
+  depends_on = [huaweicloud_elb_loadbalancer.test]
+  action     = "filter"
+
+  tags {
+    key    = "foo0"
+    values = ["bar0"]
+  }
+
+  tags {
+    key    = "foo1"
+    values = ["bar1"]
+  }
+}
+
+locals {
+  tag_key   = "foo0"
+  tag_value = "bar0"
+}
+
+output "tags_filter_is_useful" {
+  value = length(data.huaweicloud_elb_loadbalancers_by_tags.filter_by_tags.resources) > 0 && alltrue(
+    [for v in data.huaweicloud_elb_loadbalancers_by_tags.filter_by_tags.resources[*].tags : anytrue(
+    [for vv in v[*].key : vv == local.tag_key]) && anytrue([for vv in v[*].value : vv == local.tag_value])]
+  )
+}
+
+data "huaweicloud_elb_loadbalancers_by_tags" "filter_by_matches" {
+  depends_on = [huaweicloud_elb_loadbalancer.test]
+  action     = "filter"
+
+  tags {
+    key    = "foo0"
+    values = ["bar0"]
+  }
+
+  tags {
+    key    = "foo1"
+    values = ["bar1"]
+  }
+
+  matches {
+    key    = "resource_name"
+    value  = "%[2]s"
+  }
+}
+
+locals {
+  match_key   = "resource_name"
+  match_value = "%[2]s"
+}
+	
+output "matches_filter_is_useful" {
+  value = length(data.huaweicloud_elb_loadbalancers_by_tags.filter_by_matches.resources) > 0
+}
+
+`, testDataSourceElbLoadbalancersByTags_base(name), name)
+}

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_loadbalancers_by_tags.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_loadbalancers_by_tags.go
@@ -1,0 +1,248 @@
+package elb
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ELB POST /v2.0/{project_id}/loadbalancers/resource_instances/action
+func DataSourceElbLoadbalancersByTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceElbLoadbalancersByTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"matches": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"super_resource_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_detail": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"total_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func flattenElbTags(tags []interface{}) []map[string]interface{} {
+	rst := make([]map[string]interface{}, 0, len(tags))
+	for _, tag := range tags {
+		rst = append(rst, map[string]interface{}{
+			"key":   utils.PathSearch("key", tag, nil),
+			"value": utils.PathSearch("value", tag, nil),
+		})
+	}
+	return rst
+}
+
+func flattenElbLoadbalancersByTagsResponseBody(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	resources := make([]interface{}, len(resp))
+	for i, v := range resp {
+		resources[i] = map[string]interface{}{
+			"resource_name":     utils.PathSearch("resource_name", v, nil),
+			"resource_id":       utils.PathSearch("resource_id", v, nil),
+			"super_resource_id": utils.PathSearch("super_resource_id", v, nil),
+			"resource_detail":   utils.PathSearch("resource_detail", v, nil),
+			"tags":              flattenElbTags(utils.PathSearch("tags", v, make([]interface{}, 0)).([]interface{})),
+		}
+	}
+	return resources
+}
+
+func expandTags(rawTags []interface{}) []map[string]interface{} {
+	tags := make([]map[string]interface{}, len(rawTags))
+	for i, raw := range rawTags {
+		tag := raw.(map[string]interface{})
+		tags[i] = map[string]interface{}{
+			"key":    tag["key"].(string),
+			"values": tag["values"].([]interface{}),
+		}
+	}
+	return tags
+}
+
+func expandMatches(rawTags []interface{}) []map[string]interface{} {
+	tags := make([]map[string]interface{}, len(rawTags))
+	for i, raw := range rawTags {
+		tag := raw.(map[string]interface{})
+		tags[i] = map[string]interface{}{
+			"key":   tag["key"].(string),
+			"value": tag["value"].(string),
+		}
+	}
+	return tags
+}
+
+func buildElbLoadbalancersByTagsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	body := map[string]interface{}{}
+	if v, ok := d.GetOk("action"); ok {
+		body["action"] = v.(string)
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		body["tags"] = expandTags(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("matches"); ok {
+		body["matches"] = expandMatches(v.([]interface{}))
+	}
+	return body
+}
+
+func dataSourceElbLoadbalancersByTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v2.0/{project_id}/loadbalancers/resource_instances/action"
+		product = "elb"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating ELB client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	var allElb []interface{}
+	offset := 0
+	totalCount := 0
+
+	for {
+		requestBody := buildElbLoadbalancersByTagsBodyParams(d)
+		if requestBody["action"] == "filter" {
+			requestBody["limit"] = "1000"
+			requestBody["offset"] = strconv.Itoa(offset)
+		}
+
+		requestOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody:         requestBody,
+		}
+		resp, err := client.Request("POST", requestPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error querying Elb by tags: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		elbs := utils.PathSearch("resources", respBody, []interface{}{}).([]interface{})
+		totalCount = int(utils.PathSearch("total_count", respBody, float64(0)).(float64))
+		if len(elbs) == 0 {
+			break
+		}
+		allElb = append(allElb, elbs...)
+		offset += len(elbs)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("resources", flattenElbLoadbalancersByTagsResponseBody(allElb)),
+		d.Set("total_count", totalCount),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add elb loadbalancers by tags data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add elb loadbalancers by tags data source
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
