### PR TITLE
chore(rocketmq): add common methods and fix some issues

### DIFF
--- a/huaweicloud/services/acceptance/rocketmq/resource_huaweicloud_dms_rocketmq_migration_task_test.go
+++ b/huaweicloud/services/acceptance/rocketmq/resource_huaweicloud_dms_rocketmq_migration_task_test.go
@@ -67,7 +67,10 @@ func TestAccRockemqMigrationTask_rocketmq(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSRocketMQInstanceID(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
@@ -75,7 +78,7 @@ func TestAccRockemqMigrationTask_rocketmq(t *testing.T) {
 				Config: testAccRockemqMigrationTask_rocketmq(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "huaweicloud_dms_rocketmq_instance.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_DMS_ROCKETMQ_INSTANCE_ID),
 					resource.TestCheckResourceAttr(resourceName, "overwrite", "true"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "rocketmq"),
@@ -124,7 +127,10 @@ func TestAccRockemqMigrationTask_rabbitToRocket(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSRocketMQInstanceID(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
@@ -132,7 +138,7 @@ func TestAccRockemqMigrationTask_rabbitToRocket(t *testing.T) {
 				Config: testAccRockemqMigrationTask_rabbitToRocket(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "huaweicloud_dms_rocketmq_instance.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_DMS_ROCKETMQ_INSTANCE_ID),
 					resource.TestCheckResourceAttr(resourceName, "overwrite", "true"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "rabbitToRocket"),
@@ -168,10 +174,8 @@ func TestAccRockemqMigrationTask_rabbitToRocket(t *testing.T) {
 
 func testAccRockemqMigrationTask_rocketmq(name string) string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "huaweicloud_dms_rocketmq_migration_task" "test" {
-  instance_id = huaweicloud_dms_rocketmq_instance.test.id
+  instance_id = "%[1]s"
   overwrite   = "true"
   name        = "%[2]s"
   type        = "rocketmq"
@@ -197,15 +201,13 @@ resource "huaweicloud_dms_rocketmq_migration_task" "test" {
     which_broker_when_consume_slow    = 1        
   }
 }
-`, testDmsRocketMQInstance_basic(name), name)
+`, acceptance.HW_DMS_ROCKETMQ_INSTANCE_ID, name)
 }
 
 func testAccRockemqMigrationTask_rabbitToRocket(name string) string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "huaweicloud_dms_rocketmq_migration_task" "test" {
-  instance_id = huaweicloud_dms_rocketmq_instance.test.id
+  instance_id = "%[1]s"
   overwrite   = "true"
   name        = "%[2]s"
   type        = "rabbitToRocket"
@@ -235,7 +237,7 @@ resource "huaweicloud_dms_rocketmq_migration_task" "test" {
     routing_key      = "%[2]s-queue"
   }
 }
-`, testDmsRocketMQInstance_basic(name), name)
+`, acceptance.HW_DMS_ROCKETMQ_INSTANCE_ID, name)
 }
 
 // testRocketmqMigrationTaskImportState is used to return an import id with format <instance_id>/<id>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Add common methods used to query instance current status and wait instance task completed.
2. Fixes an issue where creating and deleting task fails when the RocketMQ instance was in some status (such as: RESTARTING).
   <img width="1417" height="156" alt="image" src="https://github.com/user-attachments/assets/0d026cf8-c344-4405-9995-a86ef439db20" />

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o rocketmq -f TestAccRockemqMigrationTask_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rocketmq" -v -coverprofile="./huaweicloud/services/acceptance/rocketmq/rocketmq_coverage.cov" -coverpkg="./huaweicloud/services/rocketmq" -run TestAccRockemqMigrationTask_ -timeout 360m -parallel 10
=== RUN   TestAccRockemqMigrationTask_rocketmq
=== PAUSE TestAccRockemqMigrationTask_rocketmq
=== RUN   TestAccRockemqMigrationTask_rabbitToRocket
=== PAUSE TestAccRockemqMigrationTask_rabbitToRocket
=== CONT  TestAccRockemqMigrationTask_rocketmq
=== CONT  TestAccRockemqMigrationTask_rabbitToRocket
--- PASS: TestAccRockemqMigrationTask_rocketmq (40.38s)
--- PASS: TestAccRockemqMigrationTask_rabbitToRocket (40.96s)
PASS
coverage: 9.8% of statements in ./huaweicloud/services/rocketmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rocketmq  41.307s coverage: 9.8% of statements in ./huaweicloud/services/rocketmq
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
