### PR TITLE
feat(hss): support `hss_kubernetes_cronjobs` data source

### DIFF
--- a/docs/data-sources/hss_kubernetes_cronjobs.md
+++ b/docs/data-sources/hss_kubernetes_cronjobs.md
@@ -1,0 +1,84 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_kubernetes_cronjobs"
+description: |-
+  Use this data source to get the list of HSS kubernetes cronjobs within HuaweiCloud.
+---
+
+# huaweicloud_hss_kubernetes_cronjobs
+
+Use this data source to get the list of HSS kubernetes cronjobs within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_kubernetes_cronjobs" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `cronjob_name` - (Optional, String) Specifies the cronjob name.
+
+* `namespace_name` - (Optional, String) Specifies the namespace name.
+
+* `cluster_name` - (Optional, String) Specifies the cluster name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `total_num` - The total number of cronjobs.
+
+* `last_update_time` - The last update time.
+
+* `cronjob_info_list` - The list of cronjobs information.
+
+  The [cronjob_info_list](#cronjob_info_list_struct) structure is documented below.
+
+<a name="cronjob_info_list_struct"></a>
+The `cronjob_info_list` block supports:
+
+* `name` - The cronjob name.
+
+* `namespace_name` - The namespace name.
+
+* `cluster_name` - The cluster name.
+
+* `status` - The status. Valid values are:
+  + **Running**: Normal operation.
+  + **Failed**: Abnormal.
+
+* `running_jobs_num` - The number of running jobs.
+
+* `schedule` - The job trigger cycle.
+
+* `image_name` - The image name.
+
+* `match_labels` - The labels.
+
+  The [match_labels](#match_labels_struct) structure is documented below.
+
+* `execute_time` - The last execution time.
+
+* `create_time` - The creation time.
+
+<a name="match_labels_struct"></a>
+The `match_labels` block supports:
+
+* `key` - The label name.
+
+* `val` - The label value.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1385,6 +1385,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_hosts":                                      hss.DataSourceHosts(),
 			"huaweicloud_hss_kubernetes_services":                        hss.DataSourceKubernetesServices(),
 			"huaweicloud_hss_kubernetes_pod_detail":                      hss.DataSourceKubernetesPodDetail(),
+			"huaweicloud_hss_kubernetes_cronjobs":                        hss.DataSourceKubernetesCronJobs(),
 			"huaweicloud_hss_policy_groups":                              hss.DataSourcePolicyGroups(),
 			"huaweicloud_hss_product_infos":                              hss.DataSourceProductInfos(),
 			"huaweicloud_hss_quotas":                                     hss.DataSourceQuotas(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_kubernetes_cronjobs_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_kubernetes_cronjobs_test.go
@@ -1,0 +1,43 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Due to testing environment limitations, this test case can only test the scenario with empty `data_list`.
+func TestAccDataSourceKubernetesCronJobs_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_kubernetes_cronjobs.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceKubernetesCronJobs_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "last_update_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "cronjob_info_list.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceKubernetesCronJobs_basic() string {
+	return `
+data "huaweicloud_hss_kubernetes_cronjobs" "test" {
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_kubernetes_cronjobs.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_kubernetes_cronjobs.go
@@ -1,0 +1,240 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/kubernetes/cronjobs
+func DataSourceKubernetesCronJobs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceKubernetesCronJobsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cronjob_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"namespace_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cluster_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"last_update_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"cronjob_info_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"namespace_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"running_jobs_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"schedule": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"image_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"match_labels": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"val": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"execute_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildKubernetesCronJobsQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=200"
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("cronjob_name"); ok {
+		queryParams = fmt.Sprintf("%s&cronjob_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("namespace_name"); ok {
+		queryParams = fmt.Sprintf("%s&namespace_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("cluster_name"); ok {
+		queryParams = fmt.Sprintf("%s&cluster_name=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceKubernetesCronJobsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		product        = "hss"
+		epsId          = cfg.GetEnterpriseProjectID(d)
+		result         = make([]interface{}, 0)
+		offset         = 0
+		totalNum       float64
+		lastUpdateTime float64
+		httpUrl        = "v5/{project_id}/kubernetes/cronjobs"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildKubernetesCronJobsQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS kubernetes cronjobs: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalNum = utils.PathSearch("total_num", respBody, float64(0)).(float64)
+		lastUpdateTime = utils.PathSearch("last_update_time", respBody, float64(0)).(float64)
+		cronjobInfoList := utils.PathSearch("cronjob_info_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(cronjobInfoList) == 0 {
+			break
+		}
+
+		result = append(result, cronjobInfoList...)
+		offset += len(cronjobInfoList)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_num", totalNum),
+		d.Set("last_update_time", lastUpdateTime),
+		d.Set("cronjob_info_list", flattenKubernetesCronJobsDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenKubernetesCronJobsDataList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"name":             utils.PathSearch("name", v, nil),
+			"namespace_name":   utils.PathSearch("namespace_name", v, nil),
+			"cluster_name":     utils.PathSearch("cluster_name", v, nil),
+			"status":           utils.PathSearch("status", v, nil),
+			"running_jobs_num": utils.PathSearch("running_jobs_num", v, nil),
+			"schedule":         utils.PathSearch("schedule", v, nil),
+			"image_name":       utils.PathSearch("image_name", v, nil),
+			"match_labels":     flattenMatchLabels(utils.PathSearch("match_labels", v, make([]interface{}, 0)).([]interface{})),
+			"execute_time":     utils.PathSearch("execute_time", v, nil),
+			"create_time":      utils.PathSearch("create_time", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenMatchLabels(labels []interface{}) []interface{} {
+	if len(labels) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(labels))
+	for _, label := range labels {
+		result = append(result, map[string]interface{}{
+			"key": utils.PathSearch("key", label, nil),
+			"val": utils.PathSearch("val", label, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_kubernetes_cronjobs` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_kubernetes_cronjobs` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceKubernetesCronJobs_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceKubernetesCronJobs_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceKubernetesCronJobs_basic
=== PAUSE TestAccDataSourceKubernetesCronJobs_basic
=== CONT  TestAccDataSourceKubernetesCronJobs_basic
--- PASS: TestAccDataSourceKubernetesCronJobs_basic (10.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       10.841s

```
<img width="905" height="35" alt="image" src="https://github.com/user-attachments/assets/2b22f462-f6c9-4c2e-9527-9cde8ff7529d" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
