### PR TITLE
feat(hss): support `hss_container_network_security_groups` data source

### DIFF
--- a/docs/data-sources/hss_container_network_security_groups.md
+++ b/docs/data-sources/hss_container_network_security_groups.md
@@ -1,0 +1,50 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_container_network_security_groups"
+description: |-
+  Use this data source to get the list of HSS container network security groups within HuaweiCloud.
+---
+
+# huaweicloud_hss_container_network_security_groups
+
+Use this data source to get the list of HSS container network security groups within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_container_network_security_groups" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need to set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `security_groups` - The list of security groups.
+
+  The [security_groups](#security_groups_struct) structure is documented below.
+
+<a name="security_groups_struct"></a>
+The `security_groups` block supports:
+
+* `security_group_id` - The security group ID.
+
+* `security_group_name` - The security group name.
+
+* `security_group_description` - The security group description.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1390,6 +1390,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_container_network_policies":                 hss.DataSourceContainerNetworkPolicies(),
 			"huaweicloud_hss_container_network_cluster":                  hss.DataSourceContainerNetworkCluster(),
 			"huaweicloud_hss_container_network_info":                     hss.DataSourceContainerNetworkInfo(),
+			"huaweicloud_hss_container_network_security_groups":          hss.DataSourceContainerNetworkSecurityGroups(),
 			"huaweicloud_hss_container_iac_files":                        hss.DataSourceContainerIacFiles(),
 			"huaweicloud_hss_container_iac_file_risks":                   hss.DataSourceContainerIacFileRisks(),
 			"huaweicloud_hss_event_handle_history":                       hss.DataSourceEventHandleHistory(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_network_security_groups_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_network_security_groups_test.go
@@ -1,0 +1,42 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceContainerNetworkSecurityGroups_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_container_network_security_groups.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceContainerNetworkSecurityGroups_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.security_group_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.security_group_name"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceContainerNetworkSecurityGroups_basic() string {
+	return `
+data "huaweicloud_hss_container_network_security_groups" "test" {
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_container_network_security_groups.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_container_network_security_groups.go
@@ -1,0 +1,134 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/container-network/security-groups
+func DataSourceContainerNetworkSecurityGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceContainerNetworkSecurityGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"security_groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"security_group_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"security_group_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildContainerNetworkSecurityGroupsQueryParams(epsId string) string {
+	queryParams := ""
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("?enterprise_project_id=%v", epsId)
+	}
+
+	return queryParams
+}
+
+func dataSourceContainerNetworkSecurityGroupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/container-network/security-groups"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildContainerNetworkSecurityGroupsQueryParams(epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS container network security groups: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("security_groups", flattenContainerNetworkSecurityGroups(respBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenContainerNetworkSecurityGroups(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	curJson, ok := resp.([]interface{})
+	if !ok || len(curJson) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(curJson))
+	for _, v := range curJson {
+		rst = append(rst, map[string]interface{}{
+			"security_group_id":          utils.PathSearch("security_group_id", v, nil),
+			"security_group_name":        utils.PathSearch("security_group_name", v, nil),
+			"security_group_description": utils.PathSearch("security_group_description", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_container_network_security_groups` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_container_network_security_groups` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceContainerNetworkSecurityGroups_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceContainerNetworkSecurityGroups_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceContainerNetworkSecurityGroups_basic
=== PAUSE TestAccDataSourceContainerNetworkSecurityGroups_basic
=== CONT  TestAccDataSourceContainerNetworkSecurityGroups_basic
--- PASS: TestAccDataSourceContainerNetworkSecurityGroups_basic (11.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       11.353s
```
<img width="974" height="32" alt="image" src="https://github.com/user-attachments/assets/d4c8c372-62e7-4044-8821-8deaf29768b4" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
