### PR TITLE
feat(dew): new resource to download csms secret backup

### DIFF
--- a/docs/resources/csms_download_secret_backup.md
+++ b/docs/resources/csms_download_secret_backup.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_csms_download_secret_backup"
+description: |-
+  Downloads a secret backup from HuaweiCloud DEW CSMS service.
+---
+
+# huaweicloud_csms_download_secret_backup
+
+Downloads a secret backup from HuaweiCloud DEW CSMS service.
+
+-> This resource is a one-time action resource. Deleting this resource will not affect the actual secret backup,
+  but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_csms_download_secret_backup" "test" {
+  secret_name = "my-secret"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `secret_name` - (Required, String, NonUpdatable) Specifies the name of the secret to download backup for.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, which is the same as the `secret_name`.
+
+* `secret_blob` - The secret backup file contains all secret version information. The backup file is encrypted and
+  encoded and cannot be directly read.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2563,6 +2563,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cpcs_instance_status_action":       dew.ResourceCpcsInstanceStatusAction(),
 
 			"huaweicloud_csms_agency":                       dew.ResourceAgency(),
+			"huaweicloud_csms_download_secret_backup":       dew.ResourceDownloadSecretBackup(),
 			"huaweicloud_csms_event":                        dew.ResourceCsmsEvent(),
 			"huaweicloud_csms_secret":                       dew.ResourceSecret(),
 			"huaweicloud_csms_secret_version_state":         dew.ResourceSecretVersionState(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -148,6 +148,7 @@ var (
 	HW_KPS_PRIVATE_KEY_FILE_PATH = os.Getenv("HW_KPS_PRIVATE_KEY_FILE_PATH")
 	HW_KPS_FAILED_TASK_ID        = os.Getenv("HW_KPS_FAILED_TASK_ID")
 	HW_CSMS_TASK_ID              = os.Getenv("HW_CSMS_TASK_ID")
+	HW_CSMS_SECRET_NAME          = os.Getenv("HW_CSMS_SECRET_NAME")
 	HW_CSMS_SECRET_ID            = os.Getenv("HW_CSMS_SECRET_ID")
 
 	HW_CPCS_CLUSTER_ID    = os.Getenv("HW_CPCS_CLUSTER_ID")
@@ -4250,6 +4251,13 @@ func TestAccPrecheckCpcsAppClusterAssociation(t *testing.T) {
 func TestAccPreCheckCsmsSecretID(t *testing.T) {
 	if HW_CSMS_SECRET_ID == "" {
 		t.Skip("HW_CSMS_SECRET_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCsmsSecretName(t *testing.T) {
+	if HW_CSMS_SECRET_NAME == "" {
+		t.Skip("HW_CSMS_SECRET_NAME must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_csms_download_secret_backup_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_csms_download_secret_backup_test.go
@@ -1,0 +1,39 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccCsmsDownloadSecretBackup_basic(t *testing.T) {
+	resourceName := "huaweicloud_csms_download_secret_backup.test"
+
+	// lintignore:AT001
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCsmsSecretName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCsmsDownloadSecretBackup_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "secret_blob"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCsmsDownloadSecretBackup_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_csms_download_secret_backup" "test" {
+  secret_name = "%s"
+}
+`, acceptance.HW_CSMS_SECRET_NAME)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_csms_download_secret_backup.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_csms_download_secret_backup.go
@@ -1,0 +1,114 @@
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW POST /v1/{project_id}/secrets/{secret_name}/backup
+func ResourceDownloadSecretBackup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDownloadSecretBackupCreate,
+		ReadContext:   resourceDownloadSecretBackupRead,
+		UpdateContext: resourceDownloadSecretBackupUpdate,
+		DeleteContext: resourceDownloadSecretBackupDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"secret_name",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"secret_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"secret_blob": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDownloadSecretBackupCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v1/{project_id}/secrets/{secret_name}/backup"
+		product    = "kms"
+		secretName = d.Get("secret_name").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{secret_name}", secretName)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error downloading DEW CSMS secret backup: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(secretName)
+
+	mErr := multierror.Append(
+		d.Set("secret_blob", utils.PathSearch("secret_blob", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDownloadSecretBackupRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDownloadSecretBackupUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDownloadSecretBackupDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to download secret backup.
+Deleting this resource will not recover the downloaded secret backup, but will only remove the resource information from
+the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to download csms secret backup

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccCsmsDownloadSecretBackup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccCsmsDownloadSecretBackup_basic -timeout 360m -parallel 10
=== RUN   TestAccCsmsDownloadSecretBackup_basic
--- PASS: TestAccCsmsDownloadSecretBackup_basic (11.02s)
PASS
coverage: 3.4% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       11.177s coverage: 3.4% of statements in ./huaweicloud/services/dew
```
<img width="1275" height="86" alt="image" src="https://github.com/user-attachments/assets/cde85a35-09ef-47e1-8c91-476c1bd18470" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
