### PR TITLE
feat(dew/cpcs): add new data source to get list of cluster ports

### DIFF
--- a/docs/data-sources/cpcs_cluster_ports.md
+++ b/docs/data-sources/cpcs_cluster_ports.md
@@ -1,0 +1,74 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cpcs_cluster_ports"
+description: |-
+  Use this data source to get the list of CPCS cluster ports.
+---
+
+# huaweicloud_cpcs_cluster_ports
+
+Use this data source to get the list of CPCS cluster ports.
+
+-> Currently, this data source is valid only in cn-north-9 region.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_cpcs_cluster_ports" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the cluster ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `result` - The list of the ports.
+  The [result](#ports_result_struct) structure is documented below.
+
+<a name="ports_result_struct"></a>
+The `result` block supports:
+
+* `id` - The UUID.
+
+* `cluster_id` - The cluster ID.
+
+* `elb_id` - The ELB ID.
+
+* `elb_ip` - The ELB IP address.
+
+* `mode` - The port mode.
+  The valid values are as follows:
+  + **PROXY**: Indicates proxy mode port.
+  + **TUNNEL**: Indicates tunnel mode custom port.
+  + **TUNNEL_FIXED**: Indicates fixed tunnel port in tunnel mode.
+
+* `listener_port` - The ELB listerner port.
+
+* `listener_id` - The ELB listerner ID.
+
+* `server_group_port` - The business port of the backend server bound to the backend service group.
+
+* `server_group_id` - The backend service group ID.
+
+* `project_id` - The project ID.
+
+* `validate_time` - The final verification time.
+
+* `wrong` - Whether the resources are abnormal.
+
+* `wrong_msg` - The resource anomaly information.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -935,10 +935,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_cpcs_associations":        dew.DataSourceAssociations(),
 			"huaweicloud_cpcs_availability_zones":  dew.DataSourceAvailabilityZones(),
 			"huaweicloud_cpcs_cluster_access_keys": dew.DataSourceCpcsClusterAccessKeys(),
+			"huaweicloud_cpcs_cluster_ports":       dew.DataSourceClusterPorts(),
+			"huaweicloud_cpcs_cluster_url":         dew.DataSourceClusterUrl(),
+			"huaweicloud_cpcs_clusters":            dew.DataSourceCpcsClusters(),
 			"huaweicloud_cpcs_images":              dew.DataSourceCpcsImages(),
 			"huaweicloud_cpcs_instances":           dew.DataSourceInstances(),
-			"huaweicloud_cpcs_clusters":            dew.DataSourceCpcsClusters(),
-			"huaweicloud_cpcs_cluster_url":         dew.DataSourceClusterUrl(),
 			"huaweicloud_cpcs_resource_infos":      dew.DataSourceResourceInfos(),
 			"huaweicloud_cpcs_vm_monitor":          dew.DataSourceVmMonitor(),
 

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_cpcs_cluster_ports_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_cpcs_cluster_ports_test.go
@@ -1,0 +1,44 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceClusterPorts_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_cpcs_cluster_ports.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			// Because there is no available data for testing, the test case is only
+			// used to verify that the API can be invoked.
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckCpcsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceClusterPorts_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "result.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceClusterPorts_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cpcs_cluster_ports" "test" {
+  cluster_id = "%s"
+}
+`, acceptance.HW_CPCS_CLUSTER_ID)
+}

--- a/huaweicloud/services/dew/data_source_huaweicloud_cpcs_cluster_ports.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_cpcs_cluster_ports.go
@@ -1,0 +1,169 @@
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW GET /v1/{project_id}/dew/cpcs/cluster/{cluster_id}/port
+func DataSourceClusterPorts() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceClusterPortsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"result": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"elb_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"elb_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"listener_port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"listener_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"server_group_port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"server_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"validate_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"wrong": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"wrong_msg": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceClusterPortsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		httpUrl   = "v1/{project_id}/dew/cpcs/cluster/{cluster_id}/port"
+		clusterId = d.Get("cluster_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("kms", region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", clusterId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving cluster ports: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	clusterPorts := utils.PathSearch("result", respBody, make([]interface{}, 0)).([]interface{})
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("result", flattenClusterPorts(clusterPorts)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenClusterPorts(results []interface{}) []interface{} {
+	if len(results) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(results))
+	for _, association := range results {
+		result = append(result, map[string]interface{}{
+			"id":                utils.PathSearch("id", association, nil),
+			"cluster_id":        utils.PathSearch("cluster_id", association, nil),
+			"elb_id":            utils.PathSearch("elb_id", association, nil),
+			"elb_ip":            utils.PathSearch("elb_ip", association, nil),
+			"mode":              utils.PathSearch("mode", association, nil),
+			"listener_port":     utils.PathSearch("listener_port", association, nil),
+			"listener_id":       utils.PathSearch("listener_id", association, nil),
+			"server_group_port": utils.PathSearch("server_group_port", association, nil),
+			"server_group_id":   utils.PathSearch("server_group_id", association, nil),
+			"project_id":        utils.PathSearch("project_id", association, nil),
+			"validate_time":     utils.PathSearch("validate_time", association, nil),
+			"wrong":             utils.PathSearch("wrong", association, nil),
+			"wrong_msg":         utils.PathSearch("wrong_msg", association, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get list of cluster ports.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dew" TESTARGS="-run TestAccDataSourceClusterPorts_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccDataSourceClusterPorts_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceClusterPorts_basic
=== PAUSE TestAccDataSourceClusterPorts_basic
=== CONT  TestAccDataSourceClusterPorts_basic
--- PASS: TestAccDataSourceClusterPorts_basic (29.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       29.658s
```
<img width="1208" height="19" alt="image" src="https://github.com/user-attachments/assets/1db6db32-d8f4-40e0-8d04-0daca25823bd" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
