### PR TITLE
feat(RDS): add rds instance no index tables data source

### DIFF
--- a/docs/data-sources/rds_instance_no_index_tables.md
+++ b/docs/data-sources/rds_instance_no_index_tables.md
@@ -1,0 +1,60 @@
+---
+subcategory: "Relational Database Service (RDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rds_instance_no_index_tables"
+description: |-
+  Use this data source to query the tables without index of an RDS instance.
+---
+
+# huaweicloud_rds_instance_no_index_tables
+
+Use this data source to query the tables without index of an RDS instance.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_rds_instance_no_index_tables" "test" {
+  instance_id = var.instance_id
+  table_type  = "no_primary_key"
+  newest      = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the RDS instance.
+
+* `table_type` - (Required, String) Specifies the type of the table. Value options: **no_primary_key**.
+
+* `newest` - (Required, Bool) Specifies whether the query should focus on retrieving the latest unindexed table.
+  Value options:
+  + **true**: The query retrieves the latest table without an index.
+  + **false**: The latest unindexed table is not retrieved during the query.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tables` - Indicates the list of tables without index of the instance.
+
+  The [tables](#tables_struct) structure is documented below.
+
+* `last_diagnose_timestamp` - Indicates the last diagnose timestamp.
+
+<a name="tables_struct"></a>
+The `tables` block supports:
+
+* `db_name` - Indicates the database name.
+
+* `schema_name` - Indicates the schema name.
+
+* `table_name` - Indicates the table namee.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1630,6 +1630,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_engine_versions":                   rds.DataSourceRdsEngineVersionsV3(),
 			"huaweicloud_rds_instances":                         rds.DataSourceRdsInstances(),
 			"huaweicloud_rds_instance_parameters_histories":     rds.DataSourceRdsInstanceParameterHistories(),
+			"huaweicloud_rds_instance_no_index_tables":          rds.DataSourceRdsInstanceNoIndexTables(),
 			"huaweicloud_rds_backups":                           rds.DataSourceRdsBackups(),
 			"huaweicloud_rds_backup_files":                      rds.DataSourceRdsBackupFiles(),
 			"huaweicloud_rds_storage_types":                     rds.DataSourceStoragetype(),

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_instance_no_index_tables_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_instance_no_index_tables_test.go
@@ -1,0 +1,46 @@
+package rds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRdsInstanceNoIndexTables_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_rds_instance_no_index_tables.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRdsInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceRdsInstanceNoIndexTables_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "tables.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "tables.0.db_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "tables.0.schema_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "tables.0.table_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "last_diagnose_timestamp"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceRdsInstanceNoIndexTables_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_rds_instance_no_index_tables" "test" {
+  instance_id = "%s"
+  table_type  = "no_primary_key"
+  newest      = true
+}
+`, acceptance.HW_RDS_INSTANCE_ID)
+}

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_instance_no_index_tables.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_instance_no_index_tables.go
@@ -1,0 +1,136 @@
+package rds
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RDS GET /v3/{project_id}/instances/{instance_id}/no-index-tables
+func DataSourceRdsInstanceNoIndexTables() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRdsInstanceNoIndexTablesRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"table_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"newest": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"tables": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"db_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"schema_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"table_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"last_diagnose_timestamp": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceRdsInstanceNoIndexTablesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/no-index-tables"
+		product = "rds"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", fmt.Sprintf("%v", d.Get("instance_id")))
+
+	getInstanceNoIndexTablesQueryParams := buildGetInstanceNoIndexTablesQueryParams(d)
+	getPath += getInstanceNoIndexTablesQueryParams
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving RDS instance no index tables: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("tables", flattenInstanceNoIndexTablesBody(getRespBody)),
+		d.Set("last_diagnose_timestamp", utils.PathSearch("last_diagnose_timestamp", getRespBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildGetInstanceNoIndexTablesQueryParams(d *schema.ResourceData) string {
+	return fmt.Sprintf("?table_type=%v&newest=%v", d.Get("table_type"), d.Get("newest"))
+}
+
+func flattenInstanceNoIndexTablesBody(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("tables", resp, make([]any, 0))
+	curArray := curJson.([]any)
+	rst := make([]any, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]any{
+			"db_name":     utils.PathSearch("db_name", v, nil),
+			"schema_name": utils.PathSearch("schema_name", v, nil),
+			"table_name":  utils.PathSearch("table_name", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add rds instance no index tables data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add rds instance no index tables data source
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDataSourceRdsInstanceNoIndexTables_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDataSourceRdsInstanceNoIndexTables_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRdsInstanceNoIndexTables_basic
=== PAUSE TestAccDataSourceRdsInstanceNoIndexTables_basic
=== CONT  TestAccDataSourceRdsInstanceNoIndexTables_basic
--- PASS: TestAccDataSourceRdsInstanceNoIndexTables_basic (19.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       19.976s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
