### PR TITLE
feat(workspace): add new resource to batch operate application visibility

### DIFF
--- a/docs/resources/workspace_application_visibility_batch_action.md
+++ b/docs/resources/workspace_application_visibility_batch_action.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_application_visibility_batch_action"
+description: |-
+  Use this resource to batch set application visibility within HuaweiCloud.
+---
+
+# huaweicloud_workspace_application_visibility_batch_action
+
+Use this resource to batch set application visibility within HuaweiCloud.
+
+-> This resource is a one-time action resource used to batch set application visibility. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "application_visibility_action" {}
+variable "operate_application_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_workspace_application_visibility_batch_action" "test" {
+  action  = var.application_visibility_action
+  app_ids = var.operate_application_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the applications to be operated are located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `action` - (Required, String, NonUpdatable) Specifies the visibility action type.  
+  Valid values are:
+  + **enable**
+  + **disable**
+
+* `app_ids` - (Required, List, NonUpdatable) Specifies the list of application IDs to be operated.  
+  Maximum of `50` applications are supported.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3611,6 +3611,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_application_rule":                     workspace.ResourceApplicationRule(),
 			"huaweicloud_workspace_application_rule_restriction":         workspace.ResourceApplicationRuleRestriction(),
 			"huaweicloud_workspace_application_rule_restriction_setting": workspace.ResourceApplicationRuleRestrictionSetting(),
+			"huaweicloud_workspace_application_visibility_batch_action":  workspace.ResourceApplicationVisibilityBatchAction(),
 			"huaweicloud_workspace_desktop_name_rule":                    workspace.ResourceDesktopNameRule(),
 			"huaweicloud_workspace_desktop":                              workspace.ResourceDesktop(),
 			"huaweicloud_workspace_desktop_notification":                 workspace.ResourceDesktopNotification(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_application_visibility_batch_action_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_application_visibility_batch_action_test.go
@@ -1,0 +1,79 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccApplicationVisibilityBatchAction_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_workspace_application_visibility_batch_action.test"
+		name         = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationVisibilityBatchAction_basic(name, "enable"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "action", "enable"),
+					resource.TestCheckResourceAttr(resourceName, "app_ids.#", "2"),
+				),
+			},
+			{
+				Config: testAccApplicationVisibilityBatchAction_basic(name, "disable"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "action", "disable"),
+					resource.TestCheckResourceAttr(resourceName, "app_ids.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccApplicationVisibilityBatchAction_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_application_catalogs" "test" {}
+
+resource "huaweicloud_workspace_application" "test" {
+  count = 2
+
+  name               = "%[1]s-${count.index}"
+  version            = "1.0.0"
+  description        = "Created by terraform script"
+  authorization_type = "ALL_USER"
+  install_type       = "QUIET_INSTALL"
+  support_os         = "Windows"
+  catalog_id         = try(data.huaweicloud_workspace_application_catalogs.test.catalogs[0].id, "NOT_FOUND")
+
+  application_file_store {
+    store_type = "LINK"
+    file_link  = "https://www.huaweicloud.com/TerraformTest.msi"
+  }
+}
+`, name)
+}
+
+func testAccApplicationVisibilityBatchAction_basic(name, action string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_application_visibility_batch_action" "test" {
+  action  = "%[2]s"
+  app_ids = huaweicloud_workspace_application.test[*].id
+
+  enable_force_new = "true"
+}
+`, testAccApplicationVisibilityBatchAction_base(name), action)
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_application_visibility_batch_action.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_application_visibility_batch_action.go
@@ -1,0 +1,127 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var applicationVisibilityBatchActionNonUpdatableParams = []string{"action", "app_ids"}
+
+// @API Workspace POST /v1/{project_id}/app-center/apps/actions/batch-enable
+// @API Workspace POST /v1/{project_id}/app-center/apps/actions/batch-disable
+func ResourceApplicationVisibilityBatchAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceApplicationVisibilityBatchActionCreate,
+		ReadContext:   resourceApplicationVisibilityBatchActionRead,
+		UpdateContext: resourceApplicationVisibilityBatchActionUpdate,
+		DeleteContext: resourceApplicationVisibilityBatchActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(applicationVisibilityBatchActionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the applications to be operated are located.`,
+			},
+
+			// Required parameters.
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The visibility action type.`,
+			},
+			"app_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of application IDs to be operated.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildApplicationVisibilityBatchActionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"items": d.Get("app_ids"),
+	}
+}
+
+func resourceApplicationVisibilityBatchActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		action  = d.Get("action").(string)
+		httpUrl = fmt.Sprintf("v1/{project_id}/app-center/apps/actions/batch-%s", action)
+	)
+
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildApplicationVisibilityBatchActionBodyParams(d),
+	}
+
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error executing application visibility batch action (%s): %s", action, err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	return resourceApplicationVisibilityBatchActionRead(ctx, d, meta)
+}
+
+func resourceApplicationVisibilityBatchActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceApplicationVisibilityBatchActionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceApplicationVisibilityBatchActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch set application visibility. Deleting this
+resource will not clear the corresponding request record, but will only remove the resource information from the tfstate
+file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource to batch operate application visibility.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1142" height="363" alt="image" src="https://github.com/user-attachments/assets/6b8ede86-f90e-4618-868c-f2775d70e74e" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to batch operate application visibility.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccApplicationVisibilityBatchAction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccApplicationVisibilityBatchAction_basic -timeout 360m -parallel 10
=== RUN   TestAccApplicationVisibilityBatchAction_basic
=== PAUSE TestAccApplicationVisibilityBatchAction_basic
=== CONT  TestAccApplicationVisibilityBatchAction_basic
--- PASS: TestAccApplicationVisibilityBatchAction_basic (27.81s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 27.895s coverage: 4.6% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
