### PR TITLE
feat(hss): support `hss_container_network_cluster` data source

### DIFF
--- a/docs/data-sources/hss_container_network_cluster.md
+++ b/docs/data-sources/hss_container_network_cluster.md
@@ -1,0 +1,75 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_container_network_cluster"
+description: |-
+  Use this data source to get the list of HSS container network cluster information within HuaweiCloud.
+---
+
+# huaweicloud_hss_container_network_cluster
+
+Use this data source to get the list of HSS container network cluster information within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_container_network_cluster" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `total_num` - The total number.
+
+* `data_list` - The list of cluster information.
+
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `cluster_id` - The cluster ID.
+
+* `cluster_name` - The cluster name.
+
+* `cluster_type` - The cluster type.  
+  The valid values are as follows:
+  + **cce**: CCE cluster.
+  + **k8s**: Native cluster.
+  + **ali**: Alibaba Cloud cluster.
+  + **tencent**: Tencent Cloud cluster.
+  + **azure**: Microsoft Azure cluster.
+  + **aws**: Amazon cluster.
+  + **self_built_hw**: Huawei Cloud self-built cluster.
+  + **self_built_idc**: IDC self-built cluster.
+
+* `version` - The cluster version.
+
+* `mode` - The network mode.  
+  The valid values are as follows:
+  + **overlay_l2**: Container tunnel network.
+  + **vpc-router**: VPC network.
+  + **eni**: Cloud native network 2.0.
+  + **native-network**: K8S native network.
+
+* `namespace_num` - The number of namespaces.
+
+* `policy_num` - The number of policies.
+
+* `protection_status` - The protection status. The valid values are **true** and **false**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1368,6 +1368,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_container_cluster_risk_affected_resources":  hss.DataSourceContainerClusterRiskAffectedResources(),
 			"huaweicloud_hss_container_cluster_statistics":               hss.DataSourceContainerClusterStatistics(),
 			"huaweicloud_hss_container_network_policies":                 hss.DataSourceContainerNetworkPolicies(),
+			"huaweicloud_hss_container_network_cluster":                  hss.DataSourceContainerNetworkCluster(),
 			"huaweicloud_hss_container_network_info":                     hss.DataSourceContainerNetworkInfo(),
 			"huaweicloud_hss_container_iac_files":                        hss.DataSourceContainerIacFiles(),
 			"huaweicloud_hss_container_iac_file_risks":                   hss.DataSourceContainerIacFileRisks(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_network_cluster_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_network_cluster_test.go
@@ -1,0 +1,42 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Due to testing environment limitations, this test case can only test the scenario with empty `data_list`.
+func TestAccDataSourceContainerNetworkCluster_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_container_network_cluster.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceContainerNetworkCluster_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceContainerNetworkCluster_basic() string {
+	return `
+data "huaweicloud_hss_container_network_cluster" "test" {
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_container_network_cluster.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_container_network_cluster.go
@@ -1,0 +1,174 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/container-network/cluster
+func DataSourceContainerNetworkCluster() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceContainerNetworkClusterRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cluster_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"namespace_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"policy_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"protection_status": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildContainerNetworkClusterQueryParams(epsId string) string {
+	queryParams := "?limit=200"
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+
+	return queryParams
+}
+
+func dataSourceContainerNetworkClusterRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		product  = "hss"
+		epsId    = cfg.GetEnterpriseProjectID(d)
+		result   = make([]interface{}, 0)
+		offset   = 0
+		totalNum = 0
+		httpUrl  = "v5/{project_id}/container-network/cluster"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildContainerNetworkClusterQueryParams(epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS container network cluster: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalNum = int(utils.PathSearch("total_num", respBody, float64(0)).(float64))
+		dataList := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataList) == 0 {
+			break
+		}
+
+		result = append(result, dataList...)
+		offset += len(dataList)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_num", totalNum),
+		d.Set("data_list", flattenContainerNetworkClusterDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenContainerNetworkClusterDataList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"cluster_id":        utils.PathSearch("cluster_id", v, nil),
+			"cluster_name":      utils.PathSearch("cluster_name", v, nil),
+			"cluster_type":      utils.PathSearch("cluster_type", v, nil),
+			"version":           utils.PathSearch("version", v, nil),
+			"mode":              utils.PathSearch("mode", v, nil),
+			"namespace_num":     utils.PathSearch("namespace_num", v, nil),
+			"policy_num":        utils.PathSearch("policy_num", v, nil),
+			"protection_status": utils.PathSearch("protection_status", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_container_network_cluster` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_container_network_cluster` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceContainerNetworkCluster_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceContainerNetworkCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceContainerNetworkCluster_basic
=== PAUSE TestAccDataSourceContainerNetworkCluster_basic
=== CONT  TestAccDataSourceContainerNetworkCluster_basic
--- PASS: TestAccDataSourceContainerNetworkCluster_basic (11.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       11.800s
```
<img width="935" height="38" alt="image" src="https://github.com/user-attachments/assets/3bd7a37a-ce3d-4961-9fa6-d435feb379fc" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
