### PR TITLE
feat(cbh): new resource to delete fault cbh instance

### DIFF
--- a/docs/resources/cbh_delete_fault_instance.md
+++ b/docs/resources/cbh_delete_fault_instance.md
@@ -1,0 +1,39 @@
+---
+subcategory: "Cloud Bastion Host (CBH)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbh_delete_fault_instance"
+description: |-
+  Manages a CBH delete fault instance resource within HuaweiCloud.
+---
+
+# huaweicloud_cbh_delete_fault_instance
+
+Manages a CBH delete fault instance resource within HuaweiCloud.
+
+-> This resource is a one-time action resource to delete a faulty CBH instance. Deleting this resource
+will not recover the deleted CBH instance, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_cbh_delete_fault_instance" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to delete the faulty CBH instance.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the faulty CBH instance to be deleted.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (same as `instance_id`).

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2386,6 +2386,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbh_instance":                   cbh.ResourceCBHInstance(),
 			"huaweicloud_cbh_reset_login_mode":           cbh.ResourceResetLoginMode(),
 			"huaweicloud_cbh_rollback_instance":          cbh.ResourceRollbackInstance(),
+			"huaweicloud_cbh_delete_fault_instance":      cbh.ResourceDeleteFaultInstance(),
 			"huaweicloud_cbh_ha_instance":                cbh.ResourceCBHHAInstance(),
 			"huaweicloud_cbh_asset_agency_authorization": cbh.ResourceAssetAgencyAuthorization(),
 

--- a/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_delete_fault_instance_test.go
+++ b/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_delete_fault_instance_test.go
@@ -1,0 +1,34 @@
+package cbh
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDeleteFaultInstance_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCbhServerID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testDeleteFaultInstance_basic,
+				ExpectError: regexp.MustCompile(`租户无权限`),
+			},
+		},
+	})
+}
+
+// The value of instance_id is a fixed value, not a variable.
+const testDeleteFaultInstance_basic = `
+resource "huaweicloud_cbh_delete_fault_instance" "test" {
+  instance_id = "183743"
+}
+`

--- a/huaweicloud/services/cbh/resource_huaweicloud_cbh_delete_fault_instance.go
+++ b/huaweicloud/services/cbh/resource_huaweicloud_cbh_delete_fault_instance.go
@@ -1,0 +1,101 @@
+package cbh
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CBH DELETE /v2/{project_id}/cbs/instance
+func ResourceDeleteFaultInstance() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDeleteFaultInstanceCreate,
+		UpdateContext: resourceDeleteFaultInstanceUpdate,
+		ReadContext:   resourceDeleteFaultInstanceRead,
+		DeleteContext: resourceDeleteFaultInstanceDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"instance_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceDeleteFaultInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v2/{project_id}/cbs/instance"
+		product    = "cbh"
+		instanceId = d.Get("instance_id").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBH client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?instance_id=%s", instanceId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting faulty CBH instance: %s", err)
+	}
+
+	d.SetId(instanceId)
+
+	return resourceDeleteFaultInstanceRead(ctx, d, meta)
+}
+
+func resourceDeleteFaultInstanceRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDeleteFaultInstanceUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDeleteFaultInstanceDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to delete a faulty CBH instance.
+Deleting this resource will not recover the deleted CBH instance, but will only remove the resource information from
+the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to delete fault cbh instance

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cbh -f TestAccDeleteFaultInstance_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbh" -v -coverprofile="./huaweicloud/services/acceptance/cbh/cbh_coverage.cov" -coverpkg="./huaweicloud/services/cbh" -run TestAccDeleteFaultInstance_basic -timeout 360m -parallel 10
=== RUN   TestAccDeleteFaultInstance_basic
=== PAUSE TestAccDeleteFaultInstance_basic
=== CONT  TestAccDeleteFaultInstance_basic
--- PASS: TestAccDeleteFaultInstance_basic (6.17s)
PASS
coverage: 3.0% of statements in ./huaweicloud/services/cbh
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       6.252s  coverage: 3.0% of statements in ./huaweicloud/services/cbh
```
<img width="1235" height="74" alt="image" src="https://github.com/user-attachments/assets/8676c36b-34a5-4e4b-a943-8b147802c6ba" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
