### PR TITLE
feat(fgs): add new data source to get supported feature information

### DIFF
--- a/docs/data-sources/fgs_feature.md
+++ b/docs/data-sources/fgs_feature.md
@@ -1,0 +1,32 @@
+---
+subcategory: "FunctionGraph"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_fgs_feature"
+description: |-
+  Use this data source to query the supported feature information of FunctionGraph within HuaweiCloud.
+---
+
+# huaweicloud_fgs_feature
+
+Use this data source to query the supported feature information of FunctionGraph within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_fgs_feature" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the feature information is located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `feature` - The feature information, in JSON format.  

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1211,6 +1211,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_async_invoke_configurations": fgs.DataSourceAsyncInvokeConfigurations(),
 			"huaweicloud_fgs_dependencies":                fgs.DataSourceDependencies(),
 			"huaweicloud_fgs_dependency_versions":         fgs.DataSourceDependencieVersions(),
+			"huaweicloud_fgs_feature":                     fgs.DataSourceFeature(),
 			"huaweicloud_fgs_function_events":             fgs.DataSourceFunctionEvents(),
 			"huaweicloud_fgs_function_tags":               fgs.DataSourceFunctionTags(),
 			"huaweicloud_fgs_function_triggers":           fgs.DataSourceFunctionTriggers(),

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_feature_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_feature_test.go
@@ -1,0 +1,36 @@
+package fgs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataFeature_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_fgs_feature.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataFeature_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(all, "feature"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataFeature_basic = `
+data "huaweicloud_fgs_feature" "test" {}
+`

--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_feature.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_feature.go
@@ -1,0 +1,84 @@
+package fgs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API FunctionGraph GET /v2/{project_id}/fgs/feature
+func DataSourceFeature() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceFeatureRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the feature information is located.`,
+			},
+			// New features may be added in the future, so JSON format will be used.
+			"feature": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The feature information, in JSON format.`,
+			},
+		},
+	}
+}
+
+func dataSourceFeatureRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/fgs/feature"
+	)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error querying feature information: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(uuid)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("feature", utils.JsonToString(respBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source(`huaweicloud_fgs_feature`) to get supported feature information.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccDataFeature_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataFeature_basic -timeout 360m -parallel 10
=== RUN   TestAccDataFeature_basic
=== PAUSE TestAccDataFeature_basic
=== CONT  TestAccDataFeature_basic
--- PASS: TestAccDataFeature_basic (17.56s)
PASS
coverage: 2.5% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       17.657s coverage: 2.5% of statements in ./huaweicloud/services/fgs
```
<img width="961" height="192" alt="image" src="https://github.com/user-attachments/assets/499a2161-26ef-4439-bfe0-1f00f29ce009" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
