### PR TITLE
feat(dew/kms): add new data source to get list of keystores

### DIFF
--- a/docs/data-sources/kms_dedicated_keystores.md
+++ b/docs/data-sources/kms_dedicated_keystores.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_kms_dedicated_keystores"
+description: |-
+  Use this datasource to get the list of dedicated keystores.
+---
+
+# huaweicloud_kms_dedicated_keystores
+
+Use this datasource to get the list of dedicated keystores.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_kms_dedicated_keystores" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `keystores` - The list of the keystores.
+
+  The [keystores](#keystores_struct) structure is documented below.
+
+<a name="keystores_struct"></a>
+The `keystores` block supports:
+
+* `keystore_id` - The keystore ID.
+
+* `domain_id` - The user domain ID.
+
+* `keystore_alias` - The keystore alias.
+
+* `keystore_type` - The keystore type.
+
+* `hsm_cluster_id` - The DHSM cluster ID.
+
+* `cluster_id` - The cluster ID.
+
+* `create_time` - The creation time of the keystore.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1468,6 +1468,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_aliases":               dew.DataSourceKmsAliases(),
 			"huaweicloud_kms_custom_keys_by_tags":   dew.DataSourceKmsCustomKeysByTags(),
 			"huaweicloud_kms_data_key":              dew.DataSourceKmsDataKeyV1(),
+			"huaweicloud_kms_dedicated_keystores":   dew.DataSourceDedicatedKeystores(),
 			"huaweicloud_kms_grants":                dew.DataSourceKmsGrants(),
 			"huaweicloud_kms_key_regions":           dew.DataSourceKMSKeyRegions(),
 			"huaweicloud_kms_key_tags":              dew.DataSourceKmsKeyTags(),

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_kms_dedicated_keystores_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_kms_dedicated_keystores_test.go
@@ -1,0 +1,37 @@
+package dew
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDedicatedKeystores_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_kms_dedicated_keystores.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			// Because there is no available data for testing, the test case is only
+			// used to verify that the API can be invoked.
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDewFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDedicatedKeystores_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "keystores.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceDedicatedKeystores_basic string = `data "huaweicloud_kms_dedicated_keystores" "test" {}`

--- a/huaweicloud/services/dew/data_source_huaweicloud_kms_dedicated_keystores.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_kms_dedicated_keystores.go
@@ -1,0 +1,145 @@
+package dew
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW GET /v1.0/{project_id}/keystores
+func DataSourceDedicatedKeystores() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDedicatedKeystoresRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"keystores": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"keystore_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"keystore_alias": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"keystore_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"hsm_cluster_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDedicatedKeystoresRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1.0/{project_id}/keystores?limit=10"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("kms", region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", getPath, offset)
+		getResp, err := client.Request("GET", currentPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving dedicated keystores: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		keystores := utils.PathSearch("keystores", getRespBody, make([]interface{}, 0)).([]interface{})
+		if len(keystores) == 0 {
+			break
+		}
+
+		result = append(result, keystores...)
+		offset += len(keystores)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("keystores", flattenDedicatedKeystores(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDedicatedKeystores(dataResp []interface{}) []interface{} {
+	if len(dataResp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(dataResp))
+	for _, v := range dataResp {
+		result = append(result, map[string]interface{}{
+			"keystore_id":    utils.PathSearch("keystore_id", v, nil),
+			"domain_id":      utils.PathSearch("domain_id", v, nil),
+			"keystore_alias": utils.PathSearch("keystore_alias", v, nil),
+			"keystore_type":  utils.PathSearch("keystore_type", v, nil),
+			"hsm_cluster_id": utils.PathSearch("hsm_cluster_id", v, nil),
+			"cluster_id":     utils.PathSearch("cluster_id", v, nil),
+			"create_time":    utils.PathSearch("create_time", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get list of keystores.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dew" TESTARGS="-run TestAccDataSourceDedicatedKeystores_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccDataSourceDedicatedKeystores_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDedicatedKeystores_basic
=== PAUSE TestAccDataSourceDedicatedKeystores_basic
=== CONT  TestAccDataSourceDedicatedKeystores_basic
--- PASS: TestAccDataSourceDedicatedKeystores_basic (30.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       30.940s
```
<img width="1208" height="19" alt="image" src="https://github.com/user-attachments/assets/013afbdf-9b82-47d5-9478-0305841ff560" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
