### PR TITLE
feat(dew): new resource to export kps private key

### DIFF
--- a/docs/resources/kps_export_private_key.md
+++ b/docs/resources/kps_export_private_key.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_kps_export_private_key"
+description: |-
+  Manages a KPS export private key resource within HuaweiCloud.
+---
+
+# huaweicloud_kps_export_private_key
+
+Manages a KPS export private key resource within HuaweiCloud.
+
+-> The current resource is a one-time resource, and destroying this resource will not recover the exported key,
+but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "name" {}
+
+data "huaweicloud_kps_keypair" "test" {
+  name = var.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, NonUpdatable) Specifies the SSH keypair name to export the private key from.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `private_key` - The private key of the keypair. This is marked as sensitive and will not be
+  displayed in logs.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3061,6 +3061,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kps_failed_tasks_delete":      dew.ResourceKpsFailedTasksDelete(),
 			"huaweicloud_kps_batch_export_private_key": dew.ResourceKpsBatchExportPrivateKey(),
 			"huaweicloud_kps_batch_import_keypair":     dew.ResourceKpsBatchImportKeypair(),
+			"huaweicloud_kps_export_private_key":       dew.ResourceKpsExportPrivateKey(),
 			"huaweicloud_kps_failed_task_delete":       dew.ResourceKpsFailedTaskDelete(),
 
 			"huaweicloud_lb_certificate":  lb.ResourceCertificateV2(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -138,6 +138,7 @@ var (
 
 	HW_DEW_ENABLE_FLAG           = os.Getenv("HW_DEW_ENABLE_FLAG")
 	HW_KPS_KEY_FILE_PATH         = os.Getenv("HW_KPS_KEY_FILE_PATH")
+	HW_KPS_KEYPAIR_NAME          = os.Getenv("HW_KPS_KEYPAIR_NAME")
 	HW_KPS_KEYPAIR_NAME_1        = os.Getenv("HW_KPS_KEYPAIR_NAME_1")
 	HW_KPS_KEYPAIR_NAME_2        = os.Getenv("HW_KPS_KEYPAIR_NAME_2")
 	HW_KPS_KEYPAIR_KEY_1         = os.Getenv("HW_KPS_KEYPAIR_KEY_1")
@@ -4248,6 +4249,13 @@ func TestAccPreCheckCsmsSecretID(t *testing.T) {
 func TestAccPreCheckKPSKeyFilePath(t *testing.T) {
 	if HW_KPS_KEY_FILE_PATH == "" {
 		t.Skip("HW_KPS_KEY_FILE_PATH must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckKPSKeyPairName(t *testing.T) {
+	if HW_KPS_KEYPAIR_NAME == "" {
+		t.Skip("HW_KPS_KEYPAIR_NAME must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_export_private_key_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_export_private_key_test.go
@@ -1,0 +1,40 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccKpsExportPrivateKey_basic(t *testing.T) {
+	rscName := "huaweicloud_kps_export_private_key.test"
+
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please ensure that there is at least one available keypair in the test environment.
+			acceptance.TestAccPreCheckKPSKeyPairName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKpsExportPrivateKey_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rscName, "private_key"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKpsExportPrivateKey_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kps_export_private_key" "test" {
+  name = "%s"
+}
+`, acceptance.HW_KPS_KEYPAIR_NAME)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_kps_export_private_key.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kps_export_private_key.go
@@ -1,0 +1,128 @@
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW POST /v3/{project_id}/keypairs/private-key/export
+func ResourceKpsExportPrivateKey() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKpsExportPrivateKeyCreate,
+		ReadContext:   resourceKpsExportPrivateKeyRead,
+		UpdateContext: resourceKpsExportPrivateKeyUpdate,
+		DeleteContext: resourceKpsExportPrivateKeyDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"name",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to create the resource.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the SSH keypair name.`,
+			},
+			"private_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: `The private key of the keypair.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceKpsExportPrivateKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/keypairs/private-key/export"
+		product = "kms"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW KPS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"keypair": map[string]interface{}{
+				"name": d.Get("name"),
+			},
+		},
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error exporting DEW KPS private key: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.Errorf("error flattening response body: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(
+		d.Set("private_key", utils.PathSearch("keypair.private_key", respBody, nil)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting private key: %s", err)
+	}
+
+	return resourceKpsExportPrivateKeyRead(ctx, d, meta)
+}
+
+func resourceKpsExportPrivateKeyRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKpsExportPrivateKeyUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKpsExportPrivateKeyDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to export private key. Deleting this resource
+	will not recover the exported private key, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to export kps private key.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccKpsExportPrivateKey_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccKpsExportPrivateKey_basic -timeout 360m -parallel 10
=== RUN   TestAccKpsExportPrivateKey_basic
=== PAUSE TestAccKpsExportPrivateKey_basic
=== CONT  TestAccKpsExportPrivateKey_basic
--- PASS: TestAccKpsExportPrivateKey_basic (11.09s)
PASS
coverage: 3.5% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       11.196s coverage: 3.5% of statements in ./huaweicloud/services/dew
```
<img width="1292" height="82" alt="image" src="https://github.com/user-attachments/assets/99881a82-7feb-473a-9d65-04c89e6e53b7" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
