### PR TITLE
feat(cbh): new resource to reset login mode

### DIFF
--- a/docs/resources/cbh_reset_login_mode.md
+++ b/docs/resources/cbh_reset_login_mode.md
@@ -1,0 +1,39 @@
+---
+subcategory: "Cloud Bastion Host (CBH)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbh_reset_login_mode"
+description: |-
+  Manages a CBH reset login mode resource within HuaweiCloud.
+---
+
+# huaweicloud_cbh_reset_login_mode
+
+Resets a CBH instance login mode resource within HuaweiCloud.
+
+-> This resource is only a one-time action resource to reset a CBH instance login mode. Deleting this resource
+will not clear the corresponding login mode, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "server_id" {}
+
+resource "huaweicloud_cbh_reset_login_mode" "test" {
+  server_id = var.server_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to reset the login mode.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `server_id` - (Required, String, NonUpdatable) Specifies the ID of the CBH instance to reset the login mode.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (same as `server_id`).

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2365,6 +2365,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbr_vault_set_resource":       cbr.ResourceVaultSetResource(),
 
 			"huaweicloud_cbh_instance":                   cbh.ResourceCBHInstance(),
+			"huaweicloud_cbh_reset_login_mode":           cbh.ResourceResetLoginMode(),
 			"huaweicloud_cbh_ha_instance":                cbh.ResourceCBHHAInstance(),
 			"huaweicloud_cbh_asset_agency_authorization": cbh.ResourceAssetAgencyAuthorization(),
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -166,6 +166,7 @@ var (
 	HW_SWR_USER             = os.Getenv("HW_SWR_USER")
 
 	HW_CBH_INSTANCE_ID = os.Getenv("HW_CBH_INSTANCE_ID")
+	HW_CBH_SERVER_ID   = os.Getenv("HW_CBH_SERVER_ID")
 
 	HW_RAM_SHARE_ACCOUNT_ID          = os.Getenv("HW_RAM_SHARE_ACCOUNT_ID")
 	HW_RAM_SHARE_RESOURCE_URN        = os.Getenv("HW_RAM_SHARE_RESOURCE_URN")
@@ -1368,6 +1369,13 @@ func TestAccPreCheckElbLoadbalancerID(t *testing.T) {
 func TestAccPreCheckCbhInstanceID(t *testing.T) {
 	if HW_CBH_INSTANCE_ID == "" {
 		t.Skip("HW_CBH_INSTANCE_ID must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCbhServerID(t *testing.T) {
+	if HW_CBH_SERVER_ID == "" {
+		t.Skip("HW_CBH_SERVER_ID must be set for this acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_reset_login_mode_test.go
+++ b/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_reset_login_mode_test.go
@@ -1,0 +1,34 @@
+package cbh
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResetLoginMode_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCbhServerID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testResetLoginMode_basic(),
+			},
+		},
+	})
+}
+
+func testResetLoginMode_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cbh_reset_login_mode" "test" {
+  server_id = "%s"
+}
+`, acceptance.HW_CBH_SERVER_ID)
+}

--- a/huaweicloud/services/cbh/resource_huaweicloud_cbh_reset_login_mode.go
+++ b/huaweicloud/services/cbh/resource_huaweicloud_cbh_reset_login_mode.go
@@ -1,0 +1,102 @@
+package cbh
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CBH PUT /v2/{project_id}/cbs/instance/login-method
+func ResourceResetLoginMode() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceResetLoginModeCreate,
+		UpdateContext: resourceResetLoginModeUpdate,
+		ReadContext:   resourceResetLoginModeRead,
+		DeleteContext: resourceResetLoginModeDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"server_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"server_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceResetLoginModeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		httpUrl  = "v2/{project_id}/cbs/instance/login-method"
+		product  = "cbh"
+		serverId = d.Get("server_id").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBH client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"server_id": serverId,
+		},
+	}
+
+	_, err = client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error resetting CBH login mode: %s", err)
+	}
+
+	d.SetId(serverId)
+
+	return resourceResetLoginModeRead(ctx, d, meta)
+}
+
+func resourceResetLoginModeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceResetLoginModeUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceResetLoginModeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to reset login mode.
+Deleting this resource will not recover the reset login mode, but will only remove the resource information from
+the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to reset login mode

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cbh -f TestAccResetLoginMode_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbh" -v -coverprofile="./huaweicloud/services/acceptance/cbh/cbh_coverage.cov" -coverpkg="./huaweicloud/services/cbh" -run TestAccResetLoginMode_basic -timeout 360m -parallel 10
=== RUN   TestAccResetLoginMode_basic
=== PAUSE TestAccResetLoginMode_basic
=== CONT  TestAccResetLoginMode_basic
--- PASS: TestAccResetLoginMode_basic (10.91s)
PASS
coverage: 2.5% of statements in ./huaweicloud/services/cbh
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       10.984s coverage: 2.5% of statements in ./huaweicloud/services/cbh
```
<img width="1258" height="78" alt="image" src="https://github.com/user-attachments/assets/c33a6aaa-22a5-4b5d-a711-eed8b62db0a2" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
