### PR TITLE
feat(workspace): add new data source to query scheduled task records

### DIFF
--- a/docs/data-sources/workspace_scheduled_task_records.md
+++ b/docs/data-sources/workspace_scheduled_task_records.md
@@ -1,0 +1,75 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_scheduled_task_records"
+description: |-
+  Use this data source to get the execution records list of the scheduled task within HuaweiCloud.
+---
+
+# huaweicloud_workspace_scheduled_task_records
+
+Use this data source to get the execution records list of the scheduled task within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "task_id" {}
+
+data "huaweicloud_workspace_scheduled_task_records" "test" {
+  task_id = var.task_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the scheduled task records are located.  
+  If omitted, the provider-level region will be used.
+
+* `task_id` - (Required, String) Specifies the ID of the scheduled task to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `records` - The list of scheduled task execution records.  
+  The [records](#scheduled_task_records_attr) structure is documented below.
+
+<a name="scheduled_task_records_attr"></a>
+The `records` block supports:
+
+* `id` - The ID of the scheduled task execution record.
+
+* `start_time` - The execution time, in RFC3339 format.
+
+* `task_type` - The type of the scheduled task.
+  + **START** - Startup
+  + **STOP** - Shutdown
+  + **REBOOT** - Restart
+  + **HIBERNATE** - Hibernate
+  + **REBUILD** - Rebuild system disk
+
+* `scheduled_type` - The execution cycle type.
+  + **FIXED_TIME** - Specified time
+  + **DAY** - Daily
+  + **WEEK** - Weekly
+  + **MONTH** - Monthly
+
+* `life_cycle_type` - The trigger scenario type.
+
+* `status` - The execution status of this execution.
+
+* `success_num` - The number of successful desktops.
+
+* `failed_num` - The number of failed desktops.
+
+* `skip_num` - The number of skipped desktops.
+
+* `time_zone` - The time zone information.
+
+* `execute_task_id` - The task ID of executing the scheduled task.
+
+* `execute_object_type` - The object type of executing the scheduled task.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2120,6 +2120,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_flavors":                workspace.DataSourceWorkspaceFlavors(),
 			"huaweicloud_workspace_policy_groups":          workspace.DataSourcePolicyGroups(),
 			"huaweicloud_workspace_scheduled_tasks":        workspace.DataSourceScheduledTasks(),
+			"huaweicloud_workspace_scheduled_task_records": workspace.DataSourceScheduledTaskRecords(),
 			"huaweicloud_workspace_service":                workspace.DataSourceService(),
 			"huaweicloud_workspace_tags":                   workspace.DataSourceTags(),
 			"huaweicloud_workspace_users":                  workspace.DataSourceUsers(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -316,6 +316,7 @@ var (
 	HW_WORKSPACE_APP_FILE_NAME                     = os.Getenv("HW_WORKSPACE_APP_FILE_NAME")
 	HW_WORKSPACE_USER_NAMES                        = os.Getenv("HW_WORKSPACE_USER_NAMES")
 	HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID             = os.Getenv("HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID")
+	HW_WORKSPACE_SCHEDULED_TASK_ID                 = os.Getenv("HW_WORKSPACE_SCHEDULED_TASK_ID")
 
 	HW_FGS_AGENCY_NAME         = os.Getenv("HW_FGS_AGENCY_NAME")
 	HW_FGS_APP_AGENCY_NAME     = os.Getenv("HW_FGS_APP_AGENCY_NAME")
@@ -2291,6 +2292,13 @@ func TestAccPreCheckWorkspaceAppServerGroup(t *testing.T) {
 		t.Skip("HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID must be set for Workspace APP acceptance tests.")
 	}
 	TestAccPreCheckWorkspaceAppServerImageInfo(t)
+}
+
+// lintignore:AT003
+func TestAccPreCheckWorkspaceScheduledTaskId(t *testing.T) {
+	if HW_WORKSPACE_SCHEDULED_TASK_ID == "" {
+		t.Skip("HW_WORKSPACE_SCHEDULED_TASK_ID must be set for Workspace acceptance tests.")
+	}
 }
 
 // lintignore:AT003

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_scheduled_task_records_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_scheduled_task_records_test.go
@@ -1,0 +1,69 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this acceptance test, make sure that the scheduled task has been executed at least once.
+func TestAccDataScheduledTaskRecords_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_workspace_scheduled_task_records.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceScheduledTaskId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataScheduledTaskRecords_invalidTaskId(),
+				ExpectError: regexp.MustCompile(`The scheduled task does not exist`),
+			},
+			{
+				Config: testAccDataScheduledTaskRecords_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "records.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.start_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.task_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.scheduled_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.success_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.failed_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.skip_num"),
+					resource.TestMatchResourceAttr(dataSource, "records.0.start_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataScheduledTaskRecords_invalidTaskId() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_scheduled_task_records" "test" {
+  task_id = "%s"
+}
+`, randUUID)
+}
+
+func testAccDataScheduledTaskRecords_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_scheduled_task_records" "test" {
+  task_id = "%s"
+}
+`, acceptance.HW_WORKSPACE_SCHEDULED_TASK_ID)
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_scheduled_task_records.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_scheduled_task_records.go
@@ -1,0 +1,211 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v2/{project_id}/scheduled-tasks/{task_id}/records
+func DataSourceScheduledTaskRecords() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceScheduledTaskRecordsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the scheduled task records are located.`,
+			},
+
+			// Required parameters.
+			"task_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the scheduled task to be queried.`,
+			},
+
+			// Attributes.
+			"records": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the scheduled task execution record.`,
+						},
+						"start_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The execution time, in RFC3339 format.`,
+						},
+						"task_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the scheduled task.`,
+						},
+						"scheduled_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The execution cycle type.`,
+						},
+						"life_cycle_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The trigger scenario type.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The execution status of this execution.`,
+						},
+						"success_num": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The number of successful desktops.`,
+						},
+						"failed_num": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The number of failed desktops.`,
+						},
+						"skip_num": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The number of skipped desktops.`,
+						},
+						"time_zone": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time zone information.`,
+						},
+						"execute_task_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The task ID of executing the scheduled task.`,
+						},
+						"execute_object_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The object type of executing the scheduled task.`,
+						},
+					},
+				},
+				Description: `The list of scheduled task execution records.`,
+			},
+		},
+	}
+}
+
+func listScheduledTaskRecords(client *golangsdk.ServiceClient, taskId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/scheduled-tasks/{task_id}/records?limit={limit}"
+		offset  = 0
+		// For API, limit default value is 10.
+		limit   = 100
+		result  = make([]interface{}, 0)
+		listOpt = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{task_id}", taskId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		listResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(listResp)
+		if err != nil {
+			return nil, err
+		}
+
+		tasksRecords := utils.PathSearch("tasks_records", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, tasksRecords...)
+		if len(tasksRecords) < limit {
+			break
+		}
+
+		offset += len(tasksRecords)
+	}
+
+	return result, nil
+}
+
+func flattenScheduledTaskRecords(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"id": utils.PathSearch("id", item, nil),
+			"start_time": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("start_time",
+				item, "").(string))/1000, false),
+			"task_type":           utils.PathSearch("task_type", item, nil),
+			"scheduled_type":      utils.PathSearch("scheduled_type", item, nil),
+			"life_cycle_type":     utils.PathSearch("life_cycle_type", item, nil),
+			"status":              utils.PathSearch("status", item, nil),
+			"success_num":         utils.PathSearch("success_num", item, nil),
+			"failed_num":          utils.PathSearch("failed_num", item, nil),
+			"skip_num":            utils.PathSearch("skip_num", item, nil),
+			"time_zone":           utils.PathSearch("time_zone", item, nil),
+			"execute_task_id":     utils.PathSearch("execute_task_id", item, nil),
+			"execute_object_type": utils.PathSearch("execute_object_type", item, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceScheduledTaskRecordsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	taskId := d.Get("task_id").(string)
+	items, err := listScheduledTaskRecords(client, taskId)
+	if err != nil {
+		return diag.Errorf("error querying Workspace scheduled task records: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate data source ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("records", flattenScheduledTaskRecords(items)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new data source that used to query the scheduled task records.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1153" height="611" alt="image" src="https://github.com/user-attachments/assets/b40a72c1-7626-42a4-b123-cc7d86102c6d" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query scheduled task records
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataScheduledTaskRecords_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataScheduledTaskRecords_basic -timeout 360m -parallel 10
=== RUN   TestAccDataScheduledTaskRecords_basic
=== PAUSE TestAccDataScheduledTaskRecords_basic
=== CONT  TestAccDataScheduledTaskRecords_basic
--- PASS: TestAccDataScheduledTaskRecords_basic (11.93s)
PASS
coverage: 3.2% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 12.013s coverage: 3.2% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
