### PR TITLE
feat(kafka): add a one-time resource to configure volume auto-scaling

### DIFF
--- a/docs/resources/dms_kafka_volume_auto_expand_configuration.md
+++ b/docs/resources/dms_kafka_volume_auto_expand_configuration.md
@@ -1,0 +1,78 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_volume_auto_expand_configuration"
+description: |-
+  Use this resource to configure the volume auto-expansion for the specified Kafka instance within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_volume_auto_expand_configuration
+
+Use this resource to configure the volume auto-expansion for the specified Kafka instance within HuaweiCloud.
+
+-> 1. This resource is unavailable for single-node instance Kafka.
+   <br/> 2. This resource is only a one-time action resource for configuring volume auto-expansion. Deleting this
+   resource will not clear the configuration, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+### Enable volume auto-expansion
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_dms_kafka_volume_auto_expand_configuration" "test" {
+  instance_id               = var.instance_id
+  auto_volume_expand_enable = true
+  expand_threshold          = 80
+  expand_increment          = 10
+  max_volume_size           = 400
+}
+```
+
+### Disable volume auto-expansion
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_dms_kafka_volume_auto_expand_configuration" "test" {
+  instance_id               = var.instance_id
+  auto_volume_expand_enable = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the Kafka instance to be configured volume
+  auto-expansion is located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the Kafka instance.
+
+* `auto_volume_expand_enable` - (Optional, Bool, NonUpdatable) Specifies whether to enable disk auto-expansion.  
+   Defaults to **false**.
+
+* `expand_threshold` - (Optional, Int, NonUpdatable) Specifies the threshold for triggering disk auto-expansion,
+  in percentage (%).  
+  The valid value ranges from `20` to `80`.  
+  This parameter is **required** when `auto_volume_expand_enable` is set to **true**.
+
+* `expand_increment` - (Optional, Int, NonUpdatable) Specifies the percentage of storage space to be expanded
+  out of the total instance storage space, in percentage (%).  
+  The valid value ranges from `10` to `100`.
+  This parameter is **required** when `auto_volume_expand_enable` is set to **true**.
+
+* `max_volume_size` - (Optional, Int, NonUpdatable) Specifies the maximum volume size for disk auto-expansion, in GB.  
+  This parameter is **required** when `auto_volume_expand_enable` is set to **true**.  
+  The value must meet the following requirements:
+  + The value must be divisible by `100`.
+  + The value must be greater than the current instance disk capacity.
+  + The value must be less than the number of nodes multiplied by `30000`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2720,6 +2720,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_user":                              kafka.ResourceDmsKafkaUser(),
 			"huaweicloud_dms_kafka_user_client_quota":                 kafka.ResourceDmsKafkaUserClientQuota(),
 			"huaweicloud_dms_kafka_user_password_reset":               kafka.ResourceUserPasswordReset(),
+			"huaweicloud_dms_kafka_volume_auto_expand_configuration":  kafka.ResourceVolumeAutoExpandConfiguration(),
 
 			"huaweicloud_dms_rabbitmq_background_task_delete": rabbitmq.ResourceDmsRabbitMQBackgroundTaskDelete(),
 			"huaweicloud_dms_rabbitmq_instance":               rabbitmq.ResourceDmsRabbitmqInstance(),

--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_volume_auto_expand_configuration_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_volume_auto_expand_configuration_test.go
@@ -1,0 +1,71 @@
+package kafka
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccVolumeAutoExpandConfiguration_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccVolumeAutoExpandConfiguration_instanceNotFound(),
+				ExpectError: regexp.MustCompile("This DMS instance does not exist"),
+			},
+			{
+				Config: testAccVolumeAutoExpandConfiguration_basic_step1(),
+			},
+			{
+				Config: testAccVolumeAutoExpandConfiguration_basic_step2(),
+			},
+		},
+	})
+}
+
+func testAccVolumeAutoExpandConfiguration_instanceNotFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_volume_auto_expand_configuration" "test" {
+  instance_id               = "%[1]s"
+  auto_volume_expand_enable = true
+  expand_threshold          = 80
+  expand_increment          = 10
+  max_volume_size           = 400
+}`, randomId)
+}
+
+func testAccVolumeAutoExpandConfiguration_basic_step1() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dms_kafka_instances" "test" {
+  instance_id = "%[1]s"
+}
+
+resource "huaweicloud_dms_kafka_volume_auto_expand_configuration" "enable" {
+  instance_id               = "%[1]s"
+  auto_volume_expand_enable = true
+  expand_threshold          = 80
+  expand_increment          = 10
+  # Must be greater than the current instance disk capacity.
+  max_volume_size = try(data.huaweicloud_dms_kafka_instances.test.instances[0].storage_space, 0) + 100
+}`, acceptance.HW_DMS_KAFKA_INSTANCE_ID)
+}
+
+func testAccVolumeAutoExpandConfiguration_basic_step2() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_volume_auto_expand_configuration" "disable" {
+  instance_id               = "%[1]s"
+  auto_volume_expand_enable = false
+}`, acceptance.HW_DMS_KAFKA_INSTANCE_ID)
+}

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_volume_auto_expand_configuration.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_volume_auto_expand_configuration.go
@@ -1,0 +1,141 @@
+package kafka
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var volumeAutoExpandConfigurationNonUpdatableParams = []string{
+	"instance_id",
+	"auto_volume_expand_enable",
+	"expand_threshold",
+	"expand_increment",
+	"max_volume_size",
+}
+
+// @API Kafka PUT /v2/{project_id}/instances/{instance_id}/auto-volume-expand
+func ResourceVolumeAutoExpandConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVolumeAutoExpandConfigurationCreate,
+		ReadContext:   resourceVolumeAutoExpandConfigurationRead,
+		UpdateContext: resourceVolumeAutoExpandConfigurationUpdate,
+		DeleteContext: resourceVolumeAutoExpandConfigurationDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(volumeAutoExpandConfigurationNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the Kafka instance is located to be configured volume auto-expansion.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the Kafka instance.`,
+			},
+			"auto_volume_expand_enable": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to enable disk auto-expansion.`,
+			},
+			"expand_threshold": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The threshold for triggering disk auto-expansion, in percentage (%).`,
+			},
+			"expand_increment": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The percentage of storage space to be expanded out of the total instance storage space, in percentage (%).`,
+			},
+			"max_volume_size": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The maximum volume size for disk auto-expansion, in GB.`,
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildVolumeAutoExpandConfigurationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"auto_volume_expand_enable": d.Get("auto_volume_expand_enable"),
+		"expand_threshold":          utils.ValueIgnoreEmpty(d.Get("expand_threshold")),
+		"expand_increment":          utils.ValueIgnoreEmpty(d.Get("expand_increment")),
+		"max_volume_size":           utils.ValueIgnoreEmpty(d.Get("max_volume_size")),
+	}
+}
+
+func resourceVolumeAutoExpandConfigurationCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		httpUrl    = "v2/{project_id}/instances/{instance_id}/auto-volume-expand"
+		instanceId = d.Get("instance_id").(string)
+	)
+	client, err := cfg.NewServiceClient("dmsv2", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", instanceId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildVolumeAutoExpandConfigurationBodyParams(d)),
+	}
+
+	_, err = client.Request("PUT", updatePath, &opt)
+	if err != nil {
+		return diag.Errorf("error configuring volume auto-expansion of the instance(%s): %s", instanceId, err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate resource ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	return nil
+}
+
+func resourceVolumeAutoExpandConfigurationRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceVolumeAutoExpandConfigurationUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceVolumeAutoExpandConfigurationDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to configure volume auto-expansion. 
+Deleting this resource will not clear the configuration, but will only remove the resource information 
+from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a one-time resource (`huaweicloud_dms_kafka_volume_auto_expand_configuration`) to configure volume auto-scaling for specified Kafka instance.

Repeated calls to the API corresponding to this resource will not result in errors.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a one-time action resource.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccVolumeAutoExpandConfiguration_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccVolumeAutoExpandConfiguration_basic -timeout 360m -parallel 10
=== RUN   TestAccVolumeAutoExpandConfiguration_basic
=== PAUSE TestAccVolumeAutoExpandConfiguration_basic
=== CONT  TestAccVolumeAutoExpandConfiguration_basic
--- PASS: TestAccVolumeAutoExpandConfiguration_basic (37.74s)
PASS
coverage: 2.1% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     37.898s coverage: 2.1% of statements in ./huaweicloud/services/kafka
```
 
<img width="1014" height="521" alt="image" src="https://github.com/user-attachments/assets/4454969c-572d-42cf-bc42-a5e052125fa4" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
