### PR TITLE
feat(hss): add new data source to get list of web framework statistics

### DIFF
--- a/docs/data-sources/hss_asset_web_framework_statistics.md
+++ b/docs/data-sources/hss_asset_web_framework_statistics.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_asset_web_framework_statistics"
+description: |-
+  Use this data source to get the list of web framework statistics.
+---
+
+# huaweicloud_hss_asset_web_framework_statistics
+
+Use this data source to get the list of web framework statistics.
+
+## Example Usage
+
+```hcl
+variable "category" {}
+
+data "huaweicloud_hss_asset_web_framework_statistics" "test" {
+  category = var.category
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `category` - (Required, String) Specifies the asset category.
+  The valid values are as follows:
+  + **host**: Host.
+  + **container**: Container.
+
+* `file_name` - (Optional, String) Specifies the web framework file name.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the hosts belong.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `data_list` - The list of web framework statistics.
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `file_name` - The web framework file name.
+
+* `num` - The number of web framework statistics.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1331,6 +1331,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_asset_user_statistics":                      hss.DataSourceAssetUserStatistics(),
 			"huaweicloud_hss_asset_users":                                hss.DataSourceAssetUsers(),
 			"huaweicloud_hss_asset_web_app_service_statistics":           hss.DataSourceAssetWebAppServiceStatistics(),
+			"huaweicloud_hss_asset_web_framework_statistics":             hss.DataSourceAssetWebFrameworkStatistics(),
 			"huaweicloud_hss_asset_website_hosts":                        hss.DataSourceAssetWebsiteHosts(),
 			"huaweicloud_hss_asset_website_statistics":                   hss.DataSourceAssetWebsiteStatistics(),
 			"huaweicloud_hss_auto_launch_statistics":                     hss.DataSourceAutoLaunchStatistics(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_asset_web_framework_statistics_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_asset_web_framework_statistics_test.go
@@ -1,0 +1,42 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAssetWebFrameworkStatistics_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_asset_web_framework_statistics.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			// Because there is no available data for testing, the test case is only
+			// used to verify that the API can be invoked.
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAssetWebFrameworkStatistics_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAssetWebFrameworkStatistics_basic = `
+data "huaweicloud_hss_asset_web_framework_statistics" "test" {
+  category              = "host"
+  enterprise_project_id = "0"
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_asset_web_framework_statistics.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_asset_web_framework_statistics.go
@@ -1,0 +1,155 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/asset/statistics/web-framework
+func DataSourceAssetWebFrameworkStatistics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAssetWebFrameworkStatisticsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"file_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"file_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAssetWebFrameworkStatisticsQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := fmt.Sprintf("?category=%v&limit=200", d.Get("category"))
+
+	if v, ok := d.GetOk("file_name"); ok {
+		queryParams = fmt.Sprintf("%s&file_name=%v", queryParams, v)
+	}
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+
+	return queryParams
+}
+
+func dataSourceAssetWebFrameworkStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		httpUrl  = "v5/{project_id}/asset/statistics/web-framework"
+		epsId    = cfg.GetEnterpriseProjectID(d)
+		offset   = 0
+		result   = make([]interface{}, 0)
+		totalNum float64
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildAssetWebFrameworkStatisticsQueryParams(d, epsId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", getPath, offset)
+		getResp, err := client.Request("GET", currentPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving web framework statistics: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataResp := utils.PathSearch("data_list", getRespBody, make([]interface{}, 0)).([]interface{})
+		if len(dataResp) == 0 {
+			break
+		}
+
+		result = append(result, dataResp...)
+
+		totalNum = utils.PathSearch("total_num", getRespBody, float64(0)).(float64)
+		if int(totalNum) == len(result) {
+			break
+		}
+
+		offset += len(dataResp)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data_list", flattenAssetWebFrameworkStatistics(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAssetWebFrameworkStatistics(dataResp []interface{}) []interface{} {
+	if len(dataResp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(dataResp))
+	for _, v := range dataResp {
+		result = append(result, map[string]interface{}{
+			"file_name": utils.PathSearch("file_name", v, nil),
+			"num":       utils.PathSearch("num", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get list of web framework statistics.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceAssetWebFrameworkStatistics_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceAssetWebFrameworkStatistics_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAssetWebFrameworkStatistics_basic
=== PAUSE TestAccDataSourceAssetWebFrameworkStatistics_basic
=== CONT  TestAccDataSourceAssetWebFrameworkStatistics_basic
--- PASS: TestAccDataSourceAssetWebFrameworkStatistics_basic (16.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       17.187s
```
<img width="1208" height="19" alt="image" src="https://github.com/user-attachments/assets/15e4a605-3e2a-4596-9fd4-79bf2be19d3b" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
