### PR TITLE
fix(apig/channel): fix error when updating without health_check

### DIFF
--- a/huaweicloud/services/apig/resource_huaweicloud_apig_channel.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_channel.go
@@ -423,9 +423,17 @@ func buildChannelHealthCheckConfig(healthConfigs []interface{}) *channels.VpcHea
 		return nil
 	}
 
+	// The `health_check` is a `Computed` and `Optional` behavior. If `health_check.protocol` is empty, it means that
+	// the `health_check` is not specified in the script, and `health_check.protocol` is defined as required in the SDK,
+	// so `health_check` should be ignored if empty, otherwise, the SDK will report an error during updates.
 	healthConfig := healthConfigs[0].(map[string]interface{})
+	protocol := healthConfig["protocol"].(string)
+	if protocol == "" {
+		return nil
+	}
+
 	return &channels.VpcHealthConfig{
-		Protocol:          healthConfig["protocol"].(string),
+		Protocol:          protocol,
 		ThresholdNormal:   healthConfig["threshold_normal"].(int),
 		ThresholdAbnormal: healthConfig["threshold_abnormal"].(int),
 		TimeInterval:      healthConfig["interval"].(int),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix the error shown in the image.
Error reason:  The `health_check` is a `Computed` and `Optional` behavior. If `health_check.protocol` is empty, it means that
the `health_check` is not specified in the script, and `health_check.protocol` is defined as required in the SDK,
so `health_check` should be ignored if empty, otherwise, the SDK will report an error during updates.

<img width="1032" height="765" alt="image" src="https://github.com/user-attachments/assets/f92c7205-6d21-4854-bfeb-48e2c4dcda8d" />


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
