### PR TITLE
feat(waf): new datasource to query security report subscription

### DIFF
--- a/docs/data-sources/waf_security_report_subscription.md
+++ b/docs/data-sources/waf_security_report_subscription.md
@@ -1,0 +1,107 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_security_report_subscription"
+description: |-
+  Use this data source to get the detail of a specific security report subscription.
+---
+
+# huaweicloud_waf_security_report_subscription
+
+Use this data source to get the detail of a specific security report subscription.
+
+## Example Usage
+
+```hcl
+variable "subscription_id" {}
+
+data "huaweicloud_waf_security_report_subscription" "test" {
+  subscription_id = var.subscription_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `subscription_id` - (Required, String) Specifies the ID of the security report subscription.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `sending_period` - The sending time period for the security report.
+  The valid values are as follows:
+  + **morning**：00:00~06:00
+  + **noon**：06:00~12:00
+  + **afternoon**：12:00~18:00
+  + **evening**：18:00~24:00
+
+* `report_name` - The security report template name.
+
+* `report_category` - The security report type.
+  The valid values are as follows:
+  + **daily_report**：Indicates security daily report.
+  + **weekly_report**：Indicates security weekly report.
+  + **monthly_report**：Indicates security monthly report.
+  + **custom_report**: Indicates custom security report.
+
+* `topic_urn` - The URN of the SMN topic for receiving reports.
+
+* `subscription_type` - The subscription type of the security report.
+  The valid values are as follows:
+  + **smn_topic**
+  + **slient**
+  + **message_center**
+
+* `report_content_subscription` - The content subscription configuration of the security report.
+
+  The [report_content_subscription](#waf_report_content_subscription) structure is documented below.
+
+* `stat_period` - The statistical period of the security report.
+
+  The [stat_period](#waf_security_report_subscription_stat_period) structure is documented below.
+
+* `is_all_enterprise_project` - Whether the subscription applies to all enterprise projects.
+
+* `enterprise_project_id` - The enterprise project ID associated with the subscription. This attribute is valid only
+  when the attribute `is_all_enterprise_project` is **false**.
+
+<a name="waf_report_content_subscription"></a>
+The `report_content_subscription` block supports:
+
+* `overview_statistics_enable` - Whether to enable overview statistics.
+
+* `group_by_day_enable` - Whether to enable daily grouping statistics.
+
+* `request_statistics_enable` - Whether to enable request statistics.
+
+* `qps_statistics_enable` - Whether to enable QPS statistics.
+
+* `bandwidth_statistics_enable` - Whether to enable bandwidth statistics.
+
+* `response_code_statistics_enable` - Whether to enable response code statistics.
+
+* `attack_type_distribution_enable` - Whether to enable attack type distribution statistics.
+
+* `top_attacked_domains_enable` - Whether to enable top attacked domains statistics.
+
+* `top_attack_source_ips_enable` - Whether to enable top attack source IPs statistics.
+
+* `top_attacked_urls_enable` - Whether to enable top attacked URLs statistics.
+
+* `top_attack_source_locations_enable` - Whether to enable top attack source locations statistics.
+
+* `top_abnormal_urls_enable` - Whether to enable top abnormal URLs statistics.
+
+<a name="waf_security_report_subscription_stat_period"></a>
+The `stat_period` block supports:
+
+* `begin_time` - The start time of the statistical period in milliseconds.
+
+* `end_time` - The end time of the statistical period in milliseconds.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2100,6 +2100,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_rules_threat_intelligence":            waf.DataSourceRulesThreatIntelligence(),
 			"huaweicloud_waf_rules_web_tamper_protection":          waf.DataSourceWafRulesWebTamperProtection(),
 			"huaweicloud_waf_security_report_history_periods":      waf.DataSourceSecurityReportHistoryPeriods(),
+			"huaweicloud_waf_security_report_subscription":         waf.DataSourceWafSecurityReportSubscription(),
 			"huaweicloud_waf_security_report_subscriptions":        waf.DataSourceSecurityReportSubscriptions(),
 			"huaweicloud_waf_source_ips":                           waf.DataSourceWafSourceIps(),
 			"huaweicloud_waf_tag_antileakage_map":                  waf.DataSourceTagAntileakageMap(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_security_report_subscription_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_security_report_subscription_test.go
@@ -1,0 +1,61 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSecurityReportSubscription_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_waf_security_report_subscription.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPrecheckWafSecurityReportSubscription(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSecurityReportSubscription_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "sending_period"),
+					resource.TestCheckResourceAttrSet(dataSource, "report_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "report_category"),
+					resource.TestCheckResourceAttrSet(dataSource, "topic_urn"),
+					resource.TestCheckResourceAttrSet(dataSource, "subscription_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "report_content_subscription.0.overview_statistics_enable"),
+					resource.TestCheckResourceAttrSet(dataSource, "report_content_subscription.0.group_by_day_enable"),
+					resource.TestCheckResourceAttrSet(dataSource, "report_content_subscription.0.request_statistics_enable"),
+					resource.TestCheckResourceAttrSet(dataSource, "report_content_subscription.0.qps_statistics_enable"),
+					resource.TestCheckResourceAttrSet(dataSource, "report_content_subscription.0.bandwidth_statistics_enable"),
+					resource.TestCheckResourceAttrSet(dataSource, "report_content_subscription.0.response_code_statistics_enable"),
+					resource.TestCheckResourceAttrSet(dataSource, "report_content_subscription.0.attack_type_distribution_enable"),
+					resource.TestCheckResourceAttrSet(dataSource, "report_content_subscription.0.top_attacked_domains_enable"),
+					resource.TestCheckResourceAttrSet(dataSource, "report_content_subscription.0.top_attack_source_ips_enable"),
+					resource.TestCheckResourceAttrSet(dataSource, "report_content_subscription.0.top_attacked_urls_enable"),
+					resource.TestCheckResourceAttrSet(dataSource, "report_content_subscription.0.top_attack_source_locations_enable"),
+					resource.TestCheckResourceAttrSet(dataSource, "report_content_subscription.0.top_abnormal_urls_enable"),
+					resource.TestCheckResourceAttrSet(dataSource, "is_all_enterprise_project"),
+					resource.TestCheckResourceAttrSet(dataSource, "enterprise_project_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceSecurityReportSubscription_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_waf_security_report_subscription" "test" {
+  subscription_id = "%s"
+}
+`, acceptance.HW_WAF_SECURITY_REPORT_SUBSCRIPTION_ID)
+}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_security_report_subscription.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_security_report_subscription.go
@@ -1,0 +1,262 @@
+package waf
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/waf/security-report/subscriptions/{subscription_id}
+func DataSourceWafSecurityReportSubscription() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceWafSecurityReportSubscriptionRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"subscription_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the security report subscription.`,
+			},
+			"sending_period": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The sending period of the security report.`,
+			},
+			"report_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the security report.`,
+			},
+			"report_category": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The category of the security report.`,
+			},
+			"topic_urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The URN of the SMN topic for receiving reports.`,
+			},
+			"subscription_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The subscription type of the security report.`,
+			},
+			"report_content_subscription": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The content subscription configuration of the security report.`,
+				Elem:        buildReportContentSubscriptionSchema(),
+			},
+			"stat_period": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The statistical period of the security report.`,
+				Elem:        buildStatPeriodSchema(),
+			},
+			"is_all_enterprise_project": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the subscription applies to all enterprise projects.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The enterprise project ID associated with the subscription.`,
+			},
+		},
+	}
+}
+
+func buildReportContentSubscriptionSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"overview_statistics_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to enable overview statistics.`,
+			},
+			"group_by_day_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to enable group by day statistics.`,
+			},
+			"request_statistics_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to enable request statistics.`,
+			},
+			"qps_statistics_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to enable QPS statistics.`,
+			},
+			"bandwidth_statistics_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to enable bandwidth statistics.`,
+			},
+			"response_code_statistics_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to enable response code statistics.`,
+			},
+			"attack_type_distribution_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to enable attack type distribution statistics.`,
+			},
+			"top_attacked_domains_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to enable top attacked domains statistics.`,
+			},
+			"top_attack_source_ips_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to enable top attack source IPs statistics.`,
+			},
+			"top_attacked_urls_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to enable top attacked URLs statistics.`,
+			},
+			"top_attack_source_locations_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to enable top attack source locations statistics.`,
+			},
+			"top_abnormal_urls_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to enable top abnormal URLs statistics.`,
+			},
+		},
+	}
+}
+
+func buildStatPeriodSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"begin_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The start time of the statistical period.`,
+			},
+			"end_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The end time of the statistical period.`,
+			},
+		},
+	}
+}
+
+func dataSourceWafSecurityReportSubscriptionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/security-report/subscriptions/{subscription_id}"
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{subscription_id}", d.Get("subscription_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving security report subscription: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	reportContentSubscription := utils.PathSearch("report_content_subscription", respBody, nil)
+	statPeriod := utils.PathSearch("stat_period", respBody, nil)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("sending_period", utils.PathSearch("sending_period", respBody, nil)),
+		d.Set("report_name", utils.PathSearch("report_name", respBody, nil)),
+		d.Set("report_category", utils.PathSearch("report_category", respBody, nil)),
+		d.Set("topic_urn", utils.PathSearch("topic_urn", respBody, nil)),
+		d.Set("subscription_type", utils.PathSearch("subscription_type", respBody, nil)),
+		d.Set("report_content_subscription", flattenReportContentSubscriptionAttribute(reportContentSubscription)),
+		d.Set("stat_period", flattenStatPeriodAttribute(statPeriod)),
+		d.Set("is_all_enterprise_project", utils.PathSearch("is_all_enterprise_project", respBody, nil)),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenReportContentSubscriptionAttribute(rawMap interface{}) []interface{} {
+	if rawMap == nil {
+		return nil
+	}
+
+	rstMap := map[string]interface{}{
+		"overview_statistics_enable":         utils.PathSearch("overview_statistics_enable", rawMap, nil),
+		"group_by_day_enable":                utils.PathSearch("group_by_day_enable", rawMap, nil),
+		"request_statistics_enable":          utils.PathSearch("request_statistics_enable", rawMap, nil),
+		"qps_statistics_enable":              utils.PathSearch("qps_statistics_enable", rawMap, nil),
+		"bandwidth_statistics_enable":        utils.PathSearch("bandwidth_statistics_enable", rawMap, nil),
+		"response_code_statistics_enable":    utils.PathSearch("response_code_statistics_enable", rawMap, nil),
+		"attack_type_distribution_enable":    utils.PathSearch("attack_type_distribution_enable", rawMap, nil),
+		"top_attacked_domains_enable":        utils.PathSearch("top_attacked_domains_enable", rawMap, nil),
+		"top_attack_source_ips_enable":       utils.PathSearch("top_attack_source_ips_enable", rawMap, nil),
+		"top_attacked_urls_enable":           utils.PathSearch("top_attacked_urls_enable", rawMap, nil),
+		"top_attack_source_locations_enable": utils.PathSearch("top_attack_source_locations_enable", rawMap, nil),
+		"top_abnormal_urls_enable":           utils.PathSearch("top_abnormal_urls_enable", rawMap, nil),
+	}
+
+	return []interface{}{rstMap}
+}
+
+func flattenStatPeriodAttribute(rawMap interface{}) []interface{} {
+	if rawMap == nil {
+		return nil
+	}
+
+	rstMap := map[string]interface{}{
+		"begin_time": utils.PathSearch("begin_time", rawMap, nil),
+		"end_time":   utils.PathSearch("end_time", rawMap, nil),
+	}
+
+	return []interface{}{rstMap}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query security report subscription

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccDataSourceSecurityReportSubscription_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccDataSourceSecurityReportSubscription_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceSecurityReportSubscription_basic
--- PASS: TestAccDataSourceSecurityReportSubscription_basic (11.97s)
PASS
coverage: 3.6% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       12.081s coverage: 3.6% of statements in ./huaweicloud/services/waf
```
<img width="1334" height="82" alt="image" src="https://github.com/user-attachments/assets/7c5d3672-8bf3-4df6-8a54-661bd0590723" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
