### PR TITLE
chore(rocketmq/migration_task|diagnosis): use new api to replace old delete api

### DIFF
--- a/huaweicloud/services/rocketmq/resource_huaweicloud_dms_rocketmq_instance_diagnosis.go
+++ b/huaweicloud/services/rocketmq/resource_huaweicloud_dms_rocketmq_instance_diagnosis.go
@@ -2,6 +2,7 @@ package rocketmq
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -19,7 +20,7 @@ import (
 
 // @API RocketMQ POST /v2/{engine}/{project_id}/instances/{instance_id}/diagnosis
 // @API RocketMQ GET /v2/{engine}/{project_id}/diagnosis/{report_id}
-// @API RocketMQ DELETE /v2/{engine}/{project_id}/instances/{instance_id}/diagnosis
+// @API RocketMQ POST /v2/{engine}/{project_id}/instances/{instance_id}/diagnosis/batch-delete
 func ResourceInstanceDiagnosis() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceInstanceDiagnosisCreate,
@@ -292,7 +293,7 @@ func resourceInstanceDiagnosisDelete(_ context.Context, d *schema.ResourceData, 
 	instanceId := d.Get("instance_id").(string)
 	reportId := d.Id()
 
-	httpUrl := "v2/{engine}/{project_id}/instances/{instance_id}/diagnosis"
+	httpUrl := "v2/{engine}/{project_id}/instances/{instance_id}/diagnosis/batch-delete"
 	httpUrl = strings.ReplaceAll(httpUrl, "{engine}", "rocketmq")
 	httpUrl = strings.ReplaceAll(httpUrl, "{project_id}", client.ProjectID)
 	httpUrl = strings.ReplaceAll(httpUrl, "{instance_id}", instanceId)
@@ -309,9 +310,9 @@ func resourceInstanceDiagnosisDelete(_ context.Context, d *schema.ResourceData, 
 		},
 	}
 
-	_, err = client.Request("DELETE", deletePath, &opt)
+	_, err = client.Request("POST", deletePath, &opt)
 	if err != nil {
-		return diag.Errorf("error deleting RocketMQ diagnosis report: %s", err)
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting RocketMQ diagnosis report (%s)", reportId))
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Use new API to replace old delete API.
+ The new [API ](https://support.huaweicloud.com/api-hrm/BatchDeleteRocketMQMigrationTask.html) corresponding to huaweicloud_dms_rocketmq_migration_task corre
+ The new [API ](https://support.huaweicloud.com/api-hrm/BatchDeleteDiagnosisRecords.html) corresponding to huaweicloud_dms_rocketmq_instance_diagnosis

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o rocketmq -f TestAccRockemqMigrationTask_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rocketmq" -v -coverprofile="./huaweicloud/services/acceptance/rocketmq/rocketmq_coverage.cov" -coverpkg="./huaweicloud/services/rocketmq" -run TestAccRockemqMigrationTask_ -timeout 360m -parallel 10
=== RUN   TestAccRockemqMigrationTask_rocketmq
=== PAUSE TestAccRockemqMigrationTask_rocketmq
=== RUN   TestAccRockemqMigrationTask_rabbitToRocket
=== PAUSE TestAccRockemqMigrationTask_rabbitToRocket
=== CONT  TestAccRockemqMigrationTask_rocketmq
=== CONT  TestAccRockemqMigrationTask_rabbitToRocket
--- PASS: TestAccRockemqMigrationTask_rocketmq (68.09s)
--- PASS: TestAccRockemqMigrationTask_rabbitToRocket (68.18s)
PASS
coverage: 9.5% of statements in ./huaweicloud/services/rocketmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rocketmq  68.349s coverage: 9.5% of statements in ./huaweicloud/services/rocketmq
```

```
./scripts/coverage.sh -o rocketmq -f TestAccDiagnosis_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rocketmq" -v -coverprofile="./huaweicloud/services/acceptance/rocketmq/rocketmq_coverage.cov" -coverpkg="./huaweicloud/services/rocketmq" -run TestAccDiagnosis_ -timeout 360m -parallel 10
=== RUN   TestAccDiagnosis_basic
=== PAUSE TestAccDiagnosis_basic
=== CONT  TestAccDiagnosis_basic
--- PASS: TestAccDiagnosis_basic (26.42s)
PASS
coverage: 11.8% of statements in ./huaweicloud/services/rocketmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rocketmq  26.500s coverage: 11.8% of statements in ./huaweicloud/services/rocketmq
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
      
       +  The status code is 200 when the migration task does not exist.
       +  huaweicloud_dms_rocketmq_instance_diagnosis
         <img width="1372" height="779" alt="image" src="https://github.com/user-attachments/assets/c3bb5ee5-a905-44ba-bc78-b11a8f5a5006" />

    bb. Related resources (parent resources) not found
     +  huaweicloud_dms_rocketmq_migration_task
        <img width="1303" height="870" alt="image" src="https://github.com/user-attachments/assets/3842728f-029b-45a7-bddc-d9ba26e69e57" />

    +  huaweicloud_dms_rocketmq_instance_diagnosis
       <img width="1236" height="858" alt="image" src="https://github.com/user-attachments/assets/e3685d08-177c-4b2f-ba94-69058206cc1e" />
