### PR TITLE
feat(cts): add new resource to manage configuration

### DIFF
--- a/docs/resources/cts_configuration.md
+++ b/docs/resources/cts_configuration.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Cloud Trace Service (CTS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cts_configuration"
+description: |-
+  Using this resource to manage CTS configuration within HuaweiCloud.
+---
+
+# huaweicloud_cts_configuration
+
+Using this resource to manage CTS configuration within HuaweiCloud.
+
+-> This resource is only a configuration resource for managing CTS configuration. Deleting this resource will not
+restore the CTS configuration to the default value, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_cts_configuration" "test" {
+  is_sync_global_trace       = true
+  is_support_read_only       = true
+  support_read_only_services = ["ECS", "EVS"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to manage the CTS configuration.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `is_sync_global_trace` - (Required, Bool) Specifies whether to synchronize global service logs from the central
+  region.
+
+* `is_support_read_only` - (Required, Bool) Specifies whether to enable the reporting of read-only audit logs for all
+  cloud services.
+
+* `support_read_only_services` - (Optional, List) Specifies the cloud services that enable read-only audit logs.  
+  The value is a list of service names, such as **ECS**, **EVS**, **VPC**, etc.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2396,9 +2396,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_cce_cluster_certificate_rotatecredentials": cce.ResourceRotatecredentials(),
 			"huaweicloud_cce_nodes_remove":                          cce.ResourceNodesRemove(),
 
-			"huaweicloud_cts_tracker":      cts.ResourceCTSTracker(),
-			"huaweicloud_cts_data_tracker": cts.ResourceCTSDataTracker(),
-			"huaweicloud_cts_notification": cts.ResourceCTSNotification(),
+			"huaweicloud_cts_tracker":       cts.ResourceCTSTracker(),
+			"huaweicloud_cts_configuration": cts.ResourceConfiguration(),
+			"huaweicloud_cts_data_tracker":  cts.ResourceCTSDataTracker(),
+			"huaweicloud_cts_notification":  cts.ResourceCTSNotification(),
 
 			"huaweicloud_cci_namespace":                 cci.ResourceCciNamespace(),
 			"huaweicloud_cci_network":                   cci.ResourceCciNetworkV1(),

--- a/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_configuration_test.go
+++ b/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_configuration_test.go
@@ -1,0 +1,91 @@
+package cts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cts"
+)
+
+func getConfigurationResourceFunc(conf *config.Config, _ *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("cts", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CTS client: %s", err)
+	}
+
+	return cts.GetConfiguration(client)
+}
+
+func TestAccConfiguration_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceName = "huaweicloud_cts_configuration.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getConfigurationResourceFunc)
+	)
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguration_basic_step1,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "is_sync_global_trace", "true"),
+					resource.TestCheckResourceAttr(resourceName, "is_support_read_only", "true"),
+					resource.TestCheckResourceAttr(resourceName, "support_read_only_services.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "support_read_only_services.0", "ECS"),
+					resource.TestCheckResourceAttr(resourceName, "support_read_only_services.1", "EVS"),
+				),
+			},
+			{
+				Config: testAccConfiguration_basic_step2,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "is_sync_global_trace", "true"),
+					resource.TestCheckResourceAttr(resourceName, "is_support_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "support_read_only_services.#", "0"),
+				),
+			},
+			{
+				Config: testAccConfiguration_basic_step3,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "is_sync_global_trace", "false"),
+					resource.TestCheckResourceAttr(resourceName, "is_support_read_only", "true"),
+					resource.TestCheckResourceAttr(resourceName, "support_read_only_services.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "support_read_only_services.0", "VPC"),
+				),
+			},
+		},
+	})
+}
+
+const testAccConfiguration_basic_step1 = `
+resource "huaweicloud_cts_configuration" "test" {
+  is_sync_global_trace       = true
+  is_support_read_only       = true
+  support_read_only_services = ["ECS", "EVS"]
+}
+`
+
+const testAccConfiguration_basic_step2 = `
+resource "huaweicloud_cts_configuration" "test" {
+  is_sync_global_trace = true
+  is_support_read_only = false
+}
+`
+
+const testAccConfiguration_basic_step3 = `
+resource "huaweicloud_cts_configuration" "test" {
+  is_sync_global_trace       = false
+  is_support_read_only       = true
+  support_read_only_services = ["VPC"]
+}
+`

