### PR TITLE
feat(hss): add new data source to get list of dynamic WTP events

### DIFF
--- a/docs/data-sources/hss_webtamper_rasp_protect_history.md
+++ b/docs/data-sources/hss_webtamper_rasp_protect_history.md
@@ -1,0 +1,80 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_webtamper_rasp_protect_history"
+description: |-
+  Use this data source to get the list of dynamic WTP events.
+---
+
+# huaweicloud_hss_webtamper_rasp_protect_history
+
+Use this data source to get the list of dynamic WTP events.
+
+## Example Usage
+
+```hcl
+variable "start_time" {}
+variable "end_time" {}
+
+data "huaweicloud_hss_webtamper_rasp_protect_history" "test" {
+  start_time = var.start_time
+  end_time   = var.end_time
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `start_time` - (Required, Int) Specifies the query start time, in milliseconds.
+  The start time cannot be earlier than `30` days ago. If an earlier time is specified,
+  the query range is still the past `30` days.
+
+* `end_time` - (Required, Int) Specifies the query end time, in milliseconds.
+  The end time cannot be earlier than the start time. The difference between the end time and start time
+  cannot exceed `30` days. If it exceeds `30` days, the end time is set to one day later than the start time.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the hosts belong.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `host_id` - (Optional, String) Specifies the ID of the host.
+
+* `alarm_level` - (Optional, Int) Specifies the alarm severity.
+  The valid values are as follows:
+  + **1**: Indicates critical
+  + **2**: Indicates major.
+  + **3**: Indicates minor.
+  + **4**: Indicates warning.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data_list` - The list of dynamic WTP events.
+  The [data_list](#hosts_data_list) structure is documented below.
+
+<a name="hosts_data_list"></a>
+The `data_list` block supports:
+
+* `host_ip` - The host IP address.
+
+* `host_name` - The host name.
+
+* `alarm_time` - The alarm time, in milliseconds.
+
+* `threat_type` - The threat type.
+
+* `alarm_level` - The alarm severity.
+
+* `source_ip` - The attack source IP address.
+
+* `attacked_url` - The attack source URL.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1436,6 +1436,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_webtamper_hosts":                            hss.DataSourceWebTamperHosts(),
 			"huaweicloud_hss_webtamper_host_management_hosts":            hss.DataSourceWebTamperHostManagementHosts(),
 			"huaweicloud_hss_webtamper_rasp_path":                        hss.DataSourceWebtamperRaspPath(),
+			"huaweicloud_hss_webtamper_rasp_protect_history":             hss.DataSourceWebtamperRaspProtectHistory(),
 			"huaweicloud_hss_webtamper_policy":                           hss.DataSourceWebTamperPolicy(),
 			"huaweicloud_hss_antivirus_custom_scan_policies":             hss.DataSourceAntivirusCustomScanPolicies(),
 			"huaweicloud_hss_antivirus_available_hosts":                  hss.DataSourceAntivirusAvailableHosts(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_webtamper_rasp_protect_history_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_webtamper_rasp_protect_history_test.go
@@ -1,0 +1,49 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceWebtamperRaspProtectHistory_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_webtamper_rasp_protect_history.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		startTime  = time.Now().Add(-24*time.Hour).UnixNano() / int64(time.Millisecond)
+		endTime    = time.Now().UnixNano() / int64(time.Millisecond)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			// Because there is no available data for testing, the test case is only
+			// used to verify that the API can be invoked.
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceWebtamperRaspProtectHistory_basic(startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceWebtamperRaspProtectHistory_basic(startTime, endTime int64) string {
+	return fmt.Sprintf(`
+data "huaweicloud_hss_webtamper_rasp_protect_history" "test" {
+  start_time            = %[1]d
+  end_time              = %[2]d
+  enterprise_project_id = "0"
+}
+`, startTime, endTime)
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_webtamper_rasp_protect_history.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_webtamper_rasp_protect_history.go
@@ -1,0 +1,185 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/webtamper/rasp/protect-history
+func DataSourceWebtamperRaspProtectHistory() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceWebtamperRaspProtectHistoryRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"start_time": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"end_time": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"alarm_level": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"host_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"alarm_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"threat_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"alarm_level": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"source_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"attacked_url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildWebtamperRaspProtectHistoryQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := fmt.Sprintf("?start_time=%v&end_time=%v&limit=200", d.Get("start_time"), d.Get("start_time"))
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("host_id"); ok {
+		queryParams = fmt.Sprintf("%s&host_id=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("alarm_level"); ok {
+		queryParams = fmt.Sprintf("%s&alarm_level=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceWebtamperRaspProtectHistoryRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		product = "hss"
+		httpUrl = "v5/{project_id}/webtamper/rasp/protect-history"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildWebtamperRaspProtectHistoryQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": region},
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", currentPath, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving dynamic WTP events: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataResp := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataResp) == 0 {
+			break
+		}
+
+		result = append(result, dataResp...)
+		offset += len(dataResp)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data_list", flattenWebtamperRaspProtectHistory(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenWebtamperRaspProtectHistory(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"host_ip":      utils.PathSearch("host_ip", v, nil),
+			"host_name":    utils.PathSearch("host_name", v, nil),
+			"alarm_time":   utils.PathSearch("alarm_time", v, nil),
+			"threat_type":  utils.PathSearch("threat_type", v, nil),
+			"alarm_level":  utils.PathSearch("alarm_level", v, nil),
+			"source_ip":    utils.PathSearch("source_ip", v, nil),
+			"attacked_url": utils.PathSearch("attacked_url", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get list of dynamic WTP events.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceWebtamperRaspProtectHistory_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceWebtamperRaspProtectHistory_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWebtamperRaspProtectHistory_basic
=== PAUSE TestAccDataSourceWebtamperRaspProtectHistory_basic
=== CONT  TestAccDataSourceWebtamperRaspProtectHistory_basic
--- PASS: TestAccDataSourceWebtamperRaspProtectHistory_basic (14.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       14.155s
```
<img width="1208" height="20" alt="image" src="https://github.com/user-attachments/assets/8f45b119-cf63-402d-ac91-6d9ae8d3e6f8" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
