### PR TITLE
feat(dew): new resource to enable or disable kms dedicated keystore

### DIFF
--- a/docs/incubating/kms_dedicated_keystore_action.md
+++ b/docs/incubating/kms_dedicated_keystore_action.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_kms_dedicated_keystore_action"
+description: |-
+  Manages actions (enable/disable) on a dedicated keystore within HuaweiCloud KMS.
+---
+
+# huaweicloud_kms_dedicated_keystore_action
+
+Manages actions (enable/disable) on a dedicated keystore within HuaweiCloud KMS.
+
+-> Destroying this resource will not affect the actual status of the dedicated keystore, but will only remove the
+  resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "keystore_id" {}
+variable "action" {}
+
+resource "huaweicloud_kms_dedicated_keystore_action" "test" {
+  keystore_id = var.keystore_id
+  action      = var.action
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to manage the dedicated keystore.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `keystore_id` - (Required, String, NonUpdatable) Specifies the ID of the dedicated keystore to manage.
+
+* `action` - (Required, String) Specifies the action to perform on the dedicated keystore.
+  Valid values are **enable** to enable the keystore or **disable** to disable it.
+
+  -> The dedicated keystore can only be disabled when it is in the enabled state. Similarly, it can only be enabled when
+    it is in the disabled state.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which is the same as the `keystore_id`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3056,6 +3056,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_data_encrypt_decrypt":      dew.ResourceKmsDataEncryptDecrypt(),
 			"huaweicloud_kms_datakey_without_plaintext": dew.ResourceKmsDatakeyWithoutPlaintext(),
 			"huaweicloud_kms_decrypt_datakey":           dew.ResourceKmsDecryptDatakey(),
+			"huaweicloud_kms_dedicated_keystore_action": dew.ResourceKmsDedicatedKeystoreAction(),
 			"huaweicloud_kms_dedicated_keystore":        dew.ResourceKmsDedicatedKeystore(),
 			"huaweicloud_kms_ec_datakey_pair":           dew.ResourceEcDatakeyPair(),
 			"huaweicloud_kms_encrypt_datakey":           dew.ResourceKmsEncryptDatakey(),

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_dedicated_keystore_action_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_dedicated_keystore_action_test.go
@@ -1,0 +1,33 @@
+package dew
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccKmsDedicatedKeystoreAction_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testKmsDedicatedKeystoreAction_basic,
+				ExpectError: regexp.MustCompile(`error disable DEW dedicated keystore in creation operation`),
+			},
+		},
+	})
+}
+
+// The keystore_id used is dummy data for testing.
+const testKmsDedicatedKeystoreAction_basic = `
+resource "huaweicloud_kms_dedicated_keystore_action" "test" {
+  keystore_id = "b8d0593a-69bc-40f3-b14d-a8b5839fc426"
+  action      = "disable"
+}`

--- a/huaweicloud/services/dew/resource_huaweicloud_kms_dedicated_keystore_action.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kms_dedicated_keystore_action.go
@@ -1,0 +1,141 @@
+package dew
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// Due to a lack of testing conditions, this resource's documentation is not publicly available.
+
+// @API DEW POST /v1.0/{project_id}/keystores/{keystore_id}/disable
+// @API DEW POST /v1.0/{project_id}/keystores/{keystore_id}/enable
+func ResourceKmsDedicatedKeystoreAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKmsDedicatedKeystoreActionCreate,
+		ReadContext:   resourceKmsDedicatedKeystoreActionRead,
+		UpdateContext: resourceKmsDedicatedKeystoreActionUpdate,
+		DeleteContext: resourceKmsDedicatedKeystoreActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"keystore_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"keystore_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of a dedicated keystore.`,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the action to be performed on the dedicated keystore.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func updateDedicatedKeystoreStatus(client *golangsdk.ServiceClient, action string, keystoreId string) error {
+	httpUrl := ""
+	switch action {
+	case "enable":
+		httpUrl = "v1.0/{project_id}/keystores/{keystore_id}/enable"
+	case "disable":
+		httpUrl = "v1.0/{project_id}/keystores/{keystore_id}/disable"
+	default:
+		return fmt.Errorf("invalid action: %s", action)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{keystore_id}", keystoreId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	return err
+}
+
+func resourceKmsDedicatedKeystoreActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		product    = "kms"
+		action     = d.Get("action").(string)
+		keystoreId = d.Get("keystore_id").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	err = updateDedicatedKeystoreStatus(client, action, keystoreId)
+	if err != nil {
+		return diag.Errorf("error %s DEW dedicated keystore in creation operation: %s", action, err)
+	}
+
+	d.SetId(keystoreId)
+
+	return resourceKmsDedicatedKeystoreActionRead(ctx, d, meta)
+}
+
+func resourceKmsDedicatedKeystoreActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceKmsDedicatedKeystoreActionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		product    = "kms"
+		action     = d.Get("action").(string)
+		keystoreId = d.Get("keystore_id").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	err = updateDedicatedKeystoreStatus(client, action, keystoreId)
+	if err != nil {
+		return diag.Errorf("error %s DEW dedicated keystore in update operation: %s", action, err)
+	}
+
+	return resourceKmsDedicatedKeystoreActionRead(ctx, d, meta)
+}
+
+func resourceKmsDedicatedKeystoreActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to perform actions on a dedicated keystore.
+Deleting this resource will not recover the dedicated keystore, but will only remove the resource information from
+the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to enable or disable kms dedicated keystore.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccKmsDedicatedKeystoreAction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccKmsDedicatedKeystoreAction_basic -timeout 360m -parallel 10
=== RUN   TestAccKmsDedicatedKeystoreAction_basic
=== PAUSE TestAccKmsDedicatedKeystoreAction_basic
=== CONT  TestAccKmsDedicatedKeystoreAction_basic
--- PASS: TestAccKmsDedicatedKeystoreAction_basic (4.64s)
PASS
coverage: 3.3% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       4.748s  coverage: 3.3% of statements in ./huaweicloud/services/dew
```
<img width="1306" height="49" alt="image" src="https://github.com/user-attachments/assets/f5233cdc-974a-4e89-bb20-0e7972ed1907" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
