### PR TITLE
feat(workspace): add new data source to query resource quotas

### DIFF
--- a/docs/data-sources/workspace_quotas.md
+++ b/docs/data-sources/workspace_quotas.md
@@ -1,0 +1,71 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_quotas"
+description: |-
+  Use this data source to get the tenant quotas of the Workspace within HuaweiCloud.
+---
+
+# huaweicloud_workspace_quotas
+
+Use this data source to get the tenant quotas of the Workspace within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_workspace_quotas" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the quotas are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `quotas` - The list of common quotas.  
+  The [quotas](#workspace_quotas_attr) structure is documented below.
+
+* `site_quotas` - The list of site quotas.  
+  The [site_quotas](#workspace_site_quotas_attr) structure is documented below.
+
+<a name="workspace_quotas_attr"></a>
+The `quotas` block supports:
+
+* `resources` - The list of quota resources.  
+  The [resources](#quota_resources_attr) structure is documented below.
+
+<a name="quota_resources_attr"></a>
+The `resources` block supports:
+
+* `type` - The resource type.
+  + **general_instances**: Number of general desktops.
+  + **Memory**: Memory capacity.
+  + **cores**: Number of CPUs.
+  + **volumes**: Number of disks.
+  + **volume_gigabytes**: Disk capacity.
+  + **gpu_instances**: Number of GPU desktops.
+  + **deh**: Cloud office host.
+  + **users**: Number of users.
+  + **policy_groups**: Number of policy groups.
+  + **Cores**: Number of CPUs (used by quota tool).
+
+* `quota` - The quota value.
+
+* `used` - The used quota value.
+
+* `unit` - The quota unit.
+
+<a name="workspace_site_quotas_attr"></a>
+The `site_quotas` block supports:
+
+* `site_id` - The site ID.
+
+* `resources` - The list of quota resources.  
+  The [resources](#quota_resources_attr) structure is documented above.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2119,6 +2119,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_hour_packages":          workspace.DataSourceHourPackages(),
 			"huaweicloud_workspace_flavors":                workspace.DataSourceWorkspaceFlavors(),
 			"huaweicloud_workspace_policy_groups":          workspace.DataSourcePolicyGroups(),
+			"huaweicloud_workspace_quotas":                 workspace.DataSourceQuotas(),
 			"huaweicloud_workspace_scheduled_tasks":        workspace.DataSourceScheduledTasks(),
 			"huaweicloud_workspace_service":                workspace.DataSourceService(),
 			"huaweicloud_workspace_tags":                   workspace.DataSourceTags(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_quotas_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_quotas_test.go
@@ -1,0 +1,44 @@
+package workspace
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataQuotas_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_workspace_quotas.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataQuotas_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "quotas.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestMatchResourceAttr(dataSourceName, "quotas.0.resources.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.resources.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.resources.0.quota"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.resources.0.used"),
+					resource.TestMatchResourceAttr(dataSourceName, "site_quotas.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestMatchResourceAttr(dataSourceName, "site_quotas.0.resources.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "site_quotas.0.resources.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "site_quotas.0.resources.0.quota"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "site_quotas.0.resources.0.used"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataQuotas_basic = `
+data "huaweicloud_workspace_quotas" "test" {}
+`

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_quotas.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_quotas.go
@@ -1,0 +1,191 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v2/{project_id}/quotas
+func DataSourceQuotas() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceQuotasRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the quotas are located.`,
+			},
+
+			// Attributes.
+			"quotas": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resources": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of quota resources.`,
+							Elem:        quotaResourceSchema(),
+						},
+					},
+				},
+				Description: `The list of common quotas.`,
+			},
+			"site_quotas": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"site_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The site ID.`,
+						},
+						"resources": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of quota resources.`,
+							Elem:        quotaResourceSchema(),
+						},
+					},
+				},
+				Description: `The list of site quotas.`,
+			},
+		},
+	}
+}
+
+func quotaResourceSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The resource type.`,
+			},
+			"quota": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The quota value.`,
+			},
+			"used": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The used quota value.`,
+			},
+			"unit": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The quota unit.`,
+			},
+		},
+	}
+}
+
+func getQuotas(client *golangsdk.ServiceClient) (interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/quotas"
+	)
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func flattenQuotaResources(resources []interface{}) []map[string]interface{} {
+	if len(resources) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(resources))
+	for _, resource := range resources {
+		result = append(result, map[string]interface{}{
+			"type":  utils.PathSearch("type", resource, nil),
+			"quota": utils.PathSearch("quota", resource, nil),
+			"used":  utils.PathSearch("used", resource, nil),
+			"unit":  utils.PathSearch("unit", resource, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenQuotas(quotas map[string]interface{}) []map[string]interface{} {
+	if len(quotas) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"resources": flattenQuotaResources(utils.PathSearch("resources", quotas, make([]interface{}, 0)).([]interface{})),
+		},
+	}
+}
+
+func flattenSiteQuotas(siteQuotas []interface{}) []map[string]interface{} {
+	if len(siteQuotas) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(siteQuotas))
+	for _, siteQuota := range siteQuotas {
+		result = append(result, map[string]interface{}{
+			"site_id":   utils.PathSearch("site_id", siteQuota, nil),
+			"resources": flattenQuotaResources(utils.PathSearch("resources", siteQuota, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func dataSourceQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	resp, err := getQuotas(client)
+	if err != nil {
+		return diag.Errorf("error querying Workspace quotas: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("quotas", flattenQuotas(utils.PathSearch("quotas", resp, make(map[string]interface{})).(map[string]interface{}))),
+		d.Set("site_quotas", flattenSiteQuotas(utils.PathSearch("site_quotas", resp, make([]interface{}, 0)).([]interface{}))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new data source to query resource quotas.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query resource quotas
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataQuotas_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataQuotas_basic -timeout 360m -parallel 10
=== RUN   TestAccDataQuotas_basic
=== PAUSE TestAccDataQuotas_basic
=== CONT  TestAccDataQuotas_basic
--- PASS: TestAccDataQuotas_basic (15.17s)
PASS
coverage: 3.1% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 15.269s coverage: 3.1% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
