### PR TITLE
feat(aom): action rule supports new parameter user_name

### DIFF
--- a/docs/resources/aom_alarm_action_rule.md
+++ b/docs/resources/aom_alarm_action_rule.md
@@ -12,16 +12,25 @@ Manages an AOM alarm action rule resource within HuaweiCloud.
 ## Example Usage
 
 ```hcl
-variable "topic_urn" {}
+variable "request_iam_user_name" {}
+variable "action_rule_name"
+variable "topic_urns_to_notify" {
+  type = list(string)
+}
 
 resource "huaweicloud_aom_alarm_action_rule" "test" {
-  name                  = "test_rule"
+  user_name             = var.request_iam_user_name
+  name                  = var.action_rule_name
   description           = "terraform test"
   type                  = "1"
   notification_template = "aom.built-in.template.zh"
 
-  smn_topics {
-    topic_urn = var.topic_urn
+  dynamic "smn_topics" {
+    for_each = var.topic_urns_to_notify
+
+    content {
+      topic_urn = smn_topics.value
+    }
   }
 }
 ```
@@ -32,6 +41,13 @@ The following arguments are supported:
 
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `user_name` - (Required, String, ForceNew) Specifies the IAM user name to which the action rule belongs.  
+  Changing this parameter will create a new resource.
+
+  !> Currently, this parameter is required in some regions and more regions will be applied this behavior in the future.
+     <br>To avoid deployment errors caused by the validation behavior of this parameter in the OpenAPI in the future, it
+     is recommended to use a provider version of at least `1.80.4` and configure this parameter.
 
 * `name` - (Required, String, ForceNew) Specifies the action rule name. The value can be a string of 1 to 100
   characters that can consist of letters, digits, underscores (_), hyphens (-) and Chinese characters,

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -1124,6 +1124,13 @@ func TestAccPreCheckUserId(t *testing.T) {
 }
 
 // lintignore:AT003
+func TestAccPreCheckUserName(t *testing.T) {
+	if HW_USER_NAME == "" {
+		t.Skip("HW_USER_NAME must be set for acceptance tests.")
+	}
+}
+
+// lintignore:AT003
 func TestAccPreCheckApigSubResourcesRelatedInfo(t *testing.T) {
 	if HW_APIG_DEDICATED_INSTANCE_ID == "" {
 		t.Skip("Before running APIG acceptance tests, please ensure the env 'HW_APIG_DEDICATED_INSTANCE_ID' has been configured")

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_action_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_action_rule.go
@@ -41,6 +41,18 @@ func ResourceAlarmActionRule() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Description: utils.SchemaDesc(
+					`The IAM user name to which the action rule belongs.`,
+					utils.SchemaDescInput{
+						Required: true,
+					},
+				),
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -138,6 +150,7 @@ func resourceAlarmActionRuleCreate(ctx context.Context, d *schema.ResourceData, 
 
 func buildAlarmActionRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
+		"user_name":             utils.ValueIgnoreEmpty(d.Get("user_name")),
 		"rule_name":             utils.ValueIgnoreEmpty(d.Get("name")),
 		"desc":                  utils.ValueIgnoreEmpty(d.Get("description")),
 		"type":                  utils.ValueIgnoreEmpty(d.Get("type")),
@@ -216,6 +229,7 @@ func resourceAlarmActionRuleRead(_ context.Context, d *schema.ResourceData, meta
 	mErr = multierror.Append(
 		mErr,
 		d.Set("region", region),
+		d.Set("user_name", utils.PathSearch("user_name", getAlarmActionRuleRespBody, nil)),
 		d.Set("name", utils.PathSearch("rule_name", getAlarmActionRuleRespBody, nil)),
 		d.Set("description", utils.PathSearch("desc", getAlarmActionRuleRespBody, nil)),
 		d.Set("type", utils.PathSearch("type", getAlarmActionRuleRespBody, nil)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

AOM action rule resource supports new parameter `user_name`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="741" height="530" alt="image" src="https://github.com/user-attachments/assets/992705d2-2fd2-4c9d-a1b5-05f9a5135ba8" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. action rule supports new parameter user_name
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o aom -f TestAccAlarmActionRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/aom" -v -coverprofile="./huaweicloud/services/acceptance/aom/aom_coverage.cov" -coverpkg="./huaweicloud/services/aom" -run TestAccAlarmActionRule_basic -timeout 360m -parallel 10
=== RUN   TestAccAlarmActionRule_basic
=== PAUSE TestAccAlarmActionRule_basic
=== CONT  TestAccAlarmActionRule_basic
--- PASS: TestAccAlarmActionRule_basic (32.05s)
PASS
coverage: 5.5% of statements in ./huaweicloud/services/aom
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       32.124s coverage: 5.5% of statements in ./huaweicloud/services/aom
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
