### PR TITLE
feat(apig): add new data source to query instance ingress ports

### DIFF
--- a/docs/data-sources/apig_instance_ingress_ports.md
+++ b/docs/data-sources/apig_instance_ingress_ports.md
@@ -1,0 +1,73 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_instance_ingress_ports"
+description: |-
+  Use this data source to query the custom ingress ports of the dedicated instance within HuaweiCloud.
+---
+
+# huaweicloud_apig_instance_ingress_ports
+
+Use this data source to query the custom ingress ports of the dedicated instance within HuaweiCloud.
+
+## Example Usage
+
+### Query all custom ingress ports under a specified instance
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_apig_instance_ingress_ports" "test" {
+  instance_id = var.instance_id
+}
+```
+
+### Query all custom ingress ports with HTTPS protocol under a specified instance
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_apig_instance_ingress_ports" "test" {
+  instance_id = var.instance_id
+  protocol    = "HTTPS"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the ingress ports are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the ingress ports belong.
+
+* `protocol` - (Optional, String) Specifies the protocol of the ingress port to be queried.  
+  The valid values are as follows:
+  + **HTTP**: The ingress port uses HTTP protocol.
+  + **HTTPS**: The ingress port uses HTTPS protocol.
+
+* `port` - (Optional, Int) Specifies the port number of the ingress port to be queried.  
+  The valid value is range from `1,024` to `49,151`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `ingress_ports` - The list of the ingress ports that matched filter parameters.  
+  The [ingress_ports](#apig_ingress_ports_attr) structure is documented below.
+
+<a name="apig_ingress_ports_attr"></a>
+The `ingress_ports` block supports:
+
+* `id` - The ID of the ingress port.
+
+* `protocol` - The protocol of the ingress port.
+
+* `port` - The port number of the ingress port.
+
+* `status` - The status of the ingress port.
+  + **normal**: The ingress port status is normal.
+  + **abnormal**: The ingress port status is abnormal and cannot be used.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -588,6 +588,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_instance_api_tags":                  apig.DataSourceInstanceApiTags(),
 			"huaweicloud_apig_instance_associated_certificates":   apig.DataSourceInstanceAssociatedCertificates(),
 			"huaweicloud_apig_instance_features":                  apig.DataSourceInstanceFeatures(),
+			"huaweicloud_apig_instance_ingress_ports":             apig.DataSourceInstanceIngressPorts(),
 			"huaweicloud_apig_instance_quotas":                    apig.DataSourceInstanceQuotas(),
 			"huaweicloud_apig_instance_supported_features":        apig.DataSourceInstanceSupportedFeatures(),
 			"huaweicloud_apig_instance_tags":                      apig.DataSourceInstanceTags(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_instance_ingress_ports_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_instance_ingress_ports_test.go
@@ -1,0 +1,132 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataInstanceIngressPorts_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_apig_instance_ingress_ports.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byProtocol   = "data.huaweicloud_apig_instance_ingress_ports.filter_by_protocol"
+		dcByProtocol = acceptance.InitDataSourceCheck(byProtocol)
+
+		byPort   = "data.huaweicloud_apig_instance_ingress_ports.filter_by_port"
+		dcByPort = acceptance.InitDataSourceCheck(byPort)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataInstanceIngressPorts_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "ingress_ports.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "ingress_ports.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "ingress_ports.0.protocol"),
+					resource.TestCheckResourceAttrSet(dataSource, "ingress_ports.0.port"),
+					resource.TestCheckResourceAttrSet(dataSource, "ingress_ports.0.status"),
+					dcByProtocol.CheckResourceExists(),
+					resource.TestCheckOutput("protocol_filter_is_useful", "true"),
+					dcByPort.CheckResourceExists(),
+					resource.TestCheckOutput("port_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataInstanceIngressPorts_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[1]s"
+}
+
+locals {
+  instance_id = data.huaweicloud_apig_instances.test.instances[0].id
+}
+
+resource "huaweicloud_apig_instance_ingress_port" "http" {
+  instance_id = local.instance_id
+  protocol    = "HTTP"
+  port        = 8080
+}
+
+resource "huaweicloud_apig_instance_ingress_port" "https" {
+  instance_id = local.instance_id
+  protocol    = "HTTPS"
+  port        = 8443
+}
+
+data "huaweicloud_apig_instance_ingress_ports" "test" {
+  depends_on = [
+    huaweicloud_apig_instance_ingress_port.http,
+    huaweicloud_apig_instance_ingress_port.https
+  ]
+
+  instance_id = local.instance_id
+}
+
+# Filter by protocol
+locals {
+  protocol = huaweicloud_apig_instance_ingress_port.http.protocol
+}
+
+data "huaweicloud_apig_instance_ingress_ports" "filter_by_protocol" {
+  depends_on = [
+    huaweicloud_apig_instance_ingress_port.http,
+    huaweicloud_apig_instance_ingress_port.https
+  ]
+
+  instance_id = local.instance_id
+  protocol    = local.protocol
+}
+
+locals {
+  protocol_filter_result = [
+    for v in data.huaweicloud_apig_instance_ingress_ports.filter_by_protocol.ingress_ports[*].protocol : v == local.protocol
+  ]
+}
+
+output "protocol_filter_is_useful" {
+  value = length(local.protocol_filter_result) > 0 && alltrue(local.protocol_filter_result)
+}
+
+# Filter by port
+locals {
+  port = huaweicloud_apig_instance_ingress_port.http.port
+}
+
+data "huaweicloud_apig_instance_ingress_ports" "filter_by_port" {
+  depends_on = [
+    huaweicloud_apig_instance_ingress_port.http,
+    huaweicloud_apig_instance_ingress_port.https
+  ]
+
+  instance_id = local.instance_id
+  port        = local.port
+}
+
+locals {
+  port_filter_result = [
+    for v in data.huaweicloud_apig_instance_ingress_ports.filter_by_port.ingress_ports[*].port : v == local.port
+  ]
+}
+
+output "port_filter_is_useful" {
+  value = length(local.port_filter_result) > 0 && alltrue(local.port_filter_result)
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_instance_ingress_ports.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_instance_ingress_ports.go
@@ -1,0 +1,119 @@
+package apig
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/custom-ingress-ports
+func DataSourceInstanceIngressPorts() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstanceIngressPortsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the ingress ports are located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the ingress ports belong.`,
+			},
+			"protocol": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The protocol of the ingress port to be queried.`,
+			},
+			"port": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The port number of the ingress port to be queried.`,
+			},
+			"ingress_ports": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the ingress port.`,
+						},
+						"protocol": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The protocol of the ingress port.`,
+						},
+						"port": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The port number of the ingress port.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the ingress port.`,
+						},
+					},
+				},
+				Description: `The list of the ingress ports that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func flattenInstanceIngressPorts(ingressPorts []interface{}) []map[string]interface{} {
+	if len(ingressPorts) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(ingressPorts))
+	for _, port := range ingressPorts {
+		result = append(result, map[string]interface{}{
+			"id":       utils.PathSearch("ingress_port_id", port, nil),
+			"protocol": utils.PathSearch("protocol", port, nil),
+			"port":     utils.PathSearch("ingress_port", port, nil),
+			"status":   utils.PathSearch("status", port, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceInstanceIngressPortsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	ingressPorts, err := listInstanceIngressPorts(client, instanceId, d)
+	if err != nil {
+		return diag.Errorf("error querying APIG instance ingress ports: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("ingress_ports", flattenInstanceIngressPorts(ingressPorts)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source that used to query the custom ingress ports under a specified instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1105" height="451" alt="image" src="https://github.com/user-attachments/assets/a70ff524-16f0-49ea-8f26-4646d577a3fc" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query instance ingress ports
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccDataInstanceIngressPorts_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataInstanceIngressPorts_basic -timeout 360m -parallel 10
=== RUN   TestAccDataInstanceIngressPorts_basic
=== PAUSE TestAccDataInstanceIngressPorts_basic
=== CONT  TestAccDataInstanceIngressPorts_basic
--- PASS: TestAccDataInstanceIngressPorts_basic (19.43s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      19.527s coverage: 3.7% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
