### PR TITLE
feat(dew): new resource to manage cpcs instance status

### DIFF
--- a/docs/resources/cpcs_instance_status_action.md
+++ b/docs/resources/cpcs_instance_status_action.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cpcs_instance_status_action"
+description: |-
+  Manages the status (enable/disable) of a CPCS instance within HuaweiCloud.
+---
+
+# huaweicloud_cpcs_instance_status_action
+
+Manages the status (enable/disable) of a CPCS instance within HuaweiCloud.
+
+-> Currently, this resource is valid only in cn-north-9 region. Destroying this resource will not change the status of
+  the CPCS instance, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "action" {}
+
+resource "huaweicloud_cpcs_instance_status_action" "test" {
+  instance_id = var.instance_id
+  action      = var.action
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to manage the CPCS instance.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the CPCS instance to manage.
+
+* `action` - (Required, String) Specifies the action to perform on the CPCS instance.
+  Valid values are **enable** to enable the instance or **disable** to disable it.
+
+  -> The CPCS instance can only be disabled when it is in the enabled state. Similarly, it can only be enabled when it
+    is in the disabled state.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which is the same as the `instance_id`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2552,6 +2552,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cpcs_app":                          dew.ResourceCpcsApp(),
 			"huaweicloud_cpcs_app_download_access_key":      dew.ResourceCpcsAppDownloadAccessKey(),
 			"huaweicloud_cpcs_cluster_authorize_access_key": dew.ResourceClusterAuthorizeAccessKey(),
+			"huaweicloud_cpcs_instance_status_action":       dew.ResourceCpcsInstanceStatusAction(),
 
 			"huaweicloud_csms_agency":                       dew.ResourceAgency(),
 			"huaweicloud_csms_event":                        dew.ResourceCsmsEvent(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -152,6 +152,7 @@ var (
 	HW_CPCS_CLUSTER_ID    = os.Getenv("HW_CPCS_CLUSTER_ID")
 	HW_CPCS_APP_ID        = os.Getenv("HW_CPCS_APP_ID")
 	HW_CPCS_ACCESS_KEY_ID = os.Getenv("HW_CPCS_ACCESS_KEY_ID")
+	HW_CPCS_INSTANCE_ID   = os.Getenv("HW_CPCS_INSTANCE_ID")
 
 	HW_DEST_REGION          = os.Getenv("HW_DEST_REGION")
 	HW_DEST_PROJECT_ID      = os.Getenv("HW_DEST_PROJECT_ID")
@@ -4220,6 +4221,13 @@ func TestAccPrecheckCpcsClusterId(t *testing.T) {
 func TestAccPrecheckCpcsAccessKeyId(t *testing.T) {
 	if HW_CPCS_ACCESS_KEY_ID == "" {
 		t.Skip("HW_CPCS_ACCESS_KEY_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPrecheckCpcsInstanceId(t *testing.T) {
+	if HW_CPCS_INSTANCE_ID == "" {
+		t.Skip("HW_CPCS_INSTANCE_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_cpcs_instance_status_action_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_cpcs_instance_status_action_test.go
@@ -1,0 +1,49 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Currently, this resource is valid only in cn-north-9 region.
+func TestAccCpcsInstanceStatusAction_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Before running test, prepare a password service cluster instance with ENABLE status.
+			acceptance.TestAccPrecheckCpcsInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testCpcsInstanceStatusAction_basic(),
+			},
+			{
+				Config: testCpcsInstanceStatusAction_basic_update(),
+			},
+		},
+	})
+}
+
+func testCpcsInstanceStatusAction_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cpcs_instance_status_action" "test" {
+  instance_id = "%s"
+  action      = "disable"
+}
+`, acceptance.HW_CPCS_INSTANCE_ID)
+}
+
+func testCpcsInstanceStatusAction_basic_update() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cpcs_instance_status_action" "test" {
+  instance_id = "%s"
+  action      = "enable"
+}
+`, acceptance.HW_CPCS_INSTANCE_ID)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_cpcs_instance_status_action.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_cpcs_instance_status_action.go
@@ -1,0 +1,136 @@
+package dew
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var instanceStatusNonUpdatableParams = []string{"instance_id"}
+
+// @API DEW POST /v1/{project_id}/dew/cpcs/instances/{instance_id}/enable
+// @API DEW POST /v1/{project_id}/dew/cpcs/instances/{instance_id}/disable
+func ResourceCpcsInstanceStatusAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCpcsInstanceStatusActionCreate,
+		ReadContext:   resourceCpcsInstanceStatusActionRead,
+		UpdateContext: resourceCpcsInstanceStatusActionUpdate,
+		DeleteContext: resourceCpcsInstanceStatusActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(instanceStatusNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func updateInstanceAction(client *golangsdk.ServiceClient, action, instanceId string) error {
+	httpUrl := ""
+	switch action {
+	case "enable":
+		httpUrl = "v1/{project_id}/dew/cpcs/instances/{instance_id}/enable"
+	case "disable":
+		httpUrl = "v1/{project_id}/dew/cpcs/instances/{instance_id}/disable"
+	default:
+		return fmt.Errorf("invalid action: %s", action)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{instance_id}", instanceId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	return err
+}
+
+func resourceCpcsInstanceStatusActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		product    = "kms"
+		action     = d.Get("action").(string)
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	err = updateInstanceAction(client, action, instanceId)
+	if err != nil {
+		return diag.Errorf("error %s DEW CPCS instance in creation operation: %s", action, err)
+	}
+
+	d.SetId(instanceId)
+
+	return resourceCpcsInstanceStatusActionRead(ctx, d, meta)
+}
+
+func resourceCpcsInstanceStatusActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceCpcsInstanceStatusActionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		product    = "kms"
+		action     = d.Get("action").(string)
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	err = updateInstanceAction(client, action, instanceId)
+	if err != nil {
+		return diag.Errorf("error %s DEW CPCS instance in update operation: %s", action, err)
+	}
+
+	return resourceCpcsInstanceStatusActionRead(ctx, d, meta)
+}
+
+func resourceCpcsInstanceStatusActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `Deleting this resource will not affect the actual instance status, but will only remove the resource
+	information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to manage cpcs instance status.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccCpcsInstanceStatusAction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccCpcsInstanceStatusAction_basic -timeout 360m -parallel 10
=== RUN   TestAccCpcsInstanceStatusAction_basic
=== PAUSE TestAccCpcsInstanceStatusAction_basic
=== CONT  TestAccCpcsInstanceStatusAction_basic
--- PASS: TestAccCpcsInstanceStatusAction_basic (18.34s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       18.449s coverage: 3.7% of statements in ./huaweicloud/services/dew
```
<img width="1307" height="71" alt="image" src="https://github.com/user-attachments/assets/ea6a5888-5a5e-4a64-985e-d3b2ea85731d" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
