### PR TITLE
feat(workspace/app): add new data source to query server group tags

### DIFF
--- a/docs/data-sources/workspace_app_server_group_tags.md
+++ b/docs/data-sources/workspace_app_server_group_tags.md
@@ -1,0 +1,54 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_server_group_tags"
+description: |-
+  Use this data source to query the tags of the server group within HuaweiCloud Workspace.
+---
+
+# huaweicloud_workspace_app_server_group_tags
+
+Use this data source to query the tags of the server group within HuaweiCloud Workspace.
+
+## Example Usage
+
+### Querying tags of all server groups
+
+```hcl
+data "huaweicloud_workspace_app_server_group_tags" "test" {}
+```
+
+### Querying tags of the specific server group
+
+```hcl
+variable "server_group_id" {}
+
+data "huaweicloud_workspace_app_server_group_tags" "test" {
+  server_group_id = var.server_group_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the server group tags are located.  
+  If omitted, the provider-level region will be used.
+
+* `server_group_id` - (Optional, String) Specifies the ID of the server group to which the tags belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tags` - The tag list of the server group.  
+  The [tags](#workspace_app_server_group_tags_attr) structure is documented below.
+
+<a name="workspace_app_server_group_tags_attr"></a>
+The `tags` block supports:
+
+* `key` - The key of the tag.
+
+* `values` - The value list of the tag.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2165,6 +2165,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_server_groups":                   workspace.DataSourceAppServerGroups(),
 			"huaweicloud_workspace_app_server_group_restrict":           workspace.DataSourceAppServerGroupRestrict(),
 			"huaweicloud_workspace_app_server_group_status":             workspace.DataSourceAppServerGroupStatus(),
+			"huaweicloud_workspace_app_server_group_tags":               workspace.DataSourceAppServerGroupTags(),
 			"huaweicloud_workspace_app_server_quotas":                   workspace.DataSourceAppServerQuotas(),
 			"huaweicloud_workspace_app_session_types":                   workspace.DataSourceSessionTypes(),
 			"huaweicloud_workspace_app_storage_policies":                workspace.DataSourceAppStoragePolicies(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_server_group_tags_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_server_group_tags_test.go
@@ -1,0 +1,89 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataAppServerGroupTags_basic(t *testing.T) {
+	var (
+		all               = "data.huaweicloud_workspace_app_server_group_tags.all"
+		dcAll             = acceptance.InitDataSourceCheck(all)
+		byServerGroupId   = "data.huaweicloud_workspace_app_server_group_tags.test"
+		dcByServerGroupId = acceptance.InitDataSourceCheck(byServerGroupId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataAppServerGroupTags_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dcAll.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "tags.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					resource.TestCheckResourceAttrSet(all, "tags.0.key"),
+					resource.TestMatchResourceAttr(all, "tags.0.values.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					dcByServerGroupId.CheckResourceExists(),
+					resource.TestMatchResourceAttr(byServerGroupId, "tags.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					resource.TestCheckResourceAttrSet(byServerGroupId, "tags.0.key"),
+					resource.TestCheckResourceAttr(byServerGroupId, "tags.0.values.#", "1"),
+					resource.TestCheckOutput("is_all_tags_include_test_tags", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataAppServerGroupTags_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_service" "test" {}
+
+resource "huaweicloud_workspace_app_server_group" "test" {
+  name             = "%[1]s"
+  os_type          = "Windows"
+  flavor_id        = "%[2]s"
+  vpc_id           = data.huaweicloud_workspace_service.test.vpc_id
+  subnet_id        = data.huaweicloud_workspace_service.test.network_ids[0]
+  system_disk_type = "SAS"
+  system_disk_size = 90
+  is_vdi           = true
+  image_id         = "%[3]s"
+  image_type       = "gold"
+  image_product_id = "%[4]s"
+
+  tags = {
+    owner = "terraform"
+    foo   = "bar"
+  }
+}
+
+data "huaweicloud_workspace_app_server_group_tags" "test" {
+  server_group_id = huaweicloud_workspace_app_server_group.test.id
+}
+
+data "huaweicloud_workspace_app_server_group_tags" "all" {
+  depends_on = [huaweicloud_workspace_app_server_group.test]
+}
+
+output "is_all_tags_include_test_tags" {
+  value = alltrue([for v in data.huaweicloud_workspace_app_server_group_tags.test.tags:
+    length([for vv in data.huaweicloud_workspace_app_server_group_tags.all.tags:
+      vv.key == v.key && contains(vv.values, v.values[0])
+    ]) > 0
+  ])
+}
+`, acceptance.RandomAccResourceName(),
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID,
+	)
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_server_group_tags.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_server_group_tags.go
@@ -1,0 +1,143 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/server-group/tags
+// @API Workspace GET /v1/{project_id}/server-group/{server_group_id}/tags
+func DataSourceAppServerGroupTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppServerGroupTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the server group tags are located.`,
+			},
+			"server_group_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the server group to which the tags belong.`,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The key of the tag.`,
+						},
+						"values": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The value list of the tag.`,
+						},
+					},
+				},
+				Description: `The tag list of the server group.`,
+			},
+		},
+	}
+}
+
+func queryServerGroupTags(client *golangsdk.ServiceClient, serverGroupId string) ([]interface{}, error) {
+	var httpUrl string
+	if serverGroupId != "" {
+		httpUrl = "v1/{project_id}/server-group/{server_group_id}/tags"
+	} else {
+		httpUrl = "v1/{project_id}/server-group/tags"
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	if serverGroupId != "" {
+		getPath = strings.ReplaceAll(getPath, "{server_group_id}", serverGroupId)
+	}
+
+	getOpts := &golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	getResp, err := client.Request("GET", getPath, getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("tags", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenServerGroupTags(tags []interface{}) []interface{} {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(tags))
+	for _, item := range tags {
+		// When querying the tags for all server groups, the return value is a list of strings.
+		// When querying a specific server group, the return value is a single string.
+		values := utils.PathSearch("values", item, nil)
+		if values == nil {
+			values = []string{utils.PathSearch("value", item, "").(string)}
+		}
+
+		tag := map[string]interface{}{
+			"key":    utils.PathSearch("key", item, nil),
+			"values": values,
+		}
+		result = append(result, tag)
+	}
+
+	return result
+}
+
+func dataSourceAppServerGroupTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating WorkSpace APP client: %s", err)
+	}
+
+	tags, err := queryServerGroupTags(client, d.Get("server_group_id").(string))
+	if err != nil {
+		return diag.Errorf("error querying Workspace APP server group tags: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("tags", flattenServerGroupTags(tags)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data(`huaweicloud_workspace_app_server_group_tags`) source to query server group tags.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataAppServerGroupTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAppServerGroupTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAppServerGroupTags_basic
=== PAUSE TestAccDataAppServerGroupTags_basic
=== CONT  TestAccDataAppServerGroupTags_basic
--- PASS: TestAccDataAppServerGroupTags_basic (26.67s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 26.754s coverage: 5.1% of statements in ./huaweicloud/services/workspace
```

<img width="1079" height="509" alt="image" src="https://github.com/user-attachments/assets/4e2ac8f6-51a1-49e2-bff2-220254d0cf99" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
