### PR TITLE
feat(apig): add new resource for instance ingress port

### DIFF
--- a/docs/resources/apig_instance_ingress_port.md
+++ b/docs/resources/apig_instance_ingress_port.md
@@ -1,0 +1,80 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_instance_ingress_port"
+description: |-
+  Manages an APIG instance custom ingress port resource within HuaweiCloud.
+---
+
+# huaweicloud_apig_instance_ingress_port
+
+Manages an APIG instance custom ingress port resource within HuaweiCloud.
+
+## Example Usage
+
+### Create a custom ingress port with HTTP protocol
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_apig_instance_ingress_port" "test" {
+  instance_id = var.instance_id
+  protocol    = "HTTP"
+  port        = 8080
+}
+```
+
+### Create a custom ingress port with HTTPS protocol
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_apig_instance_ingress_port" "test" {
+  instance_id = var.instance_id
+  protocol    = "HTTPS"
+  port        = 8443
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the ingress port is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the dedicated instance to which the custom
+  ingress port belongs.
+
+* `protocol` - (Required, String, NonUpdatable) Specifies the protocol of the custom ingress port.  
+  The valid values are as follows:
+  + **HTTP**: The custom ingress port uses HTTP protocol.
+  + **HTTPS**: The custom ingress port uses HTTPS protocol.
+
+* `port` - (Required, Int, NonUpdatable) Specifies the port number of the custom ingress port.  
+  The valid value is range from `1,024` to `49,151`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. The value is the ingress port ID.
+
+* `status` - The status of the custom ingress port.
+  + **normal**: The custom ingress port status is normal.
+  + **abnormal**: The custom ingress port status is abnormal and cannot be used.
+
+## Import
+
+The resource can be imported using the `instance_id` and `id` (also `ingress_port_id`), separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_apig_instance_ingress_port.test <instance_id>/<id>
+```
+
+If the value of `ingress_port_id` is unknown, it can be imported using `instance_id`, `protocol`, and `port`, separated
+by slashes (/), e.g.
+
+```bash
+$ terraform import huaweicloud_apig_instance_ingress_port.test <instance_id>/<protocol>/<port>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2301,6 +2301,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_group":                                      apig.ResourceApigGroupV2(),
 			"huaweicloud_apig_group_domain_associate":                     apig.ResourceGroupDomainAssociate(),
 			"huaweicloud_apig_instance_feature":                           apig.ResourceInstanceFeature(),
+			"huaweicloud_apig_instance_ingress_port":                      apig.ResourceInstanceIngressPort(),
 			"huaweicloud_apig_instance_routes":                            apig.ResourceInstanceRoutes(),
 			"huaweicloud_apig_instance":                                   apig.ResourceApigInstanceV2(),
 			"huaweicloud_apig_orchestration_rule":                         apig.ResourceOrchestrationRule(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_ingress_port_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_ingress_port_test.go
@@ -1,0 +1,161 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
+)
+
+func getInstanceIngressPortFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("apig", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating APIG client: %s", err)
+	}
+
+	instanceId := state.Primary.Attributes["instance_id"]
+	ingressPortId := state.Primary.ID
+
+	return apig.GetInstanceIngressPortById(client, instanceId, ingressPortId)
+}
+
+func TestAccInstanceIngressPort_basic(t *testing.T) {
+	var (
+		ingressPort interface{}
+
+		protocolHTTP    = "huaweicloud_apig_instance_ingress_port.http"
+		rcProtocolHTTP  = acceptance.InitResourceCheck(protocolHTTP, &ingressPort, getInstanceIngressPortFunc)
+		protocolHTTPS   = "huaweicloud_apig_instance_ingress_port.https"
+		rcProtocolHTTPS = acceptance.InitResourceCheck(protocolHTTPS, &ingressPort, getInstanceIngressPortFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcProtocolHTTP.CheckResourceDestroy(),
+			rcProtocolHTTPS.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceIngressPort_basic_step1(),
+				Check: resource.ComposeTestCheckFunc(
+					rcProtocolHTTP.CheckResourceExists(),
+					resource.TestCheckResourceAttr(protocolHTTP, "protocol", "HTTP"),
+					resource.TestCheckResourceAttr(protocolHTTP, "port", "8080"),
+					resource.TestCheckResourceAttrSet(protocolHTTP, "status"),
+				),
+			},
+			{
+				ResourceName:      protocolHTTP,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccInstanceIngressPortIDImportStateFunc(protocolHTTP),
+			},
+			{
+				ResourceName:      protocolHTTP,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccInstanceIngressPortProtocolPortImportStateFunc(protocolHTTP),
+			},
+			{
+				Config: testAccInstanceIngressPort_basic_step2(),
+				Check: resource.ComposeTestCheckFunc(
+					rcProtocolHTTPS.CheckResourceExists(),
+					resource.TestCheckResourceAttr(protocolHTTPS, "protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(protocolHTTPS, "port", "8443"),
+					resource.TestCheckResourceAttrSet(protocolHTTPS, "status"),
+				),
+			},
+			{
+				ResourceName:      protocolHTTPS,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccInstanceIngressPortIDImportStateFunc(protocolHTTPS),
+			},
+			{
+				ResourceName:      protocolHTTPS,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccInstanceIngressPortProtocolPortImportStateFunc(protocolHTTPS),
+			},
+		},
+	})
+}
+
+func testAccInstanceIngressPortIDImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+		instanceId := rs.Primary.Attributes["instance_id"]
+		ingressPortId := rs.Primary.ID
+		if instanceId == "" || ingressPortId == "" {
+			return "", fmt.Errorf("missing some attributes, want '<instance_id>/<id>', but '%s/%s'",
+				instanceId, ingressPortId)
+		}
+		return fmt.Sprintf("%s/%s", instanceId, ingressPortId), nil
+	}
+}
+
+func testAccInstanceIngressPortProtocolPortImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+		instanceId := rs.Primary.Attributes["instance_id"]
+		protocol := rs.Primary.Attributes["protocol"]
+		port := rs.Primary.Attributes["port"]
+		if instanceId == "" || protocol == "" || port == "" {
+			return "", fmt.Errorf("missing some attributes, want '<instance_id>/<protocol>/<port>', but '%s/%s/%s'",
+				instanceId, protocol, port)
+		}
+		return fmt.Sprintf("%s/%s/%s", instanceId, protocol, port), nil
+	}
+}
+
+func testAccInstanceIngressPort_basic_step1() string {
+	return fmt.Sprintf(`
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[1]s"
+}
+
+locals {
+  instance_id = data.huaweicloud_apig_instances.test.instances[0].id
+}
+
+resource "huaweicloud_apig_instance_ingress_port" "http" {
+  instance_id = local.instance_id
+  protocol    = "HTTP"
+  port        = 8080
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
+}
+
+func testAccInstanceIngressPort_basic_step2() string {
+	return fmt.Sprintf(`
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[1]s"
+}
+
+locals {
+  instance_id = data.huaweicloud_apig_instances.test.instances[0].id
+}
+
+resource "huaweicloud_apig_instance_ingress_port" "https" {
+  instance_id = local.instance_id
+  protocol    = "HTTPS"
+  port        = 8443
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance_ingress_port.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance_ingress_port.go
@@ -1,0 +1,327 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var instanceIngressPortNonUpdatableParams = []string{"instance_id", "protocol", "port"}
+
+// @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/custom-ingress-ports
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/custom-ingress-ports
+// @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/custom-ingress-ports/{ingress_port_id}
+func ResourceInstanceIngressPort() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInstanceIngressPortCreate,
+		ReadContext:   resourceInstanceIngressPortRead,
+		UpdateContext: resourceInstanceIngressPortUpdate,
+		DeleteContext: resourceInstanceIngressPortDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceInstanceIngressPortImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(instanceIngressPortNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the ingress port is located.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the custom ingress port belongs.`,
+			},
+			"protocol": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The protocol of the custom ingress port.`,
+			},
+			"port": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The port number of the custom ingress port.`,
+			},
+
+			// Attributes.
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the custom ingress port.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildInstanceIngressPortBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"protocol":     d.Get("protocol"),
+		"ingress_port": d.Get("port"),
+	}
+}
+
+func resourceInstanceIngressPortCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	// Lock the resource to prevent concurrent creations (error APIC.9224 will be returned if multiple requests are sent
+	// concurrently)
+	config.MutexKV.Lock(instanceId)
+	defer config.MutexKV.Unlock(instanceId)
+
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/custom-ingress-ports"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildInstanceIngressPortBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating APIG instance ingress port: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	ingressPortId := utils.PathSearch("ingress_port_id", respBody, "").(string)
+	if ingressPortId == "" {
+		return diag.Errorf("unable to find the ingress port ID from the API response")
+	}
+	d.SetId(ingressPortId)
+
+	return resourceInstanceIngressPortRead(ctx, d, meta)
+}
+
+func buildInstanceIngressPortsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("protocol"); ok {
+		res = fmt.Sprintf("%s&protocol=%v", res, v)
+	}
+	if v, ok := d.GetOk("port"); ok {
+		res = fmt.Sprintf("%s&ingress_port=%v", res, v)
+	}
+
+	return res
+}
+
+func listInstanceIngressPorts(client *golangsdk.ServiceClient, instanceId string, d ...*schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/apigw/instances/{instance_id}/custom-ingress-ports?limit={limit}"
+		result  = make([]interface{}, 0)
+		limit   = 500
+		offset  = 0
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	if len(d) > 0 {
+		listPath += buildInstanceIngressPortsQueryParams(d[0])
+	}
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		ingressPortInfos := utils.PathSearch("ingress_port_infos", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, ingressPortInfos...)
+		if len(ingressPortInfos) < limit {
+			break
+		}
+		offset += len(ingressPortInfos)
+	}
+
+	return result, nil
+}
+
+func GetInstanceIngressPortById(client *golangsdk.ServiceClient, instanceId, ingressPortId string, d ...*schema.ResourceData) (interface{}, error) {
+	ingressPorts, err := listInstanceIngressPorts(client, instanceId, d...)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ingressPort := range ingressPorts {
+		portId := utils.PathSearch("ingress_port_id", ingressPort, "").(string)
+		if portId == ingressPortId {
+			return ingressPort, nil
+		}
+	}
+
+	return nil, golangsdk.ErrDefault404{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Method:    "GET",
+			URL:       "/v2/{project_id}/apigw/instances/{instance_id}/custom-ingress-ports",
+			RequestId: "NONE",
+			Body:      []byte(fmt.Sprintf("ingress port (%s) is not found", ingressPortId)),
+		},
+	}
+}
+
+func resourceInstanceIngressPortRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	ingressPort, err := GetInstanceIngressPortById(client, instanceId, d.Id(), d)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error retrieving APIG instance ingress port (%s)", d.Id()))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("instance_id", instanceId),
+		d.Set("protocol", utils.PathSearch("protocol", ingressPort, nil)),
+		d.Set("port", utils.PathSearch("ingress_port", ingressPort, nil)),
+		d.Set("status", utils.PathSearch("status", ingressPort, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceInstanceIngressPortUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceInstanceIngressPortDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	var (
+		httpUrl       = "v2/{project_id}/apigw/instances/{instance_id}/custom-ingress-ports/{ingress_port_id}"
+		instanceId    = d.Get("instance_id").(string)
+		ingressPortId = d.Id()
+	)
+
+	// Lock the resource to prevent concurrent deletions (error APIC.9224 will be returned if multiple requests are sent
+	// concurrently)
+	config.MutexKV.Lock(instanceId)
+	defer config.MutexKV.Unlock(instanceId)
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceId)
+	deletePath = strings.ReplaceAll(deletePath, "{ingress_port_id}", ingressPortId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes:          []int{204},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", "APIC.7200"),
+			fmt.Sprintf("error deleting APIG instance ingress port (%s)", ingressPortId))
+	}
+
+	return nil
+}
+
+func resourceInstanceIngressPortImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+
+	switch len(parts) {
+	case 2:
+		if !utils.IsUUID(parts[1]) {
+			return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<id>', but got '%s'", importedId)
+		}
+		d.SetId(parts[1])
+		return []*schema.ResourceData{d}, d.Set("instance_id", parts[0])
+	case 3:
+		if utils.IsUUID(parts[1]) {
+			return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<protocol>/<port>', but got '%s'", importedId)
+		}
+		portNum, err := strconv.Atoi(parts[2])
+		if err != nil {
+			return nil, fmt.Errorf("invalid port number, want '<instance_id>/<protocol>/<port>', but got '%s'", importedId)
+		}
+
+		// Store the instance ID as the temporary resource ID first, then update it once the ingress port ID is obtained.
+		d.SetId(parts[0])
+		mErr := multierror.Append(nil,
+			d.Set("instance_id", parts[0]),
+			d.Set("protocol", parts[1]),
+			d.Set("port", portNum),
+		)
+		if err := mErr.ErrorOrNil(); err != nil {
+			return nil, fmt.Errorf("failed to set values in import state, %s", err)
+		}
+
+		cfg := meta.(*config.Config)
+		region := cfg.GetRegion(d)
+		client, err := cfg.NewServiceClient("apig", region)
+		if err != nil {
+			return nil, fmt.Errorf("error creating APIG client: %s", err)
+		}
+		respBody, err := listInstanceIngressPorts(client, parts[0], d)
+		if err != nil {
+			return nil, err
+		}
+		d.SetId(utils.PathSearch("[0].ingress_port_id", respBody, "").(string))
+		return []*schema.ResourceData{d}, nil
+	}
+
+	return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<id>' or "+
+		"'<instance_id>/<protocol>/<port>', but got '%s'", importedId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new resource to manage the custom ingress port to which the APIG instance belongs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1259" height="661" alt="image" src="https://github.com/user-attachments/assets/9a4b7e4b-0c2c-4c26-99e6-6e6d00c87532" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource for instance ingress port
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccInstanceIngressPort_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccInstanceIngressPort_basic -timeout 360m -parallel 10
=== RUN   TestAccInstanceIngressPort_basic
=== PAUSE TestAccInstanceIngressPort_basic
=== CONT  TestAccInstanceIngressPort_basic
--- PASS: TestAccInstanceIngressPort_basic (39.66s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      39.766s coverage: 3.7% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="863" height="508" alt="image" src="https://github.com/user-attachments/assets/ab8e19fa-817b-4513-91aa-5dafa201f7f2" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1410" height="1068" alt="image" src="https://github.com/user-attachments/assets/6dd3aa1d-07ba-4b66-9818-fd1f58a59598" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
