### PR TITLE
feat(apig): instance tags data source supports new API method

### DIFF
--- a/docs/data-sources/apig_instance_tags.md
+++ b/docs/data-sources/apig_instance_tags.md
@@ -27,7 +27,7 @@ The following arguments are supported:
 * `region` - (Optional, String) Specifies the region in which to query the instance tags.  
   If omitted, the provider-level region will be used.
 
-* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the tags belong.
+* `instance_id` - (Optional, String) Specifies the ID of the dedicated instance to which the tags belong.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_instance_tags_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_instance_tags_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-// Before running this acceptance test, please make sure at least two tags that the instance have.
-func TestAccDataSourceInstanceTags_basic(t *testing.T) {
+func TestAccDataInstanceTags_basic(t *testing.T) {
 	var (
-		dataSourceName = "data.huaweicloud_apig_instance_tags.test"
-		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		dcAll                = "data.huaweicloud_apig_instance_tags.all"
+		dcFilterByInstanceId = "data.huaweicloud_apig_instance_tags.test"
+		byInstanceId         = acceptance.InitDataSourceCheck(dcFilterByInstanceId)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -23,16 +23,22 @@ func TestAccDataSourceInstanceTags_basic(t *testing.T) {
 			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source:            "hashicorp/random",
+				VersionConstraint: "3.0.0",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceInstanceTags_basic(),
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dataSourceName, "tags.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
-					resource.TestCheckResourceAttrSet(dataSourceName, "tags.0.key"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "tags.0.value"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "tags.1.key"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "tags.1.value"),
+					byInstanceId.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dcFilterByInstanceId, "tags.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					resource.TestCheckResourceAttrSet(dcFilterByInstanceId, "tags.0.key"),
+					resource.TestCheckResourceAttrSet(dcFilterByInstanceId, "tags.0.value"),
+					resource.TestMatchResourceAttr(dcAll, "tags.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					resource.TestCheckOutput("is_all_tags_include_test_tags", "true"),
 				),
 			},
 		},
@@ -41,8 +47,49 @@ func TestAccDataSourceInstanceTags_basic(t *testing.T) {
 
 func testAccDataSourceInstanceTags_basic() string {
 	return fmt.Sprintf(`
-data "huaweicloud_apig_instance_tags" "test" {
-  instance_id = "%s"
+resource "random_string" "access_key" {
+  length  = 5
+  special = false
 }
-`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
+
+data "huaweicloud_identity_projects" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_tms_resource_tags" "test" {
+  project_id = try([for v in data.huaweicloud_identity_projects.test.projects: v.id if v.name == "%[1]s"][0], null)
+
+  resources {
+    resource_type = "apig" # Dedicated instance
+    resource_id   = "%[2]s"
+  }
+
+  tags = {
+    key   = "key${random_string.access_key.result}"
+    value = "value${random_string.access_key.result}"
+  }
+}
+
+data "huaweicloud_apig_instance_tags" "test" {
+  depends_on = [
+    huaweicloud_tms_resource_tags.test
+  ]
+
+  instance_id = "%[2]s"
+}
+
+data "huaweicloud_apig_instance_tags" "all" {
+  depends_on = [
+    huaweicloud_tms_resource_tags.test
+  ]
+}
+
+output "is_all_tags_include_test_tags" {
+  value = alltrue([for v in data.huaweicloud_apig_instance_tags.test.tags:
+    length([for vv in data.huaweicloud_apig_instance_tags.all.tags:
+      vv.key == v.key && vv.value == v.value
+    ]) > 0
+  ])
+}
+`, acceptance.HW_REGION_NAME, acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
instance tags data source supports new API method:
```
GET /v2/{project_id}/apigw/instance-tags
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
instance tags data source supports new API method
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccDataInstanceTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataInstanceTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataInstanceTags_basic
=== PAUSE TestAccDataInstanceTags_basic
=== CONT  TestAccDataInstanceTags_basic
--- PASS: TestAccDataInstanceTags_basic (19.93s)
PASS
coverage: 2.2% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      20.055s coverage: 2.2% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
