### PR TITLE
feat(dew): new datasource to query cpcs vm monitor

### DIFF
--- a/docs/data-sources/cpcs_vm_monitor.md
+++ b/docs/data-sources/cpcs_vm_monitor.md
@@ -1,0 +1,81 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cpcs_vm_monitor"
+description: |-
+  Use this data source to query the VM monitoring data from HuaweiCloud CPCS service.
+---
+
+# huaweicloud_cpcs_vm_monitor
+
+Use this data source to query the VM monitoring data from HuaweiCloud CPCS service.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cpcs_vm_monitor" "test" {
+  namespace   = "ECS"
+  metric_name = "mem_util"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `namespace` - (Required, String) Specifies the namespace of the monitoring data.
+  Valid values are **ECS** and **DHSM**.
+
+* `metric_name` - (Required, String) Specifies the name of the metric to query.
+  Valid values are **cpu_util**, **mem_util**, and **network_outgoing_bytes_rate_inband**.
+
+* `instance_id` - (Optional, String) Specifies the ID of the instance to monitor.
+
+* `vsm_id` - (Optional, String) Specifies the ID of the virtual machine.
+
+* `from` - (Optional, Int) Specifies the start time of the query in milliseconds since epoch.
+  Defaults to `0`, which means the query starts from three days ago.
+
+* `to` - (Optional, Int) Specifies the end time of the query in milliseconds since epoch.
+  Defaults to `0`, which means the query ends at the current time.
+
+* `period` - (Optional, Int) Specifies the statistical data period.
+  Defaults to `0`, which means the default period is `5` minutes.
+
+* `filter` - (Optional, String) Specifies the statistical value type.
+  Defaults to **min**, which means querying the minimum value.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `datapoints` - The list of monitoring data points.
+  The [datapoints](#datapoints_struct) structure is documented below.
+
+* `metric_name_output` - The name of the metric that was queried.
+
+* `max` - The maximum value of the metric in the time range.
+
+* `average` - The average value of the metric in the time range.
+
+<a name="datapoints_struct"></a>
+The `datapoints` block supports:
+
+* `max` - The maximum value of the metric.
+
+* `min` - The minimum value of the metric.
+
+* `average` - The average value of the metric.
+
+* `sum` - The sum of the metric values.
+
+* `variance` - The variance of the metric values.
+
+* `timestamp` - The timestamp of the data point in milliseconds since epoch.
+
+* `unit` - The unit of the metric value.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -939,6 +939,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cpcs_instances":           dew.DataSourceInstances(),
 			"huaweicloud_cpcs_clusters":            dew.DataSourceCpcsClusters(),
 			"huaweicloud_cpcs_resource_infos":      dew.DataSourceResourceInfos(),
+			"huaweicloud_cpcs_vm_monitor":          dew.DataSourceVmMonitor(),
 
 			"huaweicloud_csms_agencies":             dew.DataSourceAgencies(),
 			"huaweicloud_csms_events":               dew.DataSourceDewCsmsEvents(),

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_cpcs_vm_monitor_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_cpcs_vm_monitor_test.go
@@ -1,0 +1,47 @@
+package dew
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceVmMonitor_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_cpcs_vm_monitor.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVmMonitor_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "datapoints.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "datapoints.0.max"),
+					resource.TestCheckResourceAttrSet(dataSource, "datapoints.0.min"),
+					resource.TestCheckResourceAttrSet(dataSource, "datapoints.0.average"),
+					resource.TestCheckResourceAttrSet(dataSource, "datapoints.0.sum"),
+					resource.TestCheckResourceAttrSet(dataSource, "datapoints.0.variance"),
+					resource.TestCheckResourceAttrSet(dataSource, "datapoints.0.timestamp"),
+					resource.TestCheckResourceAttrSet(dataSource, "metric_name_output"),
+					resource.TestCheckResourceAttrSet(dataSource, "max"),
+					resource.TestCheckResourceAttrSet(dataSource, "average"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceVmMonitor_basic = `
+data "huaweicloud_cpcs_vm_monitor" "test" {
+  namespace   = "ECS"
+  metric_name = "mem_util"
+}`

--- a/huaweicloud/services/dew/data_source_huaweicloud_cpcs_vm_monitor.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_cpcs_vm_monitor.go
@@ -1,0 +1,210 @@
+package dew
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW GET /v1/{project_id}/dew/cpcs/vm-monitor
+func DataSourceVmMonitor() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceVmMonitorRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"namespace": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"metric_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vsm_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"from": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"to": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"period": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"datapoints": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"max": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"min": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"average": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"sum": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"variance": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"timestamp": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"unit": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"metric_name_output": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"max": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"average": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildVmMonitorQueryParams(d *schema.ResourceData) string {
+	rst := fmt.Sprintf("?namespace=%s&metric_name=%s", d.Get("namespace").(string), d.Get("metric_name").(string))
+
+	if v, ok := d.GetOk("instance_id"); ok {
+		rst += fmt.Sprintf("&instance_id=%v", v)
+	}
+
+	if v, ok := d.GetOk("vsm_id"); ok {
+		rst += fmt.Sprintf("&vsm_id=%v", v)
+	}
+
+	if v, ok := d.GetOk("from"); ok {
+		rst += fmt.Sprintf("&from=%v", v)
+	}
+
+	if v, ok := d.GetOk("to"); ok {
+		rst += fmt.Sprintf("&to=%v", v)
+	}
+
+	if v, ok := d.GetOk("period"); ok {
+		rst += fmt.Sprintf("&period=%v", v)
+	}
+
+	if v, ok := d.GetOk("filter"); ok {
+		rst += fmt.Sprintf("&filter=%v", v)
+	}
+
+	return rst
+}
+
+func resourceVmMonitorRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/dew/cpcs/vm-monitor"
+	)
+
+	client, err := cfg.NewServiceClient("kms", region)
+	if err != nil {
+		return diag.Errorf("error creating DEW KMS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildVmMonitorQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving vm monitor: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("datapoints", flattenDatapoints(utils.PathSearch("datapoints", respBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("metric_name_output", utils.PathSearch("metric_name", respBody, nil)),
+		d.Set("max", utils.PathSearch("max", respBody, nil)),
+		d.Set("average", utils.PathSearch("average", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDatapoints(datapoints []interface{}) []map[string]interface{} {
+	if len(datapoints) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(datapoints))
+	for _, dp := range datapoints {
+		result = append(result, map[string]interface{}{
+			"max":       utils.PathSearch("max", dp, nil),
+			"min":       utils.PathSearch("min", dp, nil),
+			"average":   utils.PathSearch("average", dp, nil),
+			"sum":       utils.PathSearch("sum", dp, nil),
+			"variance":  utils.PathSearch("variance", dp, nil),
+			"timestamp": utils.PathSearch("timestamp", dp, nil),
+			"unit":      utils.PathSearch("unit", dp, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query cpcs vm monitor

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccDataSourceVmMonitor_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccDataSourceVmMonitor_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceVmMonitor_basic
=== PAUSE TestAccDataSourceVmMonitor_basic
=== CONT  TestAccDataSourceVmMonitor_basic
--- PASS: TestAccDataSourceVmMonitor_basic (11.01s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       11.145s coverage: 3.8% of statements in ./huaweicloud/services/dew
```
<img width="1306" height="91" alt="image" src="https://github.com/user-attachments/assets/70ceadf5-863c-4a6c-b1a8-9f58aa1a5955" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
