### PR TITLE
feat(dew): new resource to authorize access key to cluster

### DIFF
--- a/docs/resources/cpcs_cluster_authorize_access_key.md
+++ b/docs/resources/cpcs_cluster_authorize_access_key.md
@@ -1,0 +1,66 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cpcs_cluster_authorize_access_key"
+description: |-
+  Manages an access key authorization resource for a CPCS cluster within HuaweiCloud.
+---
+
+# huaweicloud_cpcs_cluster_authorize_access_key
+
+Manages an access key authorization resource for a CPCS cluster within HuaweiCloud.
+
+-> Currently, this resource is valid only in cn-north-9 region.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+variable "app_id" {}
+variable "access_key_id" {}
+
+resource "huaweicloud_cpcs_cluster_authorize_access_key" "test" {
+  cluster_id    = var.cluster_id
+  app_id        = var.app_id
+  access_key_id = var.access_key_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the CPCS cluster.
+
+* `app_id` - (Required, String, NonUpdatable) Specifies the ID of the application.
+  It must be the value of the `app_id` that is already associated with the cluster.
+
+* `access_key_id` - (Required, String, NonUpdatable) Specifies the ID of the access key to be authorized.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (Randomly generated UUID).
+
+* `status` - The status of the access key.
+
+* `app_name` - The name of the application.
+
+* `access_key` - The access key (sensitive, will be marked as sensitive in the state).
+
+* `key_name` - The name of the access key.
+
+* `create_time` - The creation time of the access key, UNIX timestamp in milliseconds.
+
+## Import
+
+The CPCS cluster access key authorization resource can be imported using the `cluster_id` and `access_key_id`,
+separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_cpcs_cluster_authorize_access_key.test <cluster_id>/<access_key_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2490,9 +2490,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_cse_microservice_instance":             cse.ResourceMicroserviceInstance(),
 			"huaweicloud_cse_nacos_namespace":                   cse.ResourceNacosNamespace(),
 
-			"huaweicloud_cpcs_app_access_key":          dew.ResourceCpcsAppAccessKey(),
-			"huaweicloud_cpcs_app_cluster_association": dew.ResourceCpcsAppClusterAssociation(),
-			"huaweicloud_cpcs_app":                     dew.ResourceCpcsApp(),
+			"huaweicloud_cpcs_app_access_key":               dew.ResourceCpcsAppAccessKey(),
+			"huaweicloud_cpcs_app_cluster_association":      dew.ResourceCpcsAppClusterAssociation(),
+			"huaweicloud_cpcs_app":                          dew.ResourceCpcsApp(),
+			"huaweicloud_cpcs_cluster_authorize_access_key": dew.ResourceClusterAuthorizeAccessKey(),
 
 			"huaweicloud_csms_agency":                       dew.ResourceAgency(),
 			"huaweicloud_csms_event":                        dew.ResourceCsmsEvent(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -148,8 +148,9 @@ var (
 	HW_CSMS_TASK_ID              = os.Getenv("HW_CSMS_TASK_ID")
 	HW_CSMS_SECRET_ID            = os.Getenv("HW_CSMS_SECRET_ID")
 
-	HW_CPCS_CLUSTER_ID = os.Getenv("HW_CPCS_CLUSTER_ID")
-	HW_CPCS_APP_ID     = os.Getenv("HW_CPCS_APP_ID")
+	HW_CPCS_CLUSTER_ID    = os.Getenv("HW_CPCS_CLUSTER_ID")
+	HW_CPCS_APP_ID        = os.Getenv("HW_CPCS_APP_ID")
+	HW_CPCS_ACCESS_KEY_ID = os.Getenv("HW_CPCS_ACCESS_KEY_ID")
 
 	HW_DEST_REGION          = os.Getenv("HW_DEST_REGION")
 	HW_DEST_PROJECT_ID      = os.Getenv("HW_DEST_PROJECT_ID")
@@ -4115,6 +4116,20 @@ func TestAccPrecheckCsmsTask(t *testing.T) {
 func TestAccPrecheckCpcsClusterId(t *testing.T) {
 	if HW_CPCS_CLUSTER_ID == "" {
 		t.Skip("HW_CPCS_CLUSTER_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPrecheckCpcsAccessKeyId(t *testing.T) {
+	if HW_CPCS_ACCESS_KEY_ID == "" {
+		t.Skip("HW_CPCS_ACCESS_KEY_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPrecheckCpcsAppId(t *testing.T) {
+	if HW_CPCS_APP_ID == "" {
+		t.Skip("HW_CPCS_APP_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_cpcs_cluster_authorize_access_key_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_cpcs_cluster_authorize_access_key_test.go
@@ -1,0 +1,98 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dew"
+)
+
+func getCpcsClusterAuthorizeAccessKeyResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("kms", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DEW client: %s", err)
+	}
+
+	clusterId := state.Primary.Attributes["cluster_id"]
+	accessKeyId := state.Primary.Attributes["access_key_id"]
+	return dew.QueryCpcsClusterAuthorizeAccessKey(client, clusterId, accessKeyId)
+}
+
+// Currently, this resource is valid only in cn-north-9 region.
+func TestAccCpcsClusterAuthorizeAccessKey_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_cpcs_cluster_authorize_access_key.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getCpcsClusterAuthorizeAccessKeyResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare a valid cluster ID, app ID, and access key ID in the environment variables.
+			acceptance.TestAccPrecheckCpcsClusterId(t)
+			acceptance.TestAccPrecheckCpcsAppId(t)
+			acceptance.TestAccPrecheckCpcsAccessKeyId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCpcsClusterAuthorizeAccessKey_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_CPCS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "app_id", acceptance.HW_CPCS_APP_ID),
+					resource.TestCheckResourceAttr(rName, "access_key_id", acceptance.HW_CPCS_ACCESS_KEY_ID),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "app_name"),
+					resource.TestCheckResourceAttrSet(rName, "key_name"),
+					resource.TestCheckResourceAttrSet(rName, "create_time"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateIdFunc: testCpcsClusterAuthorizeAccessKeyImportState(rName),
+				ImportStateVerifyIgnore: []string{
+					"app_id",
+				},
+			},
+		},
+	})
+}
+
+func testCpcsClusterAuthorizeAccessKey_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cpcs_cluster_authorize_access_key" "test" {
+  cluster_id    = "%s"
+  app_id        = "%s"
+  access_key_id = "%s"
+}
+`, acceptance.HW_CPCS_CLUSTER_ID, acceptance.HW_CPCS_APP_ID, acceptance.HW_CPCS_ACCESS_KEY_ID)
+}
+
+func testCpcsClusterAuthorizeAccessKeyImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+		if rs.Primary.Attributes["cluster_id"] == "" || rs.Primary.Attributes["access_key_id"] == "" {
+			return "", fmt.Errorf("required attributes (cluster_id, access_key_id) of resource (%s) not found", name)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["cluster_id"], rs.Primary.Attributes["access_key_id"]), nil
+	}
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_cpcs_cluster_authorize_access_key.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_cpcs_cluster_authorize_access_key.go
@@ -1,0 +1,261 @@
+package dew
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW POST /v1/{project_id}/dew/cpcs/cluster/{cluster_id}/authorize-access-keys
+// @API DEW POST /v1/{project_id}/dew/cpcs/cluster/{cluster_id}/de-authorize-access-keys
+// @API DEW GET /v1/{project_id}/dew/cpcs/cluster/{cluster_id}/access-keys
+func ResourceClusterAuthorizeAccessKey() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceClusterAuthorizeAccessKeyCreate,
+		ReadContext:   resourceClusterAuthorizeAccessKeyRead,
+		UpdateContext: resourceClusterAuthorizeAccessKeyUpdate,
+		DeleteContext: resourceClusterAuthorizeAccessKeyDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceClusterAuthorizeAccessKeyImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"cluster_id",
+			"app_id",
+			"access_key_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			// no response value
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the cluster.`,
+			},
+			// no response value
+			"app_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the application.`,
+			},
+			// The official documentation describes this field as allowing "all" to be entered, signifying authorization
+			// for all applications. However, in actual testing, entering "all" results in an error,
+			// so this value is not mentioned in the provider documentation.
+			"access_key_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the access key.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the access key.`,
+			},
+			"app_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the application.`,
+			},
+			"access_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: `The access key.`,
+			},
+			"key_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the access key.`,
+			},
+			"create_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The creation time of the access key, UNIX timestamp in milliseconds.`,
+			},
+		},
+	}
+}
+
+func resourceClusterAuthorizeAccessKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/dew/cpcs/cluster/{cluster_id}/authorize-access-keys"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{cluster_id}", d.Get("cluster_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"app_id":         d.Get("app_id").(string),
+			"access_key_ids": []string{d.Get("access_key_id").(string)},
+		},
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error authorizing access key for DEW CPCS cluster: %s", err)
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID: %s", err)
+	}
+	d.SetId(generateId)
+
+	return resourceClusterAuthorizeAccessKeyRead(ctx, d, meta)
+}
+
+func QueryCpcsClusterAuthorizeAccessKey(client *golangsdk.ServiceClient, clusterId, accessKeyId string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/dew/cpcs/cluster/{cluster_id}/access-keys"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{cluster_id}", clusterId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	var (
+		pageNum       = 1
+		allAccessKeys []interface{}
+		expression    = fmt.Sprintf("[?access_key_id=='%s']|[0]", accessKeyId)
+	)
+
+	for {
+		requestPathWithPageNum := requestPath + fmt.Sprintf("?page_num=%d", pageNum)
+		resp, err := client.Request("GET", requestPathWithPageNum, &requestOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		accessKeys := utils.PathSearch("result", respBody, make([]interface{}, 0)).([]interface{})
+		if len(accessKeys) == 0 {
+			break
+		}
+
+		allAccessKeys = append(allAccessKeys, accessKeys...)
+		pageNum++
+	}
+
+	targetAccessKey := utils.PathSearch(expression, allAccessKeys, nil)
+	if targetAccessKey == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return targetAccessKey, nil
+}
+
+func resourceClusterAuthorizeAccessKeyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		product   = "kms"
+		clusterId = d.Get("cluster_id").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	accessKeyDetail, err := QueryCpcsClusterAuthorizeAccessKey(client, clusterId, d.Get("access_key_id").(string))
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DEW CPCS cluster authorize access key")
+	}
+
+	mErr := multierror.Append(
+		d.Set("cluster_id", clusterId),
+		d.Set("access_key_id", utils.PathSearch("access_key_id", accessKeyDetail, nil)),
+		d.Set("status", utils.PathSearch("status", accessKeyDetail, nil)),
+		d.Set("app_name", utils.PathSearch("app_name", accessKeyDetail, nil)),
+		d.Set("access_key", utils.PathSearch("access_key", accessKeyDetail, nil)),
+		d.Set("key_name", utils.PathSearch("key_name", accessKeyDetail, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", accessKeyDetail, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceClusterAuthorizeAccessKeyUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceClusterAuthorizeAccessKeyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/dew/cpcs/cluster/{cluster_id}/de-authorize-access-keys"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{cluster_id}", d.Get("cluster_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"app_id":         d.Get("app_id").(string),
+			"access_key_ids": []string{d.Get("access_key_id").(string)},
+		},
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DEW CPCS cluster authorize access key: %s", err)
+	}
+
+	return nil
+}
+
+func resourceClusterAuthorizeAccessKeyImportState(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, must be <cluster_id>/<access_key_id>, but got %s", d.Id())
+	}
+
+	mErr := multierror.Append(
+		d.Set("cluster_id", parts[0]),
+		d.Set("access_key_id", parts[1]),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to authorize access key to cluster

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccCpcsClusterAuthorizeAccessKey_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccCpcsClusterAuthorizeAccessKey_basic -timeout 360m -parallel 10
=== RUN   TestAccCpcsClusterAuthorizeAccessKey_basic
=== PAUSE TestAccCpcsClusterAuthorizeAccessKey_basic
=== CONT  TestAccCpcsClusterAuthorizeAccessKey_basic
--- PASS: TestAccCpcsClusterAuthorizeAccessKey_basic (15.20s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       15.307s coverage: 4.6% of statements in ./huaweicloud/services/dew
```
<img width="1320" height="93" alt="image" src="https://github.com/user-attachments/assets/1a3bcd4d-94c0-4bc4-ad37-844cabf178c4" />


* [X] Documentation updated.
* [X] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1045" height="189" alt="image" src="https://github.com/user-attachments/assets/9039df48-fb89-4f2c-901d-b4d56ebac278" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
