### PR TITLE
feat(dns): deprecated region parameter

### DIFF
--- a/docs/data-sources/dns_custom_lines.md
+++ b/docs/data-sources/dns_custom_lines.md
@@ -20,9 +20,6 @@ data "huaweicloud_dns_custom_lines" "test" {}
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to query the resource.
-  If omitted, the provider-level region will be used.
-
 * `line_id` - (Optional, String) Specifies the ID of the custom line. Fuzzy search is supported.
 
 * `name` - (Optional, String) Specifies the name of the custom line. Fuzzy search is supported.

--- a/docs/data-sources/dns_nameservers.md
+++ b/docs/data-sources/dns_nameservers.md
@@ -22,9 +22,6 @@ data "huaweicloud_dns_nameservers" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to query the resource.
-  If omitted, the provider-level region will be used.
-
 * `type` - (Optional, String) Specifies the type of the name server.
   The valid values are as follows:
    + **public**

--- a/docs/data-sources/dns_public_zone_lines.md
+++ b/docs/data-sources/dns_public_zone_lines.md
@@ -24,9 +24,6 @@ data "huaweicloud_dns_public_zone_lines" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to query the resource.
-  If omitted, the provider-level region will be used.
-
 * `zone_id` - (Required, String) Specifies the zone ID.
 
 ## Attribute Reference

--- a/docs/data-sources/dns_quotas.md
+++ b/docs/data-sources/dns_quotas.md
@@ -24,9 +24,6 @@ data "huaweicloud_dns_quotas" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to query the resource.
-  If omitted, the provider-level region will be used.
-
 * `domain_id` - (Required, String) Specifies the account ID of IAM user.
 
 * `type` - (Optional, String) Specifies the resource type.  

--- a/docs/resources/dns_custom_line.md
+++ b/docs/resources/dns_custom_line.md
@@ -30,9 +30,6 @@ resource "huaweicloud_dns_custom_line" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
-  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
-
 * `name` - (Required, String) Specifies the custom line name.  
   The value consists of `1` to `80` characters including Chinese characters, English letters, digits, hyphens (-),
   underscores (_) and dots (.). The name of each resolution line set by one account must be unique.

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_custom_line.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_custom_line.go
@@ -44,6 +44,12 @@ func ResourceCustomLine() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+				Description: utils.SchemaDesc(
+					`The region where the custom line is located`,
+					utils.SchemaDescInput{
+						Deprecated: true,
+					},
+				),
 			},
 			"name": {
 				Type:        schema.TypeString,
@@ -73,8 +79,14 @@ func ResourceCustomLine() *schema.Resource {
 }
 
 func resourceCustomLineCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var region string
 	cfg := meta.(*config.Config)
-	createCustomLineClient, err := cfg.NewServiceClient("dns", cfg.GetRegion(d))
+	if v, ok := d.GetOk("region"); ok {
+		region = v.(string)
+		cfg.RegionClient = true
+	}
+
+	createCustomLineClient, err := cfg.NewServiceClient("dns", region)
 	if err != nil {
 		return diag.Errorf("error creating DNS Client: %s", err)
 	}
@@ -171,8 +183,12 @@ func GetCustomLineById(client *golangsdk.ServiceClient, customLineId string) (in
 }
 
 func resourceCustomLineRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var region string
 	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+	if v, ok := d.GetOk("region"); ok {
+		region = v.(string)
+		cfg.RegionClient = true
+	}
 
 	getCustomLineClient, err := cfg.NewServiceClient("dns", region)
 	if err != nil {
@@ -196,8 +212,12 @@ func resourceCustomLineRead(_ context.Context, d *schema.ResourceData, meta inte
 }
 
 func resourceCustomLineUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var region string
 	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+	if v, ok := d.GetOk("region"); ok {
+		region = v.(string)
+		cfg.RegionClient = true
+	}
 	updateCustomLineClient, err := cfg.NewServiceClient("dns", region)
 	if err != nil {
 		return diag.Errorf("error creating DNS Client: %s", err)
@@ -235,8 +255,14 @@ func resourceCustomLineDelete(ctx context.Context, d *schema.ResourceData, meta 
 		cfg                     = meta.(*config.Config)
 		deleteCustomLineHttpUrl = "v2.1/customlines/{line_id}"
 		customLineId            = d.Id()
+		region                  = ""
 	)
-	deleteCustomLineClient, err := cfg.NewServiceClient("dns", cfg.GetRegion(d))
+	if v, ok := d.GetOk("region"); ok {
+		region = v.(string)
+		cfg.RegionClient = true
+	}
+
+	deleteCustomLineClient, err := cfg.NewServiceClient("dns", region)
 	if err != nil {
 		return diag.Errorf("error creating DNS Client: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
deprecated region parameter

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

#### data.huaweicloud_dns_custom_lines
```md
=== RUN   TestAccDataCustomLines_basic
=== PAUSE TestAccDataCustomLines_basic
=== CONT  TestAccDataCustomLines_basic
--- PASS: TestAccDataCustomLines_basic (35.26s)
PASS
```


#### data.huaweicloud_dns_nameservers
```md
=== RUN   TestAccDataNameservers_basic
=== PAUSE TestAccDataNameservers_basic
=== CONT  TestAccDataNameservers_basic
--- PASS: TestAccDataNameservers_basic (11.58s)
PASS
```


#### data.huaweicloud_dns_quotas
```md
=== RUN   TestAccDataQuotas_basic
=== PAUSE TestAccDataQuotas_basic
=== CONT  TestAccDataQuotas_basic
--- PASS: TestAccDataQuotas_basic (24.24s)
PASS
```


#### data.huaweicloud_dns_public_zone_lines
```md
=== RUN   TestAccDataSourceDNSPublicZoneLines_basic
=== PAUSE TestAccDataSourceDNSPublicZoneLines_basic
=== CONT  TestAccDataSourceDNSPublicZoneLines_basic
--- PASS: TestAccDataSourceDNSPublicZoneLines_basic (21.53s)
PASS
```

#### huaweicloud_dns_custom_line
```md
=== RUN   TestAccCustomLine_basic
=== PAUSE TestAccCustomLine_basic
=== CONT  TestAccCustomLine_basic
--- PASS: TestAccCustomLine_basic (36.22s)
PASS
```

#### huaweicloud_dns_recordset_v2
```md
=== RUN   TestAccDNSV2RecordSet_basic
=== PAUSE TestAccDNSV2RecordSet_basic
=== CONT  TestAccDNSV2RecordSet_basic
--- PASS: TestAccDNSV2RecordSet_basic (61.48s)
PASS
```
