### PR TITLE
feat(workspace): add new data source to query scheduled tasks

### DIFF
--- a/docs/data-sources/workspace_scheduled_tasks.md
+++ b/docs/data-sources/workspace_scheduled_tasks.md
@@ -1,0 +1,103 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_scheduled_tasks"
+description: |-
+  Use this data source to get the list of Workspace scheduled tasks within HuaweiCloud.
+---
+
+# huaweicloud_workspace_scheduled_tasks
+
+Use this data source to get the list of Workspace scheduled tasks within HuaweiCloud.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+data "huaweicloud_workspace_scheduled_tasks" "test" {}
+```
+
+### Filter scheduled tasks by task name
+
+```hcl
+variable "task_name" {}
+
+data "huaweicloud_workspace_scheduled_tasks" "test" {
+  task_name = var.task_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the scheduled tasks are located.  
+  If omitted, the provider-level region will be used.
+
+* `task_name` - (Optional, String) Specifies the name of the scheduled task to be queried.  
+  Fuzzy match is supported.
+
+* `task_type` - (Optional, String) Specifies the type of the scheduled task.  
+  The valid values are as follows:
+  + **START**
+  + **STOP**
+  + **REBOOT**
+  + **HIBERNATE**
+  + **REBUILD**
+  + **EXECUTE_SCRIPT**
+  + **CREATE_SNAPSHOT**
+
+* `scheduled_type` - (Optional, String) Specifies the execution cycle type of the scheduled task.  
+  The valid values are as follows:
+  + **FIXED_TIME**
+  + **DAY**
+  + **WEEK**
+  + **MONTH**
+  + **LIFE_CYCLE**
+
+* `last_status` - (Optional, String) Specifies the last execution status of the scheduled task.  
+  The valid values are as follows:
+  + **SUCCESS**
+  + **SKIP**
+  + **FAIL**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tasks` - The list of scheduled tasks that match the filter parameters.  
+  The [tasks](#workspace_scheduled_tasks_attr) structure is documented below.
+
+<a name="workspace_scheduled_tasks_attr"></a>
+The `tasks` block supports:
+
+* `id` - The ID of the scheduled task.
+
+* `name` - The name of the scheduled task.
+
+* `type` - The type of the scheduled task.
+
+* `scheduled_type` - The execution cycle type of the scheduled task.
+
+* `life_cycle_type` - The trigger scenario type of the scheduled task.
+
+* `last_status` - The last execution status of the scheduled task.
+
+* `next_execution_time` - The next execution time of the scheduled task, format is **2006-01-02 15:04:05 GMT+08:00**.
+
+* `enable` - Whether the scheduled task is enabled.
+
+* `description` - The description of the scheduled task.
+
+* `time_zone` - The time zone of the scheduled task.
+
+* `priority` - The priority of the scheduled task.
+
+  -> Only trigger task return this attribute.
+
+* `wait_time` - The wait time after the trigger scenario for the scheduled task.
+
+  -> Only trigger task return this attribute.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2102,6 +2102,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_hour_packages":          workspace.DataSourceHourPackages(),
 			"huaweicloud_workspace_flavors":                workspace.DataSourceWorkspaceFlavors(),
 			"huaweicloud_workspace_policy_groups":          workspace.DataSourcePolicyGroups(),
+			"huaweicloud_workspace_scheduled_tasks":        workspace.DataSourceScheduledTasks(),
 			"huaweicloud_workspace_service":                workspace.DataSourceService(),
 			"huaweicloud_workspace_tags":                   workspace.DataSourceTags(),
 			"huaweicloud_workspace_users":                  workspace.DataSourceUsers(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_scheduled_tasks_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_scheduled_tasks_test.go
@@ -1,0 +1,129 @@
+package workspace
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataScheduledTasks_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_workspace_scheduled_tasks.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byTaskName   = "data.huaweicloud_workspace_scheduled_tasks.filter_by_task_name"
+		dcByTaskName = acceptance.InitDataSourceCheck(byTaskName)
+
+		byTaskType   = "data.huaweicloud_workspace_scheduled_tasks.filter_by_task_type"
+		dcByTaskType = acceptance.InitDataSourceCheck(byTaskType)
+
+		byScheduledType   = "data.huaweicloud_workspace_scheduled_tasks.filter_by_scheduled_type"
+		dcByScheduledType = acceptance.InitDataSourceCheck(byScheduledType)
+
+		byLastStatus   = "data.huaweicloud_workspace_scheduled_tasks.filter_by_last_status"
+		dcByLastStatus = acceptance.InitDataSourceCheck(byLastStatus)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataScheduledTasks_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "tasks.#", regexp.MustCompile(`^[0-9]+$`)),
+					dcByTaskName.CheckResourceExists(),
+					resource.TestCheckOutput("is_task_name_filter_useful", "true"),
+					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.id"),
+					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.name"),
+					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.type"),
+					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.scheduled_type"),
+					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.enable"),
+					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.time_zone"),
+					dcByTaskType.CheckResourceExists(),
+					resource.TestCheckOutput("is_task_type_filter_useful", "true"),
+					dcByScheduledType.CheckResourceExists(),
+					resource.TestCheckOutput("is_scheduled_type_filter_useful", "true"),
+					dcByLastStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_last_status_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataScheduledTasks_basic = `
+# Query all scheduled tasks without any filter parameters.
+data "huaweicloud_workspace_scheduled_tasks" "test" {}
+
+locals {
+  task_name      = try(data.huaweicloud_workspace_scheduled_tasks.test.tasks[0].name, "NOT_FOUND")
+  task_type      = try(data.huaweicloud_workspace_scheduled_tasks.test.tasks[0].type, "NOT_FOUND")
+  scheduled_type = try(data.huaweicloud_workspace_scheduled_tasks.test.tasks[0].scheduled_type, "NOT_FOUND")
+  last_status    = try([for v in data.huaweicloud_workspace_scheduled_tasks.test.tasks : v.last_status if v.last_status != ""][0], "NOT_FOUND")
+}
+
+# Filter by task name.
+data "huaweicloud_workspace_scheduled_tasks" "filter_by_task_name" {
+  task_name = local.task_name
+}
+
+locals {
+  task_name_filter_result = [
+    for v in data.huaweicloud_workspace_scheduled_tasks.filter_by_task_name.tasks : strcontains(v.name, local.task_name)
+  ]
+}
+
+output "is_task_name_filter_useful" {
+  value = length(local.task_name_filter_result) > 0 && alltrue(local.task_name_filter_result)
+}
+
+# Filter by task type.
+data "huaweicloud_workspace_scheduled_tasks" "filter_by_task_type" {
+  task_type = local.task_type
+}
+
+locals {
+  task_type_filter_result = [
+    for v in data.huaweicloud_workspace_scheduled_tasks.filter_by_task_type.tasks : v.type == local.task_type
+  ]
+}
+
+output "is_task_type_filter_useful" {
+  value = length(local.task_type_filter_result) > 0 && alltrue(local.task_type_filter_result)
+}
+
+# Filter by scheduled type.
+data "huaweicloud_workspace_scheduled_tasks" "filter_by_scheduled_type" {
+  scheduled_type = local.scheduled_type
+}
+
+locals {
+  scheduled_type_filter_result = [
+    for v in data.huaweicloud_workspace_scheduled_tasks.filter_by_scheduled_type.tasks : v.scheduled_type == local.scheduled_type
+  ]
+}
+
+output "is_scheduled_type_filter_useful" {
+  value = length(local.scheduled_type_filter_result) > 0 && alltrue(local.scheduled_type_filter_result)
+}
+
+# Filter by last status.
+data "huaweicloud_workspace_scheduled_tasks" "filter_by_last_status" {
+  last_status = local.last_status
+}
+
+locals {
+  last_status_filter_result = [
+    for v in data.huaweicloud_workspace_scheduled_tasks.filter_by_last_status.tasks : v.last_status == local.last_status
+  ]
+}
+
+output "is_last_status_filter_useful" {
+  value = length(local.last_status_filter_result) > 0 && alltrue(local.last_status_filter_result)
+}
+`

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_scheduled_tasks.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_scheduled_tasks.go
@@ -1,0 +1,238 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v2/{project_id}/scheduled-tasks
+func DataSourceScheduledTasks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceScheduledTasksRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the scheduled tasks are located.`,
+			},
+
+			// Optional parameters.
+			"task_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the scheduled task to be queried.`,
+			},
+			"task_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type of the scheduled task to be queried.`,
+			},
+			"scheduled_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The execution cycle type of the scheduled task to be queried.`,
+			},
+			"last_status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The last execution status of the scheduled task to be queried.`,
+			},
+
+			// Attributes.
+			"tasks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the scheduled task.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the scheduled task.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the scheduled task.`,
+						},
+						"scheduled_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The execution cycle type of the scheduled task.`,
+						},
+						"life_cycle_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The trigger scenario type of the scheduled task.`,
+						},
+						"last_status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The last execution status of the scheduled task.`,
+						},
+						"next_execution_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The next execution time of the scheduled task.`,
+						},
+						"enable": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the scheduled task is enabled.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the scheduled task.`,
+						},
+						"time_zone": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time zone of the scheduled task.`,
+						},
+						"priority": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The priority of the scheduled task.`,
+						},
+						"wait_time": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The wait time after the trigger scenario for the scheduled task.`,
+						},
+					},
+				},
+				Description: `The list of the scheduled tasks that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildScheduledTasksQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("task_name"); ok {
+		res = fmt.Sprintf("%s&task_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("task_type"); ok {
+		res = fmt.Sprintf("%s&task_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("scheduled_type"); ok {
+		res = fmt.Sprintf("%s&scheduled_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("last_status"); ok {
+		res = fmt.Sprintf("%s&last_status=%v", res, v)
+	}
+
+	return res
+}
+
+func listScheduledTasks(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/scheduled-tasks?limit={limit}"
+		limit   = 50
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildScheduledTasksQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		scheduledTasks := utils.PathSearch("scheduled_tasks", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, scheduledTasks...)
+		if len(scheduledTasks) < limit {
+			break
+		}
+		offset += len(scheduledTasks)
+	}
+
+	return result, nil
+}
+
+func flattenScheduledTasks(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(items))
+	for i, item := range items {
+		result[i] = map[string]interface{}{
+			"id":                  utils.PathSearch("id", item, nil),
+			"name":                utils.PathSearch("task_name", item, nil),
+			"type":                utils.PathSearch("task_type", item, nil),
+			"scheduled_type":      utils.PathSearch("scheduled_type", item, nil),
+			"life_cycle_type":     utils.PathSearch("life_cycle_type", item, nil),
+			"last_status":         utils.PathSearch("last_status", item, nil),
+			"next_execution_time": utils.PathSearch("next_execution_time", item, nil),
+			"enable":              utils.PathSearch("enable", item, nil),
+			"description":         utils.PathSearch("description", item, nil),
+			"priority":            utils.PathSearch("priority", item, nil),
+			"time_zone":           utils.PathSearch("time_zone", item, nil),
+			"wait_time":           utils.PathSearch("wait_time", item, nil),
+		}
+	}
+
+	return result
+}
+
+func dataSourceScheduledTasksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	resp, err := listScheduledTasks(client, d)
+	if err != nil {
+		return diag.Errorf("error querying Workspace scheduled tasks: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("tasks", flattenScheduledTasks(resp)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new data source that used to query the Workspace scheduled tasks.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1137" height="409" alt="image" src="https://github.com/user-attachments/assets/f1f4844b-af0a-4851-b49b-24cbe8c02e6d" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query scheduled tasks
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataScheduledTasks_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataScheduledTasks_basic -timeout 360m -parallel 10
=== RUN   TestAccDataScheduledTasks_basic
=== PAUSE TestAccDataScheduledTasks_basic
=== CONT  TestAccDataScheduledTasks_basic
--- PASS: TestAccDataScheduledTasks_basic (11.25s)
PASS
coverage: 3.4% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 11.331s coverage: 3.4% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
