### PR TITLE
feat(fgs): add a new data source to query all triggers

### DIFF
--- a/docs/data-sources/fgs_triggers.md
+++ b/docs/data-sources/fgs_triggers.md
@@ -1,0 +1,54 @@
+---
+subcategory: "FunctionGraph"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_fgs_triggers"
+description: |-
+  Use this data source to query trigger list under all functions within HuaweiCloud.
+---
+
+# huaweicloud_fgs_triggers
+
+Use this data source to query trigger list under all functions within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_fgs_triggers" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the triggers are located.  
+  If omitted, the provider-level region will be used.
+
+* `trigger_type` - (Optional, String) Specifies the type of the trigger.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `triggers` - The list of triggers that match the filter parameters.  
+  The [triggers](#fgs_triggers_attr) structure is documented below.
+
+<a name="fgs_triggers_attr"></a>
+The `triggers` block supports:
+
+* `trigger_id` - The ID of the trigger.
+
+* `trigger_type_code` - The type of the trigger.
+
+* `trigger_status` - The status of the trigger.
+  + **ACTIVE**
+  + **DISABLED**
+
+* `event_data` - The detailed configuration of the trigger, in JSON format.
+
+* `func_urn` - The URN of the function to which the trigger belongs.
+
+* `created_time` - The creation time of the trigger.
+
+* `last_updated_time` - The latest update time of the trigger.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1217,6 +1217,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_resource_tags":               fgs.DataSourceResourceTags(),
 			"huaweicloud_fgs_resources_filter":            fgs.DataSourceResourcesFilter(),
 			"huaweicloud_fgs_trigger_types":               fgs.DataSourceTriggerTypes(),
+			"huaweicloud_fgs_triggers":                    fgs.DataSourceTriggers(),
 
 			"huaweicloud_ga_accelerators":       ga.DataSourceAccelerators(),
 			"huaweicloud_ga_access_logs":        ga.DataSourceGaAccessLogs(),

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_triggers_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_triggers_test.go
@@ -1,0 +1,101 @@
+package fgs
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataTriggers_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_fgs_triggers.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byType   = "data.huaweicloud_fgs_triggers.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataTriggers_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "triggers.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "triggers.0.trigger_id"),
+					resource.TestCheckResourceAttrSet(all, "triggers.0.trigger_type_code"),
+					resource.TestCheckResourceAttrSet(all, "triggers.0.trigger_status"),
+					resource.TestCheckResourceAttrSet(all, "triggers.0.func_urn"),
+					resource.TestCheckResourceAttrSet(all, "triggers.0.event_data"),
+					resource.TestCheckResourceAttrSet(all, "triggers.0.created_time"),
+					resource.TestCheckResourceAttrSet(all, "triggers.0.last_updated_time"),
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataTriggers_base() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_fgs_function" "test" {
+  name        = "%[1]s"
+  app         = "default"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python3.6"
+  code_type   = "inline"
+  func_code   = "def handler (event, context):\n    return {'statusCode': 200, 'body': 'Hello World'}"
+}
+
+resource "huaweicloud_fgs_function_trigger" "test" {
+  function_urn = huaweicloud_fgs_function.test.urn
+  type         = "TIMER"
+  event_data   = jsonencode({
+    name           = "%[1]s_rate",
+    schedule_type  = "Rate",
+    sync_execution = false,
+    user_event     = "Created by terraform script",
+    schedule       = "3m"
+  })
+}
+`, acceptance.RandomAccResourceName())
+}
+
+func testAccDataTriggers_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_fgs_triggers" "test" {
+  depends_on = [huaweicloud_fgs_function_trigger.test]
+}
+
+locals {
+  trigger_type = huaweicloud_fgs_function_trigger.test.type
+}
+
+data "huaweicloud_fgs_triggers" "filter_by_type" {
+  trigger_type = local.trigger_type
+
+  depends_on = [huaweicloud_fgs_function_trigger.test]
+}
+
+locals {
+  type_filter_results = [for v in data.huaweicloud_fgs_triggers.filter_by_type.triggers[*].trigger_type_code : v == local.trigger_type]
+}
+
+output "is_type_filter_useful" {
+  value = length(local.type_filter_results) > 0 && alltrue(local.type_filter_results)
+}
+`, testAccDataTriggers_base())
+}

--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_triggers.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_triggers.go
@@ -1,0 +1,183 @@
+package fgs
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API FunctionGraph GET /v2/{project_id}/fgs/triggers
+func DataSourceTriggers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTriggersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the triggers are located.`,
+			},
+			"trigger_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type of the trigger.`,
+			},
+			"triggers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"trigger_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the trigger.`,
+						},
+						"trigger_type_code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the trigger.`,
+						},
+						"trigger_status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the trigger.`,
+						},
+						"event_data": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The detailed configuration of the trigger, in JSON format.`,
+						},
+						"func_urn": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The URN of the function to which the trigger belongs.`,
+						},
+						"created_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the trigger.`,
+						},
+						"last_updated_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the trigger.`,
+						},
+					},
+				},
+				Description: `The list of triggers that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func getTriggers(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/fgs/triggers"
+		marker  = ""
+		limit   = 500
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = fmt.Sprintf("%s?maxitems=%v", listPath, limit)
+	if triggerType, ok := d.GetOk("trigger_type"); ok {
+		listPath = fmt.Sprintf("%s&trigger_type=%v", listPath, triggerType)
+	}
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithMarker := listPath
+		if marker != "" {
+			listPathWithMarker = fmt.Sprintf("%s&marker=%s", listPath, marker)
+		}
+
+		requestResp, err := client.Request("GET", listPathWithMarker, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		triggers := utils.PathSearch("triggers", respBody, make([]interface{}, 0)).([]interface{})
+		if len(triggers) < 1 {
+			break
+		}
+
+		result = append(result, triggers...)
+		if len(triggers) < limit {
+			break
+		}
+		marker = strconv.Itoa(int(utils.PathSearch("next_marker", respBody, float64(0)).(float64)))
+	}
+
+	return result, nil
+}
+
+func dataSourceTriggersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	triggers, err := getTriggers(client, d)
+	if err != nil {
+		return diag.Errorf("error querying triggers: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("triggers", flattenTriggersList(triggers)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenTriggersList(triggers []interface{}) []map[string]interface{} {
+	if len(triggers) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(triggers))
+	for _, trigger := range triggers {
+		result = append(result, map[string]interface{}{
+			"trigger_id":        utils.PathSearch("trigger_id", trigger, nil),
+			"trigger_type_code": utils.PathSearch("trigger_type_code", trigger, nil),
+			"trigger_status":    utils.PathSearch("trigger_status", trigger, nil),
+			"event_data":        utils.JsonToString(utils.PathSearch("event_data", trigger, nil)),
+			"func_urn":          utils.PathSearch("func_urn", trigger, nil),
+			"created_time":      utils.PathSearch("created_time", trigger, nil),
+			"last_updated_time": utils.PathSearch("last_updated_time", trigger, nil),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source to query trigger list undes all functions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source and its corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccDataTriggers_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataTriggers_basic -timeout 360m -parallel 10
=== RUN   TestAccDataTriggers_basic
=== PAUSE TestAccDataTriggers_basic
=== CONT  TestAccDataTriggers_basic
--- PASS: TestAccDataTriggers_basic (27.78s)
PASS
coverage: 14.8% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       27.873s coverage: 14.8% of statements in ./huaweicloud/services/fgs
```
<img width="929" height="387" alt="image" src="https://github.com/user-attachments/assets/53fd4cc5-686e-439d-aeb3-b7840fd75c2f" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
