### PR TITLE
feat(cbh): new resource to change single node cbh instance type

### DIFF
--- a/docs/resources/cbh_change_instance_type.md
+++ b/docs/resources/cbh_change_instance_type.md
@@ -1,0 +1,53 @@
+---
+subcategory: "Cloud Bastion Host (CBH)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbh_change_instance_type"
+description: |-
+  Manages a resource to change single node CBH instance type within HuaweiCloud.
+---
+
+# huaweicloud_cbh_change_instance_type
+
+Manages a resource to change single node CBH instance type within HuaweiCloud.
+
+-> This resource is only a one-time action resource to change a CBH instance type. Deleting this resource
+will not clear the corresponding change instance type, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "server_id" {}
+variable "availability_zone" {}
+
+resource "huaweicloud_cbh_change_instance_type" "test" {
+  server_id         = var.server_id
+  availability_zone = var.availability_zone
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to change a CBH instance type.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `server_id` - (Required, String, NonUpdatable) Specifies the ID of the single node CBH instance to change type.
+  
+  -> This field only supports passing the single node CBH instance ID. Passing the primary/standby instance ID may result
+  in a timeout exception.
+
+* `availability_zone` - (Optional, String, NonUpdatable) Specifies the availability zone of the single node CBH instance
+  to change type.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (same as `server_id`).
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2396,6 +2396,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbh_delete_fault_instance":      cbh.ResourceDeleteFaultInstance(),
 			"huaweicloud_cbh_ha_instance":                cbh.ResourceCBHHAInstance(),
 			"huaweicloud_cbh_asset_agency_authorization": cbh.ResourceAssetAgencyAuthorization(),
+			"huaweicloud_cbh_change_instance_type":       cbh.ResourceChangeInstanceType(),
 
 			"huaweicloud_cc_connection":                                     cc.ResourceCloudConnection(),
 			"huaweicloud_cc_network_instance":                               cc.ResourceNetworkInstance(),

--- a/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_change_instance_type_test.go
+++ b/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_change_instance_type_test.go
@@ -1,0 +1,34 @@
+package cbh
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccChangeInstanceType_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCbhServerID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testChangeInstanceType_basic(),
+			},
+		},
+	})
+}
+
+func testChangeInstanceType_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cbh_change_instance_type" "test" {
+  server_id = "%s"
+}
+`, acceptance.HW_CBH_SERVER_ID)
+}

--- a/huaweicloud/services/cbh/resource_huaweicloud_cbh_change_instance_type.go
+++ b/huaweicloud/services/cbh/resource_huaweicloud_cbh_change_instance_type.go
@@ -1,0 +1,155 @@
+package cbh
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CBH PUT /v2/{project_id}/cbs/instance/type
+// @API BSS POST /v3/orders/customer-orders/pay
+// @API BSS GET /v2/orders/customer-orders/details/{order_id}
+// @API BSS POST /v2/orders/suscriptions/resources/query
+func ResourceChangeInstanceType() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceChangeInstanceTypeCreate,
+		UpdateContext: resourceChangeInstanceTypeUpdate,
+		ReadContext:   resourceChangeInstanceTypeRead,
+		DeleteContext: resourceChangeInstanceTypeDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"server_id",
+			"availability_zone",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"server_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildChangeInstanceTypeQueryParams(d *schema.ResourceData) string {
+	rst := fmt.Sprintf("?server_id=%s", d.Get("server_id").(string))
+
+	if v, ok := d.GetOk("availability_zone"); ok {
+		rst += fmt.Sprintf("&availability_zone=%s", v)
+	}
+	return rst
+}
+
+// The API supports configuring the `is_auto_pay` field for automatic payments, but this field doesn't actually work.
+// Therefore, it's better to manually pay for orders using the CBC API instead.
+func resourceChangeInstanceTypeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		httpUrl  = "v2/{project_id}/cbs/instance/type"
+		product  = "cbh"
+		serverId = d.Get("server_id").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBH client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildChangeInstanceTypeQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error changing CBH instance type: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	orderId := utils.PathSearch("order_id", respBody, "").(string)
+	if orderId == "" {
+		return diag.Errorf("error changing CBH instance type: order ID is empty in API response")
+	}
+
+	d.SetId(serverId)
+
+	bssClient, err := cfg.NewServiceClient("bssv2", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating BSS client: %s", err)
+	}
+
+	if err := cbc.PaySubscriptionOrder(bssClient, orderId); err != nil {
+		return diag.Errorf("error paying for the order (%s) of changing the CBH instance type: %s", orderId, err)
+	}
+
+	if err := common.WaitOrderComplete(ctx, bssClient, orderId, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, err = common.WaitOrderResourceComplete(ctx, bssClient, orderId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for the order (%s) of changing the CBH instance type to complete: %s", orderId, err)
+	}
+
+	return resourceChangeInstanceTypeRead(ctx, d, meta)
+}
+
+func resourceChangeInstanceTypeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceChangeInstanceTypeUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceChangeInstanceTypeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to change CBH instance type.
+Deleting this resource will not recover the change CBH instance type, but will only remove the resource information from
+the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to change single node cbh instance type.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cbh -f TestAccChangeInstanceType_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbh" -v -coverprofile="./huaweicloud/services/acceptance/cbh/cbh_coverage.cov" -coverpkg="./huaweicloud/services/cbh" -run TestAccChangeInstanceType_basic -timeout 360m -parallel 10
=== RUN   TestAccChangeInstanceType_basic
=== PAUSE TestAccChangeInstanceType_basic
=== CONT  TestAccChangeInstanceType_basic
--- PASS: TestAccChangeInstanceType_basic (649.02s)
PASS
coverage: 4.3% of statements in ./huaweicloud/services/cbh
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       649.124s        coverage: 4.3% of statements in ./huaweicloud/services/cbh
```
<img width="1296" height="91" alt="image" src="https://github.com/user-attachments/assets/cdc9680d-7b98-452c-846c-62d300b62984" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
