### PR TITLE
feat(hss): support `hss_container_kubernetes_clusters_risks` data source

### DIFF
--- a/docs/data-sources/hss_container_kubernetes_clusters_risks.md
+++ b/docs/data-sources/hss_container_kubernetes_clusters_risks.md
@@ -1,0 +1,79 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_container_kubernetes_clusters_risks"
+description: |-
+  Use this data source to get the list of HSS container kubernetes clusters risks within HuaweiCloud.
+---
+
+# huaweicloud_hss_container_kubernetes_clusters_risks
+
+Use this data source to get the list of HSS container kubernetes clusters risks within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id_list" {
+  type = list(string)
+}
+
+data "huaweicloud_hss_container_kubernetes_clusters_risks" "test" {
+  cluster_id_list = var.cluster_id_list
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `cluster_id_list` - (Required, List) Specifies the cluster ID list.
+
+* `detect_type` - (Optional, String) Specifies the detect type.  
+  The valid values are as follows:
+  + **image**: Image risk.
+  + **baseline**: Baseline risk.
+  + **vul**: Vulnerability risk.
+  + **event**: Intrusion risk.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `total_num` - The total number of clusters.
+
+* `data_list` - The list of cluster risks.
+
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `images_num` - The number of risky images.
+
+* `baseline_risk_num` - The total number of baseline check risks.
+
+* `vul_num` - The number of vulnerabilities.
+
+* `event_num` - The number of alarm events.
+
+* `protect_node_num` - The number of protected nodes in the cluster.
+
+* `node_total_num` - The total number of nodes in the cluster.
+
+* `cluster_id` - The cluster ID.
+
+* `charging_mode` - The charging mode.  
+  The valid values are as follows:
+  + **on_demand**: Pay-per-use.
+  + **free**: Free.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1357,6 +1357,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_container_kubernetes":                       hss.DataSourceContainerKubernetes(),
 			"huaweicloud_hss_container_kubernetes_clusters":              hss.DataSourceContainerKubernetesClusters(),
 			"huaweicloud_hss_container_kubernetes_clusters_configs":      hss.DataSourceContainerKubernetesClustersConfigs(),
+			"huaweicloud_hss_container_kubernetes_clusters_risks":        hss.DataSourceContainerKubernetesClustersRisks(),
 			"huaweicloud_hss_container_kubernetes_endpoints":             hss.DataSourceContainerKubernetesEndpoints(),
 			"huaweicloud_hss_container_kubernetes_endpoint_detail":       hss.DataSourceContainerKubernetesEndpointDetail(),
 			"huaweicloud_hss_container_nodes":                            hss.DataSourceContainerNodes(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_kubernetes_clusters_risks_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_kubernetes_clusters_risks_test.go
@@ -1,0 +1,45 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Due to testing environment limitations, this test case can only test the scenario with empty `data_list`.
+func TestAccDataSourceContainerKubernetesClustersRisks_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_container_kubernetes_clusters_risks.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceContainerKubernetesClustersRisks_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.#"),
+				),
+			},
+		},
+	})
+}
+
+// The `cluster_id_list` used is dummy data for testing.
+func testDataSourceContainerKubernetesClustersRisks_basic() string {
+	return `
+data "huaweicloud_hss_container_kubernetes_clusters_risks" "test" {
+  cluster_id_list       = ["f69812ba-bf72-11f0-a281-0255ac10024f"]
+  detect_type           = "image"
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_container_kubernetes_clusters_risks.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_container_kubernetes_clusters_risks.go
@@ -1,0 +1,176 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS POST /v5/{project_id}/container/kubernetes/clusters/risks/query
+func DataSourceContainerKubernetesClustersRisks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceContainerKubernetesClustersRisksRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cluster_id_list": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"detect_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"images_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"baseline_risk_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"vul_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"event_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"protect_node_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"node_total_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"cluster_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"charging_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildContainerKubernetesClustersRisksQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%v", epsId)
+	}
+
+	return ""
+}
+
+func buildContainerKubernetesClustersRisksBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"cluster_id_list": utils.ExpandToStringList(d.Get("cluster_id_list").([]interface{})),
+		"detect_type":     utils.ValueIgnoreEmpty(d.Get("detect_type")),
+	}
+}
+
+func dataSourceContainerKubernetesClustersRisksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/container/kubernetes/clusters/risks/query"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildContainerKubernetesClustersRisksQueryParams(epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildContainerKubernetesClustersRisksBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS container kubernetes clusters risks: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataList := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_num", utils.PathSearch("total_num", respBody, nil)),
+		d.Set("data_list", flattenContainerKubernetesClustersRisksDataList(dataList)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenContainerKubernetesClustersRisksDataList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"images_num":        utils.PathSearch("images_num", v, nil),
+			"baseline_risk_num": utils.PathSearch("baseline_risk_num", v, nil),
+			"vul_num":           utils.PathSearch("vul_num", v, nil),
+			"event_num":         utils.PathSearch("event_num", v, nil),
+			"protect_node_num":  utils.PathSearch("protect_node_num", v, nil),
+			"node_total_num":    utils.PathSearch("node_total_num", v, nil),
+			"cluster_id":        utils.PathSearch("cluster_id", v, nil),
+			"charging_mode":     utils.PathSearch("charging_mode", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_container_kubernetes_clusters_risks` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_container_kubernetes_clusters_risks` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceContainerKubernetesClustersRisks_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceContainerKubernetesClustersRisks_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceContainerKubernetesClustersRisks_basic
=== PAUSE TestAccDataSourceContainerKubernetesClustersRisks_basic
=== CONT  TestAccDataSourceContainerKubernetesClustersRisks_basic
--- PASS: TestAccDataSourceContainerKubernetesClustersRisks_basic (10.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       10.199s
```
<img width="982" height="31" alt="image" src="https://github.com/user-attachments/assets/fdf2a070-2b5e-46c5-99a5-36084dc38584" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
