### PR TITLE
feat(cbh): new datasource to query cbh instance om url

### DIFF
--- a/docs/data-sources/cbh_instance_om_url.md
+++ b/docs/data-sources/cbh_instance_om_url.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Cloud Bastion Host (CBH)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbh_instance_om_url"
+description: |-
+  Use this data source to get the OM URL for a managed host in a CBH instance within HuaweiCloud.
+---
+
+# huaweicloud_cbh_instance_om_url
+
+Use this data source to get the OM URL for a managed host in a CBH instance within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "server_id" {}
+variable "ip_address" {}
+variable "host_account_name" {}
+
+data "huaweicloud_cbh_instance_om_url" "test" {
+  server_id         = var.server_id
+  ip_address        = var.ip_address
+  host_account_name = var.host_account_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `server_id` - (Required, String) Specifies the ID of the CBH instance.
+
+* `ip_address` - (Required, String) Specifies the IP address of the managed host.
+
+* `host_account_name` - (Required, String) Specifies the account name of the managed host.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `login_url` - The OM login URL for the managed host.
+
+* `state` - The state of getting the OM URL. Possible values include:
+  + **SUCCESS**: Successfully retrieved the OM URL. If the status is not SUCCESS, the task failed. Locate the cause by
+    referring to the following error codes and the corresponding descriptions.
+  + **IAM_USER_CONFLICT**: IAM user conflict.
+  + **HOST_NOT_MANAGE**: The host is not managed.
+  + **HOST_ACCOUNT_NOT_EXIST**: The host account does not exist.
+  + **IAM_USER_NO_PERMISSION**: IAM user has no permission.
+  + **CUR_VERSION_NOT_SUPPORT_OPERATION**: Current version does not support this operation.
+  + **INS_WHITE_LIST_INITIALIZING**: Instance whitelist is initializing.
+  + **UNKNOWN_ERROR**: Unknown error occurred.
+
+* `description` - The description when failed to get the OM URL.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -659,6 +659,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbh_instance_ecs_quota": cbh.DataSourceInstanceEcsQuota(),
 			"huaweicloud_cbh_instance_admin_url": cbh.DataSourceInstanceAdminUrl(),
 			"huaweicloud_cbh_instance_login_url": cbh.DataSourceInstanceLoginUrl(),
+			"huaweicloud_cbh_instance_om_url":    cbh.DataSourceInstanceOmUrl(),
 
 			"huaweicloud_cc_authorizations":                               cc.DataSourceCcAuthorizations(),
 			"huaweicloud_cc_bandwidth_packages":                           cc.DataSourceCcBandwidthPackages(),

--- a/huaweicloud/services/acceptance/cbh/data_source_huaweicloud_cbh_instance_om_url_test.go
+++ b/huaweicloud/services/acceptance/cbh/data_source_huaweicloud_cbh_instance_om_url_test.go
@@ -1,0 +1,47 @@
+package cbh
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceInstanceOmUrl_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_cbh_instance_om_url.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare a CBH instance ID and config it to the environment variable.
+			acceptance.TestAccPreCheckCbhServerID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceInstanceOmUrl_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSource, "state", "HOST_NOT_MANAGE"),
+					resource.TestCheckResourceAttr(dataSource, "description", "主机未被CBH纳管。"),
+				),
+			},
+		},
+	})
+}
+
+// The IP address and account name of the managed host are fixed values.
+func testDataSourceInstanceOmUrl_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cbh_instance_om_url" "test" {
+  server_id         = "%s"
+  ip_address        = "192.168.0.7"
+  host_account_name = "root"
+}
+`, acceptance.HW_CBH_SERVER_ID)
+}

--- a/huaweicloud/services/cbh/data_source_huaweicloud_cbh_instance_om_url.go
+++ b/huaweicloud/services/cbh/data_source_huaweicloud_cbh_instance_om_url.go
@@ -1,0 +1,123 @@
+package cbh
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CBH GET /v2/{project_id}/cbs/instance/get-om-url
+func DataSourceInstanceOmUrl() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstanceOmUrlRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource.`,
+			},
+			"server_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the CBH instance.`,
+			},
+			"ip_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the IP address of the managed host.`,
+			},
+			"host_account_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the account name of the managed host.`,
+			},
+			"state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The state of getting the OM URL.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description when failed to get the OM URL.`,
+			},
+			"login_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The OM login URL.`,
+			},
+		},
+	}
+}
+
+func buildInstanceOmUrlQueryParams(d *schema.ResourceData) string {
+	var (
+		serverId        = d.Get("server_id").(string)
+		ipAddress       = d.Get("ip_address").(string)
+		hostAccountName = d.Get("host_account_name").(string)
+	)
+
+	return fmt.Sprintf("?server_id=%s&ip_address=%s&host_account_name=%s", serverId, ipAddress, hostAccountName)
+}
+
+func dataSourceInstanceOmUrlRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/cbs/instance/get-om-url"
+		product = "cbh"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBH client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildInstanceOmUrlQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CBH instance OM URL: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("state", utils.PathSearch("state", respBody, nil)),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("login_url", utils.PathSearch("login_url", respBody, nil)),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting CBH instance OM URL fields: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query cbh instance om url

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cbh -f TestAccDataSourceInstanceOmUrl_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbh" -v -coverprofile="./huaweicloud/services/acceptance/cbh/cbh_coverage.cov" -coverpkg="./huaweicloud/services/cbh" -run TestAccDataSourceInstanceOmUrl_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceInstanceOmUrl_basic
=== PAUSE TestAccDataSourceInstanceOmUrl_basic
=== CONT  TestAccDataSourceInstanceOmUrl_basic
--- PASS: TestAccDataSourceInstanceOmUrl_basic (13.61s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/cbh
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       13.709s coverage: 3.7% of statements in ./huaweicloud/services/cbh
```
<img width="1257" height="77" alt="image" src="https://github.com/user-attachments/assets/59447d54-6691-428e-9dad-037929a152f1" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
