### PR TITLE
feat(fgs): query triggers data source supports new API

### DIFF
--- a/docs/data-sources/fgs_function_triggers.md
+++ b/docs/data-sources/fgs_function_triggers.md
@@ -24,10 +24,10 @@ data "huaweicloud_fgs_function_triggers" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to query the data source.
+* `region` - (Optional, String) Specifies the region where the triggers are located.
   If omitted, the provider-level region will be used.
 
-* `function_urn` - (Required, String) Specifies the function URN to which the trigger belongs.
+* `function_urn` - (Optional, String) Specifies the URN of the function URN to which the triggers belong.
 
 * `trigger_id` - (Optional, String) Specifies the ID of the function trigger.
 
@@ -70,7 +70,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID.
 
-* `triggers` - All triggers that match the filter parameters.
+* `triggers` - All triggers that match the filter parameters.  
   The [triggers](#function_triggers) structure is documented below.
 
 <a name="function_triggers"></a>
@@ -80,7 +80,10 @@ The `triggers` block supports:
 
 * `type` - The type of the function trigger.
 
-* `event_data` - The detailed configuration of the function trigger.
+* `event_data` - The detailed configuration of the function trigger, in JSON format.
+
+* `function_urn` - The URN of the function URN to which the triggers belong.  
+  This field is not empty only when the `function_urn` parameter is not specified.
 
 * `status` - The current status of the function trigger.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The data source(`huaweicloud_fgs_function_triggers`) supports new [API](https://support.huaweicloud.com/api-functiongraph/ListActiveTrigger.html).

+ Change `function_urn` to an optional behavior.
+ Add new attribute: `triggers.function_urn`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccDataFunctionTriggers_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccDataFunctionTriggers_basic -timeout 360m -parallel 10
=== RUN   TestAccDataFunctionTriggers_basic
=== PAUSE TestAccDataFunctionTriggers_basic
=== CONT  TestAccDataFunctionTriggers_basic
--- PASS: TestAccDataFunctionTriggers_basic (35.81s)
PASS
coverage: 15.8% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       35.903s coverage: 15.8% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
