### PR TITLE
feat(hss): support `hss_ransomware_backup_operation_logs` data source

### DIFF
--- a/docs/data-sources/hss_ransomware_backup_operation_logs.md
+++ b/docs/data-sources/hss_ransomware_backup_operation_logs.md
@@ -1,0 +1,90 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_ransomware_backup_operation_logs"
+description: |-
+  Use this data source to get the list of HSS ransomware backup operation logs within HuaweiCloud.
+---
+
+# huaweicloud_hss_ransomware_backup_operation_logs
+
+Use this data source to get the list of HSS ransomware backup operation logs within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_ransomware_backup_operation_logs" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `status` - (Optional, String) Specifies the restore status.  
+  The valid values are as follows:
+  + **success**: Success.
+  + **skipped**: Skipped.
+  + **failed**: Failed.
+  + **running**: Running.
+  + **timeout**: Timeout.
+  + **waiting**: Waiting.
+
+* `resource_name` - (Optional, String) Specifies the server name.
+
+* `last_days` - (Optional, Int) Specifies the query time range.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `total_num` - The total number.
+
+* `data_list` - The list of operation logs.
+
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `host_id` - The host ID.
+
+* `host_name` - The host name.
+
+* `backup_name` - The backup name.
+
+* `process` - The restore progress (percentage).
+
+* `status` - The restore status.  
+  The valid values are as follows:
+  + **success**: Success.
+  + **skipped**: Skipped.
+  + **failed**: Failed.
+  + **running**: Running.
+  + **timeout**: Timeout.
+  + **waiting**: Waiting.
+
+* `started_at` - The task start time.
+
+* `ended_at` - The task end time.
+
+* `error_info` - The failure information.
+
+  The [error_info](#error_info_struct) structure is documented below.
+
+<a name="error_info_struct"></a>
+The `error_info` block supports:
+
+* `code` - The error code.
+
+* `message` - The error message.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1417,6 +1417,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_product_infos":                              hss.DataSourceProductInfos(),
 			"huaweicloud_hss_quotas":                                     hss.DataSourceQuotas(),
 			"huaweicloud_hss_ransomware_protection_policies":             hss.DataSourceRansomwareProtectionPolicies(),
+			"huaweicloud_hss_ransomware_backup_operation_logs":           hss.DataSourceRansomwareBackupOperationLogs(),
 			"huaweicloud_hss_rasp_events":                                hss.DataSourceRaspEvents(),
 			"huaweicloud_hss_rasp_policies":                              hss.DataSourceRaspPolicies(),
 			"huaweicloud_hss_rasp_policy_detail":                         hss.DataSourceRaspPolicyDetail(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_ransomware_backup_operation_logs_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_ransomware_backup_operation_logs_test.go
@@ -1,0 +1,42 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Due to testing environment limitations, this test case can only test the scenario with empty `data_list`.
+func TestAccDataSourceRansomwareBackupOperationLogs_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_ransomware_backup_operation_logs.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceRansomwareBackupOperationLogs_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceRansomwareBackupOperationLogs_basic() string {
+	return `
+data "huaweicloud_hss_ransomware_backup_operation_logs" "test" {
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_ransomware_backup_operation_logs.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_ransomware_backup_operation_logs.go
@@ -1,0 +1,220 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/ransomware/backup/operation-logs
+func DataSourceRansomwareBackupOperationLogs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRansomwareBackupOperationLogsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"last_days": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"host_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"backup_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"process": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"started_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ended_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"error_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"code": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"message": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildRansomwareBackupOperationLogsQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=200"
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		queryParams = fmt.Sprintf("%s&status=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("resource_name"); ok {
+		queryParams = fmt.Sprintf("%s&resource_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("last_days"); ok {
+		queryParams = fmt.Sprintf("%s&last_days=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceRansomwareBackupOperationLogsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		product  = "hss"
+		epsId    = cfg.GetEnterpriseProjectID(d)
+		result   = make([]interface{}, 0)
+		offset   = 0
+		totalNum float64
+		httpUrl  = "v5/{project_id}/ransomware/backup/operation-logs"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildRansomwareBackupOperationLogsQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS ransomware backup operation logs: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalNum = utils.PathSearch("total_num", respBody, float64(0)).(float64)
+		dataList := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataList) == 0 {
+			break
+		}
+
+		result = append(result, dataList...)
+		offset += len(dataList)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_num", totalNum),
+		d.Set("data_list", flattenRansomwareBackupOperationLogsDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRansomwareBackupOperationLogsDataList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"host_id":     utils.PathSearch("host_id", v, nil),
+			"host_name":   utils.PathSearch("host_name", v, nil),
+			"backup_name": utils.PathSearch("backup_name", v, nil),
+			"process":     utils.PathSearch("process", v, nil),
+			"status":      utils.PathSearch("status", v, nil),
+			"started_at":  utils.PathSearch("started_at", v, nil),
+			"ended_at":    utils.PathSearch("ended_at", v, nil),
+			"error_info":  flattenRansomwareBackupOperationLogsErrorInfo(utils.PathSearch("error_info", v, nil)),
+		})
+	}
+
+	return rst
+}
+
+func flattenRansomwareBackupOperationLogsErrorInfo(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"code":    utils.PathSearch("code", resp, nil),
+			"message": utils.PathSearch("message", resp, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_ransomware_backup_operation_logs` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_ransomware_backup_operation_logs` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceRansomwareBackupOperationLogs_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceRansomwareBackupOperationLogs_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRansomwareBackupOperationLogs_basic
=== PAUSE TestAccDataSourceRansomwareBackupOperationLogs_basic
=== CONT  TestAccDataSourceRansomwareBackupOperationLogs_basic
--- PASS: TestAccDataSourceRansomwareBackupOperationLogs_basic (12.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       12.700s

```
<img width="987" height="28" alt="image" src="https://github.com/user-attachments/assets/b5ab4401-6e20-41a4-a54b-d0304c91ad75" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
