### PR TITLE
feat(aom): add new resource to manage alarm inhibit rule

### DIFF
--- a/docs/resources/aom_alarm_inhibit_rule.md
+++ b/docs/resources/aom_alarm_inhibit_rule.md
@@ -1,0 +1,180 @@
+---
+subcategory: "Application Operations Management (AOM 2.0)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aom_alarm_inhibit_rule"
+description:  |-
+  Manages an AOM alarm inhibit rule resource within HuaweiCloud.
+---
+
+# huaweicloud_aom_alarm_inhibit_rule
+
+Manages an AOM alarm inhibit rule resource within HuaweiCloud.
+
+## Example Usage
+
+### Create a basic alarm inhibit rule with source and target matches
+
+```hcl
+variable "inhibit_rule_name" {}
+variable "source_matches" {
+  type = list(object({
+    conditions = list(object({
+      key     = string
+      operate = string
+      values  = optional(list(string), null)
+    }))
+  }))
+}
+variable "target_matches" {
+  type = list(object({
+    conditions = list(object({
+      key     = string
+      operate = string
+      values  = optional(list(string), null)
+    }))
+  }))
+}
+
+resource "huaweicloud_aom_alarm_inhibit_rule" "test" {
+  name = var.inhibit_rule_name
+
+  dynamic "source_matches" {
+    for_each = var.source_matches
+
+    content {
+      dynamic "conditions" {
+        for_each = source_matches.value.conditions
+
+        content {
+          key     = conditions.value.key
+          operate = conditions.value.operate
+          values  = conditions.value.values
+        }
+      }
+    }
+  }
+
+  dynamic "target_matches" {
+    for_each = var.target_matches
+
+    content {
+      dynamic "conditions" {
+        for_each = target_matches.value.conditions
+
+        content {
+          key     = conditions.value.key
+          operate = conditions.value.operate
+          values  = conditions.value.values
+        }
+      }
+    }
+  }
+}
+```
+
+### Create an orchestrated alarm inhibit rule with match_v3
+
+```hcl
+variable "inhibit_rule_name" {}
+variable "alarm_group_rule_name" {}
+variable "match_v3" {}
+
+resource "huaweicloud_aom_alarm_inhibit_rule" "test" {
+  name               = var.inhibit_rule_name
+  binding_group_rule = var.alarm_group_rule_name
+  match_v3           = var.match_v3
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the alarm inhibit rule is located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the alarm inhibit rule.
+  The name can contain `1` to `100` characters, only letters, digits and underscores (_) are allowed.  
+  The name cannot start or end with an underscore.
+
+* `description` - (Optional, String) Specifies the description of the alarm inhibit rule.  
+  The description contains a maximum of `1,024` characters.
+
+* `binding_group_rule` - (Optional, String) Specifies the rule name associated with the alarm inhibit rule.  
+  For details, please refer to the [documentation](https://support.huaweicloud.com/api-aom/AddInhibitRule.html#AddInhibitRule__request_InhibitMatchV3Tag).
+
+  This parameter is available only when orchestrated alarm inhibit rule is supported.
+
+* `match_v3` - (Optional, String) Specifies the orchestrated alarm inhibit rule definition, in JSON format.  
+  This parameter is **required** when orchestrated alarm inhibit rule is supported.
+
+* `source_matches` - (Optional, List) Specifies the parallel match conditions for root alerts that suppress
+  other alerts.  
+  The [source_matches](#alarm_inhibit_rule_matches) structure is documented below.  
+  This parameter is **required** when orchestrated alarm inhibit rule is not supported.  
+  The maximum number of elements is `10`.
+
+* `target_matches` - (Optional, List) Specifies the parallel match conditions for target alerts that
+  will be suppressed.  
+  The [target_matches](#alarm_inhibit_rule_matches) structure is documented below.
+  This parameter is **required** when orchestrated alarm inhibit rule is not supported.  
+  The maximum number of elements is `10`.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the ID of the enterprise project to which
+  the alarm inhibit rule belongs.  
+  This parameter is only valid for enterprise users, if omitted, default enterprise project will be used.
+
+<a name="alarm_inhibit_rule_matches"></a>
+The `source_matches` and `target_matches` block supports:
+
+* `conditions` - (Required, List) Specifies the serial conditions within a parallel condition group.  
+  The [conditions](#alarm_inhibit_rule_matches_conditions) structure is documented below.  
+  The maximum number of elements is `10`.
+
+<a name="alarm_inhibit_rule_matches_conditions"></a>
+The `conditions` block supports:
+
+* `key` - (Required, String) Specifies the key of the alarm.  
+  The valid values are as follows:
+  + Specified tag name: The tag name can only contain Chinese characters, letters, numbers and underscores (_).
+  + **event_severity**: Event severity.
+  + **resource_provider**: Alarm source.
+  + **resource_type**: Resource type.
+
+* `operate` - (Required, String) Specifies the match operator for the alarm key.  
+  The valid values are as follows:
+  + **EQUALS**
+  + **EXIST**
+  + **REGEX**
+
+* `values` - (Optional, List) Specifies the value list corresponding to the key of the alarm.  
+  Each value cannot exceed `256` characters when the `operate` is **REGEX**.  
+  + If `key` is **event_severity** and the `operate` is **EQUALS**, the valid values are **Critical**, **Major**,
+    **Minor** and **Info**.
+  + If `key` is **resource_provider**, the value can be any of the resource types specified when creating an alarm rule
+    or customizing an alarm report. Types can include **host**, **container**, **process**, etc.
+  + If `key` is **resource_type**, the value can be any of the service names that triggered the alarm or event.
+    The service names can include **AOM**, **LTS**, **CCE**, etc.
+  + If `key` is a tag, the value can be any of the tag values ​​corresponding to the tag name. Tag values ​​can
+    only contain Chinese characters, letters, numbers, and underscores (_).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also the alarm inhibit rule name.
+
+## Import
+
+The alarm inhibit rule can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_aom_alarm_inhibit_rule.test <id>
+```
+
+For the alarm inhibit rule with the `enterprise_project_id`, its enterprise project ID need to be specified
+additionanlly when importing, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_aom_alarm_inhibit_rule.test <id>/<enterprise_project_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2177,6 +2177,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_aom_alarm_action_rule":              aom.ResourceAlarmActionRule(),
 			"huaweicloud_aom_alarm_group_rule":               aom.ResourceAlarmGroupRule(),
