### PR TITLE
feat(cdn): add new resource for verify domain owner

### DIFF
--- a/docs/resources/cdn_domain_owner_verify.md
+++ b/docs/resources/cdn_domain_owner_verify.md
@@ -1,0 +1,64 @@
+---
+subcategory: "Content Delivery Network (CDN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cdn_domain_owner_verify"
+description: |-
+  Use this resource to verify domain owner within HuaweiCloud.
+---
+
+# huaweicloud_cdn_domain_owner_verify
+
+Use this resource to verify domain owner within HuaweiCloud.
+
+-> This is resource only a one-time action resource for verify domain owner. Deleting this resource
+   will not clear the corresponding request record, but will only remove the resource information
+   from the tfstate file.
+
+## Example Usage
+
+### Verify domain ownership with default verification method
+
+```hcl
+variable "domain_name" {}
+
+resource "huaweicloud_cdn_domain_owner_verify" "test" {
+  domain_name = var.domain_name
+}
+```
+
+### Verify domain ownership with DNS verification
+
+```hcl
+variable "domain_name" {}
+
+resource "huaweicloud_cdn_domain_owner_verify" "test" {
+  domain_name = var.domain_name
+  verify_type = "dns"
+}
+```
+
+### Verify domain ownership with file verification
+
+```hcl
+variable "domain_name" {}
+
+resource "huaweicloud_cdn_domain_owner_verify" "test" {
+  domain_name = var.domain_name
+  verify_type = "file"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_name` - (Required, String, NonUpdatable) Specifies the domain name to be verified.
+
+* `verify_type` - (Optional, String, NonUpdatable) Specifies the verification method.  
+  The valid values are as follows:
+  + **dns**: DNS resolution verification.
+  + **file**: File verification.
+  + **all**: Both DNS and file verification will be performed, and verification
+    succeeds if either method passes.
+
+  Defaults to **all**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2496,6 +2496,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdn_cache_refresh":                 cdn.ResourceCacheRefresh(),
 			"huaweicloud_cdn_certificate_associate_domains": cdn.ResourceCertificateAssociateDomains(),
 			"huaweicloud_cdn_domain_batch_copy":             cdn.ResourceDomainBatchCopy(),
+			"huaweicloud_cdn_domain_owner_verify":           cdn.ResourceDomainOwnerVerify(),
 
 			"huaweicloud_ces_alarmrule":                                     ces.ResourceAlarmRule(),
 			"huaweicloud_ces_alarm_template":                                ces.ResourceCesAlarmTemplate(),

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_owner_verify_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_owner_verify_test.go
@@ -1,0 +1,48 @@
+package cdn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDomainOwnerVerify_basic(t *testing.T) {
+	// Avoid CheckDestroy, because there is nothing in the resource destroy method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCDN(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainOwnerVerify_basic(),
+			},
+			{
+				Config: testAccDomainOwnerVerify_basic_step1(),
+			},
+		},
+	})
+}
+
+func testAccDomainOwnerVerify_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_domain_owner_verify" "test" {
+  domain_name = "%[1]s"
+}
+`, acceptance.HW_CDN_DOMAIN_NAME)
+}
+
+func testAccDomainOwnerVerify_basic_step1() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_domain_owner_verify" "test_with_dns" {
+  domain_name = "%[1]s"
+  verify_type = "dns"
+}
+`, acceptance.HW_CDN_DOMAIN_NAME)
+}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain_owner_verify.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain_owner_verify.go
@@ -1,0 +1,131 @@
+package cdn
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var domainOwnerVerifyNonUpdatableParams = []string{"domain_name", "verify_type"}
+
+// @API CDN POST /v1.0/cdn/configuration/domains/{domain_name}/verify-owner
+func ResourceDomainOwnerVerify() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDomainOwnerVerifyCreate,
+		ReadContext:   resourceDomainOwnerVerifyRead,
+		UpdateContext: resourceDomainOwnerVerifyUpdate,
+		DeleteContext: resourceDomainOwnerVerifyDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(domainOwnerVerifyNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"domain_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The domain name to be verified.`,
+			},
+
+			// Optional parameters.
+			"verify_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The verification method.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildDomainOwnerVerifyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	verifyType := "all"
+
+	if v, ok := d.GetOk("verify_type"); ok {
+		verifyType = v.(string)
+	}
+
+	return map[string]interface{}{
+		"verify_type": verifyType,
+	}
+}
+
+func resourceDomainOwnerVerifyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		httpUrl    = "v1.0/cdn/configuration/domains/{domain_name}/verify-owner"
+		domainName = d.Get("domain_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	verifyPath := client.Endpoint + httpUrl
+	verifyPath = strings.ReplaceAll(verifyPath, "{domain_name}", domainName)
+	verifyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildDomainOwnerVerifyBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", verifyPath, &verifyOpt)
+	if err != nil {
+		return diag.Errorf("error verifying domain owner: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	result := utils.PathSearch("result", respBody, false).(bool)
+	if !result {
+		return diag.Errorf("domain ownership verification failed for domain: %s", domainName)
+	}
+
+	return resourceDomainOwnerVerifyRead(ctx, d, meta)
+}
+
+func resourceDomainOwnerVerifyRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDomainOwnerVerifyUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDomainOwnerVerifyDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This is resource only a one-time action resource for verify domain owner. Deleting this resource
+will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(cdn): add new resource for verify domain owner

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccDomainOwnerVerify_basic -timeout 360m -parallel 10
=== RUN   TestAccDomainOwnerVerify_basic
=== PAUSE TestAccDomainOwnerVerify_basic
=== CONT  TestAccDomainOwnerVerify_basic
--- PASS: TestAccDomainOwnerVerify_basic (45.85s)
PASS
coverage: 3.5% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       45.959s coverage: 3.5% of statements in ./huaweicloud/services/cdn
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.