### PR TITLE
feat(hss): support `hss_cluster_protect_alarm_events` data source

### DIFF
--- a/docs/data-sources/hss_cluster_protect_alarm_events.md
+++ b/docs/data-sources/hss_cluster_protect_alarm_events.md
@@ -1,0 +1,106 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_cluster_protect_alarm_events"
+description: |-
+  Use this data source to get the list of HSS cluster protect all alarm events within HuaweiCloud.
+---
+
+# huaweicloud_hss_cluster_protect_alarm_events
+
+Use this data source to get the list of HSS cluster protect all alarm events within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_cluster_protect_alarm_events" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `cluster_id` - (Optional, String) Specifies the cluster ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `total_num` - The total number.
+
+* `last_update_time` - The last update time.
+
+* `data_list` - The list of cluster protect alarm events.
+
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `action` - The blocking action.
+
+* `cluster_name` - The cluster name.
+
+* `cluster_id` - The cluster ID.
+
+* `event_name` - The event name.
+
+* `event_class_id` - The event unique identifier.
+
+* `event_id` - The event ID.
+
+* `event_type` - The event type.
+
+* `event_content` - The event content.
+
+* `handle_status` - The handling status.  
+  The valid values are as follows:
+  + **unhandled**: Unhandled.
+  + **handled**: Handled.
+
+* `create_time` - The creation time.
+
+* `update_time` - The update time.
+
+* `project_id` - The project ID.
+
+* `enterprise_project_id` - The enterprise project ID.
+
+* `policy_name` - The policy name.
+
+* `policy_id` - The policy ID.
+
+* `resource_info` - The event resource information.
+
+  The [resource_info](#resource_info_struct) structure is documented below.
+
+<a name="resource_info_struct"></a>
+The `resource_info` block supports:
+
+* `enforcement_action` - The enforcement action.
+
+* `group` - The group.
+
+* `message` - The message.
+
+* `name` - The name.
+
+* `namespace` - The namespace.
+
+* `version` - The version.
+
+* `kind` - The resource type.
+
+* `resource_name` - The resource name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1343,6 +1343,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_cluster_protect_overview":                   hss.DataSourceClusterProtectOverview(),
 			"huaweicloud_hss_cluster_protect_default_policies":           hss.DataSourceClusterProtectDefaultPolicies(),
 			"huaweicloud_hss_cluster_protect_protection_items":           hss.DataSourceClusterProtectProtectionItems(),
+			"huaweicloud_hss_cluster_protect_alarm_events":               hss.DataSourceClusterProtectAlarmEvents(),
 			"huaweicloud_hss_image_asset_statistics":                     hss.DataSourceImageAssetStatistics(),
 			"huaweicloud_hss_common_task_statistics":                     hss.DataSourceCommonTaskStatistics(),
 			"huaweicloud_hss_common_tasks":                               hss.DataSourceCommonTasks(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_cluster_protect_alarm_events_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_cluster_protect_alarm_events_test.go
@@ -1,0 +1,43 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Due to testing environment limitations, this test case can only test the scenario with empty `data_list`.
+func TestAccDataSourceClusterProtectAlarmEvents_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_cluster_protect_alarm_events.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceClusterProtectAlarmEvents_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "last_update_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceClusterProtectAlarmEvents_basic() string {
+	return `
+data "huaweicloud_hss_cluster_protect_alarm_events" "test" {
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_cluster_protect_alarm_events.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_cluster_protect_alarm_events.go
@@ -1,0 +1,283 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/cluster-protect/events
+func DataSourceClusterProtectAlarmEvents() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceClusterProtectAlarmEventsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"last_update_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"action": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"event_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"event_class_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"event_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"event_type": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"event_content": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"handle_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enforcement_action": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"group": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"message": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"namespace": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"resource_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildClusterProtectAlarmEventsQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=200"
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("cluster_id"); ok {
+		queryParams = fmt.Sprintf("%s&cluster_id=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceClusterProtectAlarmEventsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		product        = "hss"
+		epsId          = cfg.GetEnterpriseProjectID(d)
+		result         = make([]interface{}, 0)
+		offset         = 0
+		totalNum       = 0
+		lastUpdateTime = 0
+		httpUrl        = "v5/{project_id}/cluster-protect/events"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildClusterProtectAlarmEventsQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS cluster protect all alarm events: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalNum = int(utils.PathSearch("total_num", respBody, float64(0)).(float64))
+		lastUpdateTime = int(utils.PathSearch("last_update_time", respBody, float64(0)).(float64))
+		dataList := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataList) == 0 {
+			break
+		}
+
+		result = append(result, dataList...)
+		offset += len(dataList)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_num", totalNum),
+		d.Set("last_update_time", lastUpdateTime),
+		d.Set("data_list", flattenClusterProtectAlarmEventsDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenClusterProtectAlarmEventsDataList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"action":                utils.PathSearch("action", v, nil),
+			"cluster_name":          utils.PathSearch("cluster_name", v, nil),
+			"cluster_id":            utils.PathSearch("cluster_id", v, nil),
+			"event_name":            utils.PathSearch("event_name", v, nil),
+			"event_class_id":        utils.PathSearch("event_class_id", v, nil),
+			"event_id":              utils.PathSearch("event_id", v, nil),
+			"event_type":            utils.PathSearch("event_type", v, nil),
+			"event_content":         utils.PathSearch("event_content", v, nil),
+			"handle_status":         utils.PathSearch("handle_status", v, nil),
+			"create_time":           utils.PathSearch("create_time", v, nil),
+			"update_time":           utils.PathSearch("update_time", v, nil),
+			"project_id":            utils.PathSearch("project_id", v, nil),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", v, nil),
+			"policy_name":           utils.PathSearch("policy_name", v, nil),
+			"policy_id":             utils.PathSearch("policy_id", v, nil),
+			"resource_info":         flattenEventsResourceInfo(utils.PathSearch("resource_info", v, nil)),
+		})
+	}
+
+	return rst
+}
+
+func flattenEventsResourceInfo(resourceInfo interface{}) []interface{} {
+	if resourceInfo == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"enforcement_action": utils.PathSearch("enforcementAction", resourceInfo, nil),
+			"group":              utils.PathSearch("group", resourceInfo, nil),
+			"message":            utils.PathSearch("message", resourceInfo, nil),
+			"name":               utils.PathSearch("name", resourceInfo, nil),
+			"namespace":          utils.PathSearch("namespace", resourceInfo, nil),
+			"version":            utils.PathSearch("version", resourceInfo, nil),
+			"kind":               utils.PathSearch("kind", resourceInfo, nil),
+			"resource_name":      utils.PathSearch("resource_name", resourceInfo, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_cluster_protect_alarm_events` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_cluster_protect_alarm_events` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceClusterProtectAlarmEvents_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceClusterProtectAlarmEvents_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceClusterProtectAlarmEvents_basic
=== PAUSE TestAccDataSourceClusterProtectAlarmEvents_basic
=== CONT  TestAccDataSourceClusterProtectAlarmEvents_basic
--- PASS: TestAccDataSourceClusterProtectAlarmEvents_basic (10.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       10.236s
```
<img width="948" height="36" alt="image" src="https://github.com/user-attachments/assets/52854f55-c540-41f7-9454-2c8d174daa62" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
