### PR TITLE
feat(dew/cpcs): add new data source to get list of CPCS instances

### DIFF
--- a/docs/data-sources/cpcs_instances.md
+++ b/docs/data-sources/cpcs_instances.md
@@ -1,0 +1,77 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cpcs_instances"
+description: |-
+  Use this data source to get the list of CPCS instances.
+---
+
+# huaweicloud_cpcs_instances
+
+Use this data source to get the list of CPCS instances.
+
+-> Currently, this data source is valid only in cn-north-9 region.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cpcs_instances" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Optional, String) Specifies the cluster ID.
+
+* `name` - (Optional, String) Specifies the instance name.
+
+* `is_normal` - (Optional, String) Specifies the instance health status.
+  The valid values are as follows:
+  + **true**: Indicates normal.
+  + **false**: Indicates abnormal.
+
+* `sort_key` - (Optional, String) Specifies the sort attribute.
+  The default value is **create_time**.
+
+* `sort_dir` - (Optional, String) Specifies the sort direction.
+  The default value is **DESC**. Valid values are **ASC** and **DESC**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `result` - Indicates the applications list.
+  The [result](#instances_result_struct) structure is documented below.
+
+<a name="instances_result_struct"></a>
+The `result` block supports:
+
+* `instance_id` - The instance ID.
+
+* `resource_id` - The CBC resource ID.
+
+* `instance_name` - The instance name.
+
+* `service_type` - The service type to which the instance belongs.
+
+* `cluster_id` - The cluster ID to which the instance belongs.
+
+* `is_normal` - The instance health status.
+
+* `status` - The instance service status.
+
+* `image_name` - The instance image name.
+
+* `specification` - The instance specification.
+
+* `az` - The vailability zone.
+
+* `expired_time` - The expire time.
+
+* `create_time` - The creation time of the instance, in UNIX timestamp format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -932,6 +932,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cpcs_availability_zones":  dew.DataSourceAvailabilityZones(),
 			"huaweicloud_cpcs_cluster_access_keys": dew.DataSourceCpcsClusterAccessKeys(),
 			"huaweicloud_cpcs_images":              dew.DataSourceCpcsImages(),
+			"huaweicloud_cpcs_instances":           dew.DataSourceInstances(),
 			"huaweicloud_cpcs_clusters":            dew.DataSourceCpcsClusters(),
 			"huaweicloud_cpcs_resource_infos":      dew.DataSourceResourceInfos(),
 

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_cpcs_instances_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_cpcs_instances_test.go
@@ -1,0 +1,75 @@
+package dew
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceInstances_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_cpcs_instances.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Before running test, prepare a password service cluster instance.
+			acceptance.TestAccPrecheckDewFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceInstances_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "result.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.instance_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.resource_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.instance_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.service_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.cluster_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.is_normal"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.image_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.specification"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.az"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.expired_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "result.0.create_time"),
+
+					resource.TestCheckOutput("cluster_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_normal_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceInstances_basic = `
+data "huaweicloud_cpcs_instances" "test" {}
+
+locals {
+  cluster_id = data.huaweicloud_cpcs_instances.test.result.0.cluster_id
+}
+
+data "huaweicloud_cpcs_instances" "cluster_id_filter" {
+  cluster_id = local.cluster_id
+}
+
+output "cluster_id_filter_useful" {
+  value = length(data.huaweicloud_cpcs_instances.cluster_id_filter.result) > 0 && alltrue(
+    [for v in data.huaweicloud_cpcs_instances.cluster_id_filter.result[*].cluster_id : v == local.cluster_id]
+  )
+}
+
+data "huaweicloud_cpcs_instances" "is_normal_filter" {
+  is_normal = format(data.huaweicloud_cpcs_instances.test.result.0.is_normal)
+}
+
+output "is_normal_filter_useful" {
+  value = length(data.huaweicloud_cpcs_instances.is_normal_filter.result) > 0
+}
+`

--- a/huaweicloud/services/dew/data_source_huaweicloud_cpcs_instances.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_cpcs_instances.go
@@ -1,0 +1,225 @@
+package dew
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW GET /v1/{project_id}/dew/cpcs/instances
+func DataSourceInstances() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstancesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// This parameter does not take effect.
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"is_normal": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"result": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"service_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_normal": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"image_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"specification": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"az": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"expired_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildInstancesQueryParams(d *schema.ResourceData) string {
+	rst := "?page_size=10"
+
+	if v, ok := d.GetOk("cluster_id"); ok {
+		rst += fmt.Sprintf("&cluster_id=%v", v)
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		rst += fmt.Sprintf("&name=%v", v)
+	}
+
+	if v, ok := d.GetOk("is_normal"); ok {
+		rst += fmt.Sprintf("&is_normal=%v", v)
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		rst += fmt.Sprintf("&sort_key=%v", v)
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%v", v)
+	}
+
+	return rst
+}
+
+// The pagination does not take effect, use `total_num` as quantitative comparison.
+func dataSourceInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		httpUrl      = "v1/{project_id}/dew/cpcs/instances"
+		pageNum      = 1
+		allInstances = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("kms", region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildInstancesQueryParams(d)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		getPathWithPageNum := fmt.Sprintf("%s&page_num=%d", getPath, pageNum)
+		resp, err := client.Request("GET", getPathWithPageNum, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving CPCS instances: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		results := utils.PathSearch("result", respBody, make([]interface{}, 0)).([]interface{})
+		if len(results) == 0 {
+			break
+		}
+
+		allInstances = append(allInstances, results...)
+
+		totalNum := int(utils.PathSearch("total_num", respBody, float64(0)).(float64))
+		if len(allInstances) >= totalNum {
+			break
+		}
+
+		pageNum++
+	}
+
+	datasourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID: %s", err)
+	}
+
+	d.SetId(datasourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("result", flattenInstancesResponseBody(allInstances)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenInstancesResponseBody(results []interface{}) []interface{} {
+	if len(results) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(results))
+	for _, association := range results {
+		result = append(result, map[string]interface{}{
+			"instance_id":   utils.PathSearch("instance_id", association, nil),
+			"resource_id":   utils.PathSearch("resource_id", association, nil),
+			"instance_name": utils.PathSearch("instance_name", association, nil),
+			"service_type":  utils.PathSearch("service_type", association, nil),
+			"cluster_id":    utils.PathSearch("cluster_id", association, nil),
+			"is_normal":     utils.PathSearch("is_normal", association, nil),
+			"status":        utils.PathSearch("status", association, nil),
+			"image_name":    utils.PathSearch("image_name", association, nil),
+			"specification": utils.PathSearch("specification", association, nil),
+			"az":            utils.PathSearch("az", association, nil),
+			"expired_time":  utils.PathSearch("expired_time", association, nil),
+			"create_time":   utils.PathSearch("create_time", association, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get list of CPCS instances.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dew" TESTARGS="-run TestAccDataSourceInstances_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccDataSourceInstances_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceInstances_basic
=== PAUSE TestAccDataSourceInstances_basic
=== CONT  TestAccDataSourceInstances_basic
--- PASS: TestAccDataSourceInstances_basic (12.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       13.029s
```
<img width="1209" height="17" alt="image" src="https://github.com/user-attachments/assets/f477db43-5eaf-4702-96fe-6b6fdf4f9bd5" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
