### PR TITLE
feat(workspace): add new one-time action resource to manage rule restriction switch

### DIFF
--- a/docs/resources/workspace_application_rule_restriction_switch.md
+++ b/docs/resources/workspace_application_rule_restriction_switch.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_application_rule_restriction_switch"
+description: |-
+  Use this resource to enable or disable the application rule restriction within HuaweiCloud.
+---
+
+# huaweicloud_workspace_application_rule_restriction_switch
+
+Use this resource to enable or disable the application rule restriction within HuaweiCloud.
+
+-> This resource is only a one-time action resource for enabling or disabling the application rule restriction. Deleting
+   this resource will not clear the corresponding request record, but will only remove the resource information from the
+   tfstate file.
+
+## Example Usage
+
+### Enable Application Rule Restriction
+
+```hcl
+resource "huaweicloud_workspace_application_rule_restriction_switch" "test" {
+  action = "enable"
+}
+```
+
+### Disable Application Rule Restriction
+
+```hcl
+resource "huaweicloud_workspace_application_rule_restriction_switch" "test" {
+  action = "disable"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the application rule restriction to be operated is
+  located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `action` - (Required, String, NonUpdatable) Specifies the action type for the application rule restriction.  
+  Valid values are:
+  + **enable**: Enable the application rule restriction.
+  + **disable**: Disable the application rule restriction.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3698,6 +3698,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_application_rule":                     workspace.ResourceApplicationRule(),
 			"huaweicloud_workspace_application_rule_restriction":         workspace.ResourceApplicationRuleRestriction(),
 			"huaweicloud_workspace_application_rule_restriction_setting": workspace.ResourceApplicationRuleRestrictionSetting(),
+			"huaweicloud_workspace_application_rule_restriction_switch":  workspace.ResourceApplicationRuleRestrictionSwitch(),
 			"huaweicloud_workspace_application_visibility_batch_action":  workspace.ResourceApplicationVisibilityBatchAction(),
 			"huaweicloud_workspace_desktop_name_rule":                    workspace.ResourceDesktopNameRule(),
 			"huaweicloud_workspace_desktop":                              workspace.ResourceDesktop(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_application_rule_restriction_switch_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_application_rule_restriction_switch_test.go
@@ -1,0 +1,55 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccApplicationRuleRestrictionSwitch_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_workspace_application_rule_restriction_switch.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationRuleRestrictionSwitch_basic_step1,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "action", "enable"),
+				),
+			},
+			{
+				Config: testAccApplicationRuleRestrictionSwitch_basic_step2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "action", "disable"),
+				),
+			},
+		},
+	})
+}
+
+const testAccApplicationRuleRestrictionSwitch_basic_step1 = `
+resource "huaweicloud_workspace_application_rule_restriction_switch" "test" {
+  action = "enable"
+
+  enable_force_new = "true"
+}
+`
+
+const testAccApplicationRuleRestrictionSwitch_basic_step2 = `
+resource "huaweicloud_workspace_application_rule_restriction_switch" "test" {
+  action = "disable"
+
+  enable_force_new = "true"
+}
+`

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_application_rule_restriction_switch.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_application_rule_restriction_switch.go
@@ -1,0 +1,116 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var applicationRuleRestrictionSwitchNonUpdatableParams = []string{
+	"action",
+}
+
+// @API Workspace POST /v1/{project_id}/app-center/app-rules/actions/enable-rule-restriction
+// @API Workspace POST /v1/{project_id}/app-center/app-rules/actions/disable-rule-restriction
+func ResourceApplicationRuleRestrictionSwitch() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceApplicationRuleRestrictionSwitchCreate,
+		ReadContext:   resourceApplicationRuleRestrictionSwitchRead,
+		UpdateContext: resourceApplicationRuleRestrictionSwitchUpdate,
+		DeleteContext: resourceApplicationRuleRestrictionSwitchDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(applicationRuleRestrictionSwitchNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the application rule restriction to be operated is located.`,
+			},
+
+			// Required parameters.
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The action type for the application rule restriction.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceApplicationRuleRestrictionSwitchCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		action  = d.Get("action").(string)
+		httpUrl = "v1/{project_id}/app-center/app-rules/actions/{action}-rule-restriction"
+	)
+
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{action}", action)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error executing application rule restriction switch (%s): %s", action, err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	return resourceApplicationRuleRestrictionSwitchRead(ctx, d, meta)
+}
+
+func resourceApplicationRuleRestrictionSwitchRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceApplicationRuleRestrictionSwitchUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceApplicationRuleRestrictionSwitchDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for enabling or disabling the application rule
+restriction. Deleting this resource will not clear the corresponding request record, but will only remove the resource
+information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new one-time action resource to manage rule restriction switch.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1188" height="446" alt="image" src="https://github.com/user-attachments/assets/7a9ae471-68db-4f8c-ad87-541b630575c2" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new one-time action resource to manage rule restriction switch.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccApplicationRuleRestrictionSwitch_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccApplicationRuleRestrictionSwitch_basic -timeout 360m -parallel 10
=== RUN   TestAccApplicationRuleRestrictionSwitch_basic
=== PAUSE TestAccApplicationRuleRestrictionSwitch_basic
=== CONT  TestAccApplicationRuleRestrictionSwitch_basic
--- PASS: TestAccApplicationRuleRestrictionSwitch_basic (20.35s)
PASS
coverage: 2.9% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 20.430s coverage: 2.9% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
