### PR TITLE
feat(aad): support `aad_user_quotas` data source

### DIFF
--- a/docs/data-sources/aad_user_quotas.md
+++ b/docs/data-sources/aad_user_quotas.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Advanced Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aad_user_quotas"
+description: |-
+  Use this data source to get the Advanced Anti-DDos user quotas within HuaweiCloud.
+---
+
+# huaweicloud_aad_user_quotas
+
+Use this data source to get the Advanced Anti-DDos user quotas within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "type" {}
+
+data "huaweicloud_aad_user_quotas" "test" {
+  type = var.type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `type` - (Required, String) Specifies the request type.
+  The valid values are **instance**, **domain**, **port**, **waf**, and **domain_port**.
+
+* `overseas_type` - (Optional, String) Specifies the protection region.
+  This parameter is mandatory when `type` is set to **domain**.
+
+* `ip` - (Optional, String) Specifies the high-defense IP. This parameter is mandatory when `type` is set to **port**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `domain` - The remaining domain quota.
+
+* `instance` - The remaining instance quota.
+
+* `port` - The remaining forwarding configuration quota for the specified IP.
+
+* `domain_port_quota` - The domain server configuration quota.
+
+* `cc_quota` - The WAF CC rule quota.
+
+* `custom` - The WAF precise protection rule quota.
+
+* `geo_ip` - The WAF regional protection quota.
+
+* `white_ip` - The WAF whitelist quota.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -530,6 +530,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aad_ddos_attack_protection_info": aad.DataSourceDdosAttackProtectionInfo(),
 			"huaweicloud_aad_attack_events":               aad.DataSourceAttackEvents(),
 			"huaweicloud_aad_connection_numbers":          aad.DataSourceConnectionNumbers(),
+			"huaweicloud_aad_user_quotas":                 aad.DataSourceUserQuotas(),
 
 			"huaweicloud_antiddos_config_ranges":                antiddos.DataSourceConfigRanges(),
 			"huaweicloud_antiddos_weekly_protection_statistics": antiddos.DataSourceWeeklyProtectionStatistics(),

--- a/huaweicloud/services/aad/data_source_huaweicloud_aad_user_quotas.go
+++ b/huaweicloud/services/aad/data_source_huaweicloud_aad_user_quotas.go
@@ -1,0 +1,136 @@
+package aad
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AAD GET /v2/aad/user/quotas
+func DataSourceUserQuotas() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceUserQuotasRead,
+
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"overseas_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"domain": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"instance": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"domain_port_quota": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"cc_quota": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"custom": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"geo_ip": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"white_ip": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildAadUserQuotasQueryParams(d *schema.ResourceData) string {
+	queryParams := fmt.Sprintf("?type=%v", d.Get("type"))
+
+	if v, ok := d.GetOk("overseas_type"); ok {
+		queryParams = fmt.Sprintf("%s&overseas_type=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("ip"); ok {
+		queryParams = fmt.Sprintf("%s&ip=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceUserQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "aad"
+		httpUrl = "v2/aad/user/quotas"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AAD client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath += buildAadUserQuotasQueryParams(d)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving AAD user quotas: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("domain", utils.PathSearch("domain", respBody, nil)),
+		d.Set("instance", utils.PathSearch("instance", respBody, nil)),
+		d.Set("port", utils.PathSearch("port", respBody, nil)),
+		d.Set("domain_port_quota", utils.PathSearch("domain_port_quota", respBody, nil)),
+		d.Set("cc_quota", utils.PathSearch("cc_quota", respBody, nil)),
+		d.Set("custom", utils.PathSearch("custom", respBody, nil)),
+		d.Set("geo_ip", utils.PathSearch("geo_ip", respBody, nil)),
+		d.Set("white_ip", utils.PathSearch("white_ip", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_user_quotas_test.go
+++ b/huaweicloud/services/acceptance/aad/data_source_huaweicloud_aad_user_quotas_test.go
@@ -1,0 +1,105 @@
+package antiddos
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceUserQuotas_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_aad_user_quotas.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceUserQuotas_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instance"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceUserQuotas_waf(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_aad_user_quotas.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceUserQuotas_waf(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "custom"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "cc_quota"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "geo_ip"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "white_ip"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceUserQuotas_domainPort(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_aad_user_quotas.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceUserQuotas_domainPort(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "domain_port_quota"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceUserQuotas_basic() string {
+	return `
+data "huaweicloud_aad_user_quotas" "test" {
+  type = "instance"
+}
+`
+}
+
+func testAccDataSourceUserQuotas_waf() string {
+	return `
+data "huaweicloud_aad_user_quotas" "test" {
+  type = "waf"
+}
+`
+}
+
+func testAccDataSourceUserQuotas_domainPort() string {
+	return `
+data "huaweicloud_aad_user_quotas" "test" {
+  type = "domain_port"
+}
+`
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `aad_user_quotas` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `aad_user_quotas` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/aad" TESTARGS="-run TestAccDataSourceUserQuotas_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aad -v -run TestAccDataSourceUserQuotas_ -timeout 360m -parallel 4
=== RUN   TestAccDataSourceUserQuotas_basic
=== PAUSE TestAccDataSourceUserQuotas_basic
=== RUN   TestAccDataSourceUserQuotas_waf
=== PAUSE TestAccDataSourceUserQuotas_waf
=== RUN   TestAccDataSourceUserQuotas_domainPort
=== PAUSE TestAccDataSourceUserQuotas_domainPort
=== CONT  TestAccDataSourceUserQuotas_basic
=== CONT  TestAccDataSourceUserQuotas_domainPort
=== CONT  TestAccDataSourceUserQuotas_waf
--- PASS: TestAccDataSourceUserQuotas_waf (12.21s)
--- PASS: TestAccDataSourceUserQuotas_basic (13.23s)
--- PASS: TestAccDataSourceUserQuotas_domainPort (13.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aad       13.824s
```
<img width="851" height="31" alt="image" src="https://github.com/user-attachments/assets/f386569d-8489-49f9-b730-6f74f065f241" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
