### PR TITLE
feat(aom): add new data source for query alarm notifications

### DIFF
--- a/docs/data-sources/aom_alarm_notified_histories.md
+++ b/docs/data-sources/aom_alarm_notified_histories.md
@@ -1,0 +1,82 @@
+---
+subcategory: "Application Operations Management (AOM 2.0)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aom_alarm_notified_histories"
+description: |-
+  Use this data source to query the notification histories of an alarm event within HuaweiCloud.
+---
+
+# huaweicloud_aom_alarm_notified_histories
+
+Use this data source to query the notification histories of an alarm event within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "event_sn" {}
+
+data "huaweicloud_aom_alarm_notified_histories" "test" {
+  event_sn = var.event_sn
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the alarm notification histories are located.  
+  If omitted, the provider-level region will be used.
+
+* `event_sn` - (Required, String) Specifies the serial number of the alarm event.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `notified_histories` - The list of notified histories.  
+  The [notified_histories](#aom_notified_histories) structure is documented below.
+
+<a name="aom_notified_histories"></a>
+The `notified_histories` block supports:
+
+* `event_sn` - The serial number of the alarm event.
+
+* `notifications` - The list of notification results that associated the event.  
+  The [notifications](#aom_notified_histories_notifications) structure is documented below.
+
+<a name="aom_notified_histories_notifications"></a>
+The `notifications` block supports:
+
+* `action_rule` - The name of the alarm notification rule.
+
+* `notifier_channel` - The notification channel type.
+
+* `smn_channel` - The result detail of the notification.
+  The [smn_channel](#aom_notified_histories_notifications_smn_channel) structure is documented below.
+
+<a name="aom_notified_histories_notifications_smn_channel"></a>
+The `smn_channel` block supports:
+
+* `sent_time` - The timestamp when the notification was sent.
+
+* `smn_notified_history` - The list of smn notification that associated the event.
+    The [smn_notified_history](#aom_notified_histories_notifications_smn_channel_info) structure is documented below.
+
+* `smn_request_id` - The request ID of the notification detail.
+
+* `smn_response_body` - The response body of the notification detail.
+
+* `smn_response_code` - The response code of the notification detail.
+
+* `smn_topic` - The SMN topic used for notification.
+
+<a name="aom_notified_histories_notifications_smn_channel_info"></a>
+The `smn_notified_history` block supports:
+
+* `smn_notified_content` - The content of the notification.
+
+* `smn_subscription_status` - The subscription status of the notification.
+
+* `smn_subscription_type` - The subscription type of the notification.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -551,6 +551,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aom_aggregation_metrics":             aom.DataSourceAggregationMetrics(),
 			"huaweicloud_aom_alarm_action_rules":              aom.DataSourceAomAlarmActionRules(),
 			"huaweicloud_aom_alarm_group_rules":               aom.DataSourceAlarmGroupRules(),
+			"huaweicloud_aom_alarm_notified_histories":        aom.DataSourceAlarmNotifiedHistories(),
 			"huaweicloud_aom_alarm_rules":                     aom.DataSourceAlarmRules(),
 			"huaweicloud_aom_alarm_rules_templates":           aom.DataSourceAlarmRulesTemplates(),
 			"huaweicloud_aom_alarm_silence_rules":             aom.DataSourceAlarmSilenceRules(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -507,6 +507,7 @@ var (
 	HW_MODELARTS_RESOURCE_POOL_NAME                   = os.Getenv("HW_MODELARTS_RESOURCE_POOL_NAME")
 	HW_MODELARTS_RESOURCE_POOL_BATCH_RESIZE_NODE_NAME = os.Getenv("HW_MODELARTS_RESOURCE_POOL_BATCH_RESIZE_NODE_NAME")
 
+	HW_AOM_ALARM_EVENT_SN                        = os.Getenv("HW_AOM_ALARM_EVENT_SN")
 	HW_AOM_INSTALLER_AGENT_ID                    = os.Getenv("HW_AOM_INSTALLER_AGENT_ID")
 	HW_AOM_MULTI_ACCOUNT_AGGREGATION_RULE_ENABLE = os.Getenv("HW_AOM_MULTI_ACCOUNT_AGGREGATION_RULE_ENABLE")
 	HW_AOM_SUB_APPLICATION_ID                    = os.Getenv("HW_AOM_SUB_APPLICATION_ID") // The CMDB sub-application ID of AOM service
@@ -3093,6 +3094,13 @@ func TestAccPreCheckLTSLogConvergeMappingConfig(t *testing.T) {
 func TestAccPreCheckLTSMemberAccountId(t *testing.T) {
 	if HW_LTS_LOG_CONVERGE_MEMBER_ACCOUNT_ID == "" {
 		t.Skip("HW_LTS_LOG_CONVERGE_MEMBER_ACCOUNT_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckAomAlarmEventSn(t *testing.T) {
+	if HW_AOM_ALARM_EVENT_SN == "" {
+		t.Skip("HW_AOM_ALARM_EVENT_SN must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/aom/data_source_huaweicloud_aom_alarm_notified_histories_test.go
+++ b/huaweicloud/services/acceptance/aom/data_source_huaweicloud_aom_alarm_notified_histories_test.go
@@ -1,0 +1,59 @@
+package aom
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataAlarmNotifiedHistories_basic(t *testing.T) {
+	resourceName := "data.huaweicloud_aom_alarm_notified_histories.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAomAlarmEventSn(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataAlarmNotifiedHistories_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestMatchResourceAttr(resourceName, "notified_histories.#", regexp.MustCompile("^[1-9]([0-9]+)?$")),
+					resource.TestCheckResourceAttr(resourceName, "notified_histories.0.event_sn", acceptance.HW_AOM_ALARM_EVENT_SN),
+					resource.TestMatchResourceAttr(resourceName, "notified_histories.0.notifications.#", regexp.MustCompile("^[1-9]([0-9]+)?$")),
+					resource.TestCheckResourceAttrSet(resourceName, "notified_histories.0.notifications.0.action_rule"),
+					resource.TestCheckResourceAttrSet(resourceName, "notified_histories.0.notifications.0.notifier_channel"),
+					resource.TestMatchResourceAttr(resourceName, "notified_histories.0.notifications.0.smn_channel.#",
+						regexp.MustCompile("^[1-9]([0-9]+)?$")),
+					resource.TestCheckResourceAttrSet(resourceName, "notified_histories.0.notifications.0.smn_channel.0.sent_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "notified_histories.0.notifications.0.smn_channel.0.smn_request_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "notified_histories.0.notifications.0.smn_channel.0.smn_response_body"),
+					resource.TestCheckResourceAttrSet(resourceName, "notified_histories.0.notifications.0.smn_channel.0.smn_response_code"),
+					resource.TestCheckResourceAttrSet(resourceName, "notified_histories.0.notifications.0.smn_channel.0.smn_topic"),
+					resource.TestMatchResourceAttr(resourceName, "notified_histories.0.notifications.0.smn_channel.0.smn_notified_history.#",
+						regexp.MustCompile("^[1-9]([0-9]+)?$")),
+					resource.TestCheckResourceAttrSet(resourceName,
+						"notified_histories.0.notifications.0.smn_channel.0.smn_notified_history.0.smn_notified_content"),
+					resource.TestCheckResourceAttrSet(resourceName,
+						"notified_histories.0.notifications.0.smn_channel.0.smn_notified_history.0.smn_subscription_status"),
+					resource.TestCheckResourceAttrSet(resourceName,
+						"notified_histories.0.notifications.0.smn_channel.0.smn_notified_history.0.smn_subscription_type"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataAlarmNotifiedHistories_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_aom_alarm_notified_histories" "test" {
+  event_sn = "%[1]s"
+}
+`, acceptance.HW_AOM_ALARM_EVENT_SN)
+}

--- a/huaweicloud/services/aom/data_source_huaweicloud_aom_alarm_notified_histories.go
+++ b/huaweicloud/services/aom/data_source_huaweicloud_aom_alarm_notified_histories.go
@@ -1,0 +1,272 @@
+package aom
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AOM GET /v2/{project_id}/alarm-notified-histories
+func DataSourceAlarmNotifiedHistories() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAlarmNotifiedHistoriesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The region where the alarm notification histories are located.",
+			},
+
+			// Required parameters
+			"event_sn": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The serial number of the alarm event.",
+			},
+
+			// Attributes
+			"notified_histories": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        alarmNotifiedHistoriesSchema(),
+				Description: "The list of notified histories.",
+			},
+		},
+	}
+}
+
+func alarmNotifiedHistoriesNotificationSmnChannelInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"smn_notified_content": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The content of the notification.",
+			},
+			"smn_subscription_status": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The subscription status of the notification.",
+			},
+			"smn_subscription_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The subscription type of the notification.",
+			},
+		},
+	}
+}
+
+func alarmNotifiedHistoriesNotificationSmnChannelSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"sent_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The timestamp when the notification was sent.",
+			},
+			"smn_notified_history": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        alarmNotifiedHistoriesNotificationSmnChannelInfoSchema(),
+				Description: "The list of smn notification that associated the event.",
+			},
+			"smn_request_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The request ID of the notification detail.",
+			},
+			"smn_response_body": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The response body of the notification detail.",
+			},
+			"smn_response_code": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The response code of the notification detail.",
+			},
+			"smn_topic": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The SMN topic used for notification.",
+			},
+		},
+	}
+}
+
+func alarmNotifiedHistoriesNotificationsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"action_rule": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the alarm notification rule.",
+			},
+			"notifier_channel": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The notification channel type.",
+			},
+			"smn_channel": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        alarmNotifiedHistoriesNotificationSmnChannelSchema(),
+				Description: "The result detail of the notification.",
+			},
+		},
+	}
+}
+
+func alarmNotifiedHistoriesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"event_sn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The serial number of the alarm event.",
+			},
+			"notifications": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        alarmNotifiedHistoriesNotificationsSchema(),
+				Description: "The list of notification results that associated the event.",
+			},
+		},
+	}
+}
+
+func buildAlarmNotifiedHistoriesQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	res = fmt.Sprintf("%s&event_sn=%v", res, d.Get("event_sn").(string))
+
+	if len(res) > 1 {
+		res = "?" + res[1:]
+	}
+	return res
+}
+
+func flattenNotificationSmnInfo(smnInfos []interface{}) []interface{} {
+	if len(smnInfos) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(smnInfos))
+	for _, smnInfo := range smnInfos {
+		result = append(result, map[string]interface{}{
+			"smn_notified_content":    utils.PathSearch("smn_notified_content", smnInfo, nil),
+			"smn_subscription_status": utils.PathSearch("smn_subscription_status", smnInfo, nil),
+			"smn_subscription_type":   utils.PathSearch("smn_subscription_type", smnInfo, nil),
+		})
+	}
+	return result
+}
+
+func flattenNotificationSmnChannel(smnChannel interface{}) []interface{} {
+	if smnChannel == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"sent_time": utils.PathSearch("sent_time", smnChannel, nil),
+			"smn_notified_history": flattenNotificationSmnInfo(
+				utils.PathSearch("smn_notified_history", smnChannel, make([]interface{}, 0)).([]interface{})),
+			"smn_request_id":    utils.PathSearch("smn_request_id", smnChannel, nil),
+			"smn_response_body": utils.PathSearch("smn_response_body", smnChannel, nil),
+			"smn_response_code": utils.PathSearch("smn_response_code", smnChannel, nil),
+			"smn_topic":         utils.PathSearch("smn_topic", smnChannel, nil),
+		},
+	}
+}
+
+func flattenNotifications(notifications []interface{}) []interface{} {
+	if len(notifications) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(notifications))
+	for _, notification := range notifications {
+		result = append(result, map[string]interface{}{
+			"action_rule":      utils.PathSearch("action_rule", notification, nil),
+			"notifier_channel": utils.PathSearch("notifier_channel", notification, nil),
+			"smn_channel": flattenNotificationSmnChannel(
+				utils.PathSearch("smn_channel", notification, nil)),
+		})
+	}
+	return result
+}
+
+func flattenNotifiedHistories(notifiedHistories []interface{}) []interface{} {
+	if len(notifiedHistories) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(notifiedHistories))
+	for _, notifiedHistory := range notifiedHistories {
+		result = append(result, map[string]interface{}{
+			"event_sn":      utils.PathSearch("event_sn", notifiedHistory, nil),
+			"notifications": flattenNotifications(utils.PathSearch("notifications", notifiedHistory, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return result
+}
+
+func dataSourceAlarmNotifiedHistoriesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("aom", region)
+	if err != nil {
+		return diag.Errorf("error creating AOM client: %s", err)
+	}
+
+	listPath := client.Endpoint + "v2/{project_id}/alarm-notified-histories"
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildAlarmNotifiedHistoriesQueryParams(d)
+	listOpts := &golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, listOpts)
+	if err != nil {
+		return diag.Errorf("error querying alarm notification histories: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	notifiedHistories := utils.PathSearch("notified_histories", respBody, make([]interface{}, 0))
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("notified_histories", flattenNotifiedHistories(notifiedHistories.([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(aom): add new data source for query alarm notifications

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add document
3. add test case
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/aom" -v -coverprofile="./huaweicloud/services/acceptance/aom/aom_coverage.cov" -coverpkg="./huaweicloud/services/aom" -run TestAccDataAlarmNotifiedHistory_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAlarmNotifiedHistory_basic
=== PAUSE TestAccDataAlarmNotifiedHistory_basic
=== CONT  TestAccDataAlarmNotifiedHistory_basic
--- PASS: TestAccDataAlarmNotifiedHistory_basic (24.71s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/aom
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       24.841s coverage: 4.2% of statements in ./huaweicloud/services/aom
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.