### PR TITLE
feat(waf): new datasource to query security report history periods

### DIFF
--- a/docs/data-sources/waf_security_report_history_periods.md
+++ b/docs/data-sources/waf_security_report_history_periods.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_security_report_history_periods"
+description: |-
+  Use this data source to get the list of security report history periods.
+---
+
+# huaweicloud_waf_security_report_history_periods
+
+Use this data source to get the list of security report history periods.
+
+## Example Usage
+
+```hcl
+variable "subscription_id" {}
+
+data "huaweicloud_waf_security_report_history_periods" "test" {
+  subscription_id = var.subscription_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `subscription_id` - (Required, String) Specifies the subscription ID of the security report.
+  This value can be queried through the datasource `huaweicloud_waf_security_report_subscriptions`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `items` - The security report history periods list.
+
+  The [items](#items_struct) structure is documented below.
+
+<a name="items_struct"></a>
+The `items` block supports:
+
+* `report_id` - The unique identifier for the security report.
+
+* `subscription_id` - The subscription ID associated with the security report.
+
+* `stat_period` - The statistical period of the historical report.
+  
+  The [stat_period](#stat_period_struct) structure is documented below.
+
+<a name="stat_period_struct"></a>
+The `stat_period` block supports:
+
+* `begin_time` - The start time of the statistical period (in milliseconds since epoch).
+
+* `end_time` - The end time of the statistical period (in milliseconds since epoch).

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2093,6 +2093,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_rules_precise_protection":             waf.DataSourceWafRulesPreciseProtection(),
 			"huaweicloud_waf_rules_threat_intelligence":            waf.DataSourceRulesThreatIntelligence(),
 			"huaweicloud_waf_rules_web_tamper_protection":          waf.DataSourceWafRulesWebTamperProtection(),
+			"huaweicloud_waf_security_report_history_periods":      waf.DataSourceSecurityReportHistoryPeriods(),
 			"huaweicloud_waf_security_report_subscriptions":        waf.DataSourceSecurityReportSubscriptions(),
 			"huaweicloud_waf_source_ips":                           waf.DataSourceWafSourceIps(),
 			"huaweicloud_waf_tag_antileakage_map":                  waf.DataSourceTagAntileakageMap(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -115,6 +115,7 @@ var (
 	HW_INTERNAL_USED          = os.Getenv("HW_INTERNAL_USED")
 
 	HW_WAF_ENABLE_FLAG                          = os.Getenv("HW_WAF_ENABLE_FLAG")
+	HW_WAF_SECURITY_REPORT_SUBSCRIPTION_ID      = os.Getenv("HW_WAF_SECURITY_REPORT_SUBSCRIPTION_ID")
 	HW_WAF_PRECHECK_GEO_IP_POLICY_RULES         = os.Getenv("HW_WAF_PRECHECK_GEO_IP_POLICY_RULES")
 	HW_WAF_PRECHECK_IP_REPUTATION_POLICY_RULES  = os.Getenv("HW_WAF_PRECHECK_IP_REPUTATION_POLICY_RULES")
 	HW_WAF_CERTIFICATE_ID                       = os.Getenv("HW_WAF_CERTIFICATE_ID")
@@ -1261,6 +1262,13 @@ func RandomPassword(customChars ...string) string {
 func TestAccPrecheckWafInstance(t *testing.T) {
 	if HW_WAF_ENABLE_FLAG == "" {
 		t.Skip("Skip the WAF acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPrecheckWafSecurityReportSubscription(t *testing.T) {
+	if HW_WAF_SECURITY_REPORT_SUBSCRIPTION_ID == "" {
+		t.Skip("HW_WAF_SECURITY_REPORT_SUBSCRIPTION_ID must be set for WAF security report subscription acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_security_report_history_periods_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_security_report_history_periods_test.go
@@ -1,0 +1,43 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSecurityReportHistoryPeriods_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_waf_security_report_history_periods.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPrecheckWafSecurityReportSubscription(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSecurityReportHistoryPeriods_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "items.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceSecurityReportHistoryPeriods_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_waf_security_report_history_periods" "test" {
+  subscription_id = "%s"
+}
+`, acceptance.HW_WAF_SECURITY_REPORT_SUBSCRIPTION_ID)
+}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_security_report_history_periods.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_security_report_history_periods.go
@@ -1,0 +1,164 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/waf/security-report/history-periods
+func DataSourceSecurityReportHistoryPeriods() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecurityReportHistoryPeriodsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"subscription_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"report_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"subscription_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"stat_period": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"begin_time": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"end_time": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildSecurityReportHistoryPeriodsQueryParams(d *schema.ResourceData, offset int) string {
+	queryParams := fmt.Sprintf("?subscription_id=%s", d.Get("subscription_id").(string))
+	if offset > 0 {
+		queryParams += fmt.Sprintf("&offset=%d", offset)
+	}
+
+	return queryParams
+}
+
+func dataSourceSecurityReportHistoryPeriodsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/security-report/history-periods"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	for {
+		currentPath := requestPath + buildSecurityReportHistoryPeriodsQueryParams(d, offset)
+		resp, err := client.Request("GET", currentPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving security report history periods: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		periods := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		if len(periods) == 0 {
+			break
+		}
+
+		result = append(result, periods...)
+		offset += len(periods)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("items", flattenSecurityReportHistoryPeriods(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSecurityReportHistoryPeriods(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		result = append(result, map[string]interface{}{
+			"report_id":       utils.PathSearch("report_id", v, nil),
+			"subscription_id": utils.PathSearch("subscription_id", v, nil),
+			"stat_period":     flattenStatPeriod(utils.PathSearch("stat_period", v, nil)),
+		})
+	}
+	return result
+}
+
+func flattenStatPeriod(statPeriod interface{}) []map[string]interface{} {
+	if statPeriod == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"begin_time": utils.PathSearch("begin_time", statPeriod, nil),
+			"end_time":   utils.PathSearch("end_time", statPeriod, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query security report history periods

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccDataSourceSecurityReportHistoryPeriods_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccDataSourceSecurityReportHistoryPeriods_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceSecurityReportHistoryPeriods_basic
--- PASS: TestAccDataSourceSecurityReportHistoryPeriods_basic (13.05s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       13.154s coverage: 3.7% of statements in ./huaweicloud/services/waf
```
<img width="1336" height="81" alt="image" src="https://github.com/user-attachments/assets/ebc41a70-3c6e-48a3-bbe6-2e32869cdf10" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