+			"huaweicloud_aom_alarm_inhibit_rule":             aom.ResourceAlarmInhibitRule(),
 			"huaweicloud_aom_alarm_rule":                     aom.ResourceAlarmRule(),
 			"huaweicloud_aom_alarm_rules_template":           aom.ResourceAlarmRulesTemplate(),
 			"huaweicloud_aom_alarm_silence_rule":             aom.ResourceAlarmSilenceRule(),

--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_alarm_inhibit_rule_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_alarm_inhibit_rule_test.go
@@ -1,0 +1,558 @@
+package aom
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/aom"
+)
+
+func getAlarmInhibitRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("aom", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating AOM client: %s", err)
+	}
+
+	return aom.GetAlarmInhibitRuleByName(client, state.Primary.Attributes["enterprise_project_id"], state.Primary.ID)
+}
+
+func TestAccAlarmInhibitRule_basic(t *testing.T) {
+	var (
+		rName = "huaweicloud_aom_alarm_inhibit_rule.test"
+		obj   interface{}
+		rc    = acceptance.InitResourceCheck(rName, &obj, getAlarmInhibitRuleResourceFunc)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlarmInhibitRule_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(rName, "source_matches.#", "3"),
+					resource.TestCheckResourceAttr(rName, "source_matches.0.conditions.#", "2"),
+					resource.TestCheckResourceAttr(rName, "source_matches.0.conditions.0.key", "event_severity"),
+					resource.TestCheckResourceAttr(rName, "source_matches.0.conditions.0.operate", "EXIST"),
+					resource.TestCheckResourceAttr(rName, "target_matches.#", "2"),
+					resource.TestCheckResourceAttr(rName, "target_matches.0.conditions.#", "2"),
+					resource.TestCheckResourceAttr(rName, "target_matches.0.conditions.1.key", "owner"),
+					resource.TestCheckResourceAttr(rName, "target_matches.0.conditions.1.operate", "REGEX"),
+					resource.TestCheckResourceAttr(rName, "target_matches.0.conditions.1.values.0", "terraform"),
+				),
+			},
+			{
+				Config: testAccAlarmInhibitRule_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "source_matches.#", "2"),
+					resource.TestCheckResourceAttr(rName, "source_matches.0.conditions.#", "1"),
+					resource.TestCheckResourceAttr(rName, "target_matches.#", "3"),
+					resource.TestCheckResourceAttr(rName, "target_matches.0.conditions.#", "1"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAlarmInhibitRule_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_aom_alarm_inhibit_rule" "test" {
+  name        = "%[1]s"
+  description = "Created by terraform script"
+
+  source_matches {
+    conditions {
+      key     = "event_severity"
+      operate = "EXIST"
+    }
+    conditions {
+      key     = "event_severity"
+      operate = "EQUALS"
+      values  = ["Critical"]
+    }
+  }
+  source_matches {
+    conditions {
+      key     = "event_severity"
+      operate = "EXIST"
+    }
+  }
+  source_matches {
+    conditions {
+      key     = "foo"
+      operate = "REGEX"
+      values  = ["bar"]
+    }
+  }
+
+  target_matches {
+    conditions {
+      key     = "event_severity"
+      operate = "EQUALS"
+      values  = ["Info"]
+    }
+    conditions {
+      key     = "owner"
+      operate = "REGEX"
+      values  = ["terraform"]
+    }
+  }
+  target_matches {
+    conditions {
+      key     = "event_severity"
+      operate = "EXIST"
+    }
+  }
+}
+`, name)
+}
+
+func testAccAlarmInhibitRule_basic_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_aom_alarm_inhibit_rule" "test" {
+  name = "%[1]s"
+
+  source_matches {
+    conditions {
+      key     = "event_severity"
+      operate = "EQUALS"
+      values  = ["Critical", "Major"]
+    }
+  }
+  source_matches {
+    conditions {
+      key     = "foo"
+      operate = "REGEX"
+      values  = ["bar"]
+    }
+    conditions {
+      key     = "event_severity"
+      operate = "EXIST"
+    }
+  }
+
+  target_matches {
+    conditions {
+      key     = "event_severity"
+      operate = "EQUALS"
+      values  = ["Info"]
+    }
+  }
+  target_matches {
+    conditions {
+      key     = "event_severity"
+      operate = "EXIST"
+    }
+  }
+  target_matches {
+    conditions {
+      key     = "owner"
+      operate = "REGEX"
+      values  = ["terraform"]
+    }
+  }
+}
+`, name)
+}
+
+// Currently, the `match_v3` field is only supported in some regions, such as `cn-north-9`.
+func TestAccAlarmInhibitRule_with_matchv3AndEpsId(t *testing.T) {
+	var (
+		obj                interface{}
+		rNameWithGroupRule = "huaweicloud_aom_alarm_inhibit_rule.test.0"
+		rcWithGroupRule    = acceptance.InitResourceCheck(rNameWithGroupRule, &obj, getAlarmInhibitRuleResourceFunc)
+
+		rNameWithoutGroupRule = "huaweicloud_aom_alarm_inhibit_rule.test.1"
+		rcWithoutGroupRule    = acceptance.InitResourceCheck(rNameWithoutGroupRule, &obj, getAlarmInhibitRuleResourceFunc)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcWithGroupRule.CheckResourceDestroy(),
+			rcWithoutGroupRule.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlarmInhibitRule_with_matchv3AndEpsId_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rcWithGroupRule.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameWithGroupRule, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrPair(rNameWithGroupRule, "binding_group_rule",
+						"huaweicloud_aom_alarm_group_rule.test", "name"),
+					resource.TestCheckResourceAttr(rNameWithGroupRule, "source_matches.#", "0"),
+					resource.TestCheckResourceAttr(rNameWithGroupRule, "target_matches.#", "0"),
+					rcWithoutGroupRule.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameWithoutGroupRule, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rNameWithoutGroupRule, "binding_group_rule", ""),
+					resource.TestCheckResourceAttr(rNameWithoutGroupRule, "source_matches.#", "0"),
+					resource.TestCheckResourceAttr(rNameWithoutGroupRule, "target_matches.#", "0"),
+				),
+			},
+			{
+				Config: testAccAlarmInhibitRule_with_matchv3AndEpsId_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rcWithGroupRule.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameWithGroupRule, "binding_group_rule", ""),
+					rcWithoutGroupRule.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rNameWithoutGroupRule, "binding_group_rule",
+						"huaweicloud_aom_alarm_group_rule.test", "name"),
+				),
+			},
+			{
+				ResourceName:      "huaweicloud_aom_alarm_inhibit_rule.test[0]",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAlarmInhibitRuleWithEpsIdImportStateFunc(rNameWithGroupRule),
+			},
+			{
+				ResourceName:      "huaweicloud_aom_alarm_inhibit_rule.test[1]",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAlarmInhibitRuleWithEpsIdImportStateFunc(rNameWithoutGroupRule),
+			},
+		},
+	})
+}
+
+// As long as the name of the alarm inhibit rule is unique, duplicate node IDs under it will not affect the creation of other rules.
+func testAccAlarmInhibitRule_with_matchv3AndEpsId_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_aom_alarm_inhibit_rule" "test" {
+  count = 2
+
+  name                  = "%[2]s${count.index}"
+  enterprise_project_id = "%[3]s"
+  binding_group_rule    = count.index == 0 ? huaweicloud_aom_alarm_group_rule.test.name : null
+
+  match_v3 = jsonencode({
+    nodes = [
+      # The node IDs naming rule: "flow" followed by 8 random characters, separated by "-", for example, "flow-VHSvKyYY".
+      # Random strings can only consist of letters, numbers, underscores, and hyphens.
+      {
+        id   = "flow-VHSvKyYY"
+        type = "Start"
+      },
+      {
+        id           = "flow-ufs5Zsn3"
+        type         = "Card"
+        businessType = "InhibitSourceCondition"
+
+        value = {
+          # The card IDs and their node IDs naming rule: "{businessType}" followed by 8 random characters, separated by "-",
+          # for example, "InhibitSourceCondition-wtJBNJD7".
+          id    = "InhibitSourceCondition-wtJBNJD7"
+          type  = "bool"
+          value = "and"
+          nodes = [
+            {
+              id    = "InhibitSourceCondition-awPpHgHv"
+              type  = "text"
+              match = {
+                key     = "resource_type"
+                operate = "EQUALS"
+                value   = ["service"]
+              }
+            },
+            {
+              id    = "InhibitSourceCondition-DmfXe2vN"
+              type  = "text"
+              match = {
+                key     = "resource_type"
+                operate = "EQUALS"
+                value   = ["service"]
+              }
+            },
+            {
+              id    = "InhibitSourceCondition-0fnYAVWg"
+              type  = "bool"
+              value = "and"
+              nodes = [
+                {
+                  id    = "InhibitSourceCondition-Xn7CUof5"
+                  type  = "text"
+                  match = {
+                    key     = "event_severity"
+                    operate = "EQUALS"
+                    value   = ["Critical"]
+                  }
+                }
+              ]
+            },
+            {
+              id    = "InhibitSourceCondition-juUOsA2L"
+              type  = "text"
+              match = {
+                key     = "resource_provider"
+                operate = "EQUALS"
+                value   = ["1"]
+              }
+            },
+            {
+              id    = "InhibitSourceCondition-JvtIwdL6"
+              type  = "text"
+              match = {
+                key     = "1"
+                operate = "EQUALS"
+                value   = ["1"]
+              }
+            }
+          ]
+        }
+      },
+      {
+        id           = "flow-eAheOiH5"
+        type         = "Card"
+        businessType = "InhibitTargetCondition"
+
+        value = {
+          id    = "InhibitSourceCondition--foPmJou"
+          type  = "bool"
+          value = "and"
+          nodes = [
+            {
+              id    = "InhibitSourceCondition--m9jJEAN"
+              type  = "text"
+              match = {
+                key     = "resource_type"
+                operate = "EQUALS"
+                value   = ["service"]
+              }
+            },
+            {
+              id    = "InhibitSourceCondition-MmTv1BZ5"
+              type  = "text"
+              match = {
+                key     = "resource_provider"
+                operate = "EQUALS"
+                value   = ["1"]
+              }
+            },
+            {
+              id    = "InhibitSourceCondition-7oz9ddLB"
+              type  = "bool"
+              value = "and"
+              nodes = [
+                {
+                  id    = "InhibitSourceCondition-oM73YTRG"
+                  type  = "text"
+                  match = {
+                    key     = "2"
+                    operate = "EQUALS"
+                    value   = ["2"]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        id   = "flow-f6P36v4a"
+        type = "End"
+      }
+    ]
+    edges = [
+      # The edge IDs naming rule: "edge" followed by 8 random characters, separated by "-", for example, "edge-M3pfK202".
+      # Random strings can only consist of letters, numbers, underscores, and hyphens.
+      # "source": The ID of the start node of the edge. The value is the ID of the node in the nodes list.
+      # "target": The ID of the end node of the edge. The value is the ID of the node in the nodes list.
+      {
+        id     = "edge-M3pfK202"
+        source = "flow-VHSvKyYY"
+        target = "flow-ufs5Zsn3"
+      },
+      {
+        id     = "edge-OrwQoSVg"
+        source = "flow-ufs5Zsn3"
+        target = "flow-eAheOiH5"
+        value  = "true"
+      },
+      {
+        id     = "edge-ukREdGnr"
+        source = "flow-ufs5Zsn3"
+        target = "flow-f6P36v4a"
+        value  = "false"
+      }
+    ]
+  })
+}
+`, testAlarmGroupRule_basic(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccAlarmInhibitRule_with_matchv3AndEpsId_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_aom_alarm_inhibit_rule" "test" {
+  count = 2
+
+  name                  = "%[2]s${count.index}"
+  enterprise_project_id = "%[3]s"
+  binding_group_rule    = count.index == 0 ? null : huaweicloud_aom_alarm_group_rule.test.name
+
+  match_v3 = jsonencode({
+    nodes = [
+      {
+        id   = "flow-VHSvKyYY"
+        type = "Start"
+      },
+      {
+        id           = "flow-ufs5Zsn3"
+        type         = "Card"
+        businessType = "InhibitSourceCondition"
+
+        value = {
+          id    = "InhibitSourceCondition-wtJBNJD7"
+          type  = "bool"
+          value = "and"
+          nodes = [
+            {
+              id    = "InhibitSourceCondition-awPpHgHv"
+              type  = "text"
+              match = {
+                key     = "resource_type"
+                operate = "EQUALS"
+                value   = ["service"]
+              }
+            },
+            {
+              id    = "InhibitSourceCondition-0fnYAVWg"
+              type  = "bool"
+              value = "and"
+              nodes = [
+                {
+                  id    = "InhibitSourceCondition-Xn7CUof5"
+                  type  = "text"
+                  match = {
+                    key     = "event_severity"
+                    operate = "EQUALS"
+                    value   = ["Critical"]
+                  }
+                }
+              ]
+            },
+          ]
+        }
+      },
+      {
+        id           = "flow-eAheOiH5"
+        type         = "Card"
+        businessType = "InhibitTargetCondition"
+
+        value = {
+          id    = "InhibitSourceCondition--foPmJou"
+          type  = "bool"
+          value = "and"
+          nodes = [
+            {
+              id    = "InhibitSourceCondition--m9jJEAN"
+              type  = "text"
+              match = {
+                key     = "resource_type"
+                operate = "EQUALS"
+                value   = ["service"]
+              }
+            },
+            {
+              id    = "InhibitSourceCondition-MmTv1BZ5"
+              type  = "text"
+              match = {
+                key     = "resource_provider"
+                operate = "EQUALS"
+                value   = ["1"]
+              }
+            },
+            {
+              id    = "InhibitSourceCondition-7oz9ddLB"
+              type  = "bool"
+              value = "and"
+              nodes = [
+                {
+                  id    = "InhibitSourceCondition-oM73YTRG"
+                  type  = "text"
+                  match = {
+                    key     = "2"
+                    operate = "EQUALS"
+                    value   = ["2"]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        id   = "flow-f6P36v4a"
+        type = "End"
+      }
+    ]
+    edges = [
+      {
+        id     = "edge-M3pfK202"
+        source = "flow-VHSvKyYY"
+        target = "flow-ufs5Zsn3"
+      },
+      {
+        id     = "edge-OrwQoSVg"
+        source = "flow-ufs5Zsn3"
+        target = "flow-eAheOiH5"
+        value  = "true"
+      },
+      {
+        id     = "edge-ukREdGnr"
+        source = "flow-ufs5Zsn3"
+        target = "flow-f6P36v4a"
+        value  = "false"
+      }
+    ]
+  })
+}
+`, testAlarmGroupRule_basic(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccAlarmInhibitRuleWithEpsIdImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+
+		epsId := rs.Primary.Attributes["enterprise_project_id"]
+		if epsId == "" {
+			return "", fmt.Errorf("The imported ID specifies an invalid format, want '<id>/<enterprise_project_id>', "+
+				"but got '%s/%s'", rs.Primary.ID, epsId)
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.ID, epsId), nil
+	}
+}

--- a/huaweicloud/services/aom/common.go
+++ b/huaweicloud/services/aom/common.go
@@ -1,0 +1,11 @@
+package aom
+
+func buildMoreHeaders(epsId string) map[string]string {
+	moreHeaders := map[string]string{
+		"Content-Type": "application/json",
+	}
+	if epsId != "" {
+		moreHeaders["Enterprise-Project-Id"] = epsId
+	}
+	return moreHeaders
+}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_inhibit_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_inhibit_rule.go
@@ -1,0 +1,395 @@
+package aom
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var alarmInhibitRuleNonUpdatableParams = []string{"name", "enterprise_project_id"}
+
+// @API AOM POST /v2/{project_id}/alert/inhibit-rules
+// @API AOM GET /v2/{project_id}/alert/inhibit-rules
+// @API AOM PUT /v2/{project_id}/alert/inhibit-rules
+// @API AOM DELETE /v2/{project_id}/alert/inhibit-rules
+func ResourceAlarmInhibitRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAlarmInhibitRuleCreate,
+		ReadContext:   resourceAlarmInhibitRuleRead,
+		UpdateContext: resourceAlarmInhibitRuleUpdate,
+		DeleteContext: resourceAlarmInhibitRuleDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceAlarmInhibitRuleImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(alarmInhibitRuleNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the alarm inhibit rule is located.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the alarm inhibit rule.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of the alarm inhibit rule.",
+			},
+			"binding_group_rule": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The rule name associated with the alarm inhibit rule.",
+			},
+			"match_v3": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsJSON,
+				Description:  "The orchestrated alarm inhibit rule definition, in JSON format.",
+			},
+			"source_matches": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"conditions": {
+							Type:        schema.TypeList,
+							Required:    true,
+							Description: "The serial conditions within a parallel condition group.",
+							Elem:        alarmInhibitRuleMatchSchema(),
+						},
+					},
+				},
+				Description: "The parallel match conditions for root alerts that suppress other alerts.",
+			},
+			"target_matches": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"conditions": {
+							Type:        schema.TypeList,
+							Required:    true,
+							Description: "The serial conditions within a parallel condition group.",
+							Elem:        alarmInhibitRuleMatchSchema(),
+						},
+					},
+				},
+				Description: "The parallel match conditions for target alerts that will be suppressed.",
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The ID of the enterprise project to which the alarm inhibit rule belongs.",
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func alarmInhibitRuleMatchSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The key of the alarm.",
+			},
+			"operate": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The match operator for the alarm key.",
+			},
+			"values": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The value list corresponding to the key of the alarm.",
+			},
+		},
+	}
+}
+
+func buildAlarmInhibitRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":               d.Get("name"),
+		"desc":               utils.ValueIgnoreEmpty(d.Get("description")),
+		"binding_group_rule": utils.ValueIgnoreEmpty(d.Get("binding_group_rule")),
+		"match_v3":           utils.StringToJson(d.Get("match_v3").(string)),
+		"source_match":       buildAlarmInhibitRuleMatches(d.Get("source_matches").([]interface{})),
+		"target_match":       buildAlarmInhibitRuleMatches(d.Get("target_matches").([]interface{})),
+	}
+}
+
+func buildAlarmInhibitRuleMatches(matches []interface{}) [][]map[string]interface{} {
+	if len(matches) == 0 {
+		return nil
+	}
+
+	result := make([][]map[string]interface{}, 0, len(matches))
+	for _, parallelGroup := range matches {
+		conditions := utils.PathSearch("conditions", parallelGroup, make([]interface{}, 0)).([]interface{})
+		serialConditions := make([]map[string]interface{}, 0, len(conditions))
+		for _, condition := range conditions {
+			serialConditions = append(serialConditions, map[string]interface{}{
+				"key":     utils.PathSearch("key", condition, nil),
+				"operate": utils.PathSearch("operate", condition, nil),
+				"value": utils.ExpandToStringListBySet(utils.PathSearch("values", condition,
+					schema.NewSet(schema.HashString, nil)).(*schema.Set)),
+			})
+		}
+
+		if len(serialConditions) > 0 {
+			result = append(result, serialConditions)
+		}
+	}
+
+	return result
+}
+
+func resourceAlarmInhibitRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v2/{project_id}/alert/inhibit-rules"
+	)
+	client, err := cfg.NewServiceClient("aom", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating AOM client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildMoreHeaders(cfg.GetEnterpriseProjectID(d)),
+		JSONBody:         utils.RemoveNil(buildAlarmInhibitRuleBodyParams(d)),
+		OkCodes:          []int{204},
+	}
+
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating alarm inhibit rule: %s", err)
+	}
+
+	d.SetId(d.Get("name").(string))
+
+	return resourceAlarmInhibitRuleRead(ctx, d, meta)
+}
+
+func GetAlarmInhibitRuleByName(client *golangsdk.ServiceClient, epsId, name string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/alert/inhibit-rules"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildMoreHeaders(epsId),
+	}
+
+	resp, err := client.Request("GET", path, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	inhibitRules, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	inhibitRule := utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0]", name), inhibitRules, nil)
+	if inhibitRule == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v2/{project_id}/alert/inhibit-rules",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("The alarm inhibit rule (%s) not found", name)),
+			},
+		}
+	}
+
+	return inhibitRule, nil
+}
+
+func resourceAlarmInhibitRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		ruleName = d.Id()
+	)
+	client, err := cfg.NewServiceClient("aom", region)
+	if err != nil {
+		return diag.Errorf("error creating AOM client: %s", err)
+	}
+
+	inhibitRule, err := GetAlarmInhibitRuleByName(client, cfg.GetEnterpriseProjectID(d), ruleName)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving alarm inhibit rule")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", inhibitRule, nil)),
+		d.Set("description", utils.PathSearch("desc", inhibitRule, nil)),
+		d.Set("binding_group_rule", utils.PathSearch("binding_group_rule", inhibitRule, nil)),
+		d.Set("match_v3", utils.JsonToString(utils.PathSearch("match_v3", inhibitRule, nil))),
+		d.Set("source_matches", flattenAlarmInhibitRuleMatches(utils.PathSearch("source_match", inhibitRule,
+			make([]interface{}, 0)).([]interface{}))),
+		d.Set("target_matches", flattenAlarmInhibitRuleMatches(utils.PathSearch("target_match", inhibitRule,
+			make([]interface{}, 0)).([]interface{}))),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", inhibitRule, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAlarmInhibitRuleMatches(matches []interface{}) []map[string]interface{} {
+	if len(matches) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(matches))
+	for _, parallelGroup := range matches {
+		serialConditions, ok := parallelGroup.([]interface{})
+		if !ok {
+			continue
+		}
+
+		conditions := make([]map[string]interface{}, 0, len(serialConditions))
+		for _, condition := range serialConditions {
+			conditions = append(conditions, map[string]interface{}{
+				"key":     utils.PathSearch("key", condition, nil),
+				"operate": utils.PathSearch("operate", condition, nil),
+				"values":  utils.PathSearch("value", condition, nil),
+			})
+		}
+
+		if len(conditions) > 0 {
+			result = append(result, map[string]interface{}{
+				"conditions": conditions,
+			})
+		}
+	}
+
+	return result
+}
+
+func buildUpdateAlarmInhibitRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"name":               d.Get("name"),
+		"desc":               d.Get("description"),
+		"binding_group_rule": d.Get("binding_group_rule"),
+		"match_v3":           utils.ValueIgnoreEmpty(utils.StringToJson(d.Get("match_v3").(string))),
+	}
+
+	if v, ok := d.GetOk("source_matches"); ok {
+		params["source_match"] = buildAlarmInhibitRuleMatches(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("target_matches"); ok {
+		params["target_match"] = buildAlarmInhibitRuleMatches(v.([]interface{}))
+	}
+
+	return params
+}
+
+func resourceAlarmInhibitRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v2/{project_id}/alert/inhibit-rules"
+	)
+	client, err := cfg.NewServiceClient("aom", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating AOM client: %s", err)
+	}
+
+	if d.HasChanges("description", "binding_group_rule", "match_v3", "source_matches", "target_matches") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+
+		opt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders:      buildMoreHeaders(cfg.GetEnterpriseProjectID(d)),
+			OkCodes:          []int{204},
+			JSONBody:         utils.RemoveNil(buildUpdateAlarmInhibitRuleBodyParams(d)),
+		}
+
+		_, err = client.Request("PUT", updatePath, &opt)
+		if err != nil {
+			return diag.Errorf("error updating alarm inhibit rule: %s", err)
+		}
+	}
+
+	return resourceAlarmInhibitRuleRead(ctx, d, meta)
+}
+
+func resourceAlarmInhibitRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		httpUrl  = "v2/{project_id}/alert/inhibit-rules"
+		ruleName = d.Get("name").(string)
+	)
+	client, err := cfg.NewServiceClient("aom", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating AOM client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildMoreHeaders(cfg.GetEnterpriseProjectID(d)),
+		JSONBody:         []string{ruleName},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		// AOM.08010002: The alarm inhibit rule does not exist
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "AOM.08010002"),
+			fmt.Sprintf("error deleting alarm inhibit rule (%s)", ruleName),
+		)
+	}
+	return nil
+}
+
+func resourceAlarmInhibitRuleImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	switch len(parts) {
+	case 1:
+		d.SetId(parts[0])
+		return []*schema.ResourceData{d}, nil
+	case 2:
+		d.SetId(parts[0])
+		return []*schema.ResourceData{d}, d.Set("enterprise_project_id", parts[1])
+	}
+	return nil, fmt.Errorf("invalid format specified for import ID, want '<id>' or "+"'<id>/<enterprise_project_id>', but got '%s'",
+		importedId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new resource(`huaweicloud_aom_alarm_inhibit_rule`) to manage alarm hibit rule.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new resource to manage alarm hibit rule.
add corresponding to document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o aom -f TestAccAlarmInhibitRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/aom" -v -coverprofile="./huaweicloud/services/acceptance/aom/aom_coverage.cov" -coverpkg="./huaweicloud/services/aom" -run TestAccAlarmInhibitRule_basic -timeout 360m -parallel 10
=== RUN   TestAccAlarmInhibitRule_basic
=== PAUSE TestAccAlarmInhibitRule_basic
=== CONT  TestAccAlarmInhibitRule_basic
--- PASS: TestAccAlarmInhibitRule_basic (49.87s)
PASS
coverage: 5.8% of statements in ./huaweicloud/services/aom
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       49.961s coverage: 5.8% of statements in ./huaweicloud/services/aom
```
```
 ./scripts/coverage.sh -o aom -f TestAccAlarmInhibitRule_with_matchv3AndEpsId
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/aom" -v -coverprofile="./huaweicloud/services/acceptance/aom/aom_coverage.cov" -coverpkg="./huaweicloud/services/aom" -run TestAccAlarmInhibitRule_with_matchv3AndEpsId -timeout 360m -parallel 10
=== RUN   TestAccAlarmInhibitRule_with_matchv3AndEpsId
=== PAUSE TestAccAlarmInhibitRule_with_matchv3AndEpsId
=== CONT  TestAccAlarmInhibitRule_with_matchv3AndEpsId
--- PASS: TestAccAlarmInhibitRule_with_matchv3AndEpsId (54.12s)
PASS
coverage: 10.2% of statements in ./huaweicloud/services/aom
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       54.545s coverage: 10.2% of statements in ./huaweicloud/services/aom
```
<img width="981" height="503" alt="image" src="https://github.com/user-attachments/assets/51b82590-ef03-4a30-87a7-7d2a8260fdbc" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
     <img width="1190" height="800" alt="image" src="https://github.com/user-attachments/assets/ac91aa53-3007-49f6-b118-5a9f32d59d64" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
     <img width="1191" height="855" alt="image" src="https://github.com/user-attachments/assets/172f19b6-bc92-4db8-8b2e-c85489eb5333" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
