### PR TITLE
feat(hss): support `hss_cluster_protect_default_policies` data source

### DIFF
--- a/docs/data-sources/hss_cluster_protect_default_policies.md
+++ b/docs/data-sources/hss_cluster_protect_default_policies.md
@@ -1,0 +1,114 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_cluster_protect_default_policies"
+description: |-
+  Use this data source to get the list of HSS cluster protect default policies within HuaweiCloud.
+---
+
+# huaweicloud_hss_cluster_protect_default_policies
+
+Use this data source to get the list of HSS cluster protect default policies within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_cluster_protect_default_policies" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `total_num` - The total number.
+
+* `general_policy_num` - The number of general policies.
+
+* `malicious_image_policy_num` - The number of malicious image policies.
+
+* `security_policy_num` - The number of security policies.
+
+* `data_list` - The list of cluster protect default policies.
+
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `cluster_id` - The cluster ID.
+
+* `cluster_name` - The cluster name.
+
+* `content` - The policy content.
+
+* `deploy_content` - The deployment content.
+
+* `parameters` - The parameters.
+
+* `policy_name` - The policy name.
+
+* `policy_id` - The policy ID.
+
+* `resources` - The resources.
+
+  The [resources](#data_list_resources_struct) structure is documented below.
+
+* `template_id` - The template ID.
+
+* `template_name` - The template name.
+
+* `template_type` - The template type.
+
+* `description` - The policy description.
+
+* `update_time` - The update time.
+
+* `create_time` - The creation time.
+
+* `image_num` - The number of protected images.
+
+* `labels_num` - The number of protected labels.
+
+* `status` - The status.
+
+* `white_images` - The white list images.
+
+  The [white_images](#data_list_white_images_struct) structure is documented below.
+
+<a name="data_list_resources_struct"></a>
+The `resources` block supports:
+
+* `cluster_id` - The cluster ID.
+
+* `cluster_name` - The cluster name.
+
+* `images` - The images.
+
+* `labels` - The labels.
+
+* `namespace` - The namespace.
+
+<a name="data_list_white_images_struct"></a>
+The `white_images` block supports:
+
+* `cluster_id` - The cluster ID.
+
+* `image_name` - The image name.
+
+* `image_version` - The image version.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1335,6 +1335,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_cluster_protect_info":                       hss.DataSourceClusterProtectInfo(),
 			"huaweicloud_hss_cluster_protect_policies":                   hss.DataSourceClusterProtectPolicies(),
 			"huaweicloud_hss_cluster_protect_overview":                   hss.DataSourceClusterProtectOverview(),
+			"huaweicloud_hss_cluster_protect_default_policies":           hss.DataSourceClusterProtectDefaultPolicies(),
 			"huaweicloud_hss_common_task_statistics":                     hss.DataSourceCommonTaskStatistics(),
 			"huaweicloud_hss_common_tasks":                               hss.DataSourceCommonTasks(),
 			"huaweicloud_hss_container_kubernetes":                       hss.DataSourceContainerKubernetes(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_cluster_protect_default_policies_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_cluster_protect_default_policies_test.go
@@ -1,0 +1,45 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Due to testing environment limitations, this test case can only test the scenario with empty `data_list`.
+func TestAccDataSourceClusterProtectDefaultPolicies_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_cluster_protect_default_policies.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceClusterProtectDefaultPolicies_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "general_policy_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "malicious_image_policy_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "security_policy_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceClusterProtectDefaultPolicies_basic() string {
+	return `
+data "huaweicloud_hss_cluster_protect_default_policies" "test" {
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_cluster_protect_default_policies.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_cluster_protect_default_policies.go
@@ -1,0 +1,323 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/cluster-protect/default-policy
+func DataSourceClusterProtectDefaultPolicies() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceClusterProtectDefaultPoliciesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"general_policy_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"malicious_image_policy_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"security_policy_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cluster_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"content": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"deploy_content": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"parameters": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resources": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cluster_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"cluster_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"images": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"labels": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"namespace": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"template_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"template_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"template_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"image_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"labels_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"white_images": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cluster_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"image_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"image_version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildClusterProtectDefaultPoliciesQueryParams(epsId string) string {
+	queryParams := "?limit=200"
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+
+	return queryParams
+}
+
+func dataSourceClusterProtectDefaultPoliciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                     = meta.(*config.Config)
+		region                  = cfg.GetRegion(d)
+		epsId                   = cfg.GetEnterpriseProjectID(d)
+		product                 = "hss"
+		httpUrl                 = "v5/{project_id}/cluster-protect/default-policy"
+		dataListResult          = make([]interface{}, 0)
+		offset                  = 0
+		totalNum                = 0
+		generalPolicyNum        = 0
+		maliciousImagePolicyNum = 0
+		securityPolicyNum       = 0
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildClusterProtectDefaultPoliciesQueryParams(epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		getResp, err := client.Request("GET", currentPath, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS cluster protect default policies: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalNum = int(utils.PathSearch("total_num", getRespBody, float64(0)).(float64))
+		generalPolicyNum = int(utils.PathSearch("general_policy_num", getRespBody, float64(0)).(float64))
+		maliciousImagePolicyNum = int(utils.PathSearch("malicious_image_policy_num", getRespBody, float64(0)).(float64))
+		securityPolicyNum = int(utils.PathSearch("security_policy_num", getRespBody, float64(0)).(float64))
+
+		dataResp := utils.PathSearch("data_list", getRespBody, make([]interface{}, 0)).([]interface{})
+		if len(dataResp) == 0 {
+			break
+		}
+
+		dataListResult = append(dataListResult, dataResp...)
+		offset += len(dataResp)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_num", totalNum),
+		d.Set("general_policy_num", generalPolicyNum),
+		d.Set("malicious_image_policy_num", maliciousImagePolicyNum),
+		d.Set("security_policy_num", securityPolicyNum),
+		d.Set("data_list", flattenClusterProtectDefaultPoliciesDataList(dataListResult)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenClusterProtectDefaultPoliciesDataList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"cluster_id":     utils.PathSearch("cluster_id", v, nil),
+			"cluster_name":   utils.PathSearch("cluster_name", v, nil),
+			"content":        utils.PathSearch("content", v, nil),
+			"deploy_content": utils.PathSearch("deploy_content", v, nil),
+			"parameters":     utils.PathSearch("parameters", v, nil),
+			"policy_name":    utils.PathSearch("policy_name", v, nil),
+			"policy_id":      utils.PathSearch("policy_id", v, nil),
+			"resources": flattenClusterProtectDefaultPoliciesResources(
+				utils.PathSearch("resources", v, make([]interface{}, 0)).([]interface{})),
+			"template_id":   utils.PathSearch("template_id", v, nil),
+			"template_name": utils.PathSearch("template_name", v, nil),
+			"template_type": utils.PathSearch("template_type", v, nil),
+			"description":   utils.PathSearch("description", v, nil),
+			"update_time":   utils.PathSearch("update_time", v, nil),
+			"create_time":   utils.PathSearch("create_time", v, nil),
+			"image_num":     utils.PathSearch("image_num", v, nil),
+			"labels_num":    utils.PathSearch("labels_num", v, nil),
+			"status":        utils.PathSearch("status", v, nil),
+			"white_images": flattenClusterProtectDefaultPoliciesWhiteImages(
+				utils.PathSearch("white_images", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return rst
+}
+
+func flattenClusterProtectDefaultPoliciesResources(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"cluster_id":   utils.PathSearch("cluster_id", v, nil),
+			"cluster_name": utils.PathSearch("cluster_name", v, nil),
+			"images":       utils.PathSearch("images", v, nil),
+			"labels":       utils.PathSearch("labels", v, nil),
+			"namespace":    utils.PathSearch("namespace", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenClusterProtectDefaultPoliciesWhiteImages(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"cluster_id":    utils.PathSearch("cluster_id", v, nil),
+			"image_name":    utils.PathSearch("image_name", v, nil),
+			"image_version": utils.PathSearch("image_version", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_cluster_protect_default_policies` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_cluster_protect_default_policies` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceClusterProtectDefaultPolicies_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceClusterProtectDefaultPolicies_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceClusterProtectDefaultPolicies_basic
=== PAUSE TestAccDataSourceClusterProtectDefaultPolicies_basic
=== CONT  TestAccDataSourceClusterProtectDefaultPolicies_basic
--- PASS: TestAccDataSourceClusterProtectDefaultPolicies_basic (10.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       10.331s
```
<img width="956" height="32" alt="image" src="https://github.com/user-attachments/assets/919bde57-0c68-4180-b472-c311ec7a58b9" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
