### PR TITLE
feat(hss): support `hss_cluster_protect_switch_mode` resource

### DIFF
--- a/docs/resources/hss_cluster_protect_switch_mode.md
+++ b/docs/resources/hss_cluster_protect_switch_mode.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_cluster_protect_switch_mode"
+description: |-
+  Manages an HSS switch cluster protection mode resource within HuaweiCloud.
+---
+
+# huaweicloud_hss_cluster_protect_switch_mode
+
+Manages an HSS switch cluster protection mode resource within HuaweiCloud.
+
+-> This resource is only a one-time action resource used to switch HSS cluster protect mode. Deleting this resource will
+  not clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "cluster_ids" {
+  type = list(string)
+}
+variable "opr" {}
+
+resource "huaweicloud_hss_cluster_protect_switch_mode" "test" {
+  cluster_ids = var.cluster_ids
+  opr         = var.opr
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `cluster_ids` - (Required, List, NonUpdatable) Specifies the cluster ID list.  
+
+* `opr` - (Required, Int, NonUpdatable) Specifies the switch mode.  
+  The valid values are as follows:
+  + **1**: Open.
+  + **0**: Close.
+  + **2**: Close and uninstall plugins.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2920,6 +2920,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_container_kubernetes_cluster_daemonset":         hss.ResourceContainerKubernetesClusterDaemonset(),
 			"huaweicloud_hss_container_kubernetes_cluster_protection_enable": hss.ResourceContainerKubernetesClusterProtectionEnable(),
 			"huaweicloud_hss_container_network_policy_sync":                  hss.ResourceContainerNetworkPolicySync(),
+			"huaweicloud_hss_cluster_protect_switch_mode":                    hss.ResourceClusterProtectSwitchMode(),
 			"huaweicloud_hss_cicd_configuration":                             hss.ResourceCiCdConfiguration(),
 			"huaweicloud_hss_honeypot_port_policy":                           hss.ResourceHoneypotPortPolicy(),
 			"huaweicloud_hss_host_protection":                                hss.ResourceHostProtection(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_cluster_protect_switch_mode_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_cluster_protect_switch_mode_test.go
@@ -1,0 +1,39 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccClusterProtectSwitchMode_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test requires setting a cluster ID under the default enterprise project that has been connected to
+			// the HSS service.
+			acceptance.TestAccPreCheckHSSClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testClusterProtectSwitchMode_basic(),
+			},
+		},
+	})
+}
+
+func testClusterProtectSwitchMode_basic() string {
+	return fmt.Sprintf(`
+
+resource "huaweicloud_hss_cluster_protect_switch_mode" "test" {
+  cluster_ids           = ["%[1]s"]
+  opr                   = 1
+  enterprise_project_id = "0"
+}
+`, acceptance.HW_HSS_CLUSTER_ID)
+}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_cluster_protect_switch_mode.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_cluster_protect_switch_mode.go
@@ -1,0 +1,137 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var clusterProtectSwitchModeNonUpdatableParams = []string{
+	"cluster_ids",
+	"opr",
+	"enterprise_project_id",
+}
+
+// @API HSS POST /v5/{project_id}/cluster-protect/switch-mod
+func ResourceClusterProtectSwitchMode() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceClusterProtectSwitchModeCreate,
+		ReadContext:   resourceClusterProtectSwitchModeRead,
+		UpdateContext: resourceClusterProtectSwitchModeUpdate,
+		DeleteContext: resourceClusterProtectSwitchModeDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(clusterProtectSwitchModeNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"cluster_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"opr": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildClusterProtectSwitchModeQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%v", epsId)
+	}
+
+	return ""
+}
+
+func buildClusterProtectSwitchModeBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"cluster_ids": utils.ExpandToStringList(d.Get("cluster_ids").([]interface{})),
+		"opr":         d.Get("opr"),
+	}
+}
+
+func resourceClusterProtectSwitchModeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v5/{project_id}/cluster-protect/switch-mod"
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildClusterProtectSwitchModeQueryParams(epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildClusterProtectSwitchModeBodyParams(d),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error switch HSS cluster protect mode: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return resourceClusterProtectSwitchModeRead(ctx, d, meta)
+}
+
+func resourceClusterProtectSwitchModeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceClusterProtectSwitchModeUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceClusterProtectSwitchModeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to switch HSS cluster protect mode. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information from the
+    tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_cluster_protect_switch_mode` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_cluster_protect_switch_mode` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccClusterProtectSwitchMode_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccClusterProtectSwitchMode_basic -timeout 360m -parallel 4
=== RUN   TestAccClusterProtectSwitchMode_basic
=== PAUSE TestAccClusterProtectSwitchMode_basic
=== CONT  TestAccClusterProtectSwitchMode_basic
--- PASS: TestAccClusterProtectSwitchMode_basic (17.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       17.351s
```
<img width="932" height="33" alt="image" src="https://github.com/user-attachments/assets/ec47ab72-e449-49c0-9f87-98ba2f28c171" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
