### PR TITLE
feat(fgs): add a new data source to query trigger types

### DIFF
--- a/docs/data-sources/fgs_trigger_types.md
+++ b/docs/data-sources/fgs_trigger_types.md
@@ -1,0 +1,32 @@
+---
+subcategory: "FunctionGraph"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_fgs_trigger_types"
+description: |-
+  Use this data source to query trigger type list within HuaweiCloud.
+---
+
+# huaweicloud_fgs_trigger_types
+
+Use this data source to query trigger type list within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_fgs_trigger_types" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the trigger types are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `types` - The list of trigger types.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1210,6 +1210,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_quotas":                      fgs.DataSourceQuotas(),
 			"huaweicloud_fgs_resource_tags":               fgs.DataSourceResourceTags(),
 			"huaweicloud_fgs_resources_filter":            fgs.DataSourceResourcesFilter(),
+			"huaweicloud_fgs_trigger_types":               fgs.DataSourceTriggerTypes(),
 
 			"huaweicloud_ga_accelerators":       ga.DataSourceAccelerators(),
 			"huaweicloud_ga_access_logs":        ga.DataSourceGaAccessLogs(),

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_trigger_types_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_trigger_types_test.go
@@ -1,0 +1,37 @@
+package fgs
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataTriggerTypes_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_fgs_trigger_types.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataTriggerTypes_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "types.#", regexp.MustCompile(`[1-9][0-9]*`)),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataTriggerTypes_basic = `
+data "huaweicloud_fgs_trigger_types" "all" {}
+`

--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_trigger_types.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_trigger_types.go
@@ -1,0 +1,87 @@
+package fgs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API FunctionGraph GET /v2/{project_id}/fgs/triggertypes
+func DataSourceTriggerTypes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTriggerTypesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the trigger types are located.`,
+			},
+			"types": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of trigger types.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func getTriggerTypes(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v2/{project_id}/fgs/triggertypes"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func dataSourceTriggerTypesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	respBody, err := getTriggerTypes(client)
+	if err != nil {
+		return diag.Errorf("error querying trigger types: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("types", utils.PathSearch("[]", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source (`huaweicloud_fgs_trigger_types`) to query trigger types.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source to query trigger types.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccDataTriggerTypes_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataTriggerTypes_basic -timeout 360m -parallel 10
=== RUN   TestAccDataTriggerTypes_basic
=== PAUSE TestAccDataTriggerTypes_basic
=== CONT  TestAccDataTriggerTypes_basic
--- PASS: TestAccDataTriggerTypes_basic (21.20s)
PASS
coverage: 2.6% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       21.427s coverage: 2.6% of statements in ./huaweicloud/services/fgs
```
<img width="950" height="364" alt="image" src="https://github.com/user-attachments/assets/db1081a9-2d5f-4a3f-8727-b877f3586897" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
