### PR TITLE
fix(kafka): topic using correct timeout and instance not report manager_user changes

### DIFF
--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance.go
@@ -519,6 +519,7 @@ func ResourceDmsKafkaInstance() *schema.Resource {
 			"manager_user": {
 				Type:       schema.TypeString,
 				Optional:   true,
+				Computed:   true,
 				ForceNew:   true,
 				Deprecated: "Deprecated",
 			},

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_topic.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_topic.go
@@ -37,6 +37,10 @@ func ResourceDmsKafkaTopic() *schema.Resource {
 			StateContext: resourceDmsKafkaTopicImport,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
 		CustomizeDiff: func(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
 			if d.HasChange("partitions") {
 				oldValue, newValue := d.GetChange("partitions")
@@ -164,7 +168,7 @@ func resourceDmsKafkaTopicCreate(ctx context.Context, d *schema.ResourceData, me
 		Pending:      []string{"PENDING"},
 		Target:       []string{"SUCCESS"},
 		Refresh:      kafkaTopicCreateRefreshFunc(dmsV2Client, d),
-		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        1 * time.Second,
 		PollInterval: 10 * time.Second,
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Topic using correct timeout and instance not report manager_user changes

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
