### PR TITLE
feat(dew): new resource to download cpcs access key

### DIFF
--- a/docs/resources/cpcs_app_download_access_key.md
+++ b/docs/resources/cpcs_app_download_access_key.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cpcs_app_download_access_key"
+description: |-
+  Downloads a CPCS application access key resource within HuaweiCloud.
+---
+
+# huaweicloud_cpcs_app_download_access_key
+
+Downloads a CPCS application access key resource within HuaweiCloud.
+
+-> Each key can only be downloaded once. Downloading it repeatedly will result in an error.
+ Please keep your key information safe.
+ Currently, this resource is valid only in cn-north-9 region.
+
+## Example Usage
+
+```hcl
+variable "app_id" {}
+variable "access_key_id" {}
+
+resource "huaweicloud_cpcs_app_download_access_key" "test" {
+  app_id        = var.app_id
+  access_key_id = var.access_key_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to download the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `app_id` - (Required, String, NonUpdatable) Specifies the application ID to which the access key belongs.
+
+* `access_key_id` - (Required, String, NonUpdatable) Specifies the ID of the access key to download.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (same as `access_key_id`).
+
+* `access_key` - The access key (AK) of the downloaded key.
+
+* `secret_key` - The secret key (SK) of the downloaded key.
+
+* `key_name` - The name of the access key.
+
+* `is_imported` - Whether the access key is imported.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2549,6 +2549,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cpcs_app_access_key":               dew.ResourceCpcsAppAccessKey(),
 			"huaweicloud_cpcs_app_cluster_association":      dew.ResourceCpcsAppClusterAssociation(),
 			"huaweicloud_cpcs_app":                          dew.ResourceCpcsApp(),
+			"huaweicloud_cpcs_app_download_access_key":      dew.ResourceCpcsAppDownloadAccessKey(),
 			"huaweicloud_cpcs_cluster_authorize_access_key": dew.ResourceClusterAuthorizeAccessKey(),
 
 			"huaweicloud_csms_agency":                       dew.ResourceAgency(),

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_cpcs_app_download_access_key_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_cpcs_app_download_access_key_test.go
@@ -1,0 +1,46 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Currently, this resource is valid only in cn-north-9 region.
+// Please note that each key can only be downloaded once.
+func TestAccCpcsAppDownloadAccessKey_basic(t *testing.T) {
+	rName := "huaweicloud_cpcs_app_download_access_key.test"
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare a valid app ID and access key ID in the environment variables.
+			acceptance.TestAccPrecheckCpcsAppId(t)
+			acceptance.TestAccPrecheckCpcsAccessKeyId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testCpcsAppDownloadAccessKey_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rName, "access_key"),
+					resource.TestCheckResourceAttrSet(rName, "secret_key"),
+					resource.TestCheckResourceAttrSet(rName, "key_name"),
+					resource.TestCheckResourceAttrSet(rName, "is_imported"),
+				),
+			},
+		},
+	})
+}
+
+func testCpcsAppDownloadAccessKey_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cpcs_app_download_access_key" "test" {
+  app_id        = "%s"
+  access_key_id = "%s"
+}
+`, acceptance.HW_CPCS_APP_ID, acceptance.HW_CPCS_ACCESS_KEY_ID)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_cpcs_app_download_access_key.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_cpcs_app_download_access_key.go
@@ -1,0 +1,133 @@
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var appAccessKeyNonUpdatableParams = []string{"app_id", "access_key_id"}
+
+// @API DEW GET /v1/{project_id}/dew/cpcs/apps/{app_id}/access-keys/{access_key_id}
+func ResourceCpcsAppDownloadAccessKey() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCpcsAppDownloadAccessKeyCreate,
+		ReadContext:   resourceCpcsAppDownloadAccessKeyRead,
+		UpdateContext: resourceCpcsAppDownloadAccessKeyUpdate,
+		DeleteContext: resourceCpcsAppDownloadAccessKeyDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(appAccessKeyNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"app_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"access_key_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"access_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"secret_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"key_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_imported": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCpcsAppDownloadAccessKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v1/{project_id}/dew/cpcs/apps/{app_id}/access-keys/{access_key_id}"
+		product     = "kms"
+		appId       = d.Get("app_id").(string)
+		accessKeyId = d.Get("access_key_id").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{app_id}", appId)
+	requestPath = strings.ReplaceAll(requestPath, "{access_key_id}", accessKeyId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error downloading DEW CPCS application access key: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(accessKeyId)
+
+	mErr := multierror.Append(
+		d.Set("access_key", utils.PathSearch("access_key", respBody, nil)),
+		d.Set("secret_key", utils.PathSearch("secret_key", respBody, nil)),
+		d.Set("key_name", utils.PathSearch("key_name", respBody, nil)),
+		d.Set("is_imported", utils.PathSearch("is_imported", respBody, nil)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting DEW CPCS application access key attributes: %s", err)
+	}
+
+	return resourceCpcsAppDownloadAccessKeyRead(ctx, d, meta)
+}
+
+func resourceCpcsAppDownloadAccessKeyRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceCpcsAppDownloadAccessKeyUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceCpcsAppDownloadAccessKeyDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to download CPC application access key.
+Deleting this resource will not recover the downloaded access key, but will only remove the resource information from
+the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to download cpcs access key

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccCpcsAppDownloadAccessKey_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccCpcsAppDownloadAccessKey_basic -timeout 360m -parallel 10
=== RUN   TestAccCpcsAppDownloadAccessKey_basic
=== PAUSE TestAccCpcsAppDownloadAccessKey_basic
=== CONT  TestAccCpcsAppDownloadAccessKey_basic
--- PASS: TestAccCpcsAppDownloadAccessKey_basic (10.50s)
PASS
coverage: 3.5% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       10.592s coverage: 3.5% of statements in ./huaweicloud/services/dew
```
<img width="1272" height="79" alt="image" src="https://github.com/user-attachments/assets/ceabec50-2343-4823-a182-d3fe67b483c4" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
