### PR TITLE
chore(workspace): rename the Workspace APP publishable applications data source

### DIFF
--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_publishable_applications_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_publishable_applications_test.go
@@ -29,6 +29,17 @@ func TestAccDataAppPublishableApplications_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				Config: testDataAppPublishableApplications_notFound(),
+				Check: resource.ComposeTestCheckFunc(
+					dcNotFound.CheckResourceExists(),
+					resource.TestCheckResourceAttr(notFound, "group_images.#", "0"),
+					// Deprecated attribute `apps` is still supported, so do not remove it.
+					resource.TestCheckResourceAttr(notFound, "apps.#", "0"),
+					// The instead of the deprecated attribute `apps`, we should use the new attribute `applications`.
+					resource.TestCheckResourceAttr(notFound, "applications.#", "0"),
+				),
+			},
+			{
 				Config: testDataAppPublishableApplications_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dcAll.CheckResourceExists(),
@@ -53,18 +64,6 @@ func TestAccDataAppPublishableApplications_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(all, "applications.0.icon_path"),
 					resource.TestCheckResourceAttrSet(all, "applications.0.icon_index"),
 					// The `description`, `work_path` and `command_param` may be empty, so do not assert them.
-				),
-			},
-			// If the incorrect test step is executed first, it will cause subsequent test steps failed.
-			{
-				Config: testDataAppPublishableApplications_notFound(),
-				Check: resource.ComposeTestCheckFunc(
-					dcNotFound.CheckResourceExists(),
-					resource.TestCheckResourceAttr(notFound, "group_images.#", "0"),
-					// Deprecated attribute `apps` is still supported, so do not remove it.
-					resource.TestCheckResourceAttr(notFound, "apps.#", "0"),
-					// The instead of the deprecated attribute `apps`, we should use the new attribute `applications`.
-					resource.TestCheckResourceAttr(notFound, "applications.#", "0"),
 				),
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Rename the data source and refactor some design of Workspace APP publishable applications

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. rename the app publishable applications data source
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataAppPublishableApplications_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAppPublishableApplications_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAppPublishableApplications_basic
=== PAUSE TestAccDataAppPublishableApplications_basic
=== CONT  TestAccDataAppPublishableApplications_basic
--- PASS: TestAccDataAppPublishableApplications_basic (646.72s)
PASS
coverage: 7.9% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 647.086s        coverage: 7.9% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