--- a/huaweicloud/services/cts/resource_huaweicloud_cts_configuration.go
+++ b/huaweicloud/services/cts/resource_huaweicloud_cts_configuration.go
@@ -1,0 +1,178 @@
+package cts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CTS PUT /v3/{project_id}/configuration
+// @API CTS GET /v3/{project_id}/configuration
+func ResourceConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceConfigurationCreate,
+		ReadContext:   resourceConfigurationRead,
+		UpdateContext: resourceConfigurationUpdate,
+		DeleteContext: resourceConfigurationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region in which to manage the CTS configuration.`,
+			},
+
+			// Required parameters.
+			"is_sync_global_trace": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: `Whether to synchronize global service logs from the central region.`,
+			},
+			"is_support_read_only": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: `Whether to enable the reporting of read-only audit logs for all cloud services.`,
+			},
+
+			// Optional parameters.
+			"support_read_only_services": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Cloud services that enable read-only audit logs.`,
+			},
+		},
+	}
+}
+
+func buildConfigurationCreateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"is_sync_global_trace":       d.Get("is_sync_global_trace"),
+		"is_support_read_only":       d.Get("is_support_read_only"),
+		"support_read_only_services": utils.ValueIgnoreEmpty(utils.ExpandToStringList(d.Get("support_read_only_services").([]interface{}))),
+	}
+}
+
+func updateConfiguration(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v3/{project_id}/configuration"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildConfigurationCreateBodyParams(d)),
+		OkCodes:          []int{204},
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return fmt.Errorf("error updating CTS configuration: %s", err)
+	}
+	return nil
+}
+
+func resourceConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("cts", region)
+	if err != nil {
+		return diag.Errorf("error creating CTS client: %s", err)
+	}
+
+	err = updateConfiguration(client, d)
+	if err != nil {
+		return diag.Errorf("error creating CTS configuration: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	return resourceConfigurationRead(ctx, d, meta)
+}
+
+func GetConfiguration(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v3/{project_id}/configuration"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceConfigurationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("cts", region)
+	if err != nil {
+		return diag.Errorf("error creating CTS client: %s", err)
+	}
+
+	configuration, err := GetConfiguration(client)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CTS configuration")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("is_sync_global_trace", utils.PathSearch("is_sync_global_trace", configuration, nil)),
+		d.Set("is_support_read_only", utils.PathSearch("is_support_read_only", configuration, nil)),
+		d.Set("support_read_only_services", utils.PathSearch("support_read_only_services", configuration, make([]interface{}, 0))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("cts", region)
+	if err != nil {
+		return diag.Errorf("error creating CTS client: %s", err)
+	}
+
+	err = updateConfiguration(client, d)
+	if err != nil {
+		return diag.Errorf("error updating CTS configuration: %s", err)
+	}
+
+	return resourceConfigurationRead(ctx, d, meta)
+}
+
+func resourceConfigurationDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a configuration resource for managing CTS configuration. Deleting this resource
+will not restore the CTS configuration to the default value, but will only remove the resource information from the
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new resource to manage CTS configuration

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports a new resource to manage CTS configuration
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cts -f TestAccConfiguration_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cts" -v -coverprofile="./huaweicloud/services/acceptance/cts/cts_coverage.cov" -coverpkg="./huaweicloud/services/cts" -run TestAccConfiguration_basic -timeout 360m -parallel 10
=== RUN   TestAccConfiguration_basic
=== PAUSE TestAccConfiguration_basic
=== CONT  TestAccConfiguration_basic
--- PASS: TestAccConfiguration_basic (35.02s)
PASS
coverage: 6.1% of statements in ./huaweicloud/services/cts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       35.095s coverage: 6.1% of statements in ./huaweicloud/services/cts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
