### PR TITLE
docs(GaussDB): fix gaussdb opengauss instance doc

### DIFF
--- a/docs/resources/gaussdb_opengauss_instance.md
+++ b/docs/resources/gaussdb_opengauss_instance.md
@@ -154,20 +154,17 @@ The following arguments are supported:
 * `time_zone` - (Optional, String, ForceNew) Specifies the time zone.
   Changing this parameter will create a new resource.
 
-* `disk_encryption_id` - (Optional, String, ForceNew) Specifies the key ID for disk encryption.
-  Changing this parameter will create a new resource.
+* `disk_encryption_id` - (Optional, String) Specifies the key ID for disk encryption.
 
-* `enable_force_switch` - (Optional, Bool, ForceNew) Specifies whether to forcibly promote a standby node to primary.
-  Defaults to **false**. Changing this parameter will create a new resource.
+* `enable_force_switch` - (Optional, Bool) Specifies whether to forcibly promote a standby node to primary.
+  Defaults to **false**.
 
-* `enable_single_float_ip` - (Optional, Bool, ForceNew) Specifies whether to enable single floating IP address policy,
-  which is only suitable for primary/standby instances. Value options:
+* `enable_single_float_ip` - (Optional, Bool) Specifies whether to enable single floating IP address policy, which is only
+  suitable for primary/standby instances. Value options:
   + **true**: This function is enabled. Only one floating IP address is bound to the primary node of a DB instance. If a
     primary/standby fail over occurs, the floating IP address does not change.
   + **false (default value)**: The function is disabled. Each node is bound to a floating IP address. If a primary/standby
     fail over occurs, the floating IP addresses change.
-
-  Changing this parameter will create a new resource.
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the GaussDB OpenGauss instance.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix gaussdb opengauss instance doc
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix gaussdb opengauss instance doc
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
