### PR TITLE
feat(waf): new datasource query rules protection types

### DIFF
--- a/docs/data-sources/waf_rules_protection_types.md
+++ b/docs/data-sources/waf_rules_protection_types.md
@@ -1,0 +1,32 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_rules_protection_types"
+description: |-
+  Use this data source to get the list of protection types.
+---
+
+# huaweicloud_waf_rules_protection_types
+
+Use this data source to get the list of protection types.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_waf_rules_protection_types" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `items` - The protection types list.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2091,6 +2091,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_rules_information_leakage_prevention": waf.DataSourceWafRulesInformationLeakagePrevention(),
 			"huaweicloud_waf_rules_known_attack_source":            waf.DataSourceWafRulesKnownAttackSource(),
 			"huaweicloud_waf_rules_precise_protection":             waf.DataSourceWafRulesPreciseProtection(),
+			"huaweicloud_waf_rules_protection_types":               waf.DataSourceRulesProtectionTypes(),
 			"huaweicloud_waf_rules_threat_intelligence":            waf.DataSourceRulesThreatIntelligence(),
 			"huaweicloud_waf_rules_web_tamper_protection":          waf.DataSourceWafRulesWebTamperProtection(),
 			"huaweicloud_waf_security_report_subscriptions":        waf.DataSourceSecurityReportSubscriptions(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_rules_protection_types_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_rules_protection_types_test.go
@@ -1,0 +1,38 @@
+package waf
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRulesProtectionTypes_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_waf_rules_protection_types.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceRulesProtectionTypes_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "items.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceRulesProtectionTypes_basic = `
+data "huaweicloud_waf_rules_protection_types" "test" {
+}
+`

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_rules_protection_types.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_rules_protection_types.go
@@ -1,0 +1,104 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/waf/rules/protection-types
+func DataSourceRulesProtectionTypes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRulesProtectionTypesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func buildRulesProtectionTypesQueryParams(offset int) string {
+	if offset > 0 {
+		return fmt.Sprintf("?offset=%d", offset)
+	}
+
+	return ""
+}
+
+func dataSourceRulesProtectionTypesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/rules/protection-types"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	for {
+		currentPath := requestPath + buildRulesProtectionTypesQueryParams(offset)
+		resp, err := client.Request("GET", currentPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving rules protection types: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		items := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		if len(items) == 0 {
+			break
+		}
+
+		result = append(result, items...)
+		offset += len(items)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("items", utils.ExpandToStringList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource query rules protection types

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccDataSourceRulesProtectionTypes_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccDataSourceRulesProtectionTypes_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceRulesProtectionTypes_basic
--- PASS: TestAccDataSourceRulesProtectionTypes_basic (16.37s)
PASS
coverage: 3.6% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       16.495s coverage: 3.6% of statements in ./huaweicloud/services/waf
```
<img width="1335" height="77" alt="image" src="https://github.com/user-attachments/assets/eede9c93-757b-4b7d-893f-4efe1bbbdbe4" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
