### PR TITLE
feat(ELB): elb pool support az affinity

### DIFF
--- a/docs/data-sources/elb_pools.md
+++ b/docs/data-sources/elb_pools.md
@@ -85,6 +85,9 @@ The following arguments are supported:
 * `protection_status` - (Optional, String) Specifies the protection status for update.
   Value options: **nonProtection**, **consoleProtection**.
 
+* `az_affinity` - (Optional, String) Specifies whether AZ affinity of a backend server group is enabled.
+  Value options: **enable=true**, **enable=false**.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -146,6 +149,9 @@ The `pools` block supports:
 * `persistence` - Indicates whether connections in the same session will be processed by the same pool member or not.
   The [object](#persistence_object) structure is documented below.
 
+* `az_affinity` - Indicates how AZ affinity is configured for the backend server group.
+  The [az_affinity](#az_affinity_struct) structure is documented below.
+
 * `quic_cid_hash_strategy` - The multi-path forwarding policy based on destination connection IDs.
   The [quic_cid_hash_strategy](#quic_cid_hash_strategy_struct) structure is documented below.
 
@@ -166,6 +172,18 @@ The `persistence` block supports:
 * `cookie_name` - The name of the cookie if persistence mode is set appropriately.
 
 * `timeout` - The stickiness duration, in minutes.
+
+<a name="az_affinity_struct"></a>
+The `az_affinity` block supports:
+
+* `enable` - Whether to enable AZ affinity for the backend server group.
+
+* `az_minimum_healthy_member_percentage` - The percentage that is used to determine the health of an AZ.
+
+* `az_minimum_healthy_member_count` - The number that is used to determine the health of an AZ.
+
+* `az_unhealthy_fallback_strategy` - How traffic will be distributed across backend servers in an AZ if the percentage
+  or number of healthy servers in the AZ of the load balancer falls below the specified value.
 
 <a name="quic_cid_hash_strategy_struct"></a>
 The `quic_cid_hash_strategy` block supports:

--- a/docs/resources/elb_pool.md
+++ b/docs/resources/elb_pool.md
@@ -192,6 +192,9 @@ The following arguments are supported:
   + **0** (default value): Not take effect.
   + **1**: Take effect when all member offline.
 
+* `az_affinity` - (Optional, List) Specifies how AZ affinity is configured for the backend server group.
+  The [az_affinity](#az_affinity_struct) structure is documented below.
+
 <a name="persistence"></a>
 The `persistence` block supports:
 
@@ -213,6 +216,53 @@ The `persistence` block supports:
     defaults to `1`.
   + When the protocol of the backend server group is **HTTP** or **HTTPS**, the value ranges from `1` to `1,440`,
     and defaults to `1,440`.
+
+<a name="az_affinity_struct"></a>
+The `az_affinity` block supports:
+
+* `enable` - (Optional, String) Specifies whether to enable AZ affinity for the backend server group. If this parameter
+  is set to **true**, ELB forwards traffic across the backend servers in the same AZ as the load balancer.
+  + AZ affinity cannot be enabled for a backend server group that has IP as backend servers whose availability_zone is
+    not specified.
+  + AZ affinity cannot be enabled if the backend server is bound to a TLS listener.
+  + This parameter is available for backend server groups that are associated with **IP**, **UDP**, and **TCP** listeners.
+  + If the parameter is set to **true**, parameter `minimum_healthy_member_count` will be ignored.
+  
+  Value options: **true**, **false**.
+
+* `az_minimum_healthy_member_percentage` - (Optional, String) Specifies a percentage that is used to determine the health
+  of an AZ. If the percentage of healthy servers in the AZ of the load balancer falls below the specified value,
+  `az_unhealthy_fallback_strategy` is triggered. `az_minimum_healthy_member_percentage` shows the percentage of backend
+  servers that are healthy in a backend server group of an AZ. The number of healthy servers is rounded up. An integer
+  ranging from **-1** to **100**. An integer from **0** to **100** indicates the percentage of healthy servers in the AZ
+  of the load balancer. **-1** indicates that `az_minimum_healthy_member_count` takes effect.
+  + If `enable` is set to **true**, `az_minimum_healthy_member_percentage` and `az_minimum_healthy_member_count` cannot
+    be set to **-1** at the same time.
+  + If `enable` is set to **true**, either `az_minimum_healthy_member_percentage` or `az_minimum_healthy_member_count`
+    must be set to -1.
+
+* `az_minimum_healthy_member_count` - (Optional, String) Specifies a number that is used to determine the health of an AZ.
+  If the number of healthy servers in the AZ of the load balancer falls below the specified value,
+  `az_unhealthy_fallback_strategy` is triggered. `az_minimum_healthy_member_count` shows the number of healthy servers in
+  a backend server group of an AZ. An integer ranging from **-1** to **10000**. An integer from **0** to **10000**
+  indicates the number of healthy servers in the AZ of the load balancer. **-1** indicates that
+  `az_minimum_healthy_member_percentage` takes effect.
+  + If `enable` is set to **true**, `az_minimum_healthy_member_percentage` and `az_minimum_healthy_member_count` cannot
+    be set to **-1** at the same time.
+  + If `enable` is set to **true**, either `az_minimum_healthy_member_percentage` or `az_minimum_healthy_member_count`
+    must be set to **-1**.
+
+* `az_unhealthy_fallback_strategy` - (Optional, String) Specifies how traffic will be distributed across backend servers
+  in an AZ if the percentage or number of healthy servers in the AZ of the load balancer falls below the specified value.
+  Value options:
+  + **forward_to_all_member_of_local_az**: forwards requests across all backend servers in the same AZ as the load
+    balancer, even if some servers are unhealthy.
+  + **forward_to_healthy_member_of_remote_az**: forwards requests across healthy backend servers in different AZs from
+    the load balancer.
+  + **forward_to_all_healthy_member**: forwards requests across healthy backend servers in all AZs.
+  + **forward_to_all_member**: forwards requests across all backend servers in all AZs, even if some servers are unhealthy.
+
+  Defaults to **forward_to_all_member_of_local_az**.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  elb pool support az affinity
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  elb pool support az affinity
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/elb/ TESTARGS='-run TestAccElbV3Pool_basic_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v -run TestAccElbV3Pool_basic_ -timeout 360m -parallel 4
=== RUN   TestAccElbV3Pool_basic_with_loadbalancer
=== PAUSE TestAccElbV3Pool_basic_with_loadbalancer
=== RUN   TestAccElbV3Pool_basic_with_listener
=== PAUSE TestAccElbV3Pool_basic_with_listener
=== RUN   TestAccElbV3Pool_basic_with_type_ip
=== PAUSE TestAccElbV3Pool_basic_with_type_ip
=== RUN   TestAccElbV3Pool_basic_with_protocol_tcp
=== PAUSE TestAccElbV3Pool_basic_with_protocol_tcp
=== RUN   TestAccElbV3Pool_basic_with_connection_drain
=== PAUSE TestAccElbV3Pool_basic_with_connection_drain
=== RUN   TestAccElbV3Pool_basic_with_ip_protocol
=== PAUSE TestAccElbV3Pool_basic_with_ip_protocol
=== CONT  TestAccElbV3Pool_basic_with_loadbalancer
=== CONT  TestAccElbV3Pool_basic_with_protocol_tcp
=== CONT  TestAccElbV3Pool_basic_with_type_ip
=== CONT  TestAccElbV3Pool_basic_with_ip_protocol
    acceptance.go:3655: HW_ELB_GATEWAY_TYPE must be set for the acceptance test
--- SKIP: TestAccElbV3Pool_basic_with_ip_protocol (0.00s)
=== CONT  TestAccElbV3Pool_basic_with_listener
--- PASS: TestAccElbV3Pool_basic_with_protocol_tcp (55.04s)
=== CONT  TestAccElbV3Pool_basic_with_connection_drain
--- PASS: TestAccElbV3Pool_basic_with_type_ip (55.10s)
--- PASS: TestAccElbV3Pool_basic_with_connection_drain (127.59s)
--- PASS: TestAccElbV3Pool_basic_with_listener (205.96s)
--- PASS: TestAccElbV3Pool_basic_with_loadbalancer (278.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       278.925s

make testacc TEST=./huaweicloud/services/acceptance/elb/ TESTARGS='-run TestAccDatasourcePools_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v -run TestAccDatasourcePools_ -timeout 360m -parallel 4
=== RUN   TestAccDatasourcePools_basic
=== PAUSE TestAccDatasourcePools_basic
=== RUN   TestAccDatasourcePools_quic
=== PAUSE TestAccDatasourcePools_quic
=== RUN   TestAccDatasourcePools_tcp
=== PAUSE TestAccDatasourcePools_tcp
=== CONT  TestAccDatasourcePools_basic
=== CONT  TestAccDatasourcePools_tcp
=== CONT  TestAccDatasourcePools_quic
--- PASS: TestAccDatasourcePools_tcp (146.20s)
--- PASS: TestAccDatasourcePools_quic (179.39s)
--- PASS: TestAccDatasourcePools_basic (619.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       619.305s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
