### PR TITLE
feat(dew): new resource to restore csms secret

### DIFF
--- a/docs/resources/csms_restore_secret.md
+++ b/docs/resources/csms_restore_secret.md
@@ -1,0 +1,81 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_csms_restore_secret"
+description: |-
+  Restores a secret from a backup content in HuaweiCloud DEW CSMS service.
+---
+
+# huaweicloud_csms_restore_secret
+
+Restores a secret from a backup content in HuaweiCloud DEW CSMS service.
+
+-> This resource is a one-time action resource. Deleting this resource will not affect the restored secret,
+  but will only remove the resource information from the tfstate file. This resource can only restore secrets that no
+  longer exist.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_csms_restore_secret" "test" {
+  secret_blob = file("your-secret-backup-file-path")
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `secret_blob` - (Required, String, NonUpdatable) Specifies the secret backup file content to restore from.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the restored secret.
+
+* `name` - The name of the restored secret.
+
+* `state` - The state of the restored secret. Possible values are:
+  + **ENABLED**: The secret is enabled.
+  + **DISABLED**: The secret is disabled.
+  + **PENDING_DELETE**: The secret is pending deletion.
+  + **FROZEN**: The secret is frozen.
+
+* `kms_key_id` - The ID of the KMS key used to encrypt the secret value.
+
+* `description` - The description of the secret.
+
+* `create_time` - The creation time of the secret, in milliseconds since the Unix epoch.
+
+* `update_time` - The last update time of the secret, in milliseconds since the Unix epoch.
+
+* `scheduled_delete_time` - The scheduled deletion time of the secret, in milliseconds since the Unix epoch.
+
+* `secret_type` - The type of the secret. Possible values are:
+  + **COMMON**: The shared secret (default), which is used to store sensitive information in an application system.
+  + **RDS**: The RDS secret, which is used to store RDS account information. (no longer supported, replaced by RDS-FG).
+  + **RDS-FG**: The RDS secret, which is used to store RDS account information.
+  + **GaussDB-FG**: The taurusDB secret, which is used to store taurusDB account information.
+
+* `auto_rotation` - The Automatic rotation. The value can be **true** (enabled) or **false** (disabled).
+  The default value is **false**.
+
+* `rotation_period` - The rotation period of the secret.
+
+* `rotation_config` - The rotation configuration of the secret.
+
+* `rotation_time` - The last rotation time of the secret, in milliseconds since the Unix epoch.
+
+* `next_rotation_time` - The next rotation time of the secret, in milliseconds since the Unix epoch.
+
+* `event_subscriptions` - The list of events subscribed to by secrets. Currently, only one event can be subscribed to.
+  When a basic event contained in an event is triggered, a notification message is sent to the notification topic
+  corresponding to the event.
+
+* `enterprise_project_id` - The ID of the enterprise project that the secret belongs to.
+
+* `rotation_func_urn` - The URN of the FunctionGraph function used for rotation.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2574,6 +2574,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_csms_event":                        dew.ResourceCsmsEvent(),
 			"huaweicloud_csms_secret":                       dew.ResourceSecret(),
 			"huaweicloud_csms_secret_version_state":         dew.ResourceSecretVersionState(),
