### PR TITLE
feat(dew): new resource to rotate csms secret

### DIFF
--- a/docs/resources/csms_secret_rotate.md
+++ b/docs/resources/csms_secret_rotate.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_csms_secret_rotate"
+description: |-
+  Manages a resource to rotate secret within HuaweiCloud.
+---
+
+# huaweicloud_csms_secret_rotate
+
+Manages a resource to rotate secret within HuaweiCloud.
+
+-> This resource is a one-time action resource. Deleting this resource will not recover the rotated secret,
+  but will only remove the resource information from the tfstate file.
+
+-> This resource does not support rotation of common secrets. Running this resource will immediately perform credential
+  rotation. Within the specified credentials, a new credential version will be created for encrypted storage of randomly
+  generated credential values ​​in the background. Simultaneously, the newly created credential version will be marked as
+  **SYSCURRENT**.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_csms_secret_rotate" "test" {
+  secret_name = "my_secret"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `secret_name` - (Required, String, NonUpdatable) Specifies the name of the secret to be rotated.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (same as the task ID).
+
+* `task_id` - The ID of the rotation task.
+
+* `rotation_func_urn` - The URN of the rotation function.
+
+* `operate_type` - The operation type of the rotation task.
+
+* `task_time` - The time when the rotation task was created.
+
+* `attempt_nums` - The number of attempts to rotate the secret.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2565,6 +2565,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_csms_secret":                       dew.ResourceSecret(),
 			"huaweicloud_csms_secret_version_state":         dew.ResourceSecretVersionState(),
 			"huaweicloud_csms_scheduled_delete_secret_task": dew.ResourceCsmsScheduledDeleteSecretTask(),
