### PR TITLE
feat(workspace): add new resource to create and authorize bucket

### DIFF
--- a/docs/resources/workspace_bucket_authorize.md
+++ b/docs/resources/workspace_bucket_authorize.md
@@ -1,0 +1,36 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_bucket_authorize"
+description: |-
+  Use this resource to create and authorize a default bucket within HuaweiCloud.
+---
+
+# huaweicloud_workspace_bucket_authorize
+
+Use this resource to create and authorize a default bucket within HuaweiCloud.
+
+-> This resource is only a one-time action resource for creating and authorizing a default bucket. Deleting this
+   resource will not delete the corresponding default bucket from the OBS service, but will only remove the resource
+   information from the tfstate file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_workspace_bucket_authorize" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the bucket to be authorized is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `bucket_name` - The name of the bucket that was created and authorized.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3699,6 +3699,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_application_rule_restriction":         workspace.ResourceApplicationRuleRestriction(),
 			"huaweicloud_workspace_application_rule_restriction_setting": workspace.ResourceApplicationRuleRestrictionSetting(),
 			"huaweicloud_workspace_application_visibility_batch_action":  workspace.ResourceApplicationVisibilityBatchAction(),
+			"huaweicloud_workspace_bucket_authorize":                     workspace.ResourceBucketAuthorize(),
 			"huaweicloud_workspace_desktop_name_rule":                    workspace.ResourceDesktopNameRule(),
 			"huaweicloud_workspace_desktop":                              workspace.ResourceDesktop(),
 			"huaweicloud_workspace_desktop_notification":                 workspace.ResourceDesktopNotification(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_bucket_authorize_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_bucket_authorize_test.go
@@ -1,0 +1,37 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceBucketAuthorize_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_workspace_bucket_authorize.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceBucketAuthorize_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "bucket_name"),
+				),
+			},
+		},
+	})
+}
+
+const testAccResourceBucketAuthorize_basic = `
+resource "huaweicloud_workspace_bucket_authorize" "test" {}
+`

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_bucket_authorize.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_bucket_authorize.go
@@ -1,0 +1,104 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace POST /v1/{project_id}/app-center/buckets
+func ResourceBucketAuthorize() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBucketAuthorizeCreate,
+		ReadContext:   resourceBucketAuthorizeRead,
+		DeleteContext: resourceBucketAuthorizeDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the bucket to be authorized is located.`,
+			},
+			"bucket_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the bucket that was created and authorized.`,
+			},
+		},
+	}
+}
+
+func resourceBucketAuthorizeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/app-center/buckets"
+	)
+
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating and authorizing bucket: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.Errorf("error flattening bucket authorization response: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("bucket_name", utils.PathSearch("bucket_name", respBody, nil)),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error setting bucket authorization attributes: %s", mErr)
+	}
+
+	return resourceBucketAuthorizeRead(ctx, d, meta)
+}
+
+func resourceBucketAuthorizeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceBucketAuthorizeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for creating and authorizing a default bucket.
+Deleting this resource will not clear the corresponding request record, but will only remove the resource information
+from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource that used to create a default bucket and authorize it.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1199" height="629" alt="image" src="https://github.com/user-attachments/assets/fab94a74-efe5-4055-b2f9-d0de45f5de7e" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource that used to create a default bucket and authorize it.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccResourceBucketAuthorize_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceBucketAuthorize_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceBucketAuthorize_basic
=== PAUSE TestAccResourceBucketAuthorize_basic
=== CONT  TestAccResourceBucketAuthorize_basic
--- PASS: TestAccResourceBucketAuthorize_basic (14.44s)
PASS
coverage: 2.9% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 14.528s coverage: 2.9% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
