### PR TITLE
feat(workspace/app): the APP server group supports to modify tags

### DIFF
--- a/docs/resources/workspace_app_server_group.md
+++ b/docs/resources/workspace_app_server_group.md
@@ -106,9 +106,8 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies the description of the server group.
 
-* `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the server group.
-  Supports up to 20 tags.  
-  Changing this creates a new resource.
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the server group.
+  Supports up to `20` tags.
   
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project to which the
   server group belong.  


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The Workspace App server group supports to update tags.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccResourceAppServerGroup_singleSession
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceAppServerGroup_singleSession -timeout 360m -parallel 10
=== RUN   TestAccResourceAppServerGroup_singleSession
=== PAUSE TestAccResourceAppServerGroup_singleSession
=== CONT  TestAccResourceAppServerGroup_singleSession
--- PASS: TestAccResourceAppServerGroup_singleSession (44.65s)
PASS
coverage: 5.2% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 44.801s coverage: 5.2% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