+			"huaweicloud_csms_secret_rotate":                dew.ResourceSecretRotate(),
 
 			"huaweicloud_css_cluster":                     css.ResourceCssCluster(),
 			"huaweicloud_css_cluster_restart":             css.ResourceCssClusterRestart(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -148,6 +148,7 @@ var (
 	HW_KPS_FAILED_TASK_ID        = os.Getenv("HW_KPS_FAILED_TASK_ID")
 	HW_CSMS_TASK_ID              = os.Getenv("HW_CSMS_TASK_ID")
 	HW_CSMS_SECRET_ID            = os.Getenv("HW_CSMS_SECRET_ID")
+	HW_CSMS_SECRET_NAME          = os.Getenv("HW_CSMS_SECRET_NAME")
 
 	HW_CPCS_CLUSTER_ID    = os.Getenv("HW_CPCS_CLUSTER_ID")
 	HW_CPCS_APP_ID        = os.Getenv("HW_CPCS_APP_ID")
@@ -4241,6 +4242,13 @@ func TestAccPrecheckCpcsAppClusterAssociation(t *testing.T) {
 func TestAccPreCheckCsmsSecretID(t *testing.T) {
 	if HW_CSMS_SECRET_ID == "" {
 		t.Skip("HW_CSMS_SECRET_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCsmsSecretName(t *testing.T) {
+	if HW_CSMS_SECRET_NAME == "" {
+		t.Skip("HW_CSMS_SECRET_NAME must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_csms_secret_rotate_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_csms_secret_rotate_test.go
@@ -1,0 +1,38 @@
+package dew
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Due to a lack of testing conditions, only failure scenarios are being tested for the time being.
+// Therefore, this test case cannot be guaranteed to be 100% reliable.
+func TestAccCsmsSecretRotate_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCsmsSecretName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCsmsSecretRotate_basic(),
+				ExpectError: regexp.MustCompile(`error waiting for DEW CSMS secret rotation task to be completed`),
+			},
+		},
+	})
+}
+
+func testAccCsmsSecretRotate_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_csms_secret_rotate" "test" {
+  secret_name = "%s"
+}
+`, acceptance.HW_CSMS_SECRET_NAME)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_csms_secret_rotate.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_csms_secret_rotate.go
@@ -1,0 +1,224 @@
+package dew
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW POST /v1/{project_id}/secrets/{secret_name}/rotate
+// @API DEW GET /v1/{project_id}/csms/tasks
+func ResourceSecretRotate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSecretRotateCreate,
+		ReadContext:   resourceSecretRotateRead,
+		UpdateContext: resourceSecretRotateUpdate,
+		DeleteContext: resourceSecretRotateDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"secret_name",
+		}),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"secret_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the name of the secret to rotate.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"task_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the rotation task.`,
+			},
+			"rotation_func_urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The URN of the rotation function.`,
+			},
+			"operate_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the operation.`,
+			},
+			"task_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The time when the rotation task was created, UNIX timestamp in milliseconds.`,
+			},
+			"attempt_nums": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of attempts to rotate the secret.`,
+			},
+		},
+	}
+}
+
+func queryCsmsTargetTask(client *golangsdk.ServiceClient, taskId string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/csms/tasks"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?task_id=%s", taskId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	taskDetail := utils.PathSearch("tasks|[0]", respBody, nil)
+	if taskDetail == nil {
+		return nil, errors.New("unable to find the DEW CSMS secret rotation task detail from the API response")
+	}
+
+	return taskDetail, nil
+}
+
+func waitingForSecretRotateTaskSuccess(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration) (interface{}, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			taskDetail, err := queryCsmsTargetTask(client, d.Id())
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			taskStatus := utils.PathSearch("task_status", taskDetail, "").(string)
+			if taskStatus == "" {
+				return nil, "ERROR", errors.New("unable to find the DEW CSMS secret rotation task status from the API response")
+			}
+
+			if taskStatus == "SUCCESS" {
+				return taskDetail, "COMPLETED", nil
+			}
+
+			if taskStatus == "FAILED" {
+				errCode := utils.PathSearch("task_error_code", taskDetail, "").(string)
+				errMsg := utils.PathSearch("task_error_msg", taskDetail, "").(string)
+				return taskDetail, "ERROR", fmt.Errorf("rotation task failed, error code: %s, error message: %s", errCode, errMsg)
+			}
+
+			return taskDetail, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	return stateConf.WaitForStateContext(ctx)
+}
+
+func resourceSecretRotateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/secrets/{secret_name}/rotate"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW KMS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{secret_name}", d.Get("secret_name").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error rotating DEW CSMS secret: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	taskId := utils.PathSearch("rotation_task_id", respBody, "").(string)
+	if taskId == "" {
+		return diag.Errorf("unable to find the DEW CSMS secret rotation task ID from the API response")
+	}
+
+	d.SetId(taskId)
+
+	taskDetail, err := waitingForSecretRotateTaskSuccess(ctx, client, d, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for DEW CSMS secret rotation task to be completed: %s", err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("task_id", taskId),
+		d.Set("rotation_func_urn", utils.PathSearch("rotation_func_urn", taskDetail, nil)),
+		d.Set("operate_type", utils.PathSearch("operate_type", taskDetail, nil)),
+		d.Set("task_time", utils.PathSearch("task_time", taskDetail, nil)),
+		d.Set("attempt_nums", utils.PathSearch("attempt_nums", taskDetail, nil)),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting DEW CSMS secret rotation task attributes: %s", err)
+	}
+
+	return resourceSecretRotateRead(ctx, d, meta)
+}
+
+func resourceSecretRotateRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceSecretRotateUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceSecretRotateDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to rotate secret.
+	Deleting this resource will not recover the rotated secret, but will only remove the resource information from
+	the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to rotate csms secret

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccCsmsSecretRotate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccCsmsSecretRotate_basic -timeout 360m -parallel 10
=== RUN   TestAccCsmsSecretRotate_basic
=== PAUSE TestAccCsmsSecretRotate_basic
=== CONT  TestAccCsmsSecretRotate_basic
--- PASS: TestAccCsmsSecretRotate_basic (11.12s)
PASS
coverage: 4.1% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       11.215s coverage: 4.1% of statements in ./huaweicloud/services/dew
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