+			"huaweicloud_csms_restore_secret":               dew.ResourceRestoreSecret(),
 			"huaweicloud_csms_scheduled_delete_secret_task": dew.ResourceCsmsScheduledDeleteSecretTask(),
 			"huaweicloud_csms_secret_rotate":                dew.ResourceSecretRotate(),
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -136,20 +136,21 @@ var (
 
 	HW_DBSS_INSATNCE_ID = os.Getenv("HW_DBSS_INSATNCE_ID")
 
-	HW_DEW_ENABLE_FLAG           = os.Getenv("HW_DEW_ENABLE_FLAG")
-	HW_KPS_KEY_FILE_PATH         = os.Getenv("HW_KPS_KEY_FILE_PATH")
-	HW_KPS_KEYPAIR_NAME          = os.Getenv("HW_KPS_KEYPAIR_NAME")
-	HW_KPS_KEYPAIR_NAME_1        = os.Getenv("HW_KPS_KEYPAIR_NAME_1")
-	HW_KPS_KEYPAIR_NAME_2        = os.Getenv("HW_KPS_KEYPAIR_NAME_2")
-	HW_KPS_KEYPAIR_KEY_1         = os.Getenv("HW_KPS_KEYPAIR_KEY_1")
-	HW_KPS_KEYPAIR_SSH_PORT      = os.Getenv("HW_KPS_KEYPAIR_SSH_PORT")
-	HW_KPS_ENABLE_FLAG           = os.Getenv("HW_KPS_ENABLE_FLAG")
-	HW_KPS_PUBLIC_KEY_FILE_PATH  = os.Getenv("HW_KPS_PUBLIC_KEY_FILE_PATH")
-	HW_KPS_PRIVATE_KEY_FILE_PATH = os.Getenv("HW_KPS_PRIVATE_KEY_FILE_PATH")
-	HW_KPS_FAILED_TASK_ID        = os.Getenv("HW_KPS_FAILED_TASK_ID")
-	HW_CSMS_TASK_ID              = os.Getenv("HW_CSMS_TASK_ID")
-	HW_CSMS_SECRET_NAME          = os.Getenv("HW_CSMS_SECRET_NAME")
-	HW_CSMS_SECRET_ID            = os.Getenv("HW_CSMS_SECRET_ID")
+	HW_DEW_ENABLE_FLAG              = os.Getenv("HW_DEW_ENABLE_FLAG")
+	HW_KPS_KEY_FILE_PATH            = os.Getenv("HW_KPS_KEY_FILE_PATH")
+	HW_KPS_KEYPAIR_NAME             = os.Getenv("HW_KPS_KEYPAIR_NAME")
+	HW_KPS_KEYPAIR_NAME_1           = os.Getenv("HW_KPS_KEYPAIR_NAME_1")
+	HW_KPS_KEYPAIR_NAME_2           = os.Getenv("HW_KPS_KEYPAIR_NAME_2")
+	HW_KPS_KEYPAIR_KEY_1            = os.Getenv("HW_KPS_KEYPAIR_KEY_1")
+	HW_KPS_KEYPAIR_SSH_PORT         = os.Getenv("HW_KPS_KEYPAIR_SSH_PORT")
+	HW_KPS_ENABLE_FLAG              = os.Getenv("HW_KPS_ENABLE_FLAG")
+	HW_KPS_PUBLIC_KEY_FILE_PATH     = os.Getenv("HW_KPS_PUBLIC_KEY_FILE_PATH")
+	HW_KPS_PRIVATE_KEY_FILE_PATH    = os.Getenv("HW_KPS_PRIVATE_KEY_FILE_PATH")
+	HW_KPS_FAILED_TASK_ID           = os.Getenv("HW_KPS_FAILED_TASK_ID")
+	HW_CSMS_TASK_ID                 = os.Getenv("HW_CSMS_TASK_ID")
+	HW_CSMS_SECRET_NAME             = os.Getenv("HW_CSMS_SECRET_NAME")
+	HW_CSMS_SECRET_BACKUP_FILE_PATH = os.Getenv("HW_CSMS_SECRET_BACKUP_FILE_PATH")
+	HW_CSMS_SECRET_ID               = os.Getenv("HW_CSMS_SECRET_ID")
 
 	HW_CPCS_CLUSTER_ID    = os.Getenv("HW_CPCS_CLUSTER_ID")
 	HW_CPCS_APP_ID        = os.Getenv("HW_CPCS_APP_ID")
@@ -4258,6 +4259,13 @@ func TestAccPreCheckCsmsSecretID(t *testing.T) {
 func TestAccPreCheckCsmsSecretName(t *testing.T) {
 	if HW_CSMS_SECRET_NAME == "" {
 		t.Skip("HW_CSMS_SECRET_NAME must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCsmsSecretBackupFilePath(t *testing.T) {
+	if HW_CSMS_SECRET_BACKUP_FILE_PATH == "" {
+		t.Skip("HW_CSMS_SECRET_BACKUP_FILE_PATH must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_csms_restore_secret_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_csms_restore_secret_test.go
@@ -1,0 +1,47 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// This resource can only restore secrets that no longer exist.
+func TestAccCsmsRestoreSecret_basic(t *testing.T) {
+	resourceName := "huaweicloud_csms_restore_secret.test"
+
+	// lintignore:AT001
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCsmsSecretBackupFilePath(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCsmsRestoreSecret_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "state"),
+					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "create_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "update_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "secret_type"),
+					resource.TestCheckResourceAttrSet(resourceName, "auto_rotation"),
+					resource.TestCheckResourceAttrSet(resourceName, "enterprise_project_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCsmsRestoreSecret_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_csms_restore_secret" "test" {
+  secret_blob = file("%s")
+}
+`, acceptance.HW_CSMS_SECRET_BACKUP_FILE_PATH)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_csms_restore_secret.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_csms_restore_secret.go
@@ -1,0 +1,200 @@
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW POST /v1/{project_id}/secrets/restore
+func ResourceRestoreSecret() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRestoreSecretCreate,
+		ReadContext:   resourceRestoreSecretRead,
+		UpdateContext: resourceRestoreSecretUpdate,
+		DeleteContext: resourceRestoreSecretDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"secret_blob",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"secret_blob": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"scheduled_delete_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"secret_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"auto_rotation": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"rotation_period": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"rotation_config": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"rotation_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"next_rotation_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"event_subscriptions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"rotation_func_urn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceRestoreSecretCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v1/{project_id}/secrets/restore"
+		product    = "kms"
+		secretBlob = d.Get("secret_blob").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DEW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestBody := map[string]interface{}{
+		"secret_blob": secretBlob,
+	}
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         requestBody,
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error restoring DEW CSMS secret: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	secretId := utils.PathSearch("secret.id", respBody, "").(string)
+	if secretId == "" {
+		return diag.Errorf("error restoring DEW CSMS secret: secret ID is not found in API response")
+	}
+
+	d.SetId(secretId)
+
+	mErr := multierror.Append(
+		d.Set("name", utils.PathSearch("secret.name", respBody, nil)),
+		d.Set("state", utils.PathSearch("secret.state", respBody, nil)),
+		d.Set("kms_key_id", utils.PathSearch("secret.kms_key_id", respBody, nil)),
+		d.Set("description", utils.PathSearch("secret.description", respBody, nil)),
+		d.Set("create_time", utils.PathSearch("secret.create_time", respBody, nil)),
+		d.Set("update_time", utils.PathSearch("secret.update_time", respBody, nil)),
+		d.Set("scheduled_delete_time", utils.PathSearch("secret.scheduled_delete_time", respBody, nil)),
+		d.Set("secret_type", utils.PathSearch("secret.secret_type", respBody, nil)),
+		d.Set("auto_rotation", utils.PathSearch("secret.auto_rotation", respBody, nil)),
+		d.Set("rotation_period", utils.PathSearch("secret.rotation_period", respBody, nil)),
+		d.Set("rotation_config", utils.PathSearch("secret.rotation_config", respBody, nil)),
+		d.Set("rotation_time", utils.PathSearch("secret.rotation_time", respBody, nil)),
+		d.Set("next_rotation_time", utils.PathSearch("secret.next_rotation_time", respBody, nil)),
+		d.Set("event_subscriptions", utils.PathSearch("secret.event_subscriptions", respBody, nil)),
+		d.Set("enterprise_project_id", utils.PathSearch("secret.enterprise_project_id", respBody, nil)),
+		d.Set("rotation_func_urn", utils.PathSearch("secret.rotation_func_urn", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceRestoreSecretRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceRestoreSecretUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceRestoreSecretDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to restore a secret from a backup blob.
+Deleting this resource will not delete the restored secret, but will only remove the resource information from
+the tfstate file. The restored secret will continue to exist in the DEW service.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to restore csms secret

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o dew -f TestAccCsmsRestoreSecret_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccCsmsRestoreSecret_basic -timeout 360m -parallel 10
=== RUN   TestAccCsmsRestoreSecret_basic
--- PASS: TestAccCsmsRestoreSecret_basic (13.53s)
PASS
coverage: 3.4% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       13.635s coverage: 3.4% of statements in ./huaweicloud/services/dew
```
<img width="1275" height="80" alt="image" src="https://github.com/user-attachments/assets/aff0f118-1612-4914-bed5-8b72145f4bed" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
