### PR TITLE
feat(aad): support `aadv2_instances` data source

### DIFF
--- a/docs/data-sources/aadv2_instances.md
+++ b/docs/data-sources/aadv2_instances.md
@@ -1,0 +1,67 @@
+---
+subcategory: "Advanced Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aadv2_instances"
+description: |-
+  Use this data source to get the list of Advanced Anti-DDos v2 instances within HuaweiCloud.
+---
+
+# huaweicloud_aadv2_instances
+
+Use this data source to get the list of Advanced Anti-DDos v2 instances within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_aadv2_instances" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_access_type` - (Optional, String) Specifies the access type.  
+  The valid values are as follows:
+  + **0**: Website instance.
+  + **1**: IP access instance.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `items` - The list of instances.
+
+  The [items](#items_struct) structure is documented below.
+
+<a name="items_struct"></a>
+The `items` block supports:
+
+* `instance_id` - The instance ID.
+
+* `instance_name` - The name of the instance.
+
+* `enterprise_project_id` - The enterprise project ID.
+
+* `instance_access_type` - The instance access type.
+
+* `pp_support` - Whether PP is supported. `1` indicates supported, and `0` indicates not supported.
+
+* `pp_enable` - Whether the customer has enabled PP. `1` indicates enabled, and `0` indicates disabled.
+
+* `overseas_type` - The protection region. `0` indicates mainland China, and `1` indicates overseas.
+
+* `vips` - The high-defense IP information.
+
+  The [vips](#vips_struct) structure is documented below.
+
+<a name="vips_struct"></a>
+The `vips` block supports:
+
+* `ip` - The IP address.
+
+* `isp` - The line.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -509,6 +509,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_access_analyzer_archive_rules": accessanalyzer.DataSourceAccessAnalyzerArchiveRules(),
 
 			"huaweicloud_aad_instances":                   aad.DataSourceAADInstances(),
+			"huaweicloud_aadv2_instances":                 aad.DataSourceV2Instances(),
 			"huaweicloud_aad_unblock_quota_statistics":    aad.DataSourceUnblockQuotaStatistics(),
 			"huaweicloud_aad_black_white_lists":           aad.DataSourceAadBlackWhiteLists(),
 			"huaweicloud_aad_web_protection_policies":     aad.DataSourceAadWebProtectionPolicies(),

--- a/huaweicloud/services/aad/data_source_huaweicloud_aadv2_instances.go
+++ b/huaweicloud/services/aad/data_source_huaweicloud_aadv2_instances.go
@@ -1,0 +1,174 @@
+package aad
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AAD GET /v2/aad/instances
+func DataSourceV2Instances() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV2InstancesRead,
+
+		Schema: map[string]*schema.Schema{
+			"instance_access_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_access_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"pp_support": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"pp_enable": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"overseas_type": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"vips": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"isp": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildV2InstancesQueryParams(d *schema.ResourceData) string {
+	if v, ok := d.GetOk("instance_access_type"); ok {
+		return fmt.Sprintf("?instance_access_type=%v", v)
+	}
+
+	return ""
+}
+
+func dataSourceV2InstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+		httpUrl = "v2/aad/instances"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath += buildV2InstancesQueryParams(d)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving AAD v2 instances: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("items", flattenV2InstancesItems(utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenV2InstancesItems(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"instance_id":           utils.PathSearch("instance_id", v, nil),
+			"instance_name":         utils.PathSearch("instance_name", v, nil),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", v, nil),
+			"instance_access_type":  utils.PathSearch("instance_access_type", v, nil),
+			"pp_support":            utils.PathSearch("pp_support", v, nil),
+			"pp_enable":             utils.PathSearch("pp_enable", v, nil),
+			"overseas_type":         utils.PathSearch("overseas_type", v, nil),
+			"vips":                  flattenV2InstancesVips(utils.PathSearch("vips", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return rst
+}
+
+func flattenV2InstancesVips(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"ip":  utils.PathSearch("ip", v, nil),
+			"isp": utils.PathSearch("isp", v, nil),
+		})
+	}
+
+	return rst
+}

--- a/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aadv2_instances_test.go
+++ b/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aadv2_instances_test.go
@@ -1,0 +1,41 @@
+package antiddos
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Due to testing environment limitations, this test case can only test the scenario with empty `items`.
+func TestAccDataSourceV2Instances_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_aadv2_instances.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceV2Instances_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceV2Instances_basic() string {
+	return `
+data "huaweicloud_aadv2_instances" "test" {
+  instance_access_type = "0"
+}
+`
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `aadv2_instances` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `aadv2_instances` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/aad" TESTARGS="-run TestAccDataSourceV2Instances_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aad -v -run TestAccDataSourceV2Instances_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceV2Instances_basic
=== PAUSE TestAccDataSourceV2Instances_basic
=== CONT  TestAccDataSourceV2Instances_basic
--- PASS: TestAccDataSourceV2Instances_basic (11.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aad       11.829s
```
<img width="861" height="28" alt="image" src="https://github.com/user-attachments/assets/09fff2b7-e76c-441d-a9a5-8ad93f0fbedd" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
