### PR TITLE
feat(fgs): add new data source to query runtime types

### DIFF
--- a/docs/data-sources/fgs_runtime_types.md
+++ b/docs/data-sources/fgs_runtime_types.md
@@ -1,0 +1,40 @@
+---
+subcategory: "FunctionGraph"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_fgs_runtime_types"
+description: |-
+  Use this data source to query runtime type list within HuaweiCloud.
+---
+
+# huaweicloud_fgs_runtime_types
+
+Use this data source to query runtime type list within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_fgs_runtime_types" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the runtime types are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `types` - The list of runtime types.  
+  The [types](#fgs_runtime_types_attr) structure is documented below.
+
+<a name="fgs_runtime_types_attr"></a>
+The `types` block supports:
+
+* `type` - The type of the runtime.
+
+* `display_name` - The display name of the runtime.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1216,6 +1216,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_quotas":                      fgs.DataSourceQuotas(),
 			"huaweicloud_fgs_resource_tags":               fgs.DataSourceResourceTags(),
 			"huaweicloud_fgs_resources_filter":            fgs.DataSourceResourcesFilter(),
+			"huaweicloud_fgs_runtime_types":               fgs.DataSourceRuntimeTypes(),
 			"huaweicloud_fgs_trigger_types":               fgs.DataSourceTriggerTypes(),
 
 			"huaweicloud_ga_accelerators":       ga.DataSourceAccelerators(),

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_runtime_types_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_runtime_types_test.go
@@ -1,0 +1,39 @@
+package fgs
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataRuntimeTypes_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_fgs_runtime_types.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataRuntimeTypes_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "types.#", regexp.MustCompile(`[1-9][0-9]*`)),
+					resource.TestCheckResourceAttrSet(all, "types.0.type"),
+					resource.TestCheckResourceAttrSet(all, "types.0.display_name"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataRuntimeTypes_basic = `
+data "huaweicloud_fgs_runtime_types" "test" {}
+`

--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_runtime_types.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_runtime_types.go
@@ -1,0 +1,109 @@
+package fgs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API FunctionGraph GET /v2/{project_id}/fgs/runtimetypes
+func DataSourceRuntimeTypes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRuntimeTypesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the runtime types are located.`,
+			},
+			"types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the runtime.`,
+						},
+						"display_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The display name of the runtime.`,
+						},
+					},
+				},
+				Description: `The list of the runtime types.`,
+			},
+		},
+	}
+}
+
+func dataSourceRuntimeTypesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/fgs/runtimetypes"
+	)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error querying runtime types: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(uuid)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("types", flattenRuntimeTypes(utils.PathSearch("[]", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRuntimeTypes(runtimeTypes []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(runtimeTypes))
+	for _, runtimeType := range runtimeTypes {
+		result = append(result, map[string]interface{}{
+			"type":         utils.PathSearch("type", runtimeType, nil),
+			"display_name": utils.PathSearch("display_name", runtimeType, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source (`huaweicloud_fgs_runtime_types`) to query supported runtime type list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source and its corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccDataRuntimeTypes_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataRuntimeTypes_basic -timeout 360m -parallel 10
=== RUN   TestAccDataRuntimeTypes_basic
=== PAUSE TestAccDataRuntimeTypes_basic
=== CONT  TestAccDataRuntimeTypes_basic
--- PASS: TestAccDataRuntimeTypes_basic (13.85s)
PASS
coverage: 2.7% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       14.150s coverage: 2.7% of statements in ./huaweicloud/services/fgs
```
<img width="995" height="364" alt="image" src="https://github.com/user-attachments/assets/83ef4079-9fb5-4040-b3e0-a6dd75c562a8" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
