### PR TITLE
docs(rds): fix import example in rds_pg_plugin_parameter

### DIFF
--- a/docs/resources/rds_pg_plugin_parameter.md
+++ b/docs/resources/rds_pg_plugin_parameter.md
@@ -47,8 +47,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-The SQL limit can be imported using the `instance_id` and `name`, separated by a slash, e.g.
+The plugin parameter can be imported using the `instance_id` and `name`, separated by a slash, e.g.
 
 ```bash
-$ terraform import huaweicloud_rds_pg_sql_limit.test <instance_id>/<name>
+$ terraform import huaweicloud_rds_pg_plugin_parameter.test <instance_id>/<name>
 ```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixes incorrect resource name in the import example documentation for `rds_pg_plugin_parameter`. The import command was incorrectly referencing `rds_pg_sql_limit` instead of `rds_pg_plugin_parameter`.

**Which issue this PR fixes**:
N/A - Documentation fix


**Special notes for your reviewer**:
This is a minor documentation correction in the import section only. No code or schema changes.

**Release note**:
`NONE`
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

* [x]  Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.