### PR TITLE
feat(workspace): add new data source to query time zones

### DIFF
--- a/docs/data-sources/workspace_timezones.md
+++ b/docs/data-sources/workspace_timezones.md
@@ -1,0 +1,44 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_timezones"
+description: |-
+  Use this data source to get the list of Workspace time zones within HuaweiCloud.
+---
+
+# huaweicloud_workspace_timezones
+
+Use this data source to get the list of Workspace time zones within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_workspace_timezones" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the time zones are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `time_zones` - The list of time zones.  
+  The [time_zones](#workspace_time_zones_attr) structure is documented below.
+
+<a name="workspace_time_zones_attr"></a>
+The `time_zones` block supports:
+
+* `name` - The name of the time zone.
+
+* `offset` - The offset of the time zone.
+
+* `us_description` - The English description of the time zone.
+
+* `cn_description` - The Chinese description of the time zone.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2104,6 +2104,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_policy_groups":          workspace.DataSourcePolicyGroups(),
 			"huaweicloud_workspace_service":                workspace.DataSourceService(),
 			"huaweicloud_workspace_tags":                   workspace.DataSourceTags(),
+			"huaweicloud_workspace_timezones":              workspace.DataSourceTimeZones(),
 			"huaweicloud_workspace_users":                  workspace.DataSourceUsers(),
 			"huaweicloud_workspace_volume_products":        workspace.DataSourceVolumeProducts(),
 

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_timezones_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_timezones_test.go
@@ -1,0 +1,39 @@
+package workspace
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceTimezones_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_workspace_timezones.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceTimezones_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "time_zones.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "time_zones.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "time_zones.0.offset"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "time_zones.0.us_description"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "time_zones.0.cn_description"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceTimezones_basic = `
+data "huaweicloud_workspace_timezones" "test" {}
+`

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_timezones.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_timezones.go
@@ -1,0 +1,134 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v2/{project_id}/common/timezones
+func DataSourceTimeZones() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTimeZonesRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the time zones are located.`,
+			},
+
+			// Attributes.
+			"time_zones": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of time zones.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the time zone.`,
+						},
+						"offset": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The offset of the time zone.`,
+						},
+						"us_description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The English description of the time zone.`,
+						},
+						"cn_description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The Chinese description of the time zone.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Currently, the filter parameter time_zone_name is not available.
+func listTimeZones(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/common/timezones"
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("time_zones", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func dataSourceTimeZonesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	resp, err := listTimeZones(client)
+	if err != nil {
+		return diag.Errorf("error querying Workspace time zones: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("time_zones", flattenTimeZones(resp)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenTimeZones(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"name":           utils.PathSearch("time_zone_name", item, nil),
+			"offset":         utils.PathSearch("time_zone", item, nil),
+			"us_description": utils.PathSearch("time_zone_desc_us", item, nil),
+			"cn_description": utils.PathSearch("time_zone_desc_cn", item, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new data source that used to query time zones.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1144" height="531" alt="image" src="https://github.com/user-attachments/assets/81507e47-c25c-405e-88b9-2b58eff7d3a2" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query time zones
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataSourceTimezones_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataSourceTimezones_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceTimezones_basic
=== PAUSE TestAccDataSourceTimezones_basic
=== CONT  TestAccDataSourceTimezones_basic
--- PASS: TestAccDataSourceTimezones_basic (13.04s)
PASS
coverage: 3.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 13.134s coverage: 3.0% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
