### PR TITLE
fix: chore(kafka/extend_flovors): use new API to replace history API

### DIFF
--- a/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_extend_flavors_test.go
+++ b/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_extend_flavors_test.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,73 +10,136 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceDmsKafkaExtendFlavors_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_dms_kafka_extend_flavors.all"
-	rName := acceptance.RandomAccResourceName()
-	dc := acceptance.InitDataSourceCheck(dataSource)
+func TestAccDataExtendFlavors_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_dms_kafka_extend_flavors.all"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byType   = "data.huaweicloud_dms_kafka_extend_flavors.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+
+		byChargingMode   = "data.huaweicloud_dms_kafka_extend_flavors.filter_by_charging_mode"
+		dcByChargingMode = acceptance.InitDataSourceCheck(byChargingMode)
+
+		byArchType   = "data.huaweicloud_dms_kafka_extend_flavors.filter_by_arch_type"
+		dcByArchType = acceptance.InitDataSourceCheck(byArchType)
+
+		byStorageSpecCode   = "data.huaweicloud_dms_kafka_extend_flavors.filter_by_storage_spec_code"
+		dcByStorageSpecCode = acceptance.InitDataSourceCheck(byStorageSpecCode)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceDataSourceDmsKafkaExtendFlavors_basic(rName),
+				Config: testAccDataExtendFlavors_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSource, "versions.#"),
-					resource.TestCheckResourceAttrSet(dataSource, "flavors.#"),
-					resource.TestCheckOutput("type_validation", "true"),
-					resource.TestCheckOutput("arch_types_validation", "true"),
-					resource.TestCheckOutput("charging_modes_validation", "true"),
-					resource.TestCheckOutput("storage_spec_code_validation", "true"),
+					resource.TestMatchResourceAttr(dataSource, "versions.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestMatchResourceAttr(dataSource, "flavors.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_useful", "true"),
+					dcByChargingMode.CheckResourceExists(),
+					resource.TestCheckOutput("is_charging_mode_useful", "true"),
+					dcByArchType.CheckResourceExists(),
+					resource.TestCheckOutput("is_arch_type_useful", "true"),
+					dcByStorageSpecCode.CheckResourceExists(),
+					resource.TestCheckOutput("is_storage_spec_code_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testDataSourceDataSourceDmsKafkaExtendFlavors_basic(name string) string {
+func testAccDataExtendFlavors_basic() string {
 	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_dms_kafka_extend_flavors" "all" {
-  depends_on = [huaweicloud_dms_kafka_instance.test]
-
-  instance_id = huaweicloud_dms_kafka_instance.test.id
+data "huaweicloud_dms_kafka_instances" "test" {
+  instance_id = "%[1]s"
 }
 
-data "huaweicloud_dms_kafka_extend_flavors" "test" {
-  depends_on = [huaweicloud_dms_kafka_instance.test]
+data "huaweicloud_dms_kafka_extend_flavors" "all" {
+  instance_id = "%[1]s"
+}
 
-  instance_id       = huaweicloud_dms_kafka_instance.test.id
-  type              = local.test_refer.type
-  arch_type         = local.test_refer.arch_types[0]
-  charging_mode     = local.test_refer.charging_modes[0]
-  storage_spec_code = local.test_refer.ios[0].storage_spec_code
+# Filter by instance type.
+locals {
+  instance_type = try(data.huaweicloud_dms_kafka_instances.test.instances[0].type, null)
+}
+
+data "huaweicloud_dms_kafka_extend_flavors" "filter_by_type" {
+  instance_id = "%[1]s"
+  type        = local.instance_type
 }
 
 locals {
-  test_refer   = data.huaweicloud_dms_kafka_extend_flavors.all.flavors[0]
-  test_results = data.huaweicloud_dms_kafka_extend_flavors.test
+  filter_by_type_result = [for v in data.huaweicloud_dms_kafka_extend_flavors.filter_by_type.flavors[*].type : v == local.instance_type]
 }
 
-output "type_validation" {
-  value = alltrue([for a in local.test_results.flavors[*].type : a == local.test_refer.type])
+output "is_type_useful" {
+  value = length(local.filter_by_type_result) > 0 && alltrue(local.filter_by_type_result)
 }
 
-output "arch_types_validation" {
-  value = alltrue([for a in local.test_results.flavors[*].arch_types : contains(a, local.test_refer.arch_types[0])])
+# Filter by instance charging mode.
+locals {
+  charging_mode = try(data.huaweicloud_dms_kafka_instances.test.instances[0].charging_mode, null)
 }
 
-output "charging_modes_validation" {
-  value = alltrue([for a in local.test_results.flavors[*].charging_modes : contains(a, local.test_refer.charging_modes[0])])
+data "huaweicloud_dms_kafka_extend_flavors" "filter_by_charging_mode" {
+  instance_id   = "%[1]s"
+  charging_mode = local.charging_mode
 }
 
-output "storage_spec_code_validation" {
-  value = alltrue([for ios in local.test_results.flavors[*].ios :
-    alltrue([for io in ios : io.storage_spec_code == local.test_refer.ios[0].storage_spec_code])])
+locals {
+  filter_by_charging_mode_result = [for v in data.huaweicloud_dms_kafka_extend_flavors.filter_by_charging_mode.flavors[*].charging_modes :
+  contains(v, local.charging_mode)]
 }
-`, testAccKafkaInstance_newFormat(name))
+
+output "is_charging_mode_useful" {
+  value = length(local.filter_by_charging_mode_result) > 0 && alltrue(local.filter_by_charging_mode_result)
+}
+
+# Filter by instance architecture type.
+locals {
+  arch_type = try(data.huaweicloud_dms_kafka_extend_flavors.all.flavors[0].arch_types[0], null)
+}
+
+data "huaweicloud_dms_kafka_extend_flavors" "filter_by_arch_type" {
+  instance_id = "%[1]s"
+  arch_type   = local.arch_type
+}
+
+locals {
+  filter_by_arch_type_result = [for v in data.huaweicloud_dms_kafka_extend_flavors.filter_by_arch_type.flavors[*].arch_types :
+  contains(v, local.arch_type)]
+}
+
+output "is_arch_type_useful" {
+  value = length(local.filter_by_arch_type_result) > 0 && alltrue(local.filter_by_arch_type_result)
+}
+
+# Filter by instance storage spec code.
+locals {
+  storage_spec_code = try(data.huaweicloud_dms_kafka_instances.test.instances[0].storage_spec_code, null)
+}
+
+data "huaweicloud_dms_kafka_extend_flavors" "filter_by_storage_spec_code" {
+  instance_id       = "%[1]s"
+  storage_spec_code = local.storage_spec_code
+}
+
+locals {
+  filter_by_storage_spec_code_result = [
+    for v in data.huaweicloud_dms_kafka_extend_flavors.filter_by_storage_spec_code.flavors[*].ios[*].storage_spec_code :
+    contains(v, local.storage_spec_code)
+  ]
+}
+
+output "is_storage_spec_code_useful" {
+  value = length(local.filter_by_storage_spec_code_result) > 0 && alltrue(local.filter_by_storage_spec_code_result)
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID)
 }

--- a/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_extend_flavors.go
+++ b/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_extend_flavors.go
@@ -249,14 +249,14 @@ func dataSourceDmsKafkaExtendFlavorsRead(_ context.Context, d *schema.ResourceDa
 	return nil
 }
 
-// @API Kafka GET /v2/{engine}/{project_id}/instances/{instance_id}/extend
+// @API Kafka GET /v2/{project_id}/kafka/instances/{instance_id}/extend
 func (w *KafkaExtendFlavorsDSWrapper) ShowEngineInstanceExtendProductInfo() (*gjson.Result, error) {
 	client, err := w.NewClient(w.Config, "dmsv2")
 	if err != nil {
 		return nil, err
 	}
 
-	uri := "/v2/kafka/{project_id}/instances/{instance_id}/extend"
+	uri := "/v2/{project_id}/kafka/instances/{instance_id}/extend"
 	uri = strings.ReplaceAll(uri, "{instance_id}", w.Get("instance_id").(string))
 
 	filterResult := filters.New().From("products").


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Fix the issue that the `storage_spec_code` filter condition is ineffective.
2. Use a new [API ](https://support.huaweicloud.com/api-kafka/ShowKafkaInstanceExtendProductInfo.html)to replace deprecated [API](https://support.huaweicloud.com/api-kafka/ShowEngineInstanceExtendProductInfo.html).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccDataExtendFlavors_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccDataExtendFlavors_basic -timeout 360m -parallel 10
=== RUN   TestAccDataExtendFlavors_basic
=== PAUSE TestAccDataExtendFlavors_basic
=== CONT  TestAccDataExtendFlavors_basic
--- PASS: TestAccDataExtendFlavors_basic (21.80s)
PASS
coverage: 6.0% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     21.881s coverage: 6.0% of statements in ./huaweicloud/services/kafka
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
