### PR TITLE
feat(fgs): add data source to query trusted agencies of the FGS service

### DIFF
--- a/docs/data-sources/fgs_service_trusted_agencies.md
+++ b/docs/data-sources/fgs_service_trusted_agencies.md
@@ -1,0 +1,41 @@
+---
+subcategory: "FunctionGraph"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_fgs_service_trusted_agencies"
+description: |-
+  Use this data source to query the list of service trusted agencies within HuaweiCloud.
+---
+
+# huaweicloud_fgs_service_trusted_agencies
+
+Use this data source to query the list of service trusted agencies within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_fgs_service_trusted_agencies" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the service trusted agencies are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - The data source ID.
+
+* `agencies` - The list of service trusted agencies.  
+  The [agencies](#fgs_service_trusted_agencies_attr) structure is documented below.
+
+<a name="fgs_service_trusted_agencies_attr"></a>
+The `agencies` block supports:
+
+* `name` - The name of the trusted agency.
+
+* `expire_time` - The expiration time of the trusted agency.  
+  When the agency never expires, the value is empty string.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1219,6 +1219,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_resource_tags":               fgs.DataSourceResourceTags(),
 			"huaweicloud_fgs_resources_filter":            fgs.DataSourceResourcesFilter(),
 			"huaweicloud_fgs_runtime_types":               fgs.DataSourceRuntimeTypes(),
+			"huaweicloud_fgs_service_trusted_agencies":    fgs.DataSourceServiceTrustedAgencies(),
 			"huaweicloud_fgs_trigger_types":               fgs.DataSourceTriggerTypes(),
 
 			"huaweicloud_ga_accelerators":       ga.DataSourceAccelerators(),

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_service_trusted_agencies_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_service_trusted_agencies_test.go
@@ -1,0 +1,40 @@
+package fgs
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this test, please ensure that you have created trusted agencies for FGS service.
+func TestAccDataServiceTrustedAgencies_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_fgs_service_trusted_agencies.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataServiceTrustedAgencies_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "agencies.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "agencies.0.name"),
+					// When the agency never expires, the "expire_time" is empty string.
+				),
+			},
+		},
+	})
+}
+
+const testAccDataServiceTrustedAgencies_basic = `
+data "huaweicloud_fgs_service_trusted_agencies" "test" {}
+`

--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_service_trusted_agencies.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_service_trusted_agencies.go
@@ -1,0 +1,119 @@
+package fgs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API FunctionGraph GET /v2/{project_id}/fgs/service-trusted-agencies
+func DataSourceServiceTrustedAgencies() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceServiceTrustedAgenciesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the service trusted agencies are located.`,
+			},
+			"agencies": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the trusted agency.`,
+						},
+						// "null" means it never expires
+						"expire_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The expiration time of the trusted agency.`,
+						},
+					},
+				},
+				Description: `The list of service trusted agencies.`,
+			},
+		},
+	}
+}
+
+func getServiceTrustedAgencies(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	httpUrl := "v2/{project_id}/fgs/service-trusted-agencies"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("[]", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func dataSourceServiceTrustedAgenciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	agencies, err := getServiceTrustedAgencies(client)
+	if err != nil {
+		return diag.Errorf("error querying service trusted agencies: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("agencies", flattenServiceTrustedAgencies(agencies)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenServiceTrustedAgencies(agencies []interface{}) []map[string]interface{} {
+	if len(agencies) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(agencies))
+	for _, agency := range agencies {
+		result = append(result, map[string]interface{}{
+			"name":        utils.PathSearch("name", agency, nil),
+			"expire_time": utils.PathSearch("expire_time", agency, nil),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source (`huaweicloud_fgs_service_trusted_agencies`) to query trusted agencies of the FGS service.

**The marker and limit pagination parameters are invalid.**

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccDataServiceTrustedAgencies_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataServiceTrustedAgencies_basic -timeout 360m -parallel 10
=== RUN   TestAccDataServiceTrustedAgencies_basic
=== PAUSE TestAccDataServiceTrustedAgencies_basic
=== CONT  TestAccDataServiceTrustedAgencies_basic
--- PASS: TestAccDataServiceTrustedAgencies_basic (14.59s)
PASS
coverage: 3.0% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       14.670s coverage: 3.0% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
